### PR TITLE
Adds new System Properties to manage how data is buffered and fetched

### DIFF
--- a/src/main/java/net/snowflake/client/core/ResultUtil.java
+++ b/src/main/java/net/snowflake/client/core/ResultUtil.java
@@ -330,6 +330,18 @@ public class ResultUtil
           resultPrefetchThreads =
               (int) resultOutput.parameters.get(
                   "CLIENT_PREFETCH_THREADS");
+        } 
+        else if (System.getProperty("snowflake.jdbc.client.prefetch_threads")
+                 != null)
+        {
+          try
+          {
+            resultPrefetchThreads = 
+                Integer.parseInt(System.getProperty("snowflake.jdbc.client.prefetch_threads"));
+          } 
+          catch (NumberFormatException e)
+          {
+          }
         }
 
         /*
@@ -347,6 +359,17 @@ public class ResultUtil
         {
           memoryUsage =
               (int) resultOutput.parameters.get("CLIENT_MEMORY_LIMIT");
+        }
+        else if (System.getProperty("snowflake.jdbc.client.memory_limit") != null)
+        {
+          try
+          {
+            memoryUsage = 
+                Integer.parseInt(System.getProperty("snowflake.jdbc.client.memory_limit"));
+          } 
+          catch (NumberFormatException e)
+          {
+          }
         }
 
         boolean efficientChunkStorage = false;


### PR DESCRIPTION
* `snowflake.jdbc.client.prefetch_threads`: overrides the built in
  default of 4 threads for prefetching data.
* `snowflake.jdbc.client.memory_limit`: overrides the built in default
  of 1.5 GB of prefetch data buffer.

For integrators, it is nice to be able to tune these parameters via
System Properties because they provide a simple and implementation
agnostic interface.