### PR TITLE
Removes username requirement if the OAuth Authenticator is used

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -416,6 +416,12 @@ public class SFSession
     isClosed = false;
   }
 
+  /**
+   * Performs a sanity check on properties. Sanity checking includes:
+   * - verifying that a server url is present
+   * - verifying various combinations of properties given the authenticator
+   * @throws SFException
+   */
   private void performSanityCheckOnProperties() throws SFException
   {
     for (SFSessionProperty property : SFSessionProperty.values())
@@ -428,19 +434,6 @@ public class SFSession
           case SERVER_URL:
             throw new SFException(ErrorCode.MISSING_SERVER_URL);
 
-          case USER:
-            throw new SFException(ErrorCode.MISSING_PASSWORD);
-
-          case PASSWORD:
-            if (isSnowflakeAuthenticator())
-            {
-              throw new SFException(ErrorCode.MISSING_PASSWORD);
-            }
-            else
-            {
-              break;
-            }
-
           default:
             throw new SFException(ErrorCode.MISSING_CONNECTION_PROPERTY,
                 property.getPropertyKey());
@@ -448,19 +441,27 @@ public class SFSession
       }
     }
 
-    // userName and password are expected
-    String userName = (String) connectionPropertiesMap.get(
-        SFSessionProperty.USER);
-    if (userName == null || userName.isEmpty())
+    String authenticator = (String) connectionPropertiesMap.get(
+        SFSessionProperty.AUTHENTICATOR);
+    if (isSnowflakeAuthenticator() ||
+        ClientAuthnDTO.AuthenticatorType.OKTA.name().equalsIgnoreCase(
+            authenticator))
     {
-      throw new SFException(ErrorCode.MISSING_USERNAME);
-    }
+      // userName and password are expected for both Snowflake and Okta.
+      String userName = (String) connectionPropertiesMap.get(
+          SFSessionProperty.USER);
+      if (userName == null || userName.isEmpty())
+      {
+        throw new SFException(ErrorCode.MISSING_USERNAME);
+      }
 
-    String password = (String) connectionPropertiesMap.get(
-        SFSessionProperty.PASSWORD);
-    if (isSnowflakeAuthenticator() && (password == null || password.isEmpty()))
-    {
-      throw new SFException(ErrorCode.MISSING_PASSWORD);
+      String password = (String) connectionPropertiesMap.get(
+          SFSessionProperty.PASSWORD);
+      if (password == null || password.isEmpty())
+
+      {
+        throw new SFException(ErrorCode.MISSING_PASSWORD);
+      }
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -19,8 +19,8 @@ import java.util.regex.Pattern;
 public enum SFSessionProperty
 {
   SERVER_URL("serverURL", true, String.class),
-  USER("user", true, String.class),
-  PASSWORD("password", true, String.class),
+  USER("user", false, String.class),
+  PASSWORD("password", false, String.class),
   ACCOUNT("account", true, String.class),
   DATABASE("database", false, String.class, "db"),
   SCHEMA("schema", false, String.class),

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -713,6 +713,13 @@ public class SessionUtil
     final ClientAuthnDTO.AuthenticatorType authenticator = getAuthenticator(
         loginInput);
 
+    if (!authenticator.equals(ClientAuthnDTO.AuthenticatorType.OAUTH))
+    {
+      // OAuth does not require a username
+      AssertUtil.assertTrue(loginInput.getUserName() != null,
+          "missing user name for opening session");
+    }
+
     try
     {
       uriBuilder = new URIBuilder(loginInput.getServerUrl());


### PR DESCRIPTION
Usernames should not be required when authenticating with an OAuth Access Token. This changeset removes the username restriction in the driver for when the OAuth Authenticator is used.