### PR TITLE
Disabled shade relocation of slf4j to fix logger initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.21</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -447,10 +448,6 @@
                      <relocation>
                        <pattern>javax.servlet</pattern>
                        <shadedPattern>${shadeBase}.javax.servlet</shadedPattern>
-                     </relocation>
-                     <relocation>
-                       <pattern>org.slf4j</pattern>
-                       <shadedPattern>${shadeBase}.org.slf4j</shadedPattern>
                      </relocation>
                      <relocation>
                        <pattern>org.jsoup</pattern>


### PR DESCRIPTION
This is to fix #16 