### PR TITLE
shade ion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,10 @@
                        <shadedPattern>${shadeBase}.amazonaws</shadedPattern>
                      </relocation>
                      <relocation>
+                       <pattern>software.amazon.ion</pattern>
+                       <shadedPattern>${shadeBase}.software.amazon.ion</shadedPattern>
+                     </relocation>
+                     <relocation>
                        <pattern>com.microsoft.azure</pattern>
                        <shadedPattern>${shadeBase}.microsoft.azure</shadedPattern>
                      </relocation>


### PR DESCRIPTION
We make extensive use of the com.amazonaws (which is shaded), software.amazon.ion isn't, but looks like it should be. This would be especially helpful when using sbt-assembly; publishing locally resolves our issues.
