### PR TITLE
Fix NumberFormatException after calling setLoginTimeout

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
@@ -102,7 +102,7 @@ public class SnowflakeBasicDataSource implements DataSource
   @Override
   public void setLoginTimeout(int seconds) throws SQLException
   {
-    properties.put("loginTimeout", seconds);
+    properties.put("loginTimeout", Integer.toString(seconds));
   }
 
   @Override


### PR DESCRIPTION
setLoginTimeout is putting a Integer value into Properties,
the call to getProperty returns null in SnowflakeConnectionV1.