### PR TITLE
Use BIGINT to represent NUMBER(38,0) as DECIMAL only range 2^31

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -124,7 +124,11 @@ public class SnowflakeUtil
         break;
 
       case FIXED:
-        colType = Types.DECIMAL;
+        if (scale == 0) {
+          colType = Types.BIGINT;
+        } else {
+          colType = Types.DECIMAL;
+        }
         extColTypeName = "NUMBER";
         break;
 


### PR DESCRIPTION
Java uses BigDecimal to present decimal, a BigDecimal consists of an arbitrary precision integer unscaled value and a 32-bit integer scale.
https://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html
https://www.cis.upenn.edu/~bcpierce/courses/629/jdkdocs/guide/jdbc/getstart/mapping.doc.html
1. 32 bit
2. May have arbitrary precision integer unscaled value.
While NUMBER(38,0)
1. 38 bit
2. Scale is 0

So decimal is not a suitable mapping for NUMBER(38,0), a better mapping maybe BIGINT.
https://www.cis.upenn.edu/~bcpierce/courses/629/jdkdocs/guide/jdbc/getstart/mapping.doc.html