### PR TITLE
Fix NPE, code cleanup in SnowflakeDatabaseMetaDataResultSet.next

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaDataResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaDataResultSet.java
@@ -125,16 +125,16 @@ class SnowflakeDatabaseMetaDataResultSet extends
   {
     logger.debug("public boolean next()");
 
-    // iterate throw the show table result until we find an entry
-    // that matches the table name
-    while (row < rows.length)
+    if (row < rows.length)
     {
       nextRow = rows[row++];
       return true;
     }
 
-    statement.close();
-    statement = null;
+    if(statement != null) {
+      statement.close();
+      statement = null;
+    }
 
     return false;
   }


### PR DESCRIPTION
Improvements to SnowflakeDatabaseMetaDataResultSet.next()

- Calling this method twice caused an NPE because a null check was missing
- Changed the `while` to an `if` because it contains a `return` statement
- Removed code comment that was not related to the code as far as I could tell