### PR TITLE
Add Java code formatting plugin (Google code style)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,18 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>


### PR DESCRIPTION
Having consistent formatting is especially important for open source projects with multiple contributors.

This PR adds a maven plugin to format the source code according to Google's code style.

The plugin will automatically format code on each build so the first time building with this will reformat all the current code. I would suggest running this once and creating a separate PR just with the formatting changes.

