### PR TITLE
Add java.sql.Driver file

### DIFF
--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+net.snowflake.client.jdbc.SnowflakeDriver


### PR DESCRIPTION
https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html specifies that JDBC 4.0 Drivers include this file.  The presence of this file removes the need to do an explicit Class.forName call before calling getConnection.