### PR TITLE
Fix null pointer exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,18 +269,6 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.6.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,18 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>

--- a/src/main/java/com/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/com/snowflake/client/jdbc/SnowflakeDriver.java
@@ -7,14 +7,10 @@ package com.snowflake.client.jdbc;
 import java.sql.Driver;
 
 /**
- * This is left in to ensure backward compatibility for old customers that
- * are still using the legacy com.snowflake.client.jdbc.SnowflakeDriver.
- * Ideally, we want to remove this class and have all customers move to
- * net.snowflake.client.jdbc.SnowflakeDriver.
+ * This is left in to ensure backward compatibility for old customers that are still using the
+ * legacy com.snowflake.client.jdbc.SnowflakeDriver. Ideally, we want to remove this class and have
+ * all customers move to net.snowflake.client.jdbc.SnowflakeDriver.
  *
- * Created by hyu on 10/10/16.
+ * <p>Created by hyu on 10/10/16.
  */
-public class SnowflakeDriver extends net.snowflake.client.jdbc.SnowflakeDriver
-      implements Driver
-{
-}
+public class SnowflakeDriver extends net.snowflake.client.jdbc.SnowflakeDriver implements Driver {}

--- a/src/main/java/net/snowflake/client/core/AssertUtil.java
+++ b/src/main/java/net/snowflake/client/core/AssertUtil.java
@@ -6,24 +6,17 @@ package net.snowflake.client.core;
 
 import net.snowflake.client.jdbc.ErrorCode;
 
-/**
- * Created by jhuang on 1/27/16.
- */
-public class AssertUtil
-{
+/** Created by jhuang on 1/27/16. */
+public class AssertUtil {
   /**
-   * Assert the condition is true, otherwise throw an internal error
-   * exception with the given message.
+   * Assert the condition is true, otherwise throw an internal error exception with the given
+   * message.
    *
    * @param condition
    * @param internalErrorMesg
    * @throws SFException
    */
-  static void assertTrue(boolean condition, String internalErrorMesg)
-      throws SFException
-  {
-    if (!condition)
-      throw new SFException(ErrorCode.INTERNAL_ERROR, internalErrorMesg);
+  static void assertTrue(boolean condition, String internalErrorMesg) throws SFException {
+    if (!condition) throw new SFException(ErrorCode.INTERNAL_ERROR, internalErrorMesg);
   }
-
 }

--- a/src/main/java/net/snowflake/client/core/BasicEvent.java
+++ b/src/main/java/net/snowflake/client/core/BasicEvent.java
@@ -5,12 +5,11 @@
 package net.snowflake.client.core;
 
 /**
- * Base Event class for events that don't need to deviate from the default
- * flush behavior.
+ * Base Event class for events that don't need to deviate from the default flush behavior.
+ *
  * @author jrosen
  */
-public class BasicEvent extends Event
-{
+public class BasicEvent extends Event {
   // Format strings for query state transitions
   private static final String requestId = "requestId: %s";
   private static final String numPings = "numberPings: %d";
@@ -20,37 +19,32 @@ public class BasicEvent extends Event
   private static final String EVENT_DUMP_PROP = "snowflake.dump_events";
   private static final Boolean doDump = System.getProperty(EVENT_DUMP_PROP) != null;
 
-  public enum QueryState
-  {
-    QUERY_STARTED      (1, "Query Started", "{" + requestId + "}"),
-    SENDING_QUERY      (2, "Sending Query", "{" + requestId + "}"),
-    WAITING_FOR_RESULT (3, "Waiting for Result", "{" + requestId + "," + numPings + "}"),
-    PROCESSING_RESULT  (4, "Processing Result", "{" + requestId + "}"),
-    CONSUMING_RESULT   (5, "Consuming Result", "{" + jobId + "," + chunkIdx + "}"),
-    QUERY_ENDED        (6, "Query ended", "{" + requestId + "}"),
-    GETTING_FILES      (8, "Getting Files", "{" + requestId + "}"),
-    PUTTING_FILES      (9, "Putting Files", "{" + requestId + "}"),
+  public enum QueryState {
+    QUERY_STARTED(1, "Query Started", "{" + requestId + "}"),
+    SENDING_QUERY(2, "Sending Query", "{" + requestId + "}"),
+    WAITING_FOR_RESULT(3, "Waiting for Result", "{" + requestId + "," + numPings + "}"),
+    PROCESSING_RESULT(4, "Processing Result", "{" + requestId + "}"),
+    CONSUMING_RESULT(5, "Consuming Result", "{" + jobId + "," + chunkIdx + "}"),
+    QUERY_ENDED(6, "Query ended", "{" + requestId + "}"),
+    GETTING_FILES(8, "Getting Files", "{" + requestId + "}"),
+    PUTTING_FILES(9, "Putting Files", "{" + requestId + "}"),
     ;
 
-    QueryState(int id, String description, String argString)
-    {
+    QueryState(int id, String description, String argString) {
       this.id = id;
       this.description = description;
       this.argString = argString;
     }
 
-    public int getId()
-    {
+    public int getId() {
       return id;
     }
 
-    public String getDescription()
-    {
+    public String getDescription() {
       return description;
     }
 
-    public String getArgString()
-    {
+    public String getArgString() {
       return argString;
     }
 
@@ -59,17 +53,14 @@ public class BasicEvent extends Event
     private final String argString;
   }
 
-  public BasicEvent(Event.EventType type, String message)
-  {
+  public BasicEvent(Event.EventType type, String message) {
     super(type, message);
   }
 
   @Override
-  public void flush()
-  {
-    if (doDump)
-    {
-      //this.writeEventDumpLine("Event: " + getType() + "; Message: " + getMessage());
+  public void flush() {
+    if (doDump) {
+      // this.writeEventDumpLine("Event: " + getType() + "; Message: " + getMessage());
     }
   }
 }

--- a/src/main/java/net/snowflake/client/core/Constants.java
+++ b/src/main/java/net/snowflake/client/core/Constants.java
@@ -7,38 +7,30 @@
  */
 package net.snowflake.client.core;
 
-/**
- * @author jhuang
- */
-public final class Constants
-{
+/** @author jhuang */
+public final class Constants {
   public static final int SESSION_EXPIRED_GS_CODE = 390112;
   public static final int AUTH_TOKEN_EXPIRED_GS_CODE = 390114;
 
-  public enum OS
-  {
-    WINDOWS, LINUX, MAC, SOLARIS
+  public enum OS {
+    WINDOWS,
+    LINUX,
+    MAC,
+    SOLARIS
   }
 
   private static OS os = null;
 
-  public static synchronized OS getOS()
-  {
-    if (os == null)
-    {
+  public static synchronized OS getOS() {
+    if (os == null) {
       String operSys = System.getProperty("os.name").toLowerCase();
-      if (operSys.contains("win"))
-      {
+      if (operSys.contains("win")) {
         os = OS.WINDOWS;
-      } else if (operSys.contains("nix") || operSys.contains("nux")
-          || operSys.contains("aix"))
-      {
+      } else if (operSys.contains("nix") || operSys.contains("nux") || operSys.contains("aix")) {
         os = OS.LINUX;
-      } else if (operSys.contains("mac"))
-      {
+      } else if (operSys.contains("mac")) {
         os = OS.MAC;
-      } else if (operSys.contains("sunos"))
-      {
+      } else if (operSys.contains("sunos")) {
         os = OS.SOLARIS;
       }
     }

--- a/src/main/java/net/snowflake/client/core/Event.java
+++ b/src/main/java/net/snowflake/client/core/Event.java
@@ -11,49 +11,42 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.zip.GZIPOutputStream;
-
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
 /**
  * Abstract class to encapsulate a Client-side Event and any methods associated with it.
+ *
  * @author jrosen
  */
-public abstract class Event
-{
+public abstract class Event {
   private static final SFLogger logger = SFLoggerFactory.getLogger(Event.class);
 
   private static final String EVENT_DUMP_FILE_NAME = "sf_event_";
   private static final String EVENT_DUMP_FILE_EXT = ".dmp.gz";
 
-  //need to check if directory exists, if not try to create it
-  //need to check file size, see if it exceeds maximum (need parameter for this)
+  // need to check if directory exists, if not try to create it
+  // need to check file size, see if it exceeds maximum (need parameter for this)
 
-  public static enum EventType
-  {
+  public static enum EventType {
     INCIDENT(1, "INCIDENT", Incident.class),
     NETWORK_ERROR(2, "NETWORK ERROR", BasicEvent.class),
-    STATE_TRANSITION (3, "STATE TRANSITION", BasicEvent.class),
-    NONE(100, "NONE", BasicEvent.class)
-    ;
+    STATE_TRANSITION(3, "STATE TRANSITION", BasicEvent.class),
+    NONE(100, "NONE", BasicEvent.class);
 
-    public int getId()
-    {
+    public int getId() {
       return id;
     }
 
-    public String getDescription()
-    {
+    public String getDescription() {
       return description;
     }
 
-    public Class<? extends Event> getEventClass()
-    {
+    public Class<? extends Event> getEventClass() {
       return eventClass;
     }
 
-    EventType(int id, String description, Class<? extends Event> eventClass)
-    {
+    EventType(int id, String description, Class<? extends Event> eventClass) {
       this.id = id;
       this.description = description;
       this.eventClass = eventClass;
@@ -67,61 +60,54 @@ public abstract class Event
   private EventType type;
   private String message;
 
-  public Event(EventType type, String message)
-  {
+  public Event(EventType type, String message) {
     Preconditions.checkArgument(type.getEventClass() == this.getClass());
 
     this.type = type;
     this.message = message;
   }
 
-  public EventType getType()
-  {
+  public EventType getType() {
     return this.type;
   }
 
-  public void setType(EventType type)
-  {
+  public void setType(EventType type) {
     this.type = type;
   }
 
-  public String getMessage()
-  {
+  public String getMessage() {
     return this.message;
   }
 
-  public void setMessage(String message)
-  {
+  public void setMessage(String message) {
     this.message = message;
   }
 
-  protected void writeEventDumpLine(String message)
-  {
-    final String eventDumpPath = EventUtil.getDumpPathPrefix() + "/" +
-        EVENT_DUMP_FILE_NAME + EventUtil.getDumpFileId() + EVENT_DUMP_FILE_EXT;
+  protected void writeEventDumpLine(String message) {
+    final String eventDumpPath =
+        EventUtil.getDumpPathPrefix()
+            + "/"
+            + EVENT_DUMP_FILE_NAME
+            + EventUtil.getDumpFileId()
+            + EVENT_DUMP_FILE_EXT;
 
     // If the event dump file is too large, truncate
-    if (new File(eventDumpPath).length() < EventUtil.getmaxDumpFileSizeBytes())
-    {
-      try
-      {
+    if (new File(eventDumpPath).length() < EventUtil.getmaxDumpFileSizeBytes()) {
+      try {
         final OutputStream outStream =
             new GZIPOutputStream(new FileOutputStream(eventDumpPath, true));
         PrintWriter eventDumper = new PrintWriter(outStream, true);
         eventDumper.println(message);
         eventDumper.flush();
         eventDumper.close();
+      } catch (IOException ex) {
+        logger.error(
+            "Could not open Event dump file {}, exception:{}", eventDumpPath, ex.getMessage());
       }
-      catch (IOException ex)
-      {
-        logger.error("Could not open Event dump file {}, exception:{}",
-                  eventDumpPath, ex.getMessage());
-      }
-    }
-    else
-    {
-      logger.error("Failed to dump Event because dump file is "
-          + "too large. Delete dump file or increase maximum dump file size.");
+    } else {
+      logger.error(
+          "Failed to dump Event because dump file is "
+              + "too large. Delete dump file or increase maximum dump file size.");
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/EventHandler.java
+++ b/src/main/java/net/snowflake/client/core/EventHandler.java
@@ -4,7 +4,6 @@
 
 package net.snowflake.client.core;
 
-import net.snowflake.client.jdbc.SnowflakeDriver;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -24,19 +23,14 @@ import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.zip.GZIPOutputStream;
-import org.joda.time.DateTime;
-
+import net.snowflake.client.jdbc.SnowflakeDriver;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import org.joda.time.DateTime;
 
-/**
- *
- * @author jrosen
- */
-public class EventHandler extends Handler
-{
-  private static final SFLogger logger =
-      SFLoggerFactory.getLogger(EventHandler.class);
+/** @author jrosen */
+public class EventHandler extends Handler {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(EventHandler.class);
 
   // Number of entries in the log buffer in memory
   protected static final long LOG_BUFFER_SIZE = (1L << 14);
@@ -70,25 +64,23 @@ public class EventHandler extends Handler
   protected static final String DISABLE_DUMP_COMPR_PROP = "snowflake.disable_log_compression";
 
   private static final int THROTTLE_DURATION_HRS =
-      System.getProperty(THROTTLE_DURATION_PROP) == null ?
-      1 : Integer.valueOf(System.getProperty(THROTTLE_DURATION_PROP));
+      System.getProperty(THROTTLE_DURATION_PROP) == null
+          ? 1
+          : Integer.valueOf(System.getProperty(THROTTLE_DURATION_PROP));
 
   private static final int INCIDENT_THROTTLE_LIMIT_PER_HR =
-      System.getProperty(THROTTLE_LIMIT_PROP) == null ?
-      1 : Integer.valueOf(System.getProperty(THROTTLE_LIMIT_PROP));
+      System.getProperty(THROTTLE_LIMIT_PROP) == null
+          ? 1
+          : Integer.valueOf(System.getProperty(THROTTLE_LIMIT_PROP));
 
   // Default values
   private static final int DEFAULT_MAX_DUMP_FILES = 100;
   private static final int DEFAULT_MAX_DUMPDIR_SIZE_MB = 128;
 
-  /**
-   * Runnable to handle periodic flushing of the event buffer
-   */
-  private class QueueFlusher implements Runnable
-  {
+  /** Runnable to handle periodic flushing of the event buffer */
+  private class QueueFlusher implements Runnable {
     @Override
-    public void run()
-    {
+    public void run() {
       flushEventBuffer();
     }
   }
@@ -103,10 +95,10 @@ public class EventHandler extends Handler
   private final int flushPeriodMs;
 
   // Map to keep track of incident signatures for throttling incidents
-  private final Map<String,AtomicInteger> incidentCounter;
+  private final Map<String, AtomicInteger> incidentCounter;
 
   // Map
-  private final Map<String,DateTime> throttledIncidents;
+  private final Map<String, DateTime> throttledIncidents;
 
   // Queue to buffer events while they are waiting to be flushed
   private final ArrayList<Event> eventBuffer;
@@ -117,8 +109,7 @@ public class EventHandler extends Handler
   // Executor to periodically flush the eventBuffer
   private ScheduledExecutorService flusher;
 
-  public EventHandler(int maxEntries, int flushPeriodMs)
-  {
+  public EventHandler(int maxEntries, int flushPeriodMs) {
     this.maxEntries = maxEntries;
     this.flushPeriodMs = flushPeriodMs;
 
@@ -136,8 +127,7 @@ public class EventHandler extends Handler
    *
    * @return size of eventBuffer
    */
-  public synchronized int getBufferSize()
-  {
+  public synchronized int getBufferSize() {
     return eventBuffer.size();
   }
 
@@ -146,145 +136,129 @@ public class EventHandler extends Handler
    *
    * @return size of log buffer
    */
-  public synchronized long getLogBufferSize()
-  {
+  public synchronized long getLogBufferSize() {
     return logBuffer.size();
   }
 
-  /**
-   * Creates and runs a new QueueFlusher thread
-   */
-  synchronized void startFlusher()
-  {
+  /** Creates and runs a new QueueFlusher thread */
+  synchronized void startFlusher() {
     // Create a new scheduled executor service with a threadfactory that
     // creates daemonized threads; this way if the user doesn't exit nicely
     // the JVM Runtime won't hang
     flusher =
-        Executors.newScheduledThreadPool(1,
-            new ThreadFactory()
-            {
+        Executors.newScheduledThreadPool(
+            1,
+            new ThreadFactory() {
               @Override
-              public Thread newThread(Runnable r)
-              {
-                Thread t =
-                    Executors.defaultThreadFactory().newThread(r);
+              public Thread newThread(Runnable r) {
+                Thread t = Executors.defaultThreadFactory().newThread(r);
                 t.setDaemon(true);
                 return t;
               }
             });
 
-    flusher.scheduleWithFixedDelay(new QueueFlusher(),
-                                   0,
-                                   flushPeriodMs,
-                                   TimeUnit.MILLISECONDS);
+    flusher.scheduleWithFixedDelay(new QueueFlusher(), 0, flushPeriodMs, TimeUnit.MILLISECONDS);
   }
 
-  /**
-   * Stops the running QueueFlusher thread, if any
-   */
-  synchronized void stopFlusher()
-  {
-    if (flusher != null)
-      flusher.shutdown();
+  /** Stops the running QueueFlusher thread, if any */
+  synchronized void stopFlusher() {
+    if (flusher != null) flusher.shutdown();
   }
 
   /*
    * Pushes an event onto the event buffer and flushes if specified or if
    * the buffer has reached maximum capacity.
    */
-  private synchronized void pushEvent(Event event, boolean flushBuffer)
-  {
+  private synchronized void pushEvent(Event event, boolean flushBuffer) {
     eventBuffer.add(event);
 
-    if (flushBuffer || eventBuffer.size() >= maxEntries)
-    {
+    if (flushBuffer || eventBuffer.size() >= maxEntries) {
       this.flushEventBuffer();
     }
   }
 
   /**
-   * Triggers a new event of type @type with message @message and flushes
-   * the eventBuffer if full
+   * Triggers a new event of type @type with message @message and flushes the eventBuffer if full
+   *
    * @param type event type
    * @param message triggering message
    */
-  void triggerBasicEvent(Event.EventType type, String message)
-  {
+  void triggerBasicEvent(Event.EventType type, String message) {
     triggerBasicEvent(type, message, false);
   }
 
   /**
-   * Triggers a new BaseEvent of type @type with message @message and flushes
-   * the eventBuffer if full or @flushBuffer is true
+   * Triggers a new BaseEvent of type @type with message @message and flushes the eventBuffer if
+   * full or @flushBuffer is true
+   *
    * @param type event type
    * @param message trigger message
    * @param flushBuffer true if push the event to flush buffer
    */
-  void triggerBasicEvent(Event.EventType type,
-                                String message,
-                                boolean flushBuffer)
-  {
+  void triggerBasicEvent(Event.EventType type, String message, boolean flushBuffer) {
     Event triggeredEvent = new BasicEvent(type, message);
 
     pushEvent(triggeredEvent, flushBuffer);
   }
 
   /**
-   * Triggers a state transition event to @newState with an identifier
-   * (eg, requestId, jobUUID, etc)
+   * Triggers a state transition event to @newState with an identifier (eg, requestId, jobUUID, etc)
+   *
    * @param newState new state
    * @param identifier event id
    */
-  void triggerStateTransition(BasicEvent.QueryState newState,
-                                     String identifier)
-  {
-    String msg = "{newState: " + newState.getDescription() + ", " +
-                  "info: " + identifier + ", " +
-                  "timestamp: " + DateTime.now().toString() +
-                 "}";
+  void triggerStateTransition(BasicEvent.QueryState newState, String identifier) {
+    String msg =
+        "{newState: "
+            + newState.getDescription()
+            + ", "
+            + "info: "
+            + identifier
+            + ", "
+            + "timestamp: "
+            + DateTime.now().toString()
+            + "}";
 
-    Event triggeredEvent =
-        new BasicEvent(Event.EventType.STATE_TRANSITION, msg);
+    Event triggeredEvent = new BasicEvent(Event.EventType.STATE_TRANSITION, msg);
 
     pushEvent(triggeredEvent, false);
   }
 
   /**
    * Triggers a new Incident with message @message and flushes the eventBuffer.
+   *
    * @param incidentInfo incident information
    */
-  void triggerIncident(Map<String,Object> incidentInfo)
-  {
+  void triggerIncident(Map<String, Object> incidentInfo) {
     logger.debug("New incident triggered, flushing event buffer");
 
-    if (SnowflakeDriver.isDisableIncidents())
-    {
+    if (SnowflakeDriver.isDisableIncidents()) {
       logger.info("Incidents disabled by Snowflake, creation failed");
       return;
     }
 
     // Extract some info about the incident
-    Map<String,Object> incidentMap =
-        (Map<String,Object>)incidentInfo.get(IncidentUtil.INCIDENT_INFO);
+    Map<String, Object> incidentMap =
+        (Map<String, Object>) incidentInfo.get(IncidentUtil.INCIDENT_INFO);
 
-    Map<String,Object> incidentReport = incidentMap == null ? null :
-          (Map<String,Object>)incidentMap.get(IncidentUtil.INCIDENT_REPORT);
+    Map<String, Object> incidentReport =
+        incidentMap == null
+            ? null
+            : (Map<String, Object>) incidentMap.get(IncidentUtil.INCIDENT_REPORT);
 
     // Get the incident ID
-    String incidentId = incidentReport == null ? null :
-        (String)incidentReport.get(IncidentUtil.INCIDENT_ID);
+    String incidentId =
+        incidentReport == null ? null : (String) incidentReport.get(IncidentUtil.INCIDENT_ID);
 
     // Get the incident signature
-    String signature = (String)incidentInfo.get(IncidentUtil.THROTTLE_SIGNATURE);
+    String signature = (String) incidentInfo.get(IncidentUtil.THROTTLE_SIGNATURE);
 
-    if (incidentId == null)
-    {
+    if (incidentId == null) {
       logger.warn("Unexpected incidentInfo format encountered");
     }
 
     // Do we need to throttle based on the signature to this incident?
-    if (needsToThrottle(signature))
-    {
+    if (needsToThrottle(signature)) {
       logger.info("Incident throttled, not reported");
       return;
     }
@@ -294,8 +268,7 @@ public class EventHandler extends Handler
     // Push the incident event and flush the event buffer.
     pushEvent(incident, true);
 
-    if (System.getProperty(DISABLE_DUMPS_PROP) == null)
-    {
+    if (System.getProperty(DISABLE_DUMPS_PROP) == null) {
       logger.debug("Dumping log buffer to local disk");
 
       // Dump the buffered log contents to disk.
@@ -308,22 +281,20 @@ public class EventHandler extends Handler
 
   /**
    * Dumps the contents of the in-memory log buffer to disk and clears the buffer.
+   *
    * @param identifier event id
    */
-  public void dumpLogBuffer(String identifier)
-  {
+  public void dumpLogBuffer(String identifier) {
     final ArrayList<LogRecord> logBufferCopy;
     final PrintWriter logDumper;
     final OutputStream outStream;
     Formatter formatter = this.getFormatter();
 
     // Check if compression of dump file is enabled
-    boolean disableCompression =
-        System.getProperty(DISABLE_DUMP_COMPR_PROP) != null;
+    boolean disableCompression = System.getProperty(DISABLE_DUMP_COMPR_PROP) != null;
 
     // If no identifying factor (eg, an incident id) was provided, get one
-    if (identifier == null)
-    {
+    if (identifier == null) {
       identifier = EventUtil.getDumpFileId();
     }
 
@@ -331,19 +302,17 @@ public class EventHandler extends Handler
     // disk with dump files
     cleanupSfDumps(true);
 
-    String logDumpPath = logDumpPathPrefix + "/" + LOG_DUMP_FILE_NAME +
-        identifier + LOG_DUMP_FILE_EXT;
+    String logDumpPath =
+        logDumpPathPrefix + "/" + LOG_DUMP_FILE_NAME + identifier + LOG_DUMP_FILE_EXT;
 
-    if (!disableCompression)
-    {
+    if (!disableCompression) {
       logDumpPath += LOG_DUMP_COMP_EXT;
     }
 
     logger.debug("EventHandler dumping log buffer to {}", logDumpPath);
 
     // Copy logBuffer because this is potentially long running.
-    synchronized (this)
-    {
+    synchronized (this) {
       logBufferCopy = new ArrayList<>(logBuffer);
       logBuffer.clear();
     }
@@ -351,25 +320,22 @@ public class EventHandler extends Handler
     File outputFile = new File(logDumpPath);
 
     /**
-     * Because log files could potentially be very large, we should never open
-     * them in append mode. It's rare that this should happen anyways...
+     * Because log files could potentially be very large, we should never open them in append mode.
+     * It's rare that this should happen anyways...
      */
-    try
-    {
+    try {
       // If the dump path doesn't already exist, create it.
-      if (outputFile.getParentFile() != null)
-      {
+      if (outputFile.getParentFile() != null) {
         outputFile.getParentFile().mkdirs();
       }
 
-      outStream = disableCompression ?
-                  new FileOutputStream(logDumpPath, false) :
-                  new GZIPOutputStream(new FileOutputStream(logDumpPath, false));
+      outStream =
+          disableCompression
+              ? new FileOutputStream(logDumpPath, false)
+              : new GZIPOutputStream(new FileOutputStream(logDumpPath, false));
 
       logDumper = new PrintWriter(outStream, true);
-    }
-    catch(IOException exc)
-    {
+    } catch (IOException exc) {
       // Not much to do here, can't dump logs so exit out.
       logger.debug("Log dump failed, exception: {}", exc.getMessage());
 
@@ -377,10 +343,8 @@ public class EventHandler extends Handler
     }
 
     // Iterate over log entries, format them, then dump them.
-    for (LogRecord entry : logBufferCopy)
-    {
-      logDumper.write(formatter != null ? formatter.format(entry) :
-                                          entry.getMessage());
+    for (LogRecord entry : logBufferCopy) {
+      logDumper.write(formatter != null ? formatter.format(entry) : entry.getMessage());
     }
 
     // Clean up
@@ -391,52 +355,47 @@ public class EventHandler extends Handler
   /**
    * Function to remove old Snowflake Dump files to make room for new ones.
    *
-   * @param deleteOldest if true, always deletes the oldest file found if max
-   *                     number of dump files has been reached
+   * @param deleteOldest if true, always deletes the oldest file found if max number of dump files
+   *     has been reached
    */
-  protected void cleanupSfDumps(boolean deleteOldest)
-  {
+  protected void cleanupSfDumps(boolean deleteOldest) {
     // Check what the maximum number of dumpfiles and the max allowable
     // aggregate dump file size is.
     int maxDumpFiles =
-        System.getProperty(MAX_NUM_DUMP_FILES_PROP) != null ?
-        Integer.valueOf(System.getProperty(MAX_NUM_DUMP_FILES_PROP)) :
-        DEFAULT_MAX_DUMP_FILES;
+        System.getProperty(MAX_NUM_DUMP_FILES_PROP) != null
+            ? Integer.valueOf(System.getProperty(MAX_NUM_DUMP_FILES_PROP))
+            : DEFAULT_MAX_DUMP_FILES;
 
     int maxDumpDirSizeMB =
-        System.getProperty(MAX_SIZE_DUMPS_MB_PROP) != null ?
-        Integer.valueOf(System.getProperty(MAX_SIZE_DUMPS_MB_PROP)) :
-        DEFAULT_MAX_DUMPDIR_SIZE_MB;
+        System.getProperty(MAX_SIZE_DUMPS_MB_PROP) != null
+            ? Integer.valueOf(System.getProperty(MAX_SIZE_DUMPS_MB_PROP))
+            : DEFAULT_MAX_DUMPDIR_SIZE_MB;
 
     File dumpDir = new File(logDumpPathPrefix);
     long dirSizeBytes = 0;
 
-    if (dumpDir.listFiles() == null)
-    {
+    if (dumpDir.listFiles() == null) {
       return;
     }
 
     // Keep a sorted list of files by size as we go in case we need to
     // delete some
     TreeSet<File> fileList =
-        new TreeSet<>(new Comparator<File>()
-        {
-          @Override
-          public int compare( File a, File b )
-          {
-            return a.length() < b.length() ? -1 : 1;
-          }
-        });
+        new TreeSet<>(
+            new Comparator<File>() {
+              @Override
+              public int compare(File a, File b) {
+                return a.length() < b.length() ? -1 : 1;
+              }
+            });
 
     // Loop over files in this directory and get rid of old ones
     // while accumulating the total size
-    for (File file : dumpDir.listFiles())
-    {
-      if ((!file.getName().startsWith(LOG_DUMP_FILE_NAME) &&
-           !file.getName().startsWith(IncidentUtil.INC_DUMP_FILE_NAME)) ||
-          (System.currentTimeMillis() - file.lastModified() > FILE_EXPN_TIME_MS &&
-          file.delete()))
-      {
+    for (File file : dumpDir.listFiles()) {
+      if ((!file.getName().startsWith(LOG_DUMP_FILE_NAME)
+              && !file.getName().startsWith(IncidentUtil.INC_DUMP_FILE_NAME))
+          || (System.currentTimeMillis() - file.lastModified() > FILE_EXPN_TIME_MS
+              && file.delete())) {
         continue;
       }
 
@@ -446,75 +405,66 @@ public class EventHandler extends Handler
 
     // If we're exceeding our max allotted disk usage, cut some stuff out;
     // else if we need to make space for a new dump delete the oldest.
-    if (dirSizeBytes >= ((long)maxDumpDirSizeMB << 20))
-    {
+    if (dirSizeBytes >= ((long) maxDumpDirSizeMB << 20)) {
       // While we take up more than half the allotted disk usage, keep deleting.
-      for (File file : fileList)
-      {
-        if (dirSizeBytes < ((long)maxDumpDirSizeMB << 19))
-        {
+      for (File file : fileList) {
+        if (dirSizeBytes < ((long) maxDumpDirSizeMB << 19)) {
           break;
         }
 
         long victimSize = file.length();
-        if (file.delete())
-        {
+        if (file.delete()) {
           dirSizeBytes -= victimSize;
         }
       }
-    }
-    else if (deleteOldest && fileList.size() >= maxDumpFiles)
-    {
+    } else if (deleteOldest && fileList.size() >= maxDumpFiles) {
       fileList.first().delete();
     }
   } // cleanupSfDumps(...)
 
   /**
-   * Function to copy the event buffer, clear it, and iterate of the copy,
-   * calling each event's flush() method one by one.
+   * Function to copy the event buffer, clear it, and iterate of the copy, calling each event's
+   * flush() method one by one.
    *
-   * NOTE: This function is subject to a race condition; while the buffer copy
-   * is being iterated over, the next round of buffer entries could be flushed
-   * creating a flush order that is not "strictly consistent". While this could
-   * hypothetically also cause the system to run out of memory due to an
-   * unbounded number of eventBuffer copies, that scenario is unlikely.
+   * <p>NOTE: This function is subject to a race condition; while the buffer copy is being iterated
+   * over, the next round of buffer entries could be flushed creating a flush order that is not
+   * "strictly consistent". While this could hypothetically also cause the system to run out of
+   * memory due to an unbounded number of eventBuffer copies, that scenario is unlikely.
    */
-  private void flushEventBuffer()
-  {
+  private void flushEventBuffer() {
     ArrayList<Event> eventBufferCopy;
 
     logger.debug("Flushing eventBuffer");
 
     // Copy event buffer because this may be long running
-    synchronized(this)
-    {
+    synchronized (this) {
       eventBufferCopy = new ArrayList<>(eventBuffer);
       eventBuffer.clear();
     }
 
-    for (Event event : eventBufferCopy)
-    {
+    for (Event event : eventBufferCopy) {
       event.flush();
     }
   }
 
   /**
-   * Checks to see if the reporting of an incident should be throttled due
-   * to the number of times the signature has been seen in the last hour
+   * Checks to see if the reporting of an incident should be throttled due to the number of times
+   * the signature has been seen in the last hour
+   *
    * @param signature incident signature
    * @return true if incidents needs to be throttled
    */
-  private synchronized boolean needsToThrottle(String signature)
-  {
+  private synchronized boolean needsToThrottle(String signature) {
     AtomicInteger sigCount;
 
     // Are we already throttling this signature?
-    if (throttledIncidents.containsKey(signature))
-    {
+    if (throttledIncidents.containsKey(signature)) {
       // Lazily check if it's time to unthrottle
-      if (throttledIncidents.get(signature).plusHours(THROTTLE_DURATION_HRS).
-              compareTo(DateTime.now()) <= 0)
-      {
+      if (throttledIncidents
+              .get(signature)
+              .plusHours(THROTTLE_DURATION_HRS)
+              .compareTo(DateTime.now())
+          <= 0) {
         // Start counting the # of times we've seen this again & stop throttling.
         throttledIncidents.remove(signature);
         incidentCounter.put(signature, new AtomicInteger(1));
@@ -525,13 +475,10 @@ public class EventHandler extends Handler
     }
 
     sigCount = incidentCounter.get(signature);
-    if (sigCount == null)
-    {
+    if (sigCount == null) {
       // If there isn't an entry to track this signature, make one.
       incidentCounter.put(signature, sigCount = new AtomicInteger(0));
-    }
-    else if (sigCount.get() + 1 >= INCIDENT_THROTTLE_LIMIT_PER_HR)
-    {
+    } else if (sigCount.get() + 1 >= INCIDENT_THROTTLE_LIMIT_PER_HR) {
       // We've hit the limit so throttle.
       incidentCounter.remove(signature);
       throttledIncidents.put(signature, DateTime.now());
@@ -542,38 +489,31 @@ public class EventHandler extends Handler
     return false;
   }
 
-
   /** Overridden methods for Handler interface */
 
-  /**
-   * Flushes all eventBuffer entries.
-   */
+  /** Flushes all eventBuffer entries. */
   @Override
-  public synchronized void flush()
-  {
+  public synchronized void flush() {
     logger.debug("EventHandler flushing loger buffer");
 
     dumpLogBuffer("");
   }
 
   /**
-   * Overridden Logger.Handler publish(...) method. Buffers unformatted log
-   * records in memory in a circular buffer-like fashion.
+   * Overridden Logger.Handler publish(...) method. Buffers unformatted log records in memory in a
+   * circular buffer-like fashion.
+   *
    * @param record log record
    */
   @Override
-  public synchronized void publish(LogRecord record)
-  {
-    if (!super.isLoggable(record) || this.getLevel() != null &&
-        record.getLevel().intValue() < this.getLevel().intValue())
-    {
+  public synchronized void publish(LogRecord record) {
+    if (!super.isLoggable(record)
+        || this.getLevel() != null && record.getLevel().intValue() < this.getLevel().intValue()) {
       return;
     }
 
-    synchronized(logBuffer)
-    {
-      if (logBuffer.size() == LOG_BUFFER_SIZE)
-      {
+    synchronized (logBuffer) {
+      if (logBuffer.size() == LOG_BUFFER_SIZE) {
         logBuffer.remove(0);
       }
 
@@ -582,8 +522,7 @@ public class EventHandler extends Handler
   }
 
   @Override
-  public void close()
-  {
+  public void close() {
     this.flushEventBuffer();
     this.stopFlusher();
   }

--- a/src/main/java/net/snowflake/client/core/EventUtil.java
+++ b/src/main/java/net/snowflake/client/core/EventUtil.java
@@ -9,92 +9,73 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Utility class to encapsulate support information pertaining to the
- * EventHandler and events.
+ * Utility class to encapsulate support information pertaining to the EventHandler and events.
+ *
  * @author jrosen
  */
-public class EventUtil
-{
+public class EventUtil {
   public static final String DUMP_PATH_PROP = "snowflake.dump_path";
   public static final String DUMP_SIZE_PROP = "snowflake.max_dump_size";
   public static final String DUMP_SUBDIR = "snowflake_dumps";
 
   private static final String DUMP_FILE_ID = UUID.randomUUID().toString();
   private static final String DUMP_PATH_PREFIX =
-      System.getProperty(DUMP_PATH_PROP) == null ?
-      "/tmp" : System.getProperty(DUMP_PATH_PROP);
+      System.getProperty(DUMP_PATH_PROP) == null ? "/tmp" : System.getProperty(DUMP_PATH_PROP);
   private static final long MAX_DUMP_FILE_SIZE_BYTES =
-      System.getProperty(DUMP_SIZE_PROP) == null ?
-      (10 << 20) : Long.valueOf(System.getProperty(DUMP_SIZE_PROP));
+      System.getProperty(DUMP_SIZE_PROP) == null
+          ? (10 << 20)
+          : Long.valueOf(System.getProperty(DUMP_SIZE_PROP));
 
-  private static AtomicReference<EventHandler> eventHandler =
-      new AtomicReference<>(null);
+  private static AtomicReference<EventHandler> eventHandler = new AtomicReference<>(null);
 
   /**
    * Initializes the common eventHandler instance for all sessions/threads
+   *
    * @param maxEntries - maximum number of buffered events before flush
    * @param flushPeriodMs - period of time between asynchronous buffer flushes
    */
-  public static synchronized void initEventHandlerInstance(int maxEntries,
-                                                           int flushPeriodMs)
-  {
-    if (eventHandler.get() == null)
-    {
+  public static synchronized void initEventHandlerInstance(int maxEntries, int flushPeriodMs) {
+    if (eventHandler.get() == null) {
       eventHandler.set(new EventHandler(maxEntries, flushPeriodMs));
     }
-    //eventHandler.startFlusher();
+    // eventHandler.startFlusher();
   }
 
-  /**
-   * @return the shared EventHandler instance
-   */
-  public static EventHandler getEventHandlerInstance()
-  {
+  /** @return the shared EventHandler instance */
+  public static EventHandler getEventHandlerInstance() {
     return eventHandler.get();
   }
 
-  public static void triggerBasicEvent(Event.EventType type,
-                                       String message,
-                                       boolean flushBuffer)
-  {
+  public static void triggerBasicEvent(Event.EventType type, String message, boolean flushBuffer) {
     EventHandler eh = eventHandler.get();
-    if (eh != null)
-    {
+    if (eh != null) {
       eh.triggerBasicEvent(type, message, flushBuffer);
     }
   }
 
-  public static void triggerStateTransition(BasicEvent.QueryState newState,
-                                            String identifier)
-  {
+  public static void triggerStateTransition(BasicEvent.QueryState newState, String identifier) {
     EventHandler eh = eventHandler.get();
-    if (eh != null)
-    {
+    if (eh != null) {
       eh.triggerStateTransition(newState, identifier);
     }
   }
 
-  public static void triggerIncident(Map<String, Object> incidentInfo)
-  {
+  public static void triggerIncident(Map<String, Object> incidentInfo) {
     EventHandler eh = eventHandler.get();
-    if (eh != null)
-    {
+    if (eh != null) {
       eh.triggerIncident(incidentInfo);
     }
   }
 
-  public static String getDumpPathPrefix()
-  {
+  public static String getDumpPathPrefix() {
     return DUMP_PATH_PREFIX + "/" + DUMP_SUBDIR;
   }
 
-  public static String getDumpFileId()
-  {
+  public static String getDumpFileId() {
     return DUMP_FILE_ID;
   }
 
-  public static long getmaxDumpFileSizeBytes()
-  {
+  public static long getmaxDumpFileSizeBytes() {
     return MAX_DUMP_FILE_SIZE_BYTES;
   }
 }

--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -6,9 +6,6 @@ package net.snowflake.client.core;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -23,15 +20,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Date;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 
-class FileCacheManager
-{
-  private static final
-  SFLogger LOGGER = SFLoggerFactory.getLogger(FileCacheManager.class);
+class FileCacheManager {
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(FileCacheManager.class);
 
-  /**
-   * Object mapper for JSON encoding and decoding
-   */
+  /** Object mapper for JSON encoding and decoding */
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private static final Charset DEFAULT_FILE_ENCODING = Charset.forName("UTF-8");
@@ -47,42 +42,34 @@ class FileCacheManager
 
   private File cacheDir;
 
-  private FileCacheManager()
-  {
-  }
+  private FileCacheManager() {}
 
-  static FileCacheManager builder()
-  {
+  static FileCacheManager builder() {
     return new FileCacheManager();
   }
 
-  FileCacheManager setCacheDirectorySystemProperty(String cacheDirectorySystemProperty)
-  {
+  FileCacheManager setCacheDirectorySystemProperty(String cacheDirectorySystemProperty) {
     this.cacheDirectorySystemProperty = cacheDirectorySystemProperty;
     return this;
   }
 
-  FileCacheManager setCacheDirectoryEnvironmentVariable(String cacheDirectoryEnvironmentVariable)
-  {
+  FileCacheManager setCacheDirectoryEnvironmentVariable(String cacheDirectoryEnvironmentVariable) {
     this.cacheDirectoryEnvironmentVariable = cacheDirectoryEnvironmentVariable;
     return this;
   }
 
-  FileCacheManager setBaseCacheFileName(String baseCacheFileName)
-  {
+  FileCacheManager setBaseCacheFileName(String baseCacheFileName) {
     this.baseCacheFileName = baseCacheFileName;
     return this;
   }
 
-  FileCacheManager setCacheExpirationInSeconds(long cacheExpirationInSeconds)
-  {
+  FileCacheManager setCacheExpirationInSeconds(long cacheExpirationInSeconds) {
     // converting from seconds to milliseconds
     this.cacheExpirationInMilliseconds = cacheExpirationInSeconds * 1000;
     return this;
   }
 
-  FileCacheManager setCacheFileLockExpirationInSeconds(long cacheFileLockExpirationInSeconds)
-  {
+  FileCacheManager setCacheFileLockExpirationInSeconds(long cacheFileLockExpirationInSeconds) {
     this.cacheFileLockExpirationInMilliseconds = cacheFileLockExpirationInSeconds * 1000;
     return this;
   }
@@ -92,165 +79,117 @@ class FileCacheManager
    *
    * @param newCacheFile a file object to override the default one.
    */
-  void overrideCacheFile(File newCacheFile)
-  {
+  void overrideCacheFile(File newCacheFile) {
     this.cacheFile = newCacheFile;
     this.cacheDir = newCacheFile.getParentFile();
     this.baseCacheFileName = newCacheFile.getName();
   }
 
-  FileCacheManager build()
-  {
+  FileCacheManager build() {
     // try to get cacheDir from system property or environment variable
-    String cacheDirPath = this.cacheDirectorySystemProperty != null ?
-        System.getProperty(this.cacheDirectorySystemProperty)
-        : null;
-    if (cacheDirPath == null)
-    {
-      cacheDirPath = this.cacheDirectoryEnvironmentVariable != null ?
-          System.getenv(this.cacheDirectoryEnvironmentVariable)
-          : null;
+    String cacheDirPath =
+        this.cacheDirectorySystemProperty != null
+            ? System.getProperty(this.cacheDirectorySystemProperty)
+            : null;
+    if (cacheDirPath == null) {
+      cacheDirPath =
+          this.cacheDirectoryEnvironmentVariable != null
+              ? System.getenv(this.cacheDirectoryEnvironmentVariable)
+              : null;
     }
 
-    if (cacheDirPath != null)
-    {
+    if (cacheDirPath != null) {
       this.cacheDir = new File(cacheDirPath);
-    }
-    else
-    {
+    } else {
       // use user home directory to store the cache file
       String homeDir = System.getProperty("user.home");
-      if (homeDir == null)
-      {
+      if (homeDir == null) {
         // use tmp dir if not exists.
         homeDir = System.getProperty("java.io.tmpdir");
       }
-      if (Constants.getOS() == Constants.OS.WINDOWS)
-      {
-        this.cacheDir = new File(
-            new File(new File(new File(homeDir,
-                "AppData"), "Local"), "Snowflake"), "Caches");
-      }
-      else if (Constants.getOS() == Constants.OS.MAC)
-      {
-        this.cacheDir = new File(new File(new File(homeDir,
-            "Library"), "Caches"), "Snowflake");
-      }
-      else
-      {
+      if (Constants.getOS() == Constants.OS.WINDOWS) {
+        this.cacheDir =
+            new File(
+                new File(new File(new File(homeDir, "AppData"), "Local"), "Snowflake"), "Caches");
+      } else if (Constants.getOS() == Constants.OS.MAC) {
+        this.cacheDir = new File(new File(new File(homeDir, "Library"), "Caches"), "Snowflake");
+      } else {
         this.cacheDir = new File(new File(homeDir, ".cache"), "snowflake");
       }
     }
-    if (!this.cacheDir.exists() && !this.cacheDir.mkdirs())
-    {
+    if (!this.cacheDir.exists() && !this.cacheDir.mkdirs()) {
       throw new RuntimeException(
-          String.format(
-              "Failed to locate or create the cache directory: %s", this.cacheDir)
-      );
+          String.format("Failed to locate or create the cache directory: %s", this.cacheDir));
     }
 
-    File cacheFileTmp = new File(
-        this.cacheDir, this.baseCacheFileName).getAbsoluteFile();
-    try
-    {
+    File cacheFileTmp = new File(this.cacheDir, this.baseCacheFileName).getAbsoluteFile();
+    try {
       // create an empty file if not exists and return true.
       // If exists. the method returns false.
       // In this particular case, it doesn't matter as long as the file is
       // writable.
       cacheFileTmp.createNewFile();
       this.cacheFile = cacheFileTmp.getCanonicalFile();
-      this.cacheLockFile = new File(
-          this.cacheFile.getParentFile(), this.baseCacheFileName + ".lck");
-    }
-    catch (IOException | SecurityException ex)
-    {
+      this.cacheLockFile =
+          new File(this.cacheFile.getParentFile(), this.baseCacheFileName + ".lck");
+    } catch (IOException | SecurityException ex) {
       throw new RuntimeException(
-          String.format(
-              "Failed to touch the cache file: %s",
-              cacheFileTmp.getAbsoluteFile())
-      );
+          String.format("Failed to touch the cache file: %s", cacheFileTmp.getAbsoluteFile()));
     }
     return this;
   }
 
-  /**
-   * Reads the cache file.
-   */
-  JsonNode readCacheFile()
-  {
-    if (cacheFile == null || !this.checkCacheLockFile())
-    {
+  /** Reads the cache file. */
+  JsonNode readCacheFile() {
+    if (cacheFile == null || !this.checkCacheLockFile()) {
       // no cache or the cache is not valid.
       return null;
     }
-    try
-    {
-      if (!cacheFile.exists())
-      {
-        LOGGER.debug(
-            "Cache file doesn't exists. File: {}", cacheFile);
+    try {
+      if (!cacheFile.exists()) {
+        LOGGER.debug("Cache file doesn't exists. File: {}", cacheFile);
         return null;
       }
 
-      try (Reader reader = new InputStreamReader(
-          new FileInputStream(cacheFile), DEFAULT_FILE_ENCODING))
-      {
+      try (Reader reader =
+          new InputStreamReader(new FileInputStream(cacheFile), DEFAULT_FILE_ENCODING)) {
         return OBJECT_MAPPER.readTree(reader);
       }
-    }
-    catch (IOException ex)
-    {
-      LOGGER.debug(
-          "Failed to read the cache file. No worry. File: {}, Err: {}",
-          cacheFile, ex);
+    } catch (IOException ex) {
+      LOGGER.debug("Failed to read the cache file. No worry. File: {}, Err: {}", cacheFile, ex);
     }
     return null;
   }
 
-  void writeCacheFile(JsonNode input)
-  {
+  void writeCacheFile(JsonNode input) {
     LOGGER.debug("Writing cache file. File={}", cacheFile);
-    if (cacheFile == null || !tryLockCacheFile())
-    {
+    if (cacheFile == null || !tryLockCacheFile()) {
       // no cache file or it failed to lock file
       return;
     }
     // NOTE: must unlock cache file
-    try
-    {
-      if (input == null)
-      {
+    try {
+      if (input == null) {
         return;
       }
-      try (Writer writer = new OutputStreamWriter(
-          new FileOutputStream(cacheFile), DEFAULT_FILE_ENCODING))
-      {
+      try (Writer writer =
+          new OutputStreamWriter(new FileOutputStream(cacheFile), DEFAULT_FILE_ENCODING)) {
         writer.write(input.toString());
       }
-    }
-    catch (IOException ex)
-    {
-      LOGGER.debug(
-          "Failed to write the cache file. File: {}",
-          cacheFile);
-    }
-    finally
-    {
-      if (!unlockCacheFile())
-      {
+    } catch (IOException ex) {
+      LOGGER.debug("Failed to write the cache file. File: {}", cacheFile);
+    } finally {
+      if (!unlockCacheFile()) {
         LOGGER.debug("Failed to unlock cache file");
       }
     }
   }
 
-  void deleteCacheFile()
-  {
-    LOGGER.debug("Deleting cache file. File={}, Lock File={}",
-        cacheFile, cacheLockFile);
+  void deleteCacheFile() {
+    LOGGER.debug("Deleting cache file. File={}, Lock File={}", cacheFile, cacheLockFile);
 
     unlockCacheFile();
-    if (!cacheFile.delete())
-    {
+    if (!cacheFile.delete()) {
       LOGGER.debug("Failed to delete the file: {}", cacheFile);
     }
   }
@@ -260,24 +199,18 @@ class FileCacheManager
    *
    * @return true if success or false
    */
-  private boolean tryLockCacheFile()
-  {
+  private boolean tryLockCacheFile() {
     int cnt = 0;
     boolean locked = false;
-    while (cnt < 100 && !(locked = lockCacheFile()))
-    {
-      try
-      {
+    while (cnt < 100 && !(locked = lockCacheFile())) {
+      try {
         Thread.sleep(100);
-      }
-      catch (InterruptedException ex)
-      {
+      } catch (InterruptedException ex) {
         // doesn't matter
       }
       ++cnt;
     }
-    if (!locked)
-    {
+    if (!locked) {
       LOGGER.debug("Failed to lock the cache file.");
     }
     return locked;
@@ -288,8 +221,7 @@ class FileCacheManager
    *
    * @return true if success or false
    */
-  private boolean lockCacheFile()
-  {
+  private boolean lockCacheFile() {
     return cacheLockFile.mkdirs();
   }
 
@@ -298,37 +230,30 @@ class FileCacheManager
    *
    * @return true if success or false
    */
-  private boolean unlockCacheFile()
-  {
+  private boolean unlockCacheFile() {
     return cacheLockFile.delete();
   }
 
-  private boolean checkCacheLockFile()
-  {
+  private boolean checkCacheLockFile() {
     long currentTime = new Date().getTime();
     long cacheFileTs = fileCreationTime(cacheFile);
 
-    if (!cacheLockFile.exists() && cacheFileTs > 0 && currentTime -
-        this.cacheExpirationInMilliseconds <= cacheFileTs)
-    {
+    if (!cacheLockFile.exists()
+        && cacheFileTs > 0
+        && currentTime - this.cacheExpirationInMilliseconds <= cacheFileTs) {
       LOGGER.debug("No cache file lock directory exists and cache file is up to date.");
       return true;
     }
 
     long lockFileTs = fileCreationTime(cacheLockFile);
-    if (lockFileTs < 0)
-    {
+    if (lockFileTs < 0) {
       // failed to get the timestamp of lock directory
       return false;
     }
-    if (lockFileTs < currentTime - this.cacheFileLockExpirationInMilliseconds)
-    {
+    if (lockFileTs < currentTime - this.cacheFileLockExpirationInMilliseconds) {
       // old lock file
-      if (!cacheLockFile.delete())
-      {
-        LOGGER.debug(
-            "Failed to delete the directory. Dir: {}",
-            cacheLockFile);
+      if (!cacheLockFile.delete()) {
+        LOGGER.debug("Failed to delete the directory. Dir: {}", cacheLockFile);
         return false;
       }
       LOGGER.debug("Deleted the cache lock directory, because it was old.");
@@ -343,25 +268,17 @@ class FileCacheManager
    *
    * @return epoch time in ms
    */
-  private static long fileCreationTime(File targetFile)
-  {
-    if (!targetFile.exists())
-    {
+  private static long fileCreationTime(File targetFile) {
+    if (!targetFile.exists()) {
       LOGGER.debug("File not exists. File: {}", targetFile);
       return -1;
     }
-    try
-    {
+    try {
       Path cacheFileLockPath = Paths.get(targetFile.getAbsolutePath());
-      BasicFileAttributes attr = Files.readAttributes(
-          cacheFileLockPath, BasicFileAttributes.class);
+      BasicFileAttributes attr = Files.readAttributes(cacheFileLockPath, BasicFileAttributes.class);
       return attr.creationTime().toMillis();
-    }
-    catch (IOException ex)
-    {
-      LOGGER.debug(
-          "Failed to get creation time. File/Dir: {}, Err: {}",
-          targetFile, ex);
+    } catch (IOException ex) {
+      LOGGER.debug("Failed to get creation time. File/Dir: {}, Err: {}", targetFile, ex);
     }
     return -1;
   }

--- a/src/main/java/net/snowflake/client/core/FileTypeDetector.java
+++ b/src/main/java/net/snowflake/client/core/FileTypeDetector.java
@@ -8,20 +8,13 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.tika.Tika;
 
-/**
- *
- * @author jhuang
- */
-/**
- * Use Tika to detect the mime type of files
- */
-public class FileTypeDetector extends java.nio.file.spi.FileTypeDetector
-{
+/** @author jhuang */
+/** Use Tika to detect the mime type of files */
+public class FileTypeDetector extends java.nio.file.spi.FileTypeDetector {
   private final Tika tika = new Tika();
 
   @Override
-  public String probeContentType(Path path) throws IOException
-  {
+  public String probeContentType(Path path) throws IOException {
     return tika.detect(path.toFile());
   }
 }

--- a/src/main/java/net/snowflake/client/core/HeartbeatBackground.java
+++ b/src/main/java/net/snowflake/client/core/HeartbeatBackground.java
@@ -12,30 +12,24 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
 /**
- * This class is a singleton which is running inside driver to heartbeat
- * snowflake server for each connection
+ * This class is a singleton which is running inside driver to heartbeat snowflake server for each
+ * connection
  */
-public class HeartbeatBackground implements Runnable
-{
+public class HeartbeatBackground implements Runnable {
   private static HeartbeatBackground singleton = new HeartbeatBackground();
 
   /** The logger. */
-  private static final SFLogger LOGGER =
-      SFLoggerFactory.getLogger(HeartbeatBackground.class);
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(HeartbeatBackground.class);
 
   // default master token validity (in seconds) is 4 hours
   private long masterTokenValidityInSecs = 4 * 3600;
 
-  /**
-   * How often heartbeat executes is calculated based on master token validity
-   * and the headroom
-   */
-  private long heartBeatIntervalInSecs = masterTokenValidityInSecs/4;
+  /** How often heartbeat executes is calculated based on master token validity and the headroom */
+  private long heartBeatIntervalInSecs = masterTokenValidityInSecs / 4;
 
   // Scheduler handling the main heartbeat background
   private ScheduledExecutorService scheduler = null;
@@ -44,63 +38,56 @@ public class HeartbeatBackground implements Runnable
   ScheduledFuture heartbeatFuture;
 
   /**
-   * List of sessions to heartbeat. Use weak hash map so that if a session
-   * object is deleted and garbaged collected, it will be removed from the
-   * list so that we will not keep doing heartbeat for it. This is to take
-   * care of the case when some application does not close session before it
+   * List of sessions to heartbeat. Use weak hash map so that if a session object is deleted and
+   * garbaged collected, it will be removed from the list so that we will not keep doing heartbeat
+   * for it. This is to take care of the case when some application does not close session before it
    * goes out of scope.
    */
-  WeakHashMap<SFSession, Boolean> sessions=new WeakHashMap<SFSession, Boolean>();
+  WeakHashMap<SFSession, Boolean> sessions = new WeakHashMap<SFSession, Boolean>();
 
   // When is the last time hearbeat started
   private long lastHeartbeatStartTimeInSecs = 0;
 
   // Method to get the heartbeat instance
-  public static HeartbeatBackground getInstance()
-  {
+  public static HeartbeatBackground getInstance() {
     return singleton;
   }
 
-  /**
-   * private constructor so that no one can try to create one
-   */
-  private HeartbeatBackground()  {}
+  /** private constructor so that no one can try to create one */
+  private HeartbeatBackground() {}
 
   /**
    * Method to add a session
    *
-   * It will compare the master token validity and stored master token validity
-   * and if it is less, we will update the stored one and the heartbeat interval
-   * and reschedule heartbeat.
+   * <p>It will compare the master token validity and stored master token validity and if it is
+   * less, we will update the stored one and the heartbeat interval and reschedule heartbeat.
    *
-   * This method is called when a session is created.
+   * <p>This method is called when a session is created.
    *
    * @param session the session will be added
-   * @param masterTokenValidityInSecs time interval for which client need to
-   *                                  check validity of master token with server
+   * @param masterTokenValidityInSecs time interval for which client need to check validity of
+   *     master token with server
    */
-  synchronized protected void addSession(SFSession session,
-                                      long masterTokenValidityInSecs)
-  {
+  protected synchronized void addSession(SFSession session, long masterTokenValidityInSecs) {
     boolean requireReschedule = false;
 
     // update heartbeat interval if master token validity has become smaller
-    if (masterTokenValidityInSecs < this.masterTokenValidityInSecs)
-    {
+    if (masterTokenValidityInSecs < this.masterTokenValidityInSecs) {
       long oldMasterTokenValidityInSecs = this.masterTokenValidityInSecs;
       long oldHeartbeatIntervalInSecs = this.heartBeatIntervalInSecs;
 
-      this.heartBeatIntervalInSecs = masterTokenValidityInSecs/4;
+      this.heartBeatIntervalInSecs = masterTokenValidityInSecs / 4;
 
       // save master token validity
       this.masterTokenValidityInSecs = masterTokenValidityInSecs;
 
-      LOGGER.debug("update heartbeat interval, master token validity"
+      LOGGER.debug(
+          "update heartbeat interval, master token validity"
               + " from {} to {}, heart beat interval from {} to {}",
-                             oldMasterTokenValidityInSecs,
-                             this.masterTokenValidityInSecs,
-                             oldHeartbeatIntervalInSecs,
-                             this.heartBeatIntervalInSecs);
+          oldMasterTokenValidityInSecs,
+          this.masterTokenValidityInSecs,
+          oldHeartbeatIntervalInSecs,
+          this.heartBeatIntervalInSecs);
 
       // heartbeat rescheduling required
       requireReschedule = true;
@@ -110,150 +97,120 @@ public class HeartbeatBackground implements Runnable
     sessions.put(session, Boolean.TRUE);
 
     /**
-     * Create scheduler if it is the first time. It uses a custom thread
-     * factory that will create daemon thread so that it will not block
-     * JVM from exiting.
+     * Create scheduler if it is the first time. It uses a custom thread factory that will create
+     * daemon thread so that it will not block JVM from exiting.
      */
-    if (this.scheduler == null)
-    {
+    if (this.scheduler == null) {
       LOGGER.debug("create heartbeat thread pool");
-      this.scheduler = Executors.newScheduledThreadPool(1,
-            new ThreadFactory()
-            {
-              @Override
-              public Thread newThread(Runnable runnable)
-              {
-                Thread thread =
-                Executors.defaultThreadFactory().newThread(runnable);
-                thread.setName("heartbeat (" + thread.getId() + ")");
-                thread.setDaemon(true);
-                return thread;
-              }
-            });
+      this.scheduler =
+          Executors.newScheduledThreadPool(
+              1,
+              new ThreadFactory() {
+                @Override
+                public Thread newThread(Runnable runnable) {
+                  Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+                  thread.setName("heartbeat (" + thread.getId() + ")");
+                  thread.setDaemon(true);
+                  return thread;
+                }
+              });
     }
 
     // schedule a heartbeat task if none exists
-    if (heartbeatFuture == null)
-    {
+    if (heartbeatFuture == null) {
       LOGGER.debug("schedule heartbeat task");
       this.scheduleHeartbeat();
     }
     // or reschedule if the master token validity has been reduced (rare event)
-    else if (requireReschedule)
-    {
+    else if (requireReschedule) {
       LOGGER.debug("Cancel existing heartbeat task");
 
       // Cancel existing task if not started yet and reschedule
-      if (heartbeatFuture.cancel(false))
-      {
+      if (heartbeatFuture.cancel(false)) {
         LOGGER.debug("Canceled existing heartbeat task, reschedule");
         this.scheduleHeartbeat();
-      }
-      else
-      {
+      } else {
         LOGGER.debug("Failed to cancel existing heartbeat task");
       }
     }
   }
 
   /**
-   * Method to remove a session. This is called when a session is closed.
-   * Notice that if a session is not closed but the session object goes out of
-   * scope, then this method will not be called. And then the session will be
-   * kept in the list of sessions to be heartbeated until the object gets
-   * garbage collected since we use weak reference to the object.
+   * Method to remove a session. This is called when a session is closed. Notice that if a session
+   * is not closed but the session object goes out of scope, then this method will not be called.
+   * And then the session will be kept in the list of sessions to be heartbeated until the object
+   * gets garbage collected since we use weak reference to the object.
    *
    * @param session the session will be removed
    */
-  synchronized protected void removeSession(SFSession session)
-  {
+  protected synchronized void removeSession(SFSession session) {
     sessions.remove(session);
   }
 
-  /**
-   * Schedule the next heartbeat
-   */
-  private void scheduleHeartbeat()
-  {
+  /** Schedule the next heartbeat */
+  private void scheduleHeartbeat() {
     // elapsed time in seconds since the last heartbeat
     long elapsedSecsSinceLastHeartBeat =
-    System.currentTimeMillis()/1000 - lastHeartbeatStartTimeInSecs;
+        System.currentTimeMillis() / 1000 - lastHeartbeatStartTimeInSecs;
 
     /**
-     * The initial delay for the new scheduling is 0 if the elapsed
-     * time is more than the heartbeat time interval, otherwise it is the
-     * difference between the heartbeat time interval and the elapsed time.
+     * The initial delay for the new scheduling is 0 if the elapsed time is more than the heartbeat
+     * time interval, otherwise it is the difference between the heartbeat time interval and the
+     * elapsed time.
      */
-    long initialDelay = Math.max(heartBeatIntervalInSecs -
-                                 elapsedSecsSinceLastHeartBeat, 0);
+    long initialDelay = Math.max(heartBeatIntervalInSecs - elapsedSecsSinceLastHeartBeat, 0);
 
-    LOGGER.debug(
-               "schedule heartbeat task with initial delay of {} seconds",
-               initialDelay);
+    LOGGER.debug("schedule heartbeat task with initial delay of {} seconds", initialDelay);
 
     // Creates and executes a periodic action to send heartbeats
-    this.heartbeatFuture =
-        this.scheduler.schedule(this, initialDelay, TimeUnit.SECONDS);
+    this.heartbeatFuture = this.scheduler.schedule(this, initialDelay, TimeUnit.SECONDS);
   }
 
   /**
-   * Run heartbeat: for each session send a heartbeat request and schedule
-   * next heartbeat as long as there are sessions left.
+   * Run heartbeat: for each session send a heartbeat request and schedule next heartbeat as long as
+   * there are sessions left.
    *
-   * Notice that the synchronization is only around the code that visits the
-   * global sessions map and the code that schedules
-   * next heartbeat, but not around the heartbeat calls for each session in
-   * order to minimize the chance of blocking the adding of a session by
-   * performing the heartbeats. This is because adding a session is called from
-   * JDBC connection creation call which directly affects application
-   * performance.
+   * <p>Notice that the synchronization is only around the code that visits the global sessions map
+   * and the code that schedules next heartbeat, but not around the heartbeat calls for each session
+   * in order to minimize the chance of blocking the adding of a session by performing the
+   * heartbeats. This is because adding a session is called from JDBC connection creation call which
+   * directly affects application performance.
    */
   @Override
-  public void run()
-  {
+  public void run() {
     /**
-     * Remember current time as the heartbeat start time. This is used for
-     * calculating the delay for the next heartbeat.
+     * Remember current time as the heartbeat start time. This is used for calculating the delay for
+     * the next heartbeat.
      */
-    this.lastHeartbeatStartTimeInSecs = System.currentTimeMillis()/1000;
+    this.lastHeartbeatStartTimeInSecs = System.currentTimeMillis() / 1000;
 
     Set<SFSession> sessionsToHeartbeat = new HashSet<SFSession>();
 
     // synchronously get a copy of the sessions from the global list
-    synchronized(this)
-    {
+    synchronized (this) {
       sessionsToHeartbeat.addAll(sessions.keySet());
     }
 
     // heartbeat every session.
-    for (SFSession session : sessionsToHeartbeat)
-    {
-      try
-      {
+    for (SFSession session : sessionsToHeartbeat) {
+      try {
         session.heartbeat();
-      }
-      catch (Throwable ex)
-      {
+      } catch (Throwable ex) {
         LOGGER.error("heartbeat error - message=" + ex.getMessage(), ex);
       }
     }
 
     /**
-     * The following is synchronized with the methods to add or remove a
-     * session so that we always make sure we have one heartbeat task scheduled
-     * when there is any session left.
+     * The following is synchronized with the methods to add or remove a session so that we always
+     * make sure we have one heartbeat task scheduled when there is any session left.
      */
-    synchronized(this)
-    {
+    synchronized (this) {
       // schedule next heartbeat
-      if (sessions.size() > 0)
-      {
+      if (sessions.size() > 0) {
         LOGGER.debug("schedule next heartbeat run");
 
         scheduleHeartbeat();
-      }
-      else
-      {
+      } else {
         LOGGER.debug("no need for heartbeat since no more sessions");
 
         // no need to heartbeat if no more session

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -4,6 +4,19 @@
 
 package net.snowflake.client.core;
 
+import static org.apache.http.client.config.CookieSpecs.DEFAULT;
+import static org.apache.http.client.config.CookieSpecs.IGNORE_COOKIES;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.net.Proxy;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.TrustManager;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.RestRequest;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
@@ -27,25 +40,8 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.ssl.SSLInitializationException;
 import org.apache.http.util.EntityUtils;
 
-import javax.net.ssl.TrustManager;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.net.Proxy;
-import java.net.Socket;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.apache.http.client.config.CookieSpecs.DEFAULT;
-import static org.apache.http.client.config.CookieSpecs.IGNORE_COOKIES;
-
-/**
- * Created by jhuang on 1/19/16.
- */
-public class HttpUtil
-{
+/** Created by jhuang on 1/19/16. */
+public class HttpUtil {
   static final SFLogger logger = SFLoggerFactory.getLogger(HttpUtil.class);
 
   static final int DEFAULT_MAX_CONNECTIONS = 100;
@@ -53,36 +49,27 @@ public class HttpUtil
   static final int DEFAULT_CONNECTION_TIMEOUT = 60000;
   static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 300000; // ms
 
-  /**
-   * The unique httpClient shared by all connections, this will benefit long
-   * lived clients
-   */
+  /** The unique httpClient shared by all connections, this will benefit long lived clients */
   private static CloseableHttpClient httpClient = null;
 
-  /**
-   * Handle on the static connection manager, to gather statistics mainly
-   */
+  /** Handle on the static connection manager, to gather statistics mainly */
   private static PoolingHttpClientConnectionManager connectionManager = null;
 
-  /**
-   * default request configuration, to be copied on individual requests.
-   */
+  /** default request configuration, to be copied on individual requests. */
   private static RequestConfig DefaultRequestConfig = null;
-
 
   private static boolean socksProxyDisabled = false;
 
   /**
    * Build an Http client using our set of default.
    *
-   * @param insecureMode  skip OCSP revocation check if true or false.
-   * @param ocspCacheFile OCSP response cache file. If null, the default
-   *                      OCSP response file will be used.
+   * @param insecureMode skip OCSP revocation check if true or false.
+   * @param ocspCacheFile OCSP response cache file. If null, the default OCSP response file will be
+   *     used.
    * @return HttpClient object
    */
   static CloseableHttpClient buildHttpClient(
-      boolean insecureMode, File ocspCacheFile, boolean useOcspCacheServer)
-  {
+      boolean insecureMode, File ocspCacheFile, boolean useOcspCacheServer) {
     // set timeout so that we don't wait forever.
     // Setup the default configuration for all requests on this client
     DefaultRequestConfig =
@@ -93,24 +80,20 @@ public class HttpUtil
             .build();
 
     TrustManager[] trustManagers = null;
-    if (!insecureMode)
-    {
+    if (!insecureMode) {
       // A custom TrustManager is required only if insecureMode is disabled,
       // which is by default in the production. insecureMode can be enabled
       // 1) OCSP service is down for reasons, 2) PowerMock test tht doesn't
       // care OCSP checks.
-      TrustManager[] tm = {
-          new SFTrustManager(ocspCacheFile, useOcspCacheServer)};
+      TrustManager[] tm = {new SFTrustManager(ocspCacheFile, useOcspCacheServer)};
       trustManagers = tm;
     }
-    try
-    {
+    try {
       Registry<ConnectionSocketFactory> registry =
           RegistryBuilder.<ConnectionSocketFactory>create()
-              .register("https",
-                  new SFSSLConnectionSocketFactory(trustManagers, socksProxyDisabled))
-              .register("http",
-                  new SFConnectionSocketFactory())
+              .register(
+                  "https", new SFSSLConnectionSocketFactory(trustManagers, socksProxyDisabled))
+              .register("http", new SFConnectionSocketFactory())
               .build();
 
       // Build a connection manager with enough connections
@@ -125,14 +108,12 @@ public class HttpUtil
               // Support JVM proxy settings
               .useSystemProperties()
               .setRedirectStrategy(new DefaultRedirectStrategy())
-              .setUserAgent("-")     // needed for Okta
+              .setUserAgent("-") // needed for Okta
               .disableCookieManagement() // SNOW-39748
               .build();
 
       return httpClient;
-    }
-    catch (NoSuchAlgorithmException | KeyManagementException ex)
-    {
+    } catch (NoSuchAlgorithmException | KeyManagementException ex) {
       throw new SSLInitializationException(ex.getMessage(), ex);
     }
   }
@@ -142,8 +123,7 @@ public class HttpUtil
    *
    * @return HttpClient object shared across all connections
    */
-  public static CloseableHttpClient getHttpClient()
-  {
+  public static CloseableHttpClient getHttpClient() {
     return initHttpClient(true, null);
   }
 
@@ -151,28 +131,20 @@ public class HttpUtil
    * Accessor for the HTTP client singleton.
    *
    * @param insecureMode skip OCSP revocation check if true.
-   * @param ocspCacheFile OCSP response cache file name. if null, the default
-   *                      file will be used.
+   * @param ocspCacheFile OCSP response cache file name. if null, the default file will be used.
    * @return HttpClient object shared across all connections
    */
-  public static CloseableHttpClient initHttpClient(boolean insecureMode, File ocspCacheFile)
-  {
-    if (httpClient == null)
-    {
-      synchronized (HttpUtil.class)
-      {
-        if (httpClient == null)
-        {
+  public static CloseableHttpClient initHttpClient(boolean insecureMode, File ocspCacheFile) {
+    if (httpClient == null) {
+      synchronized (HttpUtil.class) {
+        if (httpClient == null) {
           String flag = System.getenv("SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED");
-          if (flag == null)
-          {
-            flag = System.getProperty(
-                "net.snowflake.jdbc.ocsp_response_cache_server_enabled");
+          if (flag == null) {
+            flag = System.getProperty("net.snowflake.jdbc.ocsp_response_cache_server_enabled");
           }
-          httpClient = buildHttpClient(
-              insecureMode,
-              ocspCacheFile,
-              flag == null || !"false".equalsIgnoreCase(flag));
+          httpClient =
+              buildHttpClient(
+                  insecureMode, ocspCacheFile, flag == null || !"false".equalsIgnoreCase(flag));
         }
       }
     }
@@ -180,17 +152,15 @@ public class HttpUtil
   }
 
   /**
-   * Return a request configuration inheriting from the default request
-   * configuration of the shared HttpClient with a different socket timeout.
+   * Return a request configuration inheriting from the default request configuration of the shared
+   * HttpClient with a different socket timeout.
    *
-   * @param soTimeoutMs    - custom socket timeout in milli-seconds
+   * @param soTimeoutMs - custom socket timeout in milli-seconds
    * @param withoutCookies - whether this request should ignore cookies or not
    * @return RequestConfig object
    */
-  public static RequestConfig
-  getDefaultRequestConfigWithSocketTimeout(int soTimeoutMs,
-                                           boolean withoutCookies)
-  {
+  public static RequestConfig getDefaultRequestConfigWithSocketTimeout(
+      int soTimeoutMs, boolean withoutCookies) {
     getHttpClient();
     final String cookieSpec = withoutCookies ? IGNORE_COOKIES : DEFAULT;
     return RequestConfig.copy(DefaultRequestConfig)
@@ -200,17 +170,14 @@ public class HttpUtil
   }
 
   /**
-   * Return a request configuration inheriting from the default request
-   * configuration of the shared HttpClient with the coopkie spec set to ignore.
+   * Return a request configuration inheriting from the default request configuration of the shared
+   * HttpClient with the coopkie spec set to ignore.
    *
    * @return RequestConfig object
    */
-  public static RequestConfig getRequestConfigWithoutcookies()
-  {
+  public static RequestConfig getRequestConfigWithoutcookies() {
     getHttpClient();
-    return RequestConfig.copy(DefaultRequestConfig)
-        .setCookieSpec(IGNORE_COOKIES)
-        .build();
+    return RequestConfig.copy(DefaultRequestConfig).setCookieSpec(IGNORE_COOKIES).build();
   }
 
   /**
@@ -218,28 +185,25 @@ public class HttpUtil
    *
    * @return HTTP Client stats in string representation
    */
-  private static String getHttpClientStats()
-  {
-    return connectionManager == null ?
-        "" :
-        connectionManager.getTotalStats().toString();
+  private static String getHttpClientStats() {
+    return connectionManager == null ? "" : connectionManager.getTotalStats().toString();
   }
 
   /**
    * Enables/disables use of the SOCKS proxy when creating sockets
+   *
    * @param socksProxyDisabled new value
    */
-  public static void setSocksProxyDisabled(boolean socksProxyDisabled)
-  {
+  public static void setSocksProxyDisabled(boolean socksProxyDisabled) {
     HttpUtil.socksProxyDisabled = socksProxyDisabled;
   }
 
   /**
    * Returns whether the SOCKS proxy is disabled for this JVM
+   *
    * @return whether the SOCKS proxy is disabled
    */
-  public static boolean isSocksProxyDisabled()
-  {
+  public static boolean isSocksProxyDisabled() {
     return HttpUtil.socksProxyDisabled;
   }
 
@@ -254,20 +218,14 @@ public class HttpUtil
    * @throws IOException raises if a general IO error occurs
    * @return response
    */
-  static String executeRequestWithoutCookies(HttpRequestBase httpRequest,
-                                             int retryTimeout,
-                                             int injectSocketTimeout,
-                                             AtomicBoolean canceling)
-      throws SnowflakeSQLException, IOException
-  {
+  static String executeRequestWithoutCookies(
+      HttpRequestBase httpRequest,
+      int retryTimeout,
+      int injectSocketTimeout,
+      AtomicBoolean canceling)
+      throws SnowflakeSQLException, IOException {
     return executeRequestInternal(
-        httpRequest,
-        retryTimeout,
-        injectSocketTimeout,
-        canceling,
-        true,
-        false,
-        true);
+        httpRequest, retryTimeout, injectSocketTimeout, canceling, true, false, true);
   }
 
   /**
@@ -281,18 +239,13 @@ public class HttpUtil
    * @throws SnowflakeSQLException if Snowflake error occurs
    * @throws IOException raises if a general IO error occurs
    */
-  public static String executeRequest(HttpRequestBase httpRequest,
-                                      int retryTimeout,
-                                      int injectSocketTimeout,
-                                      AtomicBoolean canceling)
-      throws SnowflakeSQLException, IOException
-  {
-    return executeRequest(
-        httpRequest,
-        retryTimeout,
-        injectSocketTimeout,
-        canceling,
-        false);
+  public static String executeRequest(
+      HttpRequestBase httpRequest,
+      int retryTimeout,
+      int injectSocketTimeout,
+      AtomicBoolean canceling)
+      throws SnowflakeSQLException, IOException {
+    return executeRequest(httpRequest, retryTimeout, injectSocketTimeout, canceling, false);
   }
 
   /**
@@ -302,19 +255,18 @@ public class HttpUtil
    * @param retryTimeout retry timeout
    * @param injectSocketTimeout injecting socket timeout
    * @param canceling canceling?
-   * @param includeRetryParameters whether to include retry parameters in
-   *                               retried requests
+   * @param includeRetryParameters whether to include retry parameters in retried requests
    * @return response
    * @throws SnowflakeSQLException if Snowflake error occurs
    * @throws IOException raises if a general IO error occurs
    */
-  public static String executeRequest(HttpRequestBase httpRequest,
-                                      int retryTimeout,
-                                      int injectSocketTimeout,
-                                      AtomicBoolean canceling,
-                                      boolean includeRetryParameters)
-      throws SnowflakeSQLException, IOException
-  {
+  public static String executeRequest(
+      HttpRequestBase httpRequest,
+      int retryTimeout,
+      int injectSocketTimeout,
+      AtomicBoolean canceling,
+      boolean includeRetryParameters)
+      throws SnowflakeSQLException, IOException {
     return executeRequestInternal(
         httpRequest,
         retryTimeout,
@@ -326,96 +278,82 @@ public class HttpUtil
   }
 
   /**
-   * Helper to execute a request with retry and check and throw exception if
-   * response is not success.
-   * This should be used only for small request has it execute the REST
-   * request and get back the result as a string.
-   * <p>
-   * Connection under the httpRequest is released.
+   * Helper to execute a request with retry and check and throw exception if response is not
+   * success. This should be used only for small request has it execute the REST request and get
+   * back the result as a string.
    *
-   * @param httpRequest         request object contains all the information
-   * @param retryTimeout        retry timeout (in seconds)
+   * <p>Connection under the httpRequest is released.
+   *
+   * @param httpRequest request object contains all the information
+   * @param retryTimeout retry timeout (in seconds)
    * @param injectSocketTimeout simulate socket timeout
-   * @param canceling           canceling flag
-   * @param withoutCookies      whether this request should ignore cookies
-   * @param includeRetryParameters whether to include retry parameters in
-   *                               retried requests
+   * @param canceling canceling flag
+   * @param withoutCookies whether this request should ignore cookies
+   * @param includeRetryParameters whether to include retry parameters in retried requests
    * @param includeRequestGuid whether to include request_guid
    * @return response in String
    * @throws SnowflakeSQLException if Snowflake error occurs
    * @throws IOException raises if a general IO error occurs
    */
-  private static String executeRequestInternal(HttpRequestBase httpRequest,
-                                               int retryTimeout,
-                                               int injectSocketTimeout,
-                                               AtomicBoolean canceling,
-                                               boolean withoutCookies,
-                                               boolean includeRetryParameters,
-                                               boolean includeRequestGuid)
-      throws SnowflakeSQLException, IOException
-  {
-    if (logger.isDebugEnabled())
-    {
-      logger.debug("Pool: {} Executing: {}",
-          HttpUtil.getHttpClientStats(),
-          httpRequest);
+  private static String executeRequestInternal(
+      HttpRequestBase httpRequest,
+      int retryTimeout,
+      int injectSocketTimeout,
+      AtomicBoolean canceling,
+      boolean withoutCookies,
+      boolean includeRetryParameters,
+      boolean includeRequestGuid)
+      throws SnowflakeSQLException, IOException {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Pool: {} Executing: {}", HttpUtil.getHttpClientStats(), httpRequest);
     }
 
     String theString;
     StringWriter writer = null;
     CloseableHttpResponse response = null;
-    try
-    {
-      response = RestRequest.execute(getHttpClient(),
-          httpRequest,
-          retryTimeout,
-          injectSocketTimeout,
-          canceling,
-          withoutCookies,
-          includeRetryParameters,
-          includeRequestGuid);
+    try {
+      response =
+          RestRequest.execute(
+              getHttpClient(),
+              httpRequest,
+              retryTimeout,
+              injectSocketTimeout,
+              canceling,
+              withoutCookies,
+              includeRetryParameters,
+              includeRequestGuid);
 
-      if (response == null ||
-          response.getStatusLine().getStatusCode() != 200)
-      {
-        logger.error("Error executing request: {}",
-            httpRequest.toString());
+      if (response == null || response.getStatusLine().getStatusCode() != 200) {
+        logger.error("Error executing request: {}", httpRequest.toString());
 
         SnowflakeUtil.logResponseDetails(response, logger);
 
-        if (response != null)
-        {
+        if (response != null) {
           EntityUtils.consume(response.getEntity());
         }
 
-        throw new SnowflakeSQLException(SqlState.IO_ERROR,
+        throw new SnowflakeSQLException(
+            SqlState.IO_ERROR,
             ErrorCode.NETWORK_ERROR.getMessageCode(),
             "HTTP status="
-                + ((response != null) ?
-                response.getStatusLine().getStatusCode() :
-                "null response"));
+                + ((response != null)
+                    ? response.getStatusLine().getStatusCode()
+                    : "null response"));
       }
 
       writer = new StringWriter();
-      try (InputStream ins = response.getEntity().getContent())
-      {
+      try (InputStream ins = response.getEntity().getContent()) {
         IOUtils.copy(ins, writer, "UTF-8");
       }
 
       theString = writer.toString();
-    }
-    finally
-    {
+    } finally {
       IOUtils.closeQuietly(writer);
       IOUtils.closeQuietly(response);
     }
 
-    if (logger.isDebugEnabled())
-    {
-      logger.debug(
-          "Pool: {} Request returned for: {}",
-          HttpUtil.getHttpClientStats(),
-          httpRequest);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Pool: {} Request returned for: {}", HttpUtil.getHttpClientStats(), httpRequest);
     }
 
     return theString;
@@ -430,87 +368,70 @@ public class HttpUtil
   //
   // Further details on this bug:
   //   http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7036144
-  public final static class HttpInputStream extends InputStream
-  {
+  public static final class HttpInputStream extends InputStream {
     private final InputStream httpIn;
 
-    public HttpInputStream(InputStream httpIn)
-    {
+    public HttpInputStream(InputStream httpIn) {
       this.httpIn = httpIn;
     }
 
     // This is the only modified function, all other
     // methods are simple wrapper around the HTTP stream.
     @Override
-    public final int available() throws IOException
-    {
+    public final int available() throws IOException {
       int available = httpIn.available();
       return available == 0 ? 1 : available;
     }
 
     // ONLY WRAPPER METHODS FROM HERE ON.
     @Override
-    public final int read() throws IOException
-    {
+    public final int read() throws IOException {
       return httpIn.read();
     }
 
     @Override
-    public final int read(byte b[]) throws IOException
-    {
+    public final int read(byte b[]) throws IOException {
       return httpIn.read(b);
     }
 
     @Override
-    public final int read(byte b[], int off, int len) throws IOException
-    {
+    public final int read(byte b[], int off, int len) throws IOException {
       return httpIn.read(b, off, len);
     }
 
     @Override
-    public final long skip(long n) throws IOException
-    {
+    public final long skip(long n) throws IOException {
       return httpIn.skip(n);
     }
 
     @Override
-    public final void close() throws IOException
-    {
+    public final void close() throws IOException {
       httpIn.close();
     }
 
     @Override
-    public synchronized void mark(int readlimit)
-    {
+    public synchronized void mark(int readlimit) {
       httpIn.mark(readlimit);
     }
 
     @Override
-    public synchronized void reset() throws IOException
-    {
+    public synchronized void reset() throws IOException {
       httpIn.reset();
     }
 
     @Override
-    public final boolean markSupported()
-    {
+    public final boolean markSupported() {
       return httpIn.markSupported();
     }
   }
 
-  private final static class SFConnectionSocketFactory
-  extends PlainConnectionSocketFactory
-  {
+  private static final class SFConnectionSocketFactory extends PlainConnectionSocketFactory {
     @Override
-    public Socket createSocket(HttpContext ctx) throws IOException
-    {
-      if (socksProxyDisabled)
-      {
+    public Socket createSocket(HttpContext ctx) throws IOException {
+      if (socksProxyDisabled) {
         return new Socket(Proxy.NO_PROXY);
       }
       return super.createSocket(ctx);
     }
   }
-
-
 }

--- a/src/main/java/net/snowflake/client/core/Incident.java
+++ b/src/main/java/net/snowflake/client/core/Incident.java
@@ -14,53 +14,47 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Random;
 import java.util.zip.GZIPOutputStream;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
-
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 
 /**
  * Incident Event class for triggering and registering Incidents with GS
+ *
  * @author jrosen
  */
-public class Incident extends Event
-{
+public class Incident extends Event {
   private static final SFLogger logger = SFLoggerFactory.getLogger(Incident.class);
 
   private static final String SF_PATH_CREATE_INCIDENT = "/incidents/create-incident";
 
   private static final Random randomGenerator = new Random();
 
-  private final Map<String,Object> incident;
+  private final Map<String, Object> incident;
 
-  public Incident(Event.EventType type, Map<String,Object> incident)
-  {
+  public Incident(Event.EventType type, Map<String, Object> incident) {
     super(type, "");
 
     this.incident = incident;
   }
 
   /**
-   * Generates the Incident Identifier. This should be reasonably unique within
-   * the time instant generated. I.e. in case there happens to be a collision
-   * (unlikely), then the id together with the timestamp can be used to
-   * disambiguate the two events. (Stolen from GS)
+   * Generates the Incident Identifier. This should be reasonably unique within the time instant
+   * generated. I.e. in case there happens to be a collision (unlikely), then the id together with
+   * the timestamp can be used to disambiguate the two events. (Stolen from GS)
+   *
    * @return incident id
    */
-  public static String generateIncidentId()
-  {
+  public static String generateIncidentId() {
     return Integer.toString(randomGenerator.nextInt(8999999) + 1000000);
   }
 
-  /**
-   * Registers the incident with Global Services
-   */
+  /** Registers the incident with Global Services */
   @Override
-  public void flush()
-  {
+  public void flush() {
     ObjectMapper mapper = new ObjectMapper();
     String json;
     String response;
@@ -68,65 +62,61 @@ public class Incident extends Event
     URI incidentURI;
     HttpPost postRequest;
 
-    logger.debug("Flushing incident, type={}, msg={}",
-          this.getType().getDescription(), this.getMessage());
+    logger.debug(
+        "Flushing incident, type={}, msg={}", this.getType().getDescription(), this.getMessage());
 
     // Get session token and incident info
-    String sessionToken =
-        (String)incident.get(SFSession.SF_HEADER_TOKEN_TAG);
-    String serverUrl =
-        (String)incident.get(SFSessionProperty.SERVER_URL.getPropertyKey());
-    Map<String,Object> incidentInfo =
-        (Map<String,Object>)incident.get(IncidentUtil.INCIDENT_INFO);
+    String sessionToken = (String) incident.get(SFSession.SF_HEADER_TOKEN_TAG);
+    String serverUrl = (String) incident.get(SFSessionProperty.SERVER_URL.getPropertyKey());
+    Map<String, Object> incidentInfo =
+        (Map<String, Object>) incident.get(IncidentUtil.INCIDENT_INFO);
 
-    if (sessionToken == null || serverUrl == null)
-    {
-      logger.debug("Incident registration failed, sessionToken or "
-              + "serverUrl not specified");
+    if (sessionToken == null || serverUrl == null) {
+      logger.debug("Incident registration failed, sessionToken or " + "serverUrl not specified");
       return;
     }
 
     // Map the incident to a json payload
-    try
-    {
+    try {
       json = mapper.writeValueAsString(incidentInfo);
-    }
-    catch (JsonProcessingException ex)
-    {
-      logger.error("Incident registration failed, could not map "
-              + "incident report to json string. Exception: {}", ex.getMessage());
+    } catch (JsonProcessingException ex) {
+      logger.error(
+          "Incident registration failed, could not map "
+              + "incident report to json string. Exception: {}",
+          ex.getMessage());
       return;
     }
 
     // Sanity check...
     Preconditions.checkNotNull(json);
 
-    try
-    {
+    try {
       URIBuilder uriBuilder = new URIBuilder(serverUrl);
       uriBuilder.setPath(SF_PATH_CREATE_INCIDENT);
       incidentURI = uriBuilder.build();
-    }
-    catch (URISyntaxException ex)
-    {
-      logger.error("Incident registration failed, "
-              + "URI could not be built. Exception: {}", ex.getMessage());
+    } catch (URISyntaxException ex) {
+      logger.error(
+          "Incident registration failed, " + "URI could not be built. Exception: {}",
+          ex.getMessage());
       return;
     }
 
-    logger.debug("Creating new HTTP request, token={}, URL={}",
-        sessionToken, incidentURI.toString());
+    logger.debug(
+        "Creating new HTTP request, token={}, URL={}", sessionToken, incidentURI.toString());
 
     postRequest = new HttpPost(incidentURI);
-    postRequest.setHeader(SFSession.SF_HEADER_AUTHORIZATION,
-          SFSession.SF_HEADER_SNOWFLAKE_AUTHTYPE + " "
-              + SFSession.SF_HEADER_TOKEN_TAG + "=\""
-              + sessionToken + "\"");
+    postRequest.setHeader(
+        SFSession.SF_HEADER_AUTHORIZATION,
+        SFSession.SF_HEADER_SNOWFLAKE_AUTHTYPE
+            + " "
+            + SFSession.SF_HEADER_TOKEN_TAG
+            + "=\""
+            + sessionToken
+            + "\"");
 
     // Compress the payload.
     ByteArrayEntity input = null;
-    try
-    {
+    try {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       GZIPOutputStream gzos = new GZIPOutputStream(baos);
       byte[] bytes = json.getBytes("UTF-8");
@@ -134,11 +124,10 @@ public class Incident extends Event
       gzos.finish();
       input = new ByteArrayEntity(baos.toByteArray());
       input.setContentType("application/json");
-    }
-    catch(IOException exc)
-    {
-      logger.warn("Incident registration failed, could not compress"
-              + " payload. Exception: {}", exc.getMessage());
+    } catch (IOException exc) {
+      logger.warn(
+          "Incident registration failed, could not compress" + " payload. Exception: {}",
+          exc.getMessage());
     }
 
     postRequest.setEntity(input);
@@ -146,18 +135,14 @@ public class Incident extends Event
 
     response = null;
 
-    try
-    {
-      response = HttpUtil.executeRequest(postRequest,
-                                         1000, 0,
-                                         null);
-    }
-    catch (Exception ex)
-    {
+    try {
+      response = HttpUtil.executeRequest(postRequest, 1000, 0, null);
+    } catch (Exception ex) {
       // No much we can do here besides complain.
       logger.error(
-          "Incident registration request failed, " +
-              "response: {}, exception: {}", response, ex.getMessage());
+          "Incident registration request failed, " + "response: {}, exception: {}",
+          response,
+          ex.getMessage());
     }
   }
 }

--- a/src/main/java/net/snowflake/client/core/IncidentUtil.java
+++ b/src/main/java/net/snowflake/client/core/IncidentUtil.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.core;
 
+import static net.snowflake.client.core.Incident.generateIncidentId;
+
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -12,9 +14,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.base.Preconditions;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeDriver;
-import net.snowflake.common.core.LoginInfoDTO;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Clock;
 import com.yammer.metrics.core.VirtualMachineMetrics;
@@ -27,20 +26,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
-import org.joda.time.DateTime;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SnowflakeDriver;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.LoginInfoDTO;
+import org.joda.time.DateTime;
 
-import static net.snowflake.client.core.Incident.generateIncidentId;
-
-/**
- *
- * @author jrosen
- */
-public class IncidentUtil
-{
-  private static final SFLogger logger =
-      SFLoggerFactory.getLogger(IncidentUtil.class);
+/** @author jrosen */
+public class IncidentUtil {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(IncidentUtil.class);
 
   // Determines size of stacktrace to be sent to GS
   private static final int STACK_TRACE_SIZE = 10;
@@ -67,9 +62,10 @@ public class IncidentUtil
   public static final String INC_DUMP_FILE_NAME = "sf_incident_";
   public static final String INC_DUMP_FILE_EXT = ".dmp.gz";
 
-   /**
-   * Creates an SFException without a cause to be thrown and generates/triggers
-   * an incident based on that exception with the specified signature.
+  /**
+   * Creates an SFException without a cause to be thrown and generates/triggers an incident based on
+   * that exception with the specified signature.
+   *
    * @param session session that will generate incident
    * @param requestId request id
    * @param jobUuid job uuid
@@ -79,44 +75,37 @@ public class IncidentUtil
    * @return generated SFException
    */
   public static SFException generateIncidentWithSignatureAndException(
-          SFSession session,
-          String requestId,
-          String jobUuid,
-          String signature,
-          ErrorCode errorCode,
-          Object... params)
-  {
+      SFSession session,
+      String requestId,
+      String jobUuid,
+      String signature,
+      ErrorCode errorCode,
+      Object... params) {
     return generateIncidentWithSignatureAndException(
-            session != null ?
-                session.getSessionToken() : null,
-            session != null ?
-                session.getServerUrl() : null,
-            requestId,
-            jobUuid,
-            signature,
-            errorCode,
-            params);
+        session != null ? session.getSessionToken() : null,
+        session != null ? session.getServerUrl() : null,
+        requestId,
+        jobUuid,
+        signature,
+        errorCode,
+        params);
   }
 
-
   public static SFException generateIncidentWithSignatureAndException(
-          String sessionToken,
-          String serverUrl,
-          String requestId,
-          String jobUuid,
-          String signature,
-          ErrorCode errorCode,
-          Object... params)
-  {
+      String sessionToken,
+      String serverUrl,
+      String requestId,
+      String jobUuid,
+      String signature,
+      ErrorCode errorCode,
+      Object... params) {
     SFException sfe = new SFException(errorCode, params);
 
     // Figure out who the caller is: that's who should be the reporter.
     StackTraceElement[] stack = sfe.getStackTrace();
     String caller = null;
-    for (int i = 1; i < stack.length; i++)
-    {
-      if (!stack[i].getMethodName().equals("generateIncidentWithException"))
-      {
+    for (int i = 1; i < stack.length; i++) {
+      if (!stack[i].getMethodName().equals("generateIncidentWithException")) {
         caller = String.valueOf(stack[i]);
         break;
       }
@@ -124,34 +113,28 @@ public class IncidentUtil
     String causeStr = sfe.toString() + " at " + caller;
 
     // Build message for GS Incident reporting
-    if (sessionToken != null && serverUrl != null)
-    {
+    if (sessionToken != null && serverUrl != null) {
 
-      Map<String,Object> incidentInfo =
-          IncidentUtil.buildIncidentReport(sessionToken,
-                                           serverUrl,
-                                           signature,
-                                           null,
-                                           requestId,
-                                           jobUuid,
-                                           causeStr);
+      Map<String, Object> incidentInfo =
+          IncidentUtil.buildIncidentReport(
+              sessionToken, serverUrl, signature, null, requestId, jobUuid, causeStr);
 
       // Send Incident message to GS and trigger log dump
       EventUtil.triggerIncident(incidentInfo);
-    }
-    else
-    {
-      logger.warn("Failed to generate incident, sessionToken valid={} "
-              + "serverUrl={}",
-                  sessionToken != null, serverUrl);
+    } else {
+      logger.warn(
+          "Failed to generate incident, sessionToken valid={} " + "serverUrl={}",
+          sessionToken != null,
+          serverUrl);
     }
 
     return sfe;
   }
 
   /**
-   * Creates an SFException without a cause to be thrown and generates/triggers
-   * an incident based on that exception.
+   * Creates an SFException without a cause to be thrown and generates/triggers an incident based on
+   * that exception.
+   *
    * @param session session that will generate incident
    * @param requestId request id
    * @param jobUuid job uuid
@@ -159,44 +142,37 @@ public class IncidentUtil
    * @param params option parameters
    * @return generated SFException
    */
-  public static SFException generateIncidentWithException(SFSession session,
-                                                          String requestId,
-                                                          String jobUuid,
-                                                          ErrorCode errorCode,
-                                                          Object... params)
-  {
-    return generateIncidentWithException(session != null ?
-                                            session.getSessionToken() : null,
-                                         session != null ?
-                                            session.getServerUrl() : null,
-                                         requestId,
-                                         jobUuid,
-                                         errorCode,
-                                         params);
+  public static SFException generateIncidentWithException(
+      SFSession session, String requestId, String jobUuid, ErrorCode errorCode, Object... params) {
+    return generateIncidentWithException(
+        session != null ? session.getSessionToken() : null,
+        session != null ? session.getServerUrl() : null,
+        requestId,
+        jobUuid,
+        errorCode,
+        params);
   }
 
-  public static SFException generateIncidentWithException(SFSession session,
-                                                          String requestId,
-                                                          String jobUuid,
-                                                          Throwable cause,
-                                                          ErrorCode errorCode,
-                                                          Object... params)
-  {
-    return generateIncidentWithException(session != null ?
-                                            session.getSessionToken() : null,
-                                         session != null ?
-                                            session.getServerUrl() : null,
-                                         requestId,
-                                         jobUuid,
-                                         cause,
-                                         errorCode,
-                                         params);
-
+  public static SFException generateIncidentWithException(
+      SFSession session,
+      String requestId,
+      String jobUuid,
+      Throwable cause,
+      ErrorCode errorCode,
+      Object... params) {
+    return generateIncidentWithException(
+        session != null ? session.getSessionToken() : null,
+        session != null ? session.getServerUrl() : null,
+        requestId,
+        jobUuid,
+        cause,
+        errorCode,
+        params);
   }
 
   /**
-   * Creates an SFException to be thrown and generates/triggers an incident
-   * based on that exception.
+   * Creates an SFException to be thrown and generates/triggers an incident based on that exception.
+   *
    * @param sessionToken session token
    * @param serverUrl snowflake url
    * @param requestId request id
@@ -206,78 +182,64 @@ public class IncidentUtil
    * @param params optional parameters
    * @return generated SFException
    */
-  public static SFException generateIncidentWithException(String sessionToken,
-                                                          String serverUrl,
-                                                          String requestId,
-                                                          String jobUuid,
-                                                          Throwable cause,
-                                                          ErrorCode errorCode,
-                                                          Object... params)
-  {
+  public static SFException generateIncidentWithException(
+      String sessionToken,
+      String serverUrl,
+      String requestId,
+      String jobUuid,
+      Throwable cause,
+      ErrorCode errorCode,
+      Object... params) {
     String causeStr = null;
 
     // Should use generateIncidentWithException without cause argument if
     // there is no cause.
-    if (cause != null)
-    {
+    if (cause != null) {
       // Use cause's caller as the reporter
       StackTraceElement[] stack = cause.getStackTrace();
       String topOfStack = null;
-      if (stack.length > 0)
-      {
+      if (stack.length > 0) {
         topOfStack = String.valueOf(stack[0]);
       }
       causeStr = cause.toString() + " at " + topOfStack;
-    }
-    else
-    {
-      logger.warn("Attempting to generate incident and"
-              + " SFException with null cause");
+    } else {
+      logger.warn("Attempting to generate incident and" + " SFException with null cause");
     }
 
     SFException sfe = new SFException(cause, errorCode, params);
 
     // Build message for GS Incident reporting
-    if (sessionToken != null && serverUrl != null)
-    {
-      Map<String,Object> incidentInfo =
-          IncidentUtil.buildIncidentReport(sessionToken,
-                                           serverUrl,
-                                           causeStr,
-                                           null,
-                                           requestId,
-                                           jobUuid,
-                                           causeStr);
+    if (sessionToken != null && serverUrl != null) {
+      Map<String, Object> incidentInfo =
+          IncidentUtil.buildIncidentReport(
+              sessionToken, serverUrl, causeStr, null, requestId, jobUuid, causeStr);
 
       // Send Incident message to GS and trigger log dump
       EventUtil.triggerIncident(incidentInfo);
-    }
-    else
-    {
-      logger.warn("Failed to generate incident, sessionToken valid={} "
-              + "serverUrl={}",
-                  sessionToken != null, serverUrl);
+    } else {
+      logger.warn(
+          "Failed to generate incident, sessionToken valid={} " + "serverUrl={}",
+          sessionToken != null,
+          serverUrl);
     }
 
     return sfe;
   }
 
-  public static SFException generateIncidentWithException(String sessionToken,
-                                                          String serverUrl,
-                                                          String requestId,
-                                                          String jobUuid,
-                                                          ErrorCode errorCode,
-                                                          Object... params)
-  {
+  public static SFException generateIncidentWithException(
+      String sessionToken,
+      String serverUrl,
+      String requestId,
+      String jobUuid,
+      ErrorCode errorCode,
+      Object... params) {
     SFException sfe = new SFException(errorCode, params);
 
     // Figure out who the caller is: that's who should be the reporter.
     StackTraceElement[] stack = sfe.getStackTrace();
     String caller = null;
-    for (int i = 1; i < stack.length; i++)
-    {
-      if (!stack[i].getMethodName().equals("generateIncidentWithException"))
-      {
+    for (int i = 1; i < stack.length; i++) {
+      if (!stack[i].getMethodName().equals("generateIncidentWithException")) {
         caller = String.valueOf(stack[i]);
         break;
       }
@@ -285,53 +247,47 @@ public class IncidentUtil
     String causeStr = sfe.toString() + " at " + caller;
 
     // Build message for GS Incident reporting
-    if (sessionToken != null && serverUrl != null)
-    {
+    if (sessionToken != null && serverUrl != null) {
 
-      Map<String,Object> incidentInfo =
-          IncidentUtil.buildIncidentReport(sessionToken,
-                                           serverUrl,
-                                           causeStr,
-                                           null,
-                                           requestId,
-                                           jobUuid,
-                                           causeStr);
+      Map<String, Object> incidentInfo =
+          IncidentUtil.buildIncidentReport(
+              sessionToken, serverUrl, causeStr, null, requestId, jobUuid, causeStr);
 
       // Send Incident message to GS and trigger log dump
       EventUtil.triggerIncident(incidentInfo);
-    }
-    else
-    {
-      logger.warn("Failed to generate incident, sessionToken valid={} "
-              + "serverUrl={}",
-                  sessionToken != null, serverUrl);
+    } else {
+      logger.warn(
+          "Failed to generate incident, sessionToken valid={} " + "serverUrl={}",
+          sessionToken != null,
+          serverUrl);
     }
 
     return sfe;
   }
 
-  public static void generateIncident(SFSession session,
-                                      String signature,
-                                      String detail,
-                                      String requestId,
-                                      String jobUuid,
-                                      Throwable cause)
-  {
-    if (session != null)
-    {
-      generateIncident(session.getSessionToken(),
-                       session.getServerUrl(),
-                       signature,
-                       detail,
-                       requestId,
-                       jobUuid,
-                       cause);
+  public static void generateIncident(
+      SFSession session,
+      String signature,
+      String detail,
+      String requestId,
+      String jobUuid,
+      Throwable cause) {
+    if (session != null) {
+      generateIncident(
+          session.getSessionToken(),
+          session.getServerUrl(),
+          signature,
+          detail,
+          requestId,
+          jobUuid,
+          cause);
     }
   }
 
   /**
-   * Generates an incident report based on the parameters passed in and
-   * triggers an incident with the EventHandler
+   * Generates an incident report based on the parameters passed in and triggers an incident with
+   * the EventHandler
+   *
    * @param sessionToken session token
    * @param serverUrl server url
    * @param signature incident signature
@@ -340,58 +296,50 @@ public class IncidentUtil
    * @param jobUuid job uuid
    * @param cause cause of incident
    */
-  public static void generateIncident(String sessionToken,
-                                      String serverUrl,
-                                      String signature,
-                                      String detail,
-                                      String requestId,
-                                      String jobUuid,
-                                      Throwable cause)
-  {
+  public static void generateIncident(
+      String sessionToken,
+      String serverUrl,
+      String signature,
+      String detail,
+      String requestId,
+      String jobUuid,
+      Throwable cause) {
     String causeStr = null;
 
-    if (cause != null)
-    {
+    if (cause != null) {
       // Whoever is generating the incident is the reporter.
       StackTraceElement[] stack = cause.getStackTrace();
       String topOfStack = null;
-      if (stack.length > 0)
-      {
+      if (stack.length > 0) {
         topOfStack = String.valueOf(stack[0]);
       }
       causeStr = cause.toString() + " at " + topOfStack;
-    }
-    else
-    {
-      logger.debug("Attempting to generate incident without cause, " +
-          "signature={}, detail={}", signature, detail);
+    } else {
+      logger.debug(
+          "Attempting to generate incident without cause, " + "signature={}, detail={}",
+          signature,
+          detail);
     }
 
-    if (sessionToken != null && serverUrl != null)
-    {
+    if (sessionToken != null && serverUrl != null) {
       // Build message for GS Incident reporting
-      Map<String,Object> incidentInfo =
-          IncidentUtil.buildIncidentReport(sessionToken,
-                                           serverUrl,
-                                           signature,
-                                           detail,
-                                           requestId,
-                                           jobUuid,
-                                           causeStr);
+      Map<String, Object> incidentInfo =
+          IncidentUtil.buildIncidentReport(
+              sessionToken, serverUrl, signature, detail, requestId, jobUuid, causeStr);
 
       // Send Incident message to GS and trigger log dump
       EventUtil.triggerIncident(incidentInfo);
-    }
-    else
-    {
-      logger.warn("Failed to generate incident, sessionToken valid={} "
-              + "serverUrl={}",
-                  sessionToken != null, serverUrl);
+    } else {
+      logger.warn(
+          "Failed to generate incident, sessionToken valid={} " + "serverUrl={}",
+          sessionToken != null,
+          serverUrl);
     }
   }
 
   /**
    * Builds an incident report to be serialized for consumption by Global Services.
+   *
    * @param signature
    * @param detail
    * @param requestId
@@ -399,20 +347,20 @@ public class IncidentUtil
    * @param cause
    * @return
    */
-  private static Map<String,Object> buildIncidentReport(String sessionToken,
-                                                        String serverUrl,
-                                                        String signature,
-                                                        String detail,
-                                                        String requestId,
-                                                        String jobUuid,
-                                                        String cause)
-  {
+  private static Map<String, Object> buildIncidentReport(
+      String sessionToken,
+      String serverUrl,
+      String signature,
+      String detail,
+      String requestId,
+      String jobUuid,
+      String cause) {
     // No session, no incident.
     Preconditions.checkArgument(sessionToken != null && serverUrl != null);
 
-    Map<String,Object> incident = new HashMap<>();
-    Map<String,Object> incidentInfo = new HashMap<>();
-    Map<String,Object> incidentReport = new HashMap<>();
+    Map<String, Object> incident = new HashMap<>();
+    Map<String, Object> incidentInfo = new HashMap<>();
+    Map<String, Object> incidentReport = new HashMap<>();
 
     // Record environment info
     incidentReport.put(CLIENT_TYPE, LoginInfoDTO.SF_JDBC_APP_ID);
@@ -426,24 +374,23 @@ public class IncidentUtil
     StackTraceElement[] stes = Thread.currentThread().getStackTrace();
 
     // Find the function that started this incident
-    while (stes[topOfStack].getMethodName().startsWith("generateIncident"))
-    {
+    while (stes[topOfStack].getMethodName().startsWith("generateIncident")) {
       topOfStack++;
     }
 
     StackTraceElement caller = stes[topOfStack];
 
-    String reporter = caller.getClassName() + ":" + caller.getMethodName() +
-                      ":" + caller.getLineNumber();
+    String reporter =
+        caller.getClassName() + ":" + caller.getMethodName() + ":" + caller.getLineNumber();
 
-    String detailMessage = (detail == null && cause == null) ? null :
-                           ((detail == null ? "" : (detail + " : ")) +
-                           (cause == null  ? "" : cause));
+    String detailMessage =
+        (detail == null && cause == null)
+            ? null
+            : ((detail == null ? "" : (detail + " : ")) + (cause == null ? "" : cause));
 
     // First N lines of the stacktrace
     StackTraceElement[] strace = new StackTraceElement[STACK_TRACE_SIZE];
-    for (int i = 0; i < STACK_TRACE_SIZE && (i + topOfStack) < stes.length; i++)
-    {
+    for (int i = 0; i < STACK_TRACE_SIZE && (i + topOfStack) < stes.length; i++) {
       strace[i] = stes[i + topOfStack];
     }
     incidentReport.put(STACKTRACE, strace);
@@ -481,17 +428,15 @@ public class IncidentUtil
   }
 
   /**
-   * Produce a one line description of the throwable, suitable for error message
-   * and log printing.
+   * Produce a one line description of the throwable, suitable for error message and log printing.
+   *
    * @param thrown thrown object
    * @return description of the thrown object
    */
-  public static String oneLiner(Throwable thrown)
-  {
+  public static String oneLiner(Throwable thrown) {
     StackTraceElement[] stack = thrown.getStackTrace();
     String topOfStack = null;
-    if (stack.length > 0)
-    {
+    if (stack.length > 0) {
       topOfStack = String.valueOf(stack[0]);
     }
     return thrown.toString() + " at " + topOfStack;
@@ -499,23 +444,21 @@ public class IncidentUtil
 
   /**
    * Dumps JVM metrics for this process.
+   *
    * @param incidentId incident id
    */
-  public static void dumpVmMetrics(String incidentId)
-  {
+  public static void dumpVmMetrics(String incidentId) {
     PrintWriter writer = null;
-    try
-    {
-      String dumpFile = EventUtil.getDumpPathPrefix() + "/" +
-                        INC_DUMP_FILE_NAME + incidentId + INC_DUMP_FILE_EXT;
+    try {
+      String dumpFile =
+          EventUtil.getDumpPathPrefix() + "/" + INC_DUMP_FILE_NAME + incidentId + INC_DUMP_FILE_EXT;
 
-      final OutputStream outStream =
-          new GZIPOutputStream(new FileOutputStream(dumpFile));
+      final OutputStream outStream = new GZIPOutputStream(new FileOutputStream(dumpFile));
       writer = new PrintWriter(outStream, true);
 
       final VirtualMachineMetrics vm = VirtualMachineMetrics.getInstance();
-      writer.print("\n\n\n---------------------------  METRICS "
-                   + "---------------------------\n\n");
+      writer.print(
+          "\n\n\n---------------------------  METRICS " + "---------------------------\n\n");
       writer.flush();
       JsonFactory jf = new JsonFactory();
       jf.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
@@ -524,14 +467,10 @@ public class IncidentUtil
       mapper.registerModule(new JodaModule());
       mapper.setDateFormat(new ISO8601DateFormat());
       mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-      MetricsServlet metrics = new MetricsServlet(Clock.defaultClock(),
-                                                  vm,
-                                                  Metrics.defaultRegistry(),
-                                                  jf,
-                                                  true);
+      MetricsServlet metrics =
+          new MetricsServlet(Clock.defaultClock(), vm, Metrics.defaultRegistry(), jf, true);
 
-      final JsonGenerator json = jf.createGenerator(outStream,
-                                                    JsonEncoding.UTF8);
+      final JsonGenerator json = jf.createGenerator(outStream, JsonEncoding.UTF8);
       json.useDefaultPrettyPrinter();
       json.writeStartObject();
 
@@ -539,9 +478,10 @@ public class IncidentUtil
       writeVmMetrics(json, vm);
 
       // Components metrics
-      metrics.writeRegularMetrics(json, // json generator
-                                  null, // class prefix
-                                  false); // include full samples
+      metrics.writeRegularMetrics(
+          json, // json generator
+          null, // class prefix
+          false); // include full samples
 
       json.writeEndObject();
       json.close();
@@ -549,31 +489,24 @@ public class IncidentUtil
       logger.debug("Creating full thread dump in dump file {}", dumpFile);
 
       // Thread dump next....
-      writer.print("\n\n\n---------------------------  THREAD DUMP "
-          + "---------------------------\n\n");
+      writer.print(
+          "\n\n\n---------------------------  THREAD DUMP " + "---------------------------\n\n");
       writer.flush();
 
       vm.threadDump(outStream);
 
       logger.debug("Dump file {} is created.", dumpFile);
-    }
-    catch(Exception exc)
-    {
-      logger.error(
-          "Unable to write dump file, exception: {}", exc.getMessage());
-    }
-    finally
-    {
-      if (writer != null)
-      {
+    } catch (Exception exc) {
+      logger.error("Unable to write dump file, exception: {}", exc.getMessage());
+    } finally {
+      if (writer != null) {
         writer.close();
       }
     }
   }
 
   private static void writeVmMetrics(JsonGenerator json, VirtualMachineMetrics vm)
-          throws IOException
-  {
+      throws IOException {
     json.writeFieldName("jvm");
     json.writeStartObject();
     {
@@ -603,8 +536,7 @@ public class IncidentUtil
         json.writeFieldName("memory_pool_usages");
         json.writeStartObject();
         {
-          for (Map.Entry<String, Double> pool : vm.memoryPoolUsage().entrySet())
-          {
+          for (Map.Entry<String, Double> pool : vm.memoryPoolUsage().entrySet()) {
             json.writeNumberField(pool.getKey(), pool.getValue());
           }
         }
@@ -612,34 +544,29 @@ public class IncidentUtil
       }
       json.writeEndObject();
 
-      final Map<String, VirtualMachineMetrics.BufferPoolStats> bufferPoolStats = vm
-              .getBufferPoolStats();
-      if (!bufferPoolStats.isEmpty())
-      {
+      final Map<String, VirtualMachineMetrics.BufferPoolStats> bufferPoolStats =
+          vm.getBufferPoolStats();
+      if (!bufferPoolStats.isEmpty()) {
         json.writeFieldName("buffers");
         json.writeStartObject();
         {
           json.writeFieldName("direct");
           json.writeStartObject();
           {
-            json.writeNumberField("count", bufferPoolStats.get("direct")
-                                  .getCount());
-            json.writeNumberField("memoryUsed", bufferPoolStats.get("direct")
-                                  .getMemoryUsed());
-            json.writeNumberField("totalCapacity", bufferPoolStats.get("direct")
-                                  .getTotalCapacity());
+            json.writeNumberField("count", bufferPoolStats.get("direct").getCount());
+            json.writeNumberField("memoryUsed", bufferPoolStats.get("direct").getMemoryUsed());
+            json.writeNumberField(
+                "totalCapacity", bufferPoolStats.get("direct").getTotalCapacity());
           }
           json.writeEndObject();
 
           json.writeFieldName("mapped");
           json.writeStartObject();
           {
-            json.writeNumberField("count", bufferPoolStats.get("mapped")
-                                  .getCount());
-            json.writeNumberField("memoryUsed", bufferPoolStats.get("mapped")
-                                  .getMemoryUsed());
-            json.writeNumberField("totalCapacity", bufferPoolStats.get("mapped")
-                                  .getTotalCapacity());
+            json.writeNumberField("count", bufferPoolStats.get("mapped").getCount());
+            json.writeNumberField("memoryUsed", bufferPoolStats.get("mapped").getMemoryUsed());
+            json.writeNumberField(
+                "totalCapacity", bufferPoolStats.get("mapped").getTotalCapacity());
           }
           json.writeEndObject();
         }
@@ -655,11 +582,8 @@ public class IncidentUtil
       json.writeFieldName("thread-states");
       json.writeStartObject();
       {
-        for (Map.Entry<Thread.State, Double> entry : vm.threadStatePercentages()
-                .entrySet())
-        {
-          json.writeNumberField(entry.getKey().toString().toLowerCase(),
-                                entry.getValue());
+        for (Map.Entry<Thread.State, Double> entry : vm.threadStatePercentages().entrySet()) {
+          json.writeNumberField(entry.getKey().toString().toLowerCase(), entry.getValue());
         }
       }
       json.writeEndObject();
@@ -667,15 +591,12 @@ public class IncidentUtil
       json.writeFieldName("garbage-collectors");
       json.writeStartObject();
       {
-        for (Map.Entry<String, VirtualMachineMetrics.GarbageCollectorStats> entry : vm
-                .garbageCollectors()
-                .entrySet())
-        {
+        for (Map.Entry<String, VirtualMachineMetrics.GarbageCollectorStats> entry :
+            vm.garbageCollectors().entrySet()) {
           json.writeFieldName(entry.getKey());
           json.writeStartObject();
           {
-            final VirtualMachineMetrics.GarbageCollectorStats gc = entry
-                    .getValue();
+            final VirtualMachineMetrics.GarbageCollectorStats gc = entry.getValue();
             json.writeNumberField("runs", gc.getRuns());
             json.writeNumberField("time", gc.getTime(TimeUnit.MILLISECONDS));
           }

--- a/src/main/java/net/snowflake/client/core/ParameterBindingDTO.java
+++ b/src/main/java/net/snowflake/client/core/ParameterBindingDTO.java
@@ -4,38 +4,28 @@
 
 package net.snowflake.client.core;
 
-/**
- * This class represents a binding object passed to server side
- * Created by hyu on 6/15/17.
- */
-public class ParameterBindingDTO
-{
+/** This class represents a binding object passed to server side Created by hyu on 6/15/17. */
+public class ParameterBindingDTO {
   /** Type of binding */
   private String type;
 
-  /** Value is a String object if it's a single bind,
-   *  otherwise is an array of String
-   */
+  /** Value is a String object if it's a single bind, otherwise is an array of String */
   private Object value;
 
-  public ParameterBindingDTO(String type, Object value)
-  {
+  public ParameterBindingDTO(String type, Object value) {
     this.type = type;
     this.value = value;
   }
 
-  public Object getValue()
-  {
+  public Object getValue() {
     return value;
   }
 
-  public String getType()
-  {
+  public String getType() {
     return type;
   }
 
-  public void setType(String type)
-  {
+  public void setType(String type) {
     this.type = type;
   }
 }

--- a/src/main/java/net/snowflake/client/core/QueryExecDTO.java
+++ b/src/main/java/net/snowflake/client/core/QueryExecDTO.java
@@ -9,14 +9,12 @@ import java.util.Map;
 /**
  * Body of a query request
  *
- * Created by hyu on 6/30/17.
+ * <p>Created by hyu on 6/30/17.
  */
-class QueryExecDTO
-{
+class QueryExecDTO {
   private String sqlText;
 
-  @Deprecated
-  private Integer sequenceId;
+  @Deprecated private Integer sequenceId;
 
   private Map<String, ParameterBindingDTO> bindings;
 
@@ -32,15 +30,15 @@ class QueryExecDTO
 
   private boolean isInternal;
 
-  QueryExecDTO(String sqlText,
-               boolean describeOnly,
-               Integer sequenceId,
-               Map<String, ParameterBindingDTO> bindings,
-               String bindStage,
-               Map<String, Object> parameters,
-               long querySubmissionTime,
-               boolean internal)
-  {
+  QueryExecDTO(
+      String sqlText,
+      boolean describeOnly,
+      Integer sequenceId,
+      Map<String, ParameterBindingDTO> bindings,
+      String bindStage,
+      Map<String, Object> parameters,
+      long querySubmissionTime,
+      boolean internal) {
     this.sqlText = sqlText;
     this.describeOnly = describeOnly;
     this.sequenceId = sequenceId;
@@ -51,95 +49,77 @@ class QueryExecDTO
     this.isInternal = internal;
   }
 
-  public String getSqlText()
-  {
+  public String getSqlText() {
     return sqlText;
   }
 
-  public void setSqlText(String sqlText)
-  {
+  public void setSqlText(String sqlText) {
     this.sqlText = sqlText;
   }
 
   @Deprecated
-  public Integer getSequenceId()
-  {
+  public Integer getSequenceId() {
     return sequenceId;
   }
 
   @Deprecated
-  public void setSequenceId(Integer sequenceId)
-  {
+  public void setSequenceId(Integer sequenceId) {
     this.sequenceId = sequenceId;
   }
 
-  public Map<String, ParameterBindingDTO> getBindings()
-  {
+  public Map<String, ParameterBindingDTO> getBindings() {
     return bindings;
   }
 
-  public void setBindings(Map<String, ParameterBindingDTO> bindings)
-  {
+  public void setBindings(Map<String, ParameterBindingDTO> bindings) {
     this.bindings = bindings;
   }
 
-  public String getBindStage()
-  {
+  public String getBindStage() {
     return bindStage;
   }
 
-  public void setBindStage(String bindStage)
-  {
+  public void setBindStage(String bindStage) {
     this.bindStage = bindStage;
   }
 
-  public boolean isDescribeOnly()
-  {
+  public boolean isDescribeOnly() {
     return describeOnly;
   }
 
-  public void setDescribeOnly(boolean describeOnly)
-  {
+  public void setDescribeOnly(boolean describeOnly) {
     this.describeOnly = describeOnly;
   }
 
-  public Map<String, Object> getParameters()
-  {
+  public Map<String, Object> getParameters() {
     return parameters;
   }
 
-  public void setParameters(Map<String, Object> parameters)
-  {
+  public void setParameters(Map<String, Object> parameters) {
     this.parameters = parameters;
   }
 
-  public String getDescribedJobId()
-  {
+  public String getDescribedJobId() {
     return describedJobId;
   }
 
-  public void setDescribedJobId(String describedJobId)
-  {
+  public void setDescribedJobId(String describedJobId) {
     this.describedJobId = describedJobId;
   }
 
-  public long getQuerySubmissionTime()
-  {
+  public long getQuerySubmissionTime() {
     return querySubmissionTime;
   }
 
-  public void setQuerySubmissionTime(long querySubmissionTime)
-  {
+  public void setQuerySubmissionTime(long querySubmissionTime) {
     this.querySubmissionTime = querySubmissionTime;
   }
 
-  public void setIsInternal(boolean isInternal)
-  {
+  public void setIsInternal(boolean isInternal) {
     this.isInternal = isInternal;
   }
 
-  public boolean getIsInternal()
-  {
+  public boolean getIsInternal() {
     return this.isInternal;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseResultSet.java
@@ -4,14 +4,6 @@
 
 package net.snowflake.client.core;
 
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.SnowflakeUtil;
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SFBinaryFormat;
-import net.snowflake.common.core.SFTime;
-import net.snowflake.common.core.SFTimestamp;
-import net.snowflake.common.core.SnowflakeDateTimeFormat;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.Date;
@@ -22,16 +14,23 @@ import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SFBinaryFormat;
+import net.snowflake.common.core.SFTime;
+import net.snowflake.common.core.SFTimestamp;
+import net.snowflake.common.core.SnowflakeDateTimeFormat;
 
 /**
  * Base class for query result set and metadata result set
  *
  * @author jhuang
  */
-public abstract class SFBaseResultSet
-{
+public abstract class SFBaseResultSet {
   static final SFLogger logger = SFLoggerFactory.getLogger(SFBaseResultSet.class);
 
   protected boolean wasNull = false;
@@ -66,122 +65,107 @@ public abstract class SFBaseResultSet
   // indicate whether the result set has been closed or not.
   protected boolean isClosed = true;
 
-  abstract public boolean isLast();
+  public abstract boolean isLast();
 
-  abstract public boolean isAfterLast();
+  public abstract boolean isAfterLast();
 
-  public void setSession(SFSession session)
-  {
+  public void setSession(SFSession session) {
     this.session = session;
   }
 
   // default implementation
-  public boolean next() throws SFException, SnowflakeSQLException
-  {
+  public boolean next() throws SFException, SnowflakeSQLException {
     logger.debug("public boolean next()");
 
     return false;
   }
 
-  public void close()
-  {
+  public void close() {
     logger.debug("public void close()");
 
     resultSetMetaData = null;
     isClosed = true;
   }
 
-  public boolean wasNull()
-  {
+  public boolean wasNull() {
     logger.debug("public boolean wasNull() returning {}", wasNull);
 
     return wasNull;
   }
 
-  public String getString(int columnIndex) throws SFException
-  {
+  public String getString(int columnIndex) throws SFException {
     logger.debug("public String getString(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
-    if (obj == null)
-    {
+    if (obj == null) {
       return null;
     }
 
     // print timestamp in string format
     int columnType = resultSetMetaData.getInternalColumnType(columnIndex);
-    switch (columnType)
-    {
+    switch (columnType) {
       case Types.BOOLEAN:
-        return ResultUtil.getBooleanAsString(
-            ResultUtil.getBoolean(obj.toString()));
+        return ResultUtil.getBooleanAsString(ResultUtil.getBoolean(obj.toString()));
 
       case Types.TIMESTAMP:
       case SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ:
       case SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ:
-
         SFTimestamp sfTS = getSFTimestamp(columnIndex);
         int columnScale = resultSetMetaData.getScale(columnIndex);
 
-        String timestampStr = ResultUtil.getSFTimestampAsString(
-            sfTS, columnType, columnScale, timestampNTZFormatter,
-            timestampLTZFormatter, timestampTZFormatter, session);
+        String timestampStr =
+            ResultUtil.getSFTimestampAsString(
+                sfTS,
+                columnType,
+                columnScale,
+                timestampNTZFormatter,
+                timestampLTZFormatter,
+                timestampTZFormatter,
+                session);
 
         if (logger.isDebugEnabled())
-          logger.debug("Converting timestamp to string from: {} to: {}",
-               obj.toString(), timestampStr);
+          logger.debug(
+              "Converting timestamp to string from: {} to: {}", obj.toString(), timestampStr);
 
         return timestampStr;
 
       case Types.DATE:
         Date date = getDate(columnIndex, timeZoneUTC);
 
-        if (dateFormatter == null)
-        {
-          throw IncidentUtil.
-              generateIncidentWithException(session, null, null,
-                                            ErrorCode.INTERNAL_ERROR,
-                                            "missing date formatter");
+        if (dateFormatter == null) {
+          throw IncidentUtil.generateIncidentWithException(
+              session, null, null, ErrorCode.INTERNAL_ERROR, "missing date formatter");
         }
 
         String dateStr = ResultUtil.getDateAsString(date, dateFormatter);
 
         if (logger.isDebugEnabled())
-          logger.debug("Converting date to string from: {} to: {}",
-               obj.toString(), dateStr);
+          logger.debug("Converting date to string from: {} to: {}", obj.toString(), dateStr);
         return dateStr;
 
       case Types.TIME:
         SFTime sfTime = getSFTime(columnIndex);
 
-        if (timeFormatter == null)
-        {
-          throw IncidentUtil
-              .generateIncidentWithException(session, null, null,
-                                             ErrorCode.INTERNAL_ERROR,
-                                             "missing time formatter");
+        if (timeFormatter == null) {
+          throw IncidentUtil.generateIncidentWithException(
+              session, null, null, ErrorCode.INTERNAL_ERROR, "missing time formatter");
         }
 
         int scale = resultSetMetaData.getScale(columnIndex);
         String timeStr = ResultUtil.getSFTimeAsString(sfTime, scale, timeFormatter);
 
         if (logger.isDebugEnabled())
-          logger.debug("Converting time to string from: {} to: {}",
-               obj.toString(), timeStr);
+          logger.debug("Converting time to string from: {} to: {}", obj.toString(), timeStr);
         return timeStr;
 
       case Types.BINARY:
-        if (binaryFormatter == null)
-        {
-          throw IncidentUtil
-              .generateIncidentWithException(session, null, null,
-                                             ErrorCode.INTERNAL_ERROR,
-                                             "missing binary formatter");
+        if (binaryFormatter == null) {
+          throw IncidentUtil.generateIncidentWithException(
+              session, null, null, ErrorCode.INTERNAL_ERROR, "missing binary formatter");
         }
 
-        if (binaryFormatter == SFBinaryFormat.HEX)
-        {
+        if (binaryFormatter == SFBinaryFormat.HEX) {
           // Shortcut: the values are already passed with hex encoding, so just
           // return the string unchanged rather than constructing an SFBinary.
           return obj.toString();
@@ -197,195 +181,138 @@ public abstract class SFBaseResultSet
     return obj.toString();
   }
 
-  public boolean getBoolean(int columnIndex) throws SFException
-  {
-    logger.debug(
-        "public boolean getBoolean(int columnIndex)");
+  public boolean getBoolean(int columnIndex) throws SFException {
+    logger.debug("public boolean getBoolean(int columnIndex)");
 
     Object obj = getObjectInternal(columnIndex);
-    if (obj == null)
-    {
+    if (obj == null) {
       return false;
     }
 
-    if (obj instanceof Boolean)
-    {
+    if (obj instanceof Boolean) {
       return (Boolean) obj;
-    }
-    else
-    {
+    } else {
       return ResultUtil.getBoolean(obj.toString());
     }
   }
 
-  public short getShort(int columnIndex) throws SFException
-  {
+  public short getShort(int columnIndex) throws SFException {
     logger.debug("public short getShort(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    if (obj instanceof String)
-    {
+    if (obj instanceof String) {
       return Short.parseShort((String) obj);
-    }
-    else
-    {
+    } else {
       return ((Number) obj).shortValue();
     }
   }
 
-  public int getInt(int columnIndex) throws SFException
-  {
+  public int getInt(int columnIndex) throws SFException {
     logger.debug("public int getInt(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    if (obj instanceof String)
-    {
+    if (obj instanceof String) {
       return Integer.parseInt((String) obj);
-    }
-    else
-    {
+    } else {
       return ((Number) obj).intValue();
     }
   }
 
-  public long getLong(int columnIndex) throws SFException
-  {
+  public long getLong(int columnIndex) throws SFException {
     logger.debug("public long getLong(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    try
-    {
-      if (obj instanceof String)
-      {
+    try {
+      if (obj instanceof String) {
         return Long.parseLong((String) obj);
-      }
-      else
-      {
+      } else {
         return ((Number) obj).longValue();
       }
-    }
-    catch (NumberFormatException nfe)
-    {
+    } catch (NumberFormatException nfe) {
       int columnType = resultSetMetaData.getColumnType(columnIndex);
-      if (Types.INTEGER == columnType
-          || Types.SMALLINT == columnType)
-      {
-        SFException sfe = new SFException(ErrorCode.INTERNAL_ERROR,
-            "Invalid long: " + obj.toString());
-        IncidentUtil.generateIncident(session, "Unable to Convert to Long",
-            null, null, null, sfe);
+      if (Types.INTEGER == columnType || Types.SMALLINT == columnType) {
+        SFException sfe =
+            new SFException(ErrorCode.INTERNAL_ERROR, "Invalid long: " + obj.toString());
+        IncidentUtil.generateIncident(session, "Unable to Convert to Long", null, null, null, sfe);
         throw sfe;
-      }
-      else
-      {
-        throw new SFException(ErrorCode.INVALID_VALUE_CONVERT,
-            columnType, "LONG", obj);
+      } else {
+        throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, columnType, "LONG", obj);
       }
     }
   }
 
-  public float getFloat(int columnIndex) throws SFException
-  {
+  public float getFloat(int columnIndex) throws SFException {
     logger.debug("public float getFloat(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    if (obj instanceof String)
-    {
-      if ("inf".equals(obj))
-      {
+    if (obj instanceof String) {
+      if ("inf".equals(obj)) {
         return Float.POSITIVE_INFINITY;
-      }
-      else if ("-inf".equals(obj))
-      {
-        return Float.NEGATIVE_INFINITY; }
-      else
-      {
+      } else if ("-inf".equals(obj)) {
+        return Float.NEGATIVE_INFINITY;
+      } else {
         return Float.parseFloat((String) obj);
       }
-    }
-    else
-    {
+    } else {
       return ((Number) obj).floatValue();
     }
   }
 
-  public double getDouble(int columnIndex) throws SFException
-  {
+  public double getDouble(int columnIndex) throws SFException {
     logger.debug("public double getDouble(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
     // snow-11974: null for getDouble should return 0
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    if (obj instanceof String)
-    {
-      if ("inf".equals(obj))
-      {
+    if (obj instanceof String) {
+      if ("inf".equals(obj)) {
         return Double.POSITIVE_INFINITY;
-      }
-      else if ("-inf".equals(obj))
-      {
+      } else if ("-inf".equals(obj)) {
         return Double.NEGATIVE_INFINITY;
-      }
-      else
-      {
+      } else {
         return Double.parseDouble((String) obj);
       }
-    }
-    else
-    {
+    } else {
       return ((Number) obj).doubleValue();
     }
   }
 
-  public byte[] getBytes(int columnIndex) throws SFException
-  {
+  public byte[] getBytes(int columnIndex) throws SFException {
     logger.debug("public byte[] getBytes(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
-    try
-    {
+    try {
       return SFBinary.fromHex(obj.toString()).getBytes();
-    }
-    catch (IllegalArgumentException ex)
-    {
-      throw new SFException(ErrorCode.INTERNAL_ERROR,
-          "Invalid binary value: " + obj.toString());
+    } catch (IllegalArgumentException ex) {
+      throw new SFException(ErrorCode.INTERNAL_ERROR, "Invalid binary value: " + obj.toString());
     }
   }
 
-  public Date getDate(int columnIndex, TimeZone tz) throws SFException
-  {
-    if (tz == null)
-    {
+  public Date getDate(int columnIndex, TimeZone tz) throws SFException {
+    if (tz == null) {
       tz = TimeZone.getDefault();
     }
 
@@ -394,138 +321,108 @@ public abstract class SFBaseResultSet
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
     int columnType = resultSetMetaData.getColumnType(columnIndex);
 
-    if (Types.TIMESTAMP == columnType)
-    {
+    if (Types.TIMESTAMP == columnType) {
       return new Date(getTimestamp(columnIndex, tz).getTime());
-    }
-    else if (Types.DATE == columnType)
-    {
+    } else if (Types.DATE == columnType) {
       return ResultUtil.getDate(obj.toString(), tz, session);
     }
     // for Types.TIME and all other type, throw user error
-    else
-    {
+    else {
       throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, columnType, "DATE", obj);
     }
   }
 
-  public Date getDate(int columnIndex) throws SFException
-  {
+  public Date getDate(int columnIndex) throws SFException {
     return getDate(columnIndex, TimeZone.getDefault());
   }
 
-  public Time getTime(int columnIndex) throws SFException
-  {
+  public Time getTime(int columnIndex) throws SFException {
     logger.debug("public Time getTime(int columnIndex)");
 
     int columnType = resultSetMetaData.getColumnType(columnIndex);
-    if (Types.TIME == columnType)
-    {
+    if (Types.TIME == columnType) {
       SFTime sfTime = getSFTime(columnIndex);
-      if (sfTime == null)
-      {
+      if (sfTime == null) {
         return null;
       }
       return new Time(sfTime.getFractionalSeconds(3));
-    }
-    else if (Types.TIMESTAMP == columnType)
-    {
+    } else if (Types.TIMESTAMP == columnType) {
       return new Time(getTimestamp(columnIndex).getTime());
-    }
-    else
-    {
-      throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, columnType, "Time",
-          getObjectInternal(columnIndex));
+    } else {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, columnType, "Time", getObjectInternal(columnIndex));
     }
   }
 
-  private SFTime getSFTime(int columnIndex) throws SFException
-  {
+  private SFTime getSFTime(int columnIndex) throws SFException {
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
     int scale = resultSetMetaData.getScale(columnIndex);
     return ResultUtil.getSFTime(obj.toString(), scale, session);
   }
 
-  private Timestamp getTimestamp(int columnIndex) throws SFException
-  {
+  private Timestamp getTimestamp(int columnIndex) throws SFException {
     return getTimestamp(columnIndex, TimeZone.getDefault());
   }
 
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz)
-      throws SFException
-  {
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SFException {
     int columnType = resultSetMetaData.getColumnType(columnIndex);
-    if (Types.TIMESTAMP == columnType)
-    {
+    if (Types.TIMESTAMP == columnType) {
       SFTimestamp sfTS = getSFTimestamp(columnIndex);
 
-      if (sfTS == null)
-      {
+      if (sfTS == null) {
         return null;
       }
 
       Timestamp res = sfTS.getTimestamp();
 
-      if (res == null)
-      {
+      if (res == null) {
         return null;
       }
       // SNOW-14777: for timestamp_ntz, we should treat the time as in client time
       // zone so adjust the timestamp by subtracting the offset of the client
       // timezone
-      if (honorClientTZForTimestampNTZ &&
-          resultSetMetaData.getInternalColumnType(columnIndex) == Types.TIMESTAMP)
-      {
+      if (honorClientTZForTimestampNTZ
+          && resultSetMetaData.getInternalColumnType(columnIndex) == Types.TIMESTAMP) {
         res = sfTS.moveToTimeZone(tz).getTimestamp();
       }
 
       Timestamp adjustedTimestamp = ResultUtil.adjustTimestamp(res);
 
       return adjustedTimestamp;
-    }
-    else if (Types.DATE == columnType)
-    {
+    } else if (Types.DATE == columnType) {
       return new Timestamp(getDate(columnIndex, tz).getTime());
-    }
-    else if (Types.TIME == columnType)
-    {
+    } else if (Types.TIME == columnType) {
       return new Timestamp(getTime(columnIndex).getTime());
-    }
-    else
-    {
-      throw new SFException(ErrorCode.INVALID_VALUE_CONVERT, columnType, "Timestamp",
-          getObjectInternal(columnIndex));
+    } else {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_CONVERT, columnType, "Timestamp", getObjectInternal(columnIndex));
     }
   }
 
-  private SFTimestamp getSFTimestamp(int columnIndex) throws SFException
-  {
-    logger.debug(
-               "public Timestamp getTimestamp(int columnIndex)");
+  private SFTimestamp getSFTimestamp(int columnIndex) throws SFException {
+    logger.debug("public Timestamp getTimestamp(int columnIndex)");
 
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
     return ResultUtil.getSFTimestamp(
         obj.toString(),
         resultSetMetaData.getScale(columnIndex),
         resultSetMetaData.getInternalColumnType(columnIndex),
-        resultVersion, timeZone, session);
+        resultVersion,
+        timeZone,
+        session);
   }
 
-  public SFResultSetMetaData getMetaData() throws SFException
-  {
+  public SFResultSetMetaData getMetaData() throws SFException {
     logger.debug("public ResultSetMetaData getMetaData()");
 
     return resultSetMetaData;
@@ -533,19 +430,15 @@ public abstract class SFBaseResultSet
 
   protected abstract Object getObjectInternal(int columnIndex) throws SFException;
 
-  public Object getObject(int columnIndex) throws SFException
-  {
-    logger.debug(
-               "public Object getObject(int columnIndex)");
+  public Object getObject(int columnIndex) throws SFException {
+    logger.debug("public Object getObject(int columnIndex)");
 
     int type = resultSetMetaData.getColumnType(columnIndex);
 
     Object obj = getObjectInternal(columnIndex);
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
-    switch(type)
-    {
+    switch (type) {
       case Types.VARCHAR:
       case Types.CHAR:
         return getString(columnIndex);
@@ -578,38 +471,28 @@ public abstract class SFBaseResultSet
         return getBoolean(columnIndex);
 
       default:
-        throw IncidentUtil.
-            generateIncidentWithException(session, null, null,
-                                          ErrorCode.FEATURE_UNSUPPORTED,
-                                          "data type: " + type);
+        throw IncidentUtil.generateIncidentWithException(
+            session, null, null, ErrorCode.FEATURE_UNSUPPORTED, "data type: " + type);
     }
   }
 
-  public BigDecimal getBigDecimal(int columnIndex) throws SFException
-  {
-    logger.debug(
-               "public BigDecimal getBigDecimal(int columnIndex)");
-
+  public BigDecimal getBigDecimal(int columnIndex) throws SFException {
+    logger.debug("public BigDecimal getBigDecimal(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
     return new BigDecimal(obj.toString());
   }
 
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SFException
-  {
-    logger.debug(
-        "public BigDecimal getBigDecimal(int columnIndex)");
-
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SFException {
+    logger.debug("public BigDecimal getBigDecimal(int columnIndex)");
 
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
     BigDecimal value = new BigDecimal(obj.toString());
 
@@ -618,51 +501,41 @@ public abstract class SFBaseResultSet
     return value;
   }
 
-  public int getRow() throws SQLException
-  {
+  public int getRow() throws SQLException {
     logger.debug("public int getRow()");
 
     return row;
   }
 
-  public boolean absolute(int row) throws SFException
-  {
+  public boolean absolute(int row) throws SFException {
     logger.debug("public boolean absolute(int row)");
 
-    throw new SFException(
-            ErrorCode.FEATURE_UNSUPPORTED, "seek to a specific row");
+    throw new SFException(ErrorCode.FEATURE_UNSUPPORTED, "seek to a specific row");
   }
 
-  public boolean relative(int rows) throws SFException
-  {
+  public boolean relative(int rows) throws SFException {
     logger.debug("public boolean relative(int rows)");
 
-    throw new SFException(
-            ErrorCode.FEATURE_UNSUPPORTED, "seek to a row relative to current row");
+    throw new SFException(ErrorCode.FEATURE_UNSUPPORTED, "seek to a row relative to current row");
   }
 
-  public boolean previous() throws SFException
-  {
+  public boolean previous() throws SFException {
     logger.debug("public boolean previous()");
 
-    throw new SFException(
-            ErrorCode.FEATURE_UNSUPPORTED, "seek to a previous row");
+    throw new SFException(ErrorCode.FEATURE_UNSUPPORTED, "seek to a previous row");
   }
 
-  protected int getNumberOfBinds()
-  {
+  protected int getNumberOfBinds() {
     return numberOfBinds;
   }
 
-  public boolean isFirst()
-  {
+  public boolean isFirst() {
     logger.debug("public boolean isFirst()");
 
     return row == 1;
   }
 
-  public boolean isBeforeFirst()
-  {
+  public boolean isBeforeFirst() {
     return row == 0;
   }
 
@@ -670,18 +543,15 @@ public abstract class SFBaseResultSet
 
   // this is useful to override the initial statement type if it is incorrect
   // (e.g. result scan yields a query type, but the results are from a DML statement)
-  public abstract void setStatementType(SFStatementType statementType) throws
-      SQLException;
+  public abstract void setStatementType(SFStatementType statementType) throws SQLException;
 
   public abstract String getQueryId();
 
-  public boolean isClosed()
-  {
+  public boolean isClosed() {
     return isClosed;
   }
 
-  public boolean isArrayBindSupported()
-  {
+  public boolean isArrayBindSupported() {
     return false;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFChildResult.java
+++ b/src/main/java/net/snowflake/client/core/SFChildResult.java
@@ -1,28 +1,22 @@
 package net.snowflake.client.core;
 
-/**
- * Data class to wrap information about child job results
- */
-public class SFChildResult
-{
+/** Data class to wrap information about child job results */
+public class SFChildResult {
   // query id of child query, to look up child result
   String id;
   // statement type of child query, to properly interpret result
   SFStatementType type;
 
-  public SFChildResult(String id, SFStatementType type)
-  {
+  public SFChildResult(String id, SFStatementType type) {
     this.id = id;
     this.type = type;
   }
 
-  String getId()
-  {
+  String getId() {
     return id;
   }
 
-  SFStatementType getType()
-  {
+  SFStatementType getType() {
     return type;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFException.java
+++ b/src/main/java/net/snowflake/client/core/SFException.java
@@ -5,15 +5,12 @@
 package net.snowflake.client.core;
 
 import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.common.core.ResourceBundleManager;
-
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
-/**
- * Created by jhuang on 1/5/16.
- */
-public class SFException extends Throwable
-{
+import net.snowflake.common.core.ResourceBundleManager;
+
+/** Created by jhuang on 1/5/16. */
+public class SFException extends Throwable {
   static final SFLogger logger = SFLoggerFactory.getLogger(SFException.class);
 
   static final ResourceBundleManager errorResourceBundleManager =
@@ -25,11 +22,10 @@ public class SFException extends Throwable
   private int vendorCode;
   private Object[] params;
 
-  public SFException(ErrorCode errorCode,
-                     Object... params)
-  {
-    super(errorResourceBundleManager.getLocalizedMessage(
-        String.valueOf(errorCode.getMessageCode()), params));
+  public SFException(ErrorCode errorCode, Object... params) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(
+            String.valueOf(errorCode.getMessageCode()), params));
 
     this.cause = null;
     this.queryId = null;
@@ -38,12 +34,11 @@ public class SFException extends Throwable
     this.params = params;
   }
 
-  public SFException(Throwable cause,
-                     ErrorCode errorCode,
-                     Object... params)
-  {
-    super(errorResourceBundleManager.getLocalizedMessage(
-        String.valueOf(errorCode.getMessageCode()), params), cause);
+  public SFException(Throwable cause, ErrorCode errorCode, Object... params) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(
+            String.valueOf(errorCode.getMessageCode()), params),
+        cause);
 
     this.cause = null;
     this.queryId = null;
@@ -52,36 +47,30 @@ public class SFException extends Throwable
     this.params = params;
   }
 
-  public Throwable getCause()
-  {
+  public Throwable getCause() {
     return cause;
   }
 
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return queryId;
   }
 
-  public String getSqlState()
-  {
+  public String getSqlState() {
     return sqlState;
   }
 
-  public int getVendorCode()
-  {
+  public int getVendorCode() {
     return vendorCode;
   }
 
-  public Object[] getParams()
-  {
+  public Object[] getParams() {
     return params;
   }
 
   @Override
-  public String toString()
-  {
-    return super.toString() +
-        (getQueryId() != null ? ", query id = " + getQueryId() : "") +
-        (getSqlState() != null ? ", sql state = " + getSqlState() : "");
+  public String toString() {
+    return super.toString()
+        + (getQueryId() != null ? ", query id = " + getQueryId() : "")
+        + (getSqlState() != null ? ", sql state = " + getSqlState() : "");
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
@@ -4,59 +4,53 @@
 
 package net.snowflake.client.core;
 
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.List;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeFileTransferAgent.CommandType;
 import net.snowflake.client.jdbc.SnowflakeFixedView;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.common.core.SqlState;
-
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.util.List;
-
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SqlState;
 
 /**
- * Fixed view result set. This class iterates through any fixed view
- * implementation and return the objects as rows
+ * Fixed view result set. This class iterates through any fixed view implementation and return the
+ * objects as rows
  *
  * @author jhuang
  */
-public class SFFixedViewResultSet extends SFBaseResultSet
-{
+public class SFFixedViewResultSet extends SFBaseResultSet {
 
-  static final SFLogger logger = SFLoggerFactory.getLogger(
-      SFFixedViewResultSet.class);
+  static final SFLogger logger = SFLoggerFactory.getLogger(SFFixedViewResultSet.class);
 
   private SnowflakeFixedView fixedView;
   private Object[] nextRow = null;
   private final CommandType commandType;
 
-  public SFFixedViewResultSet(SnowflakeFixedView fixedView,
-                              CommandType commandType)
-          throws SnowflakeSQLException
-  {
+  public SFFixedViewResultSet(SnowflakeFixedView fixedView, CommandType commandType)
+      throws SnowflakeSQLException {
     this.fixedView = fixedView;
     this.commandType = commandType;
 
-    try
-    {
-      resultSetMetaData
-          = new SFResultSetMetaData(fixedView.describeColumns(), session,
-                                    timestampNTZFormatter,
-                                    timestampLTZFormatter,
-                                    timestampTZFormatter,
-                                    dateFormatter,
-                                    timeFormatter);
+    try {
+      resultSetMetaData =
+          new SFResultSetMetaData(
+              fixedView.describeColumns(),
+              session,
+              timestampNTZFormatter,
+              timestampLTZFormatter,
+              timestampTZFormatter,
+              dateFormatter,
+              timeFormatter);
 
-    }
-    catch (Exception ex)
-    {
-      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                      "Failed to describe fixed view: "
-                                      + fixedView.getClass().getName());
+    } catch (Exception ex) {
+      throw new SnowflakeSQLException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Failed to describe fixed view: " + fixedView.getClass().getName());
     }
   }
 
@@ -67,34 +61,31 @@ public class SFFixedViewResultSet extends SFBaseResultSet
    * @throws net.snowflake.client.core.SFException if failed to get next row
    */
   @Override
-  public boolean next() throws SFException
-  {
+  public boolean next() throws SFException {
     logger.debug("next called");
 
     List<Object> nextRowList;
-    try
-    {
+    try {
       // call the fixed view next row method
       nextRowList = fixedView.getNextRow();
-    }
-    catch (Exception ex)
-    {
-      throw IncidentUtil.
-          generateIncidentWithException(session, null, null,
-                                        ex, ErrorCode.INTERNAL_ERROR,
-                                        "Error getting next row from fixed view");
+    } catch (Exception ex) {
+      throw IncidentUtil.generateIncidentWithException(
+          session,
+          null,
+          null,
+          ex,
+          ErrorCode.INTERNAL_ERROR,
+          "Error getting next row from fixed view");
     }
 
     row++;
 
-    if (nextRowList == null)
-    {
+    if (nextRowList == null) {
       logger.debug("end of result");
       return false;
     }
 
-    if (nextRow == null)
-    {
+    if (nextRow == null) {
       nextRow = new Object[nextRowList.size()];
     }
     nextRow = nextRowList.toArray(nextRow);
@@ -103,20 +94,15 @@ public class SFFixedViewResultSet extends SFBaseResultSet
   }
 
   @Override
-  protected Object getObjectInternal(int columnIndex) throws SFException
-  {
-    logger.debug(
-               "public Object getObjectInternal(int columnIndex)");
+  protected Object getObjectInternal(int columnIndex) throws SFException {
+    logger.debug("public Object getObjectInternal(int columnIndex)");
 
-    if (nextRow == null)
-    {
-      throw IncidentUtil.
-          generateIncidentWithException(session, null, null,
-                                        ErrorCode.ROW_DOES_NOT_EXIST);
+    if (nextRow == null) {
+      throw IncidentUtil.generateIncidentWithException(
+          session, null, null, ErrorCode.ROW_DOES_NOT_EXIST);
     }
 
-    if (columnIndex <= 0 || columnIndex > nextRow.length)
-    {
+    if (columnIndex <= 0 || columnIndex > nextRow.length) {
       throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
 
@@ -126,8 +112,7 @@ public class SFFixedViewResultSet extends SFBaseResultSet
   }
 
   @Override
-  public void close()
-  {
+  public void close() {
     super.close();
     // free the object so that they can be Garbage collected
     nextRow = null;
@@ -135,40 +120,31 @@ public class SFFixedViewResultSet extends SFBaseResultSet
   }
 
   @Override
-  public SFStatementType getStatementType()
-  {
-    if (this.commandType == CommandType.DOWNLOAD)
-    {
+  public SFStatementType getStatementType() {
+    if (this.commandType == CommandType.DOWNLOAD) {
       return SFStatementType.GET;
-    }
-    else
-    {
+    } else {
       return SFStatementType.PUT;
     }
   }
 
   @Override
-  public void setStatementType(SFStatementType statementType)
-      throws SQLException
-  {
+  public void setStatementType(SFStatementType statementType) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isLast()
-  {
-    return row  == fixedView.getTotalRows();
+  public boolean isLast() {
+    return row == fixedView.getTotalRows();
   }
 
   @Override
-  public boolean isAfterLast()
-  {
+  public boolean isAfterLast() {
     return row > fixedView.getTotalRows();
   }
 
   @Override
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return "";
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -4,33 +4,33 @@
 
 package net.snowflake.client.core;
 
+import static net.snowflake.client.core.StmtUtil.eventHandler;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.client.jdbc.telemetry.Telemetry;
-import net.snowflake.client.jdbc.telemetry.TelemetryData;
-import net.snowflake.client.jdbc.telemetry.TelemetryField;
-import net.snowflake.client.jdbc.telemetry.TelemetryUtil;
-import net.snowflake.common.core.SqlState;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Comparator;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeChunkDownloader;
 import net.snowflake.client.jdbc.SnowflakeResultChunk;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
-
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Comparator;
+import net.snowflake.client.jdbc.telemetry.Telemetry;
+import net.snowflake.client.jdbc.telemetry.TelemetryData;
+import net.snowflake.client.jdbc.telemetry.TelemetryField;
+import net.snowflake.client.jdbc.telemetry.TelemetryUtil;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
-
-import static net.snowflake.client.core.StmtUtil.eventHandler;
+import net.snowflake.common.core.SqlState;
 
 /**
  * Snowflake ResultSet implementation
+ *
  * <p>
+ *
  * @author jhuang
  */
-public class SFResultSet extends SFBaseResultSet
-{
+public class SFResultSet extends SFBaseResultSet {
   static final SFLogger logger = SFLoggerFactory.getLogger(SFResultSet.class);
 
   private int columnCount = 0;
@@ -68,12 +68,10 @@ public class SFResultSet extends SFBaseResultSet
 
   private Telemetry telemetryClient;
 
-
   /**
-   * Constructor takes a result from the API response that we get from
-   * executing a SQL statement.
+   * Constructor takes a result from the API response that we get from executing a SQL statement.
    *
-   * The constructor will initialize the ResultSetMetaData.
+   * <p>The constructor will initialize the ResultSetMetaData.
    *
    * @param result result data in JSON form
    * @param statement statement object
@@ -81,11 +79,8 @@ public class SFResultSet extends SFBaseResultSet
    * @throws SQLException exception raised from general SQL layers
    * @throws SFException exception raised from Snowflake components
    */
-  public SFResultSet(JsonNode result,
-                     SFStatement statement,
-                     boolean sortResult)
-      throws SQLException, SFException
-  {
+  public SFResultSet(JsonNode result, SFStatement statement, boolean sortResult)
+      throws SQLException, SFException {
     this.statement = statement;
     this.columnCount = 0;
     this.sortResult = sortResult;
@@ -95,13 +90,14 @@ public class SFResultSet extends SFBaseResultSet
     this.telemetryClient = session.getTelemetryClient();
 
     ResultUtil.ResultInput resultInput = new ResultUtil.ResultInput();
-    resultInput.setResultJSON(result)
+    resultInput
+        .setResultJSON(result)
         .setConnectionTimeout(session.getHttpClientConnectionTimeout())
         .setSocketTimeout(session.getHttpClientSocketTimeout())
         .setNetworkTimeoutInMilli(session.getNetworkTimeoutInMilli());
 
-    ResultUtil.ResultOutput resultOutput = ResultUtil
-        .processResult(resultInput, statement.getSession());
+    ResultUtil.ResultOutput resultOutput =
+        ResultUtil.processResult(resultInput, statement.getSession());
 
     this.queryId = resultOutput.getQueryId();
     this.statementType = resultOutput.getStatementType();
@@ -118,8 +114,7 @@ public class SFResultSet extends SFBaseResultSet
     this.dateFormatter = resultOutput.getDateFormatter();
     this.timeFormatter = resultOutput.getTimeFormatter();
     this.timeZone = resultOutput.getTimeZone();
-    this.honorClientTZForTimestampNTZ =
-        resultOutput.isHonorClientTZForTimestampNTZ();
+    this.honorClientTZForTimestampNTZ = resultOutput.isHonorClientTZForTimestampNTZ();
     this.binaryFormatter = resultOutput.getBinaryFormatter();
     this.resultVersion = resultOutput.getResultVersion();
     this.numberOfBinds = resultOutput.getNumberOfBinds();
@@ -135,56 +130,51 @@ public class SFResultSet extends SFBaseResultSet
     SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSession());
 
     // sort result set if needed
-    if (sortResult)
-    {
+    if (sortResult) {
       // we don't support sort result when there are offline chunks
-      if (chunkCount > 0)
-      {
-        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                        ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
+      if (chunkCount > 0) {
+        throw new SnowflakeSQLException(
+            SqlState.FEATURE_NOT_SUPPORTED,
+            ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
       }
 
       sortResultSet();
     }
 
     // if server gives a send time, log time it took to arrive
-    if (resultOutput.getSendResultTime() != 0)
-    {
+    if (resultOutput.getSendResultTime() != 0) {
       long timeConsumeFirstResult = this.firstChunkTime - resultOutput.getSendResultTime();
       logMetric(TelemetryField.TIME_CONSUME_FIRST_RESULT, timeConsumeFirstResult);
     }
 
-    eventHandler.triggerStateTransition(BasicEvent.QueryState.CONSUMING_RESULT,
+    eventHandler.triggerStateTransition(
+        BasicEvent.QueryState.CONSUMING_RESULT,
         String.format(QueryState.CONSUMING_RESULT.getArgString(), queryId, 0));
 
-    resultSetMetaData = new SFResultSetMetaData(resultOutput.getResultColumnMetadata(),
-                                                queryId,
-                                                session,
-                                                this.timestampNTZFormatter,
-                                                this.timestampLTZFormatter,
-                                                this.timestampTZFormatter,
-                                                this.dateFormatter,
-                                                this.timeFormatter);
+    resultSetMetaData =
+        new SFResultSetMetaData(
+            resultOutput.getResultColumnMetadata(),
+            queryId,
+            session,
+            this.timestampNTZFormatter,
+            this.timestampLTZFormatter,
+            this.timestampTZFormatter,
+            this.dateFormatter,
+            this.timeFormatter);
   }
 
-  private boolean fetchNextRow() throws SFException, SnowflakeSQLException
-  {
-    if (sortResult)
-    {
+  private boolean fetchNextRow() throws SFException, SnowflakeSQLException {
+    if (sortResult) {
       return fetchNextRowSorted();
-    }
-    else
-    {
+    } else {
       return fetchNextRowUnsorted();
     }
   }
 
-  private boolean fetchNextRowSorted()
-  {
+  private boolean fetchNextRowSorted() {
     currentChunkRowIndex++;
 
-    if (currentChunkRowIndex < currentChunkRowCount)
-    {
+    if (currentChunkRowIndex < currentChunkRowCount) {
       return true;
     }
 
@@ -195,29 +185,23 @@ public class SFResultSet extends SFBaseResultSet
     return false;
   }
 
-  private boolean fetchNextRowUnsorted() throws SFException, SnowflakeSQLException
-  {
+  private boolean fetchNextRowUnsorted() throws SFException, SnowflakeSQLException {
     logger.debug("Entering fetchJSONNextRow");
 
     currentChunkRowIndex++;
 
-    if (currentChunkRowIndex < currentChunkRowCount)
-    {
+    if (currentChunkRowIndex < currentChunkRowCount) {
       return true;
     }
 
     // let GC collect first rowset
     firstChunkRowset = null;
 
-    if (nextChunkIndex < chunkCount)
-    {
-      try
-      {
+    if (nextChunkIndex < chunkCount) {
+      try {
         eventHandler.triggerStateTransition(
             BasicEvent.QueryState.CONSUMING_RESULT,
-            String.format(QueryState.CONSUMING_RESULT.getArgString(),
-                          queryId,
-                          nextChunkIndex));
+            String.format(QueryState.CONSUMING_RESULT.getArgString(), queryId, nextChunkIndex));
 
         SnowflakeResultChunk nextChunk = chunkDownloader.getNextChunkToConsume();
 
@@ -231,20 +215,17 @@ public class SFResultSet extends SFBaseResultSet
         currentChunkRowCount = nextChunk.getRowCount();
         currentChunk = nextChunk;
 
-        logger.debug("Moving to chunk index {}, row count={}",
-                   nextChunkIndex, currentChunkRowCount);
+        logger.debug(
+            "Moving to chunk index {}, row count={}", nextChunkIndex, currentChunkRowCount);
 
         nextChunkIndex++;
 
         return true;
-      } catch (InterruptedException ex)
-      {
-        throw new SnowflakeSQLException(SqlState.QUERY_CANCELED,
-                                        ErrorCode.INTERRUPTED.getMessageCode());
+      } catch (InterruptedException ex) {
+        throw new SnowflakeSQLException(
+            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
       }
-    }
-    else if (chunkCount > 0)
-    {
+    } else if (chunkCount > 0) {
       logger.debug("End of chunks");
       SnowflakeChunkDownloader.Metrics metrics = chunkDownloader.terminate();
       logChunkDownloaderMetrics(metrics);
@@ -253,16 +234,13 @@ public class SFResultSet extends SFBaseResultSet
     return false;
   }
 
-  private void logMetric(TelemetryField field, long value)
-  {
+  private void logMetric(TelemetryField field, long value) {
     TelemetryData data = TelemetryUtil.buildJobData(this.queryId, field, value);
     this.telemetryClient.tryAddLogToBatch(data);
   }
 
-  private void logChunkDownloaderMetrics(SnowflakeChunkDownloader.Metrics metrics)
-  {
-    if (metrics != null)
-    {
+  private void logChunkDownloaderMetrics(SnowflakeChunkDownloader.Metrics metrics) {
+    if (metrics != null) {
       logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS, metrics.millisWaiting);
       logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS, metrics.millisDownloading);
       logMetric(TelemetryField.TIME_PARSING_CHUNKS, metrics.millisParsing);
@@ -275,39 +253,31 @@ public class SFResultSet extends SFBaseResultSet
    * @return true if next row exists, false otherwise
    */
   @Override
-  public boolean next() throws SFException, SnowflakeSQLException
-  {
-    if (isClosed())
-    {
+  public boolean next() throws SFException, SnowflakeSQLException {
+    if (isClosed()) {
       throw new SFException(ErrorCode.RESULTSET_ALREADY_CLOSED);
     }
 
     // otherwise try to fetch again
-    if (fetchNextRow())
-    {
+    if (fetchNextRow()) {
       row++;
-      if (isLast())
-      {
+      if (isLast()) {
         long timeConsumeLastResult = System.currentTimeMillis() - this.firstChunkTime;
         logMetric(TelemetryField.TIME_CONSUME_LAST_RESULT, timeConsumeLastResult);
       }
       return true;
-    }
-    else
-    {
+    } else {
       logger.debug("end of result");
 
       /*
        * Here we check if the result has been truncated and throw exception if
        * so.
        */
-      if (totalRowCountTruncated ||
-          System.getProperty("snowflake.enable_incident_test2") != null &&
-          System.getProperty("snowflake.enable_incident_test2").equals("true"))
-      {
-        throw IncidentUtil.
-            generateIncidentWithException(session, null, queryId,
-                                          ErrorCode.MAX_RESULT_LIMIT_EXCEEDED);
+      if (totalRowCountTruncated
+          || System.getProperty("snowflake.enable_incident_test2") != null
+              && System.getProperty("snowflake.enable_incident_test2").equals("true")) {
+        throw IncidentUtil.generateIncidentWithException(
+            session, null, queryId, ErrorCode.MAX_RESULT_LIMIT_EXCEEDED);
       }
 
       // mark end of result
@@ -316,116 +286,91 @@ public class SFResultSet extends SFBaseResultSet
   }
 
   @Override
-  protected Object getObjectInternal(int columnIndex) throws SFException
-  {
+  protected Object getObjectInternal(int columnIndex) throws SFException {
     logger.debug("getObjectInternal: {}", columnIndex);
-    if (columnIndex <= 0 || columnIndex > resultSetMetaData.getColumnCount())
-    {
+    if (columnIndex <= 0 || columnIndex > resultSetMetaData.getColumnCount()) {
       throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
 
     final int internalColumnIndex = columnIndex - 1;
     Object retValue = null;
-    if (sortResult)
-    {
-      retValue = firstChunkSortedRowSet[
-              currentChunkRowIndex][internalColumnIndex];
-    }
-    else if (firstChunkRowset != null)
-    {
-      retValue = SnowflakeResultChunk.extractCell(firstChunkRowset,
-              currentChunkRowIndex,
-              internalColumnIndex);
-    }
-    else
-    {
+    if (sortResult) {
+      retValue = firstChunkSortedRowSet[currentChunkRowIndex][internalColumnIndex];
+    } else if (firstChunkRowset != null) {
+      retValue =
+          SnowflakeResultChunk.extractCell(
+              firstChunkRowset, currentChunkRowIndex, internalColumnIndex);
+    } else {
       retValue = currentChunk.getCell(currentChunkRowIndex, internalColumnIndex);
     }
     wasNull = retValue == null;
     return retValue;
   }
 
-  private void sortResultSet() throws SnowflakeSQLException, SFException
-  {
+  private void sortResultSet() throws SnowflakeSQLException, SFException {
     // first fetch rows into firstChunkSortedRowSet
     firstChunkSortedRowSet = new Object[currentChunkRowCount][];
 
-    for (int rowIdx = 0; rowIdx < currentChunkRowCount; rowIdx++)
-    {
+    for (int rowIdx = 0; rowIdx < currentChunkRowCount; rowIdx++) {
       firstChunkSortedRowSet[rowIdx] = new Object[columnCount];
-      for (int colIdx = 0; colIdx < columnCount; colIdx++)
-      {
+      for (int colIdx = 0; colIdx < columnCount; colIdx++) {
         firstChunkSortedRowSet[rowIdx][colIdx] =
-            SnowflakeResultChunk.extractCell(firstChunkRowset,
-                                             rowIdx, colIdx);
+            SnowflakeResultChunk.extractCell(firstChunkRowset, rowIdx, colIdx);
       }
     }
 
     // now sort it
-    Arrays.sort(firstChunkSortedRowSet,
-                new Comparator<Object[]>()
-                {
-                  public int compare(Object[] a, Object[] b)
-                  {
-                    int numCols = a.length;
+    Arrays.sort(
+        firstChunkSortedRowSet,
+        new Comparator<Object[]>() {
+          public int compare(Object[] a, Object[] b) {
+            int numCols = a.length;
 
-                    for (int colIdx = 0; colIdx < numCols; colIdx++)
-                    {
-                      if (a[colIdx] == null && b[colIdx] == null)
-                      {
-                        continue;
-                      }
+            for (int colIdx = 0; colIdx < numCols; colIdx++) {
+              if (a[colIdx] == null && b[colIdx] == null) {
+                continue;
+              }
 
-                      // null is considered bigger than all values
-                      if (a[colIdx] == null)
-                      {
-                        return 1;
-                      }
+              // null is considered bigger than all values
+              if (a[colIdx] == null) {
+                return 1;
+              }
 
-                      if (b[colIdx] == null)
-                      {
-                        return -1;
-                      }
+              if (b[colIdx] == null) {
+                return -1;
+              }
 
-                      int res
-                          = a[colIdx].toString().compareTo(b[colIdx].toString());
+              int res = a[colIdx].toString().compareTo(b[colIdx].toString());
 
-                      // continue to next column if no difference
-                      if (res == 0)
-                      {
-                        continue;
-                      }
+              // continue to next column if no difference
+              if (res == 0) {
+                continue;
+              }
 
-                      return res;
-                    }
+              return res;
+            }
 
-                    // all columns are the same
-                    return 0;
-                  }
-                });
+            // all columns are the same
+            return 0;
+          }
+        });
   }
 
   @Override
-  public boolean isLast()
-  {
-    return nextChunkIndex == chunkCount &&
-        currentChunkRowIndex + 1 == currentChunkRowCount;
+  public boolean isLast() {
+    return nextChunkIndex == chunkCount && currentChunkRowIndex + 1 == currentChunkRowCount;
   }
 
   @Override
-  public boolean isAfterLast()
-  {
-    return nextChunkIndex == chunkCount &&
-        currentChunkRowIndex >= currentChunkRowCount;
+  public boolean isAfterLast() {
+    return nextChunkIndex == chunkCount && currentChunkRowIndex >= currentChunkRowCount;
   }
 
   @Override
-  public void close()
-  {
+  public void close() {
     super.close();
 
-    if (chunkDownloader != null)
-    {
+    if (chunkDownloader != null) {
       SnowflakeChunkDownloader.Metrics metrics = chunkDownloader.terminate();
       logChunkDownloaderMetrics(metrics);
       firstChunkSortedRowSet = null;
@@ -435,26 +380,22 @@ public class SFResultSet extends SFBaseResultSet
   }
 
   @Override
-  public SFStatementType getStatementType()
-  {
+  public SFStatementType getStatementType() {
     return statementType;
   }
 
   @Override
-  public void setStatementType(SFStatementType statementType)
-  {
+  public void setStatementType(SFStatementType statementType) {
     this.statementType = statementType;
   }
 
   @Override
-  public boolean isArrayBindSupported()
-  {
+  public boolean isArrayBindSupported() {
     return this.arrayBindSupported;
   }
 
   @Override
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return queryId;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
@@ -4,13 +4,6 @@
 
 package net.snowflake.client.core;
 
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeColumnMetadata;
-import net.snowflake.client.jdbc.SnowflakeUtil;
-import net.snowflake.common.core.SFTime;
-import net.snowflake.common.core.SFTimestamp;
-import net.snowflake.common.core.SnowflakeDateTimeFormat;
-
 import java.sql.Date;
 import java.sql.ResultSetMetaData;
 import java.sql.Types;
@@ -19,18 +12,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SnowflakeColumnMetadata;
+import net.snowflake.client.jdbc.SnowflakeUtil;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SFTime;
+import net.snowflake.common.core.SFTimestamp;
+import net.snowflake.common.core.SnowflakeDateTimeFormat;
 
 /**
  * Snowflake ResultSetMetaData
  *
  * @author jhuang
  */
-public class SFResultSetMetaData
-{
-  static final SFLogger logger =
-      SFLoggerFactory.getLogger(SFResultSetMetaData.class);
+public class SFResultSetMetaData {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SFResultSetMetaData.class);
 
   private int columnCount = 0;
 
@@ -86,12 +83,12 @@ public class SFResultSetMetaData
 
   private int dateStringLength = 10;
 
-  public SFResultSetMetaData(int columnCount,
-                             List<String> columnNames,
-                             List<String> columnTypeNames,
-                             List<Integer> columnTypes,
-                             SFSession session)
-  {
+  public SFResultSetMetaData(
+      int columnCount,
+      List<String> columnNames,
+      List<String> columnTypeNames,
+      List<Integer> columnTypes,
+      SFSession session) {
     this.columnCount = columnCount;
     this.columnNames = columnNames;
     this.columnTypeNames = columnTypeNames;
@@ -99,31 +96,34 @@ public class SFResultSetMetaData
     this.session = session;
   }
 
-  public SFResultSetMetaData(List<SnowflakeColumnMetadata> columnMetadata,
-                             SFSession session,
-                             SnowflakeDateTimeFormat timestampNTZFormatter,
-                             SnowflakeDateTimeFormat timestampLTZFormatter,
-                             SnowflakeDateTimeFormat timestampTZFormatter,
-                             SnowflakeDateTimeFormat dateFormatter,
-                             SnowflakeDateTimeFormat timeFormatter)
-  {
-    this(columnMetadata, "none", session, timestampNTZFormatter,
-          timestampLTZFormatter,
-          timestampTZFormatter,
-          dateFormatter,
-          timeFormatter);
+  public SFResultSetMetaData(
+      List<SnowflakeColumnMetadata> columnMetadata,
+      SFSession session,
+      SnowflakeDateTimeFormat timestampNTZFormatter,
+      SnowflakeDateTimeFormat timestampLTZFormatter,
+      SnowflakeDateTimeFormat timestampTZFormatter,
+      SnowflakeDateTimeFormat dateFormatter,
+      SnowflakeDateTimeFormat timeFormatter) {
+    this(
+        columnMetadata,
+        "none",
+        session,
+        timestampNTZFormatter,
+        timestampLTZFormatter,
+        timestampTZFormatter,
+        dateFormatter,
+        timeFormatter);
   }
 
-  public SFResultSetMetaData(List<SnowflakeColumnMetadata> columnMetadata,
-                             String queryId,
-                             SFSession session,
-                             SnowflakeDateTimeFormat timestampNTZFormatter,
-                             SnowflakeDateTimeFormat timestampLTZFormatter,
-                             SnowflakeDateTimeFormat timestampTZFormatter,
-                             SnowflakeDateTimeFormat dateFormatter,
-                             SnowflakeDateTimeFormat timeFormatter
-                             )
-  {
+  public SFResultSetMetaData(
+      List<SnowflakeColumnMetadata> columnMetadata,
+      String queryId,
+      SFSession session,
+      SnowflakeDateTimeFormat timestampNTZFormatter,
+      SnowflakeDateTimeFormat timestampLTZFormatter,
+      SnowflakeDateTimeFormat timestampTZFormatter,
+      SnowflakeDateTimeFormat dateFormatter,
+      SnowflakeDateTimeFormat timeFormatter) {
     this.columnCount = columnMetadata.size();
     this.queryId = queryId;
     this.timestampNTZFormatter = timestampNTZFormatter;
@@ -144,15 +144,16 @@ public class SFResultSetMetaData
     this.columnSrcTables = new ArrayList<String>(this.columnCount);
     this.columnDisplaySizes = new ArrayList<Integer>(this.columnCount);
 
-    for(int colIdx = 0; colIdx < columnCount; colIdx ++)
-    {
+    for (int colIdx = 0; colIdx < columnCount; colIdx++) {
       columnNames.add(columnMetadata.get(colIdx).getName());
       columnTypeNames.add(columnMetadata.get(colIdx).getTypeName());
       precisions.add(calculatePrecision(columnMetadata.get(colIdx)));
       columnTypes.add(columnMetadata.get(colIdx).getType());
       scales.add(columnMetadata.get(colIdx).getScale());
-      nullables.add(columnMetadata.get(colIdx).isNullable() ?
-        ResultSetMetaData.columnNullable : ResultSetMetaData.columnNoNulls);
+      nullables.add(
+          columnMetadata.get(colIdx).isNullable()
+              ? ResultSetMetaData.columnNullable
+              : ResultSetMetaData.columnNoNulls);
       columnSrcDatabases.add(columnMetadata.get(colIdx).getColumnSrcDatabase());
       columnSrcSchemas.add(columnMetadata.get(colIdx).getColumnSrcSchema());
       columnSrcTables.add(columnMetadata.get(colIdx).getColumnSrcTable());
@@ -162,11 +163,9 @@ public class SFResultSetMetaData
     this.session = session;
   }
 
-  private Integer calculatePrecision(SnowflakeColumnMetadata columnMetadata)
-  {
+  private Integer calculatePrecision(SnowflakeColumnMetadata columnMetadata) {
     int columnType = columnMetadata.getType();
-    switch(columnType)
-    {
+    switch (columnType) {
       case Types.CHAR:
       case Types.VARCHAR:
       case Types.BINARY:
@@ -185,18 +184,16 @@ public class SFResultSetMetaData
         return timestampTZStringLength;
       case Types.TIMESTAMP:
         return timestampNTZStringLength;
-      // for double and boolean
-      // Precision is not applicable hence return 0
+        // for double and boolean
+        // Precision is not applicable hence return 0
       default:
         return 0;
     }
   }
 
-  private Integer calculateDisplaySize(SnowflakeColumnMetadata columnMetadata)
-  {
+  private Integer calculateDisplaySize(SnowflakeColumnMetadata columnMetadata) {
     int columnType = columnMetadata.getType();
-    switch(columnType)
-    {
+    switch (columnType) {
       case Types.CHAR:
       case Types.VARCHAR:
       case Types.BINARY:
@@ -234,84 +231,97 @@ public class SFResultSetMetaData
     }
   }
 
-  private void calculateDateTimeStringLength()
-  {
-    SFTimestamp ts = SFTimestamp.fromMilliseconds(System.currentTimeMillis(), TimeZone.getDefault());
-    try
-    {
-      if (timestampNTZFormatter != null)
-      {
-        String tsNTZStr = ResultUtil.getSFTimestampAsString(ts, Types.TIMESTAMP, 9, timestampNTZFormatter,
-            timestampLTZFormatter, timestampTZFormatter, session);
+  private void calculateDateTimeStringLength() {
+    SFTimestamp ts =
+        SFTimestamp.fromMilliseconds(System.currentTimeMillis(), TimeZone.getDefault());
+    try {
+      if (timestampNTZFormatter != null) {
+        String tsNTZStr =
+            ResultUtil.getSFTimestampAsString(
+                ts,
+                Types.TIMESTAMP,
+                9,
+                timestampNTZFormatter,
+                timestampLTZFormatter,
+                timestampTZFormatter,
+                session);
         timestampNTZStringLength = tsNTZStr.length();
       }
-      if (timestampLTZFormatter != null)
-      {
-        String tsLTZStr = ResultUtil.getSFTimestampAsString(ts, SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ, 9,
-            timestampNTZFormatter, timestampLTZFormatter, timestampTZFormatter, session);
+      if (timestampLTZFormatter != null) {
+        String tsLTZStr =
+            ResultUtil.getSFTimestampAsString(
+                ts,
+                SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ,
+                9,
+                timestampNTZFormatter,
+                timestampLTZFormatter,
+                timestampTZFormatter,
+                session);
         timestampLTZStringLength = tsLTZStr.length();
       }
-      if (timestampTZFormatter != null)
-      {
-        String tsTZStr = ResultUtil.getSFTimestampAsString(ts, SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ, 9,
-            timestampNTZFormatter, timestampLTZFormatter, timestampTZFormatter, session);
+      if (timestampTZFormatter != null) {
+        String tsTZStr =
+            ResultUtil.getSFTimestampAsString(
+                ts,
+                SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ,
+                9,
+                timestampNTZFormatter,
+                timestampLTZFormatter,
+                timestampTZFormatter,
+                session);
         timestampTZStringLength = tsTZStr.length();
       }
 
       SFTime time = SFTime.fromTimestamp(ts);
-      if (timeFormatter != null)
-      {
+      if (timeFormatter != null) {
         timeStringLength = ResultUtil.getSFTimeAsString(time, 9, timeFormatter).length();
       }
-      if (dateFormatter != null)
-      {
-        dateStringLength = ResultUtil.getDateAsString(new Date(2015, 11, 11), dateFormatter).length();
+      if (dateFormatter != null) {
+        dateStringLength =
+            ResultUtil.getDateAsString(new Date(2015, 11, 11), dateFormatter).length();
       }
-    } catch (SFException e)
-    {
+    } catch (SFException e) {
       logger.warn("Failed to calculate the display size. Use default one.");
     }
   }
 
   /**
    * get the query id
+   *
    * @return query id
    */
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return queryId;
   }
 
   /**
    * Get the list of column names
+   *
    * @return column names in list
    */
-  public List<String> getColumnNames()
-  {
+  public List<String> getColumnNames() {
     return columnNames;
   }
 
   /**
    * Get the index of the column by name
+   *
    * @param columnName column name
    * @return index of the column that names matches the column name
    */
-  public int getColumnIndex(String columnName)
-  {
+  public int getColumnIndex(String columnName) {
     boolean caseInsensitive = session != null && session.isResultColumnCaseInsensitive();
     columnName = caseInsensitive ? columnName.toUpperCase() : columnName;
-    Map<String, Integer> nameToIndexMap = caseInsensitive ?
-                    columnNameUpperCasePositionMap : columnNamePositionMap;
+    Map<String, Integer> nameToIndexMap =
+        caseInsensitive ? columnNameUpperCasePositionMap : columnNamePositionMap;
 
-    if (nameToIndexMap.get(columnName) != null)
-    {
+    if (nameToIndexMap.get(columnName) != null) {
       return nameToIndexMap.get(columnName);
-    }
-    else
-    {
-      int columnIndex = caseInsensitive ?
-          ResultUtil.listSearchCaseInsensitive(columnNames, columnName) :
-          columnNames.indexOf(columnName);
+    } else {
+      int columnIndex =
+          caseInsensitive
+              ? ResultUtil.listSearchCaseInsensitive(columnNames, columnName)
+              : columnNames.indexOf(columnName);
       nameToIndexMap.put(columnName, columnIndex);
       return columnIndex;
     }
@@ -322,159 +332,132 @@ public class SFResultSetMetaData
    *
    * @return column count
    */
-  public int getColumnCount()
-  {
+  public int getColumnCount() {
     logger.debug("public int getColumnCount()");
 
     return columnCount;
   }
 
-  public int getColumnType(int column) throws SFException
-  {
+  public int getColumnType(int column) throws SFException {
     logger.debug("public int getColumnType(int column)");
 
     int internalColumnType = getInternalColumnType(column);
 
     int externalColumnType = internalColumnType;
 
-    if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ ||
-        internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ)
+    if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ
+        || internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ)
       externalColumnType = Types.TIMESTAMP;
 
-      logger.debug("column type = {}", externalColumnType);
+    logger.debug("column type = {}", externalColumnType);
 
     return externalColumnType;
   }
 
-  public int getInternalColumnType(int column) throws SFException
-  {
+  public int getInternalColumnType(int column) throws SFException {
     logger.debug("public int getInternalColumnType(int column)");
 
-    int columnIdx = column-1;
-    if (column < 1 || column > columnTypes.size())
-    {
+    int columnIdx = column - 1;
+    if (column < 1 || column > columnTypes.size()) {
       throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, column);
     }
 
-    if(columnTypes.get(columnIdx) == null)
-    {
+    if (columnTypes.get(columnIdx) == null) {
       throw IncidentUtil.generateIncidentWithSignatureAndException(
-              session, null, queryId,
-              "Missing column type",
-              ErrorCode.INTERNAL_ERROR,
-              "Missing column type for column " + column);
+          session,
+          null,
+          queryId,
+          "Missing column type",
+          ErrorCode.INTERNAL_ERROR,
+          "Missing column type for column " + column);
     }
 
     return columnTypes.get(columnIdx);
   }
 
-  public String getColumnTypeName(int column) throws SFException
-  {
+  public String getColumnTypeName(int column) throws SFException {
     logger.debug("public String getColumnTypeName(int column)");
 
-    if (column < 1 || column > columnTypeNames.size())
-    {
+    if (column < 1 || column > columnTypeNames.size()) {
       throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, column);
     }
 
-    if(columnTypeNames == null || columnTypeNames.get(column-1) == null)
-    {
-      throw
-          IncidentUtil.generateIncidentWithSignatureAndException(
-                  session, null, queryId,
-                  "Missing column type",
-                  ErrorCode.INTERNAL_ERROR,
-                  "Missing column type for column " + column);
+    if (columnTypeNames == null || columnTypeNames.get(column - 1) == null) {
+      throw IncidentUtil.generateIncidentWithSignatureAndException(
+          session,
+          null,
+          queryId,
+          "Missing column type",
+          ErrorCode.INTERNAL_ERROR,
+          "Missing column type for column " + column);
     }
 
-    return columnTypeNames.get(column-1);
+    return columnTypeNames.get(column - 1);
   }
 
-  public int getScale(int column)
-  {
+  public int getScale(int column) {
     logger.debug("public int getScale(int column)");
 
-    if (scales != null && scales.size() >= column)
-    {
-      return scales.get(column-1);
-    }
-    else
-    {
+    if (scales != null && scales.size() >= column) {
+      return scales.get(column - 1);
+    } else {
       // TODO: fix this later to use different defaults for number or timestamp
       return 9;
     }
   }
 
-  public int getPrecision(int column)
-  {
+  public int getPrecision(int column) {
     logger.debug("public int getPrecision(int column)");
 
-    if (precisions != null && precisions.size() >= column)
-    {
-      return precisions.get(column-1);
-    }
-    else
-    {
+    if (precisions != null && precisions.size() >= column) {
+      return precisions.get(column - 1);
+    } else {
       // TODO: fix this later to use different defaults for number or timestamp
       return 9;
     }
   }
 
-  public boolean isSigned(int column)
-  {
+  public boolean isSigned(int column) {
     logger.debug("public boolean isSigned(int column)");
 
-    return (columnTypes.get(column-1) == Types.INTEGER ||
-        columnTypes.get(column-1) == Types.DECIMAL ||
-        columnTypes.get(column-1) == Types.BIGINT  ||
-        columnTypes.get(column-1) == Types.DOUBLE);
+    return (columnTypes.get(column - 1) == Types.INTEGER
+        || columnTypes.get(column - 1) == Types.DECIMAL
+        || columnTypes.get(column - 1) == Types.BIGINT
+        || columnTypes.get(column - 1) == Types.DOUBLE);
   }
 
-  public String getColumnLabel(int column)
-  {
+  public String getColumnLabel(int column) {
     logger.debug("public String getColumnLabel(int column)");
 
-    if(columnNames != null)
-      return columnNames.get(column-1);
-    else
-      return "C" + Integer.toString(column-1);
+    if (columnNames != null) return columnNames.get(column - 1);
+    else return "C" + Integer.toString(column - 1);
   }
 
-  public String getColumnName(int column)
-  {
+  public String getColumnName(int column) {
     logger.debug("public String getColumnName(int column)");
 
-    if(columnNames != null)
-      return columnNames.get(column-1);
-    else
-      return "C" + Integer.toString(column-1);
+    if (columnNames != null) return columnNames.get(column - 1);
+    else return "C" + Integer.toString(column - 1);
   }
 
-  public int isNullable(int column)
-  {
-    if (nullables != null)
-      return nullables.get(column-1);
-    else
-      return ResultSetMetaData.columnNullableUnknown;
+  public int isNullable(int column) {
+    if (nullables != null) return nullables.get(column - 1);
+    else return ResultSetMetaData.columnNullableUnknown;
   }
 
-  public String getCatalogName(int column)
-  {
-    return columnSrcDatabases.get(column-1);
+  public String getCatalogName(int column) {
+    return columnSrcDatabases.get(column - 1);
   }
 
-  public String getSchemaName(int column)
-  {
-    return columnSrcSchemas.get(column-1);
+  public String getSchemaName(int column) {
+    return columnSrcSchemas.get(column - 1);
   }
 
-  public String getTableName(int column)
-  {
-    return columnSrcTables.get(column-1);
+  public String getTableName(int column) {
+    return columnSrcTables.get(column - 1);
   }
 
-  public Integer getColumnDisplaySize(int column)
-  {
-    return columnDisplaySizes.get(column-1);
+  public Integer getColumnDisplaySize(int column) {
+    return columnDisplaySizes.get(column - 1);
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFSSLConnectionSocketFactory.java
+++ b/src/main/java/net/snowflake/client/core/SFSSLConnectionSocketFactory.java
@@ -4,49 +4,40 @@
 
 package net.snowflake.client.core;
 
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.protocol.HttpContext;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLServerSocketFactory;
-import javax.net.ssl.TrustManager;
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.Socket;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.TrustManager;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
 
-/**
- * Snowflake custom SSLConnectionSocketFactory
- */
-public class SFSSLConnectionSocketFactory extends SSLConnectionSocketFactory
-{
-  static final SFLogger logger = SFLoggerFactory.getLogger(
-      SFSSLConnectionSocketFactory.class);
+/** Snowflake custom SSLConnectionSocketFactory */
+public class SFSSLConnectionSocketFactory extends SSLConnectionSocketFactory {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SFSSLConnectionSocketFactory.class);
 
   private static final String SSL_VERSION = "TLSv1.2";
 
   private final boolean socksProxyDisabled;
 
-  public SFSSLConnectionSocketFactory(TrustManager[] trustManagers,
-                                      boolean socksProxyDisabled)
-      throws NoSuchAlgorithmException, KeyManagementException
-  {
+  public SFSSLConnectionSocketFactory(TrustManager[] trustManagers, boolean socksProxyDisabled)
+      throws NoSuchAlgorithmException, KeyManagementException {
     super(
         initSSLContext(trustManagers),
-        new String[]{SSL_VERSION},
+        new String[] {SSL_VERSION},
         decideCipherSuites(),
-        SSLConnectionSocketFactory.getDefaultHostnameVerifier()
-    );
+        SSLConnectionSocketFactory.getDefaultHostnameVerifier());
     this.socksProxyDisabled = socksProxyDisabled;
   }
 
   private static SSLContext initSSLContext(TrustManager[] trustManagers)
-      throws NoSuchAlgorithmException, KeyManagementException
-  {
+      throws NoSuchAlgorithmException, KeyManagementException {
     // enforce using SSL_VERSION
     SSLContext sslContext = SSLContext.getInstance(SSL_VERSION);
     sslContext.init(
@@ -57,10 +48,8 @@ public class SFSSLConnectionSocketFactory extends SSLConnectionSocketFactory
   }
 
   @Override
-  public Socket createSocket(HttpContext ctx) throws IOException
-  {
-    return socksProxyDisabled ? new Socket(Proxy.NO_PROXY)
-        : super.createSocket(ctx);
+  public Socket createSocket(HttpContext ctx) throws IOException {
+    return socksProxyDisabled ? new Socket(Proxy.NO_PROXY) : super.createSocket(ctx);
   }
 
   /**
@@ -68,23 +57,22 @@ public class SFSSLConnectionSocketFactory extends SSLConnectionSocketFactory
    *
    * @return List of cipher suites.
    */
-  private static String[] decideCipherSuites()
-  {
+  private static String[] decideCipherSuites() {
     String sysCipherSuites = System.getProperty("https.cipherSuites");
 
-    String[] cipherSuites =  sysCipherSuites != null ? sysCipherSuites.split(",") :
-        // use jdk default cipher suites
-        ((SSLServerSocketFactory) SSLServerSocketFactory.getDefault())
-            .getDefaultCipherSuites();
+    String[] cipherSuites =
+        sysCipherSuites != null
+            ? sysCipherSuites.split(",")
+            :
+            // use jdk default cipher suites
+            ((SSLServerSocketFactory) SSLServerSocketFactory.getDefault()).getDefaultCipherSuites();
 
     // cipher suites need to be picked up in code explicitly for jdk 1.7
     // https://stackoverflow.com/questions/44378970/
-    if (logger.isTraceEnabled())
-    {
+    if (logger.isTraceEnabled()) {
       logger.trace("Cipher suites used: {}", Arrays.toString(cipherSuites));
     }
 
     return cipherSuites;
   }
-
 }

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -4,20 +4,13 @@
 
 package net.snowflake.client.core;
 
-/**
- * Created by jhuang on 11/3/15.
- */
-
-import net.snowflake.client.jdbc.ErrorCode;
-
+/** Created by jhuang on 11/3/15. */
 import java.security.PrivateKey;
 import java.util.regex.Pattern;
+import net.snowflake.client.jdbc.ErrorCode;
 
-/**
- * session properties accepted for opening a new session.
- */
-public enum SFSessionProperty
-{
+/** session properties accepted for opening a new session. */
+public enum SFSessionProperty {
   SERVER_URL("serverURL", true, String.class),
   USER("user", false, String.class),
   PASSWORD("password", false, String.class),
@@ -61,112 +54,81 @@ public enum SFSessionProperty
   // application name matcher
   static Pattern APPLICATION_REGEX = Pattern.compile("^[A-Za-z][A-Za-z0-9\\.\\-_]{1,50}$");
 
-  public boolean isRequired()
-  {
+  public boolean isRequired() {
     return required;
   }
 
-  public String getPropertyKey()
-  {
+  public String getPropertyKey() {
     return propertyKey;
   }
 
-  public Class getValueType()
-  {
+  public Class getValueType() {
     return valueType;
   }
 
-  SFSessionProperty(String propertyKey,
-                    boolean required,
-                    Class valueType,
-                    String... aliases)
-  {
+  SFSessionProperty(String propertyKey, boolean required, Class valueType, String... aliases) {
     this.propertyKey = propertyKey;
     this.required = required;
     this.valueType = valueType;
     this.aliases = aliases;
   }
 
-  static SFSessionProperty lookupByKey(String propertyKey)
-  {
-    for (SFSessionProperty property : SFSessionProperty.values())
-    {
-      if (property.propertyKey.equalsIgnoreCase(propertyKey))
-      {
+  static SFSessionProperty lookupByKey(String propertyKey) {
+    for (SFSessionProperty property : SFSessionProperty.values()) {
+      if (property.propertyKey.equalsIgnoreCase(propertyKey)) {
         return property;
-      }
-      else
-      {
-        for(String alias : property.aliases)
-        {
-          if (alias.equalsIgnoreCase(propertyKey))
-          {
+      } else {
+        for (String alias : property.aliases) {
+          if (alias.equalsIgnoreCase(propertyKey)) {
             return property;
           }
         }
       }
     }
-    return  null;
+    return null;
   }
 
   /**
    * Check if property value is desired class. Convert if possible
+   *
    * @param property
    * @param propertyValue
    * @return
    * @throws SFException
    */
-  static Object checkPropertyValue(SFSessionProperty property,
-                                   Object propertyValue)
-      throws SFException
-  {
-    if (propertyValue == null)
-    {
+  static Object checkPropertyValue(SFSessionProperty property, Object propertyValue)
+      throws SFException {
+    if (propertyValue == null) {
       return null;
     }
 
-    if (property.getValueType().isAssignableFrom(propertyValue.getClass()))
-    {
-      switch (property)
-      {
+    if (property.getValueType().isAssignableFrom(propertyValue.getClass())) {
+      switch (property) {
         case APPLICATION:
-          if (APPLICATION_REGEX.matcher((String)propertyValue).find())
-          {
+          if (APPLICATION_REGEX.matcher((String) propertyValue).find()) {
             return propertyValue;
-          }
-          else
-          {
-            throw new SFException(ErrorCode.INVALID_PARAMETER_VALUE,
-                propertyValue, property);
+          } else {
+            throw new SFException(ErrorCode.INVALID_PARAMETER_VALUE, propertyValue, property);
           }
         default:
           return propertyValue;
       }
-    }
-    else
-    {
-      if (property.getValueType() == Boolean.class &&
-          propertyValue instanceof String)
-      {
-        if ("on".equalsIgnoreCase((String) propertyValue) ||
-            "true".equalsIgnoreCase((String) propertyValue))
-        {
+    } else {
+      if (property.getValueType() == Boolean.class && propertyValue instanceof String) {
+        if ("on".equalsIgnoreCase((String) propertyValue)
+            || "true".equalsIgnoreCase((String) propertyValue)) {
           return true;
-        }
-        else if ("off".equalsIgnoreCase((String) propertyValue) ||
-            "false".equalsIgnoreCase((String) propertyValue))
-        {
+        } else if ("off".equalsIgnoreCase((String) propertyValue)
+            || "false".equalsIgnoreCase((String) propertyValue)) {
           return false;
         }
-      }
-      else if (property.getValueType() == Integer.class &&
-          propertyValue instanceof String)
-      {
-        return Integer.valueOf((String)propertyValue);
+      } else if (property.getValueType() == Integer.class && propertyValue instanceof String) {
+        return Integer.valueOf((String) propertyValue);
       }
     }
 
-    throw new SFException(ErrorCode.INVALID_PARAMETER_TYPE,
+    throw new SFException(
+        ErrorCode.INVALID_PARAMETER_TYPE,
         propertyValue.getClass().getName(),
         property.getValueType().getName());
   }

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -5,6 +5,19 @@
 package net.snowflake.client.core;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.core.bind.BindException;
 import net.snowflake.client.core.bind.BindUploader;
@@ -19,29 +32,13 @@ import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 import org.apache.http.client.methods.HttpRequestBase;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 /**
  * Snowflake statement
  *
  * @author jhuang
  */
-public class SFStatement
-{
-  public enum CallingMethod
-  {
+public class SFStatement {
+  public enum CallingMethod {
     EXECUTE,
     EXECUTE_UPDATE,
     EXECUTE_QUERY
@@ -73,9 +70,9 @@ public class SFStatement
   private SnowflakeFileTransferAgent transferAgent = null;
 
   // statement level parameters
-  private final Map<String, Object> statementParametersMap =  new HashMap<String, Object>();
+  private final Map<String, Object> statementParametersMap = new HashMap<String, Object>();
 
-  final private static int MAX_STATEMENT_PARAMETERS = 1000;
+  private static final int MAX_STATEMENT_PARAMETERS = 1000;
 
   /** id used in combine describe and execute */
   private String describeJobUUID;
@@ -89,53 +86,45 @@ public class SFStatement
   /**
    * Add a statement parameter
    *
-   * Make sure a property is not added more than once and the number of
-   * properties does not exceed limit.
+   * <p>Make sure a property is not added more than once and the number of properties does not
+   * exceed limit.
    *
    * @param propertyName property name
    * @param propertyValue property value
    * @throws SFException if too many parameters for a statement
    */
-  public void addProperty(String propertyName, Object propertyValue)
-      throws SFException
-  {
+  public void addProperty(String propertyName, Object propertyValue) throws SFException {
     statementParametersMap.put(propertyName, propertyValue);
 
     // for query timeout, we implement it on client side for now
-    if ("query_timeout".equalsIgnoreCase(propertyName))
-    {
+    if ("query_timeout".equalsIgnoreCase(propertyName)) {
       queryTimeout = (Integer) propertyValue;
     }
 
     // check if the number of session properties exceed limit
-    if (statementParametersMap.size() > MAX_STATEMENT_PARAMETERS)
-    {
-      throw new SFException(
-              ErrorCode.TOO_MANY_STATEMENT_PARAMETERS, MAX_STATEMENT_PARAMETERS);
+    if (statementParametersMap.size() > MAX_STATEMENT_PARAMETERS) {
+      throw new SFException(ErrorCode.TOO_MANY_STATEMENT_PARAMETERS, MAX_STATEMENT_PARAMETERS);
     }
   }
 
-  public SFStatement(SFSession session)
-  {
+  public SFStatement(SFSession session) {
     logger.debug(" public SFStatement(SFSession session)");
 
     this.session = session;
     Integer queryTimeout = session == null ? null : session.getQueryTimeout();
-    this.queryTimeout =  queryTimeout != null ? queryTimeout : this.queryTimeout;
+    this.queryTimeout = queryTimeout != null ? queryTimeout : this.queryTimeout;
   }
 
   /**
    * Sanity check query text
+   *
    * @param sql The SQL statement to check
    * @throws java.sql.SQLException
    */
-  private void sanityCheckQuery(String sql) throws SQLException
-  {
-    if (sql == null || sql.isEmpty())
-    {
-      throw new SnowflakeSQLException(SqlState.SQL_STATEMENT_NOT_YET_COMPLETE,
-          ErrorCode.INVALID_SQL.getMessageCode(), sql);
-
+  private void sanityCheckQuery(String sql) throws SQLException {
+    if (sql == null || sql.isEmpty()) {
+      throw new SnowflakeSQLException(
+          SqlState.SQL_STATEMENT_NOT_YET_COMPLETE, ErrorCode.INVALID_SQL.getMessageCode(), sql);
     }
   }
 
@@ -153,17 +142,15 @@ public class SFStatement
       Map<String, ParameterBindingDTO> parametersBinding,
       boolean describeOnly,
       CallingMethod caller)
-      throws SQLException, SFException
-  {
+      throws SQLException, SFException {
     sanityCheckQuery(sql);
 
     String trimmedSql = sql.trim();
 
     // snowflake specific client side commands
-    if (isFileTransfer(trimmedSql))
-    {
+    if (isFileTransfer(trimmedSql)) {
       // PUT/GET command
-      logger.debug( "Executing file transfer locally: {}", sql);
+      logger.debug("Executing file transfer locally: {}", sql);
 
       return executeFileTransfer(sql);
     }
@@ -174,8 +161,7 @@ public class SFStatement
         parametersBinding,
         describeOnly,
         describeOnly, // internal query if describeOnly is true
-        caller
-    );
+        caller);
   }
 
   /**
@@ -186,21 +172,23 @@ public class SFStatement
    * @throws SQLException if connection is already closed
    * @throws SFException if result set is null
    */
-  public SFStatementMetaData describe(String sql) throws SFException, SQLException
-  {
+  public SFStatementMetaData describe(String sql) throws SFException, SQLException {
     SFBaseResultSet baseResultSet = executeQuery(sql, null, true, null);
 
     describeJobUUID = baseResultSet.getQueryId();
 
-    return new SFStatementMetaData(baseResultSet.getMetaData(),
-                                   baseResultSet.getStatementType(),
-                                   baseResultSet.getNumberOfBinds(),
-                                   baseResultSet.isArrayBindSupported());
+    return new SFStatementMetaData(
+        baseResultSet.getMetaData(),
+        baseResultSet.getStatementType(),
+        baseResultSet.getNumberOfBinds(),
+        baseResultSet.isArrayBindSupported());
   }
 
   /**
    * Internal method for executing a query with bindings accepted.
+   *
    * <p>
+   *
    * @param sql sql statement
    * @param parameterBindings binding information
    * @param describeOnly true if just showing result set metadata
@@ -216,28 +204,21 @@ public class SFStatement
       boolean describeOnly,
       boolean internal,
       CallingMethod caller)
-      throws SQLException, SFException
-  {
+      throws SQLException, SFException {
     resetState();
 
-    logger.debug( "executeQuery: {}", sql);
+    logger.debug("executeQuery: {}", sql);
 
-    if (session.isClosed())
-    {
+    if (session.isClosed()) {
       throw new SQLException("connection is closed");
     }
 
-    Object result = executeHelper(sql,
-        StmtUtil.SF_MEDIA_TYPE,
-        parameterBindings,
-        describeOnly,
-        internal);
+    Object result =
+        executeHelper(sql, StmtUtil.SF_MEDIA_TYPE, parameterBindings, describeOnly, internal);
 
-    if (result == null)
-    {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                      "got null result");
+    if (result == null) {
+      throw new SnowflakeSQLException(
+          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), "got null result");
     }
 
     /*
@@ -247,10 +228,9 @@ public class SFStatement
 
     boolean sortResult = sortProperty != null && (Boolean) sortProperty;
 
-    logger.debug( "Creating result set");
+    logger.debug("Creating result set");
 
-    try
-    {
+    try {
       JsonNode jsonResult = (JsonNode) result;
       resultSet = new SFResultSet(jsonResult, this, sortResult);
       childResults = ResultUtil.getChildResults(session, requestId, jsonResult);
@@ -258,83 +238,61 @@ public class SFStatement
       // if child results are available, skip over this result set and set the
       // current result to the first child's result.
       // we still construct the first result set for its side effects.
-      if (!childResults.isEmpty())
-      {
+      if (!childResults.isEmpty()) {
         SFStatementType type = childResults.get(0).type;
 
         // ensure first query type matches the calling JDBC method, if exists
-        if (caller == CallingMethod.EXECUTE_QUERY && !type.isGenerateResultSet())
-        {
-          throw new SnowflakeSQLException(
-              ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET);
-        }
-        else if (caller == CallingMethod.EXECUTE_UPDATE && type.isGenerateResultSet())
-        {
-          throw new SnowflakeSQLException(
-              ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT);
+        if (caller == CallingMethod.EXECUTE_QUERY && !type.isGenerateResultSet()) {
+          throw new SnowflakeSQLException(ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET);
+        } else if (caller == CallingMethod.EXECUTE_UPDATE && type.isGenerateResultSet()) {
+          throw new SnowflakeSQLException(ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT);
         }
 
         // this will update resultSet to point to the first child result before we return it
         getMoreResults();
       }
-    }
-    catch (SnowflakeSQLException | OutOfMemoryError ex)
-    {
+    } catch (SnowflakeSQLException | OutOfMemoryError ex) {
       // snow-24428: no need to generate incident for exceptions we generate
       // snow-29403: or client OOM
       throw ex;
-    }
-    catch (Throwable ex)
-    {
+    } catch (Throwable ex) {
       // SNOW-22813 log exception
       logger.error("Exception creating result", ex);
 
       throw IncidentUtil.generateIncidentWithException(
-          session,
-          null,
-          null, ex,
-          ErrorCode.INTERNAL_ERROR,
-          "exception creating result");
+          session, null, null, ex, ErrorCode.INTERNAL_ERROR, "exception creating result");
     }
-    logger.debug( "Done creating result set");
+    logger.debug("Done creating result set");
 
     return resultSet;
   }
 
   /**
    * Set a time bomb to cancel the outstanding query when timeout is reached.
+   *
    * @param executor object to execute statement cancel request
    */
-  private void setTimeBomb(ScheduledExecutorService executor)
-  {
-    class TimeBombTask implements Callable<Void>
-    {
+  private void setTimeBomb(ScheduledExecutorService executor) {
+    class TimeBombTask implements Callable<Void> {
 
       private final SFStatement statement;
 
-      private TimeBombTask(SFStatement statement)
-      {
+      private TimeBombTask(SFStatement statement) {
         this.statement = statement;
       }
 
       @Override
-      public Void call() throws SQLException
-      {
-        try
-        {
+      public Void call() throws SQLException {
+        try {
           statement.cancel();
-        }
-        catch (SFException ex)
-        {
-          throw new SnowflakeSQLException(ex, ex.getSqlState(),
-              ex.getVendorCode(), ex.getParams());
+        } catch (SFException ex) {
+          throw new SnowflakeSQLException(ex, ex.getSqlState(), ex.getVendorCode(), ex.getParams());
         }
         return null;
       }
     }
 
-    executor.schedule(new TimeBombTask(this), this.queryTimeout,
-        TimeUnit.SECONDS);
+    executor.schedule(new TimeBombTask(this), this.queryTimeout, TimeUnit.SECONDS);
   }
 
   /**
@@ -349,35 +307,30 @@ public class SFStatement
    * @throws SFException if query is canceled
    * @throws SnowflakeSQLException if query is already running
    */
-  public
-  Object executeHelper(String sql,
-                       String mediaType,
-                       Map<String, ParameterBindingDTO> bindValues,
-                       boolean describeOnly,
-                       boolean internal)
-      throws SnowflakeSQLException, SFException
-  {
+  public Object executeHelper(
+      String sql,
+      String mediaType,
+      Map<String, ParameterBindingDTO> bindValues,
+      boolean describeOnly,
+      boolean internal)
+      throws SnowflakeSQLException, SFException {
     ScheduledExecutorService executor = null;
 
-    try
-    {
-      synchronized (this)
-      {
-        if (isClosed)
-        {
+    try {
+      synchronized (this) {
+        if (isClosed) {
           throw new SFException(ErrorCode.STATEMENT_CLOSED);
         }
 
         // initialize a sequence id if not closed or not for aborting
-        if (canceling.get())
-        {
+        if (canceling.get()) {
           // nothing to do if canceled
           throw new SFException(ErrorCode.QUERY_CANCELED);
         }
 
-        if (this.requestId != null)
-        {
-          throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+        if (this.requestId != null) {
+          throw new SnowflakeSQLException(
+              SqlState.FEATURE_NOT_SUPPORTED,
               ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode());
         }
 
@@ -387,7 +340,8 @@ public class SFStatement
         this.sqlText = sql;
       }
 
-      EventUtil.triggerStateTransition(BasicEvent.QueryState.QUERY_STARTED,
+      EventUtil.triggerStateTransition(
+          BasicEvent.QueryState.QUERY_STARTED,
           String.format(QueryState.QUERY_STARTED.getArgString(), requestId));
 
       // if there are a large number of bind values, we should upload them to stage
@@ -398,25 +352,24 @@ public class SFStatement
           && session.getArrayBindStageThreshold() <= numBinds
           && !describeOnly
           && !hasUnsupportedStageBind
-          && BindUploader.isArrayBind(bindValues))
-      {
-        try (BindUploader uploader = BindUploader.newInstance(session, requestId))
-        {
+          && BindUploader.isArrayBind(bindValues)) {
+        try (BindUploader uploader = BindUploader.newInstance(session, requestId)) {
           uploader.upload(bindValues);
           bindStagePath = uploader.getStagePath();
-        }
-        catch (BindException ex)
-        {
-          logger.warn("Exception encountered trying to upload binds to stage. Attaching binds in payload instead. ", ex);
+        } catch (BindException ex) {
+          logger.warn(
+              "Exception encountered trying to upload binds to stage. Attaching binds in payload instead. ",
+              ex);
           TelemetryData errorLog = TelemetryUtil.buildJobData(this.requestId, ex.type.field, 1);
           this.session.getTelemetryClient().tryAddLogToBatch(errorLog);
-          IncidentUtil.generateIncident(session, "Failed to upload binds to stage",
-              null, requestId, null, ex);
+          IncidentUtil.generateIncident(
+              session, "Failed to upload binds to stage", null, requestId, null, ex);
         }
       }
 
       StmtUtil.StmtInput stmtInput = new StmtUtil.StmtInput();
-      stmtInput.setSql(sql)
+      stmtInput
+          .setSql(sql)
           .setMediaType(mediaType)
           .setInternal(internal)
           .setDescribeOnly(describeOnly)
@@ -435,30 +388,23 @@ public class SFStatement
           .setQuerySubmissionTime(System.currentTimeMillis())
           .setServiceName(session.getServiceName());
 
-      if (bindStagePath != null)
-      {
-        stmtInput.setBindValues(null)
-            .setBindStage(bindStagePath);
+      if (bindStagePath != null) {
+        stmtInput.setBindValues(null).setBindStage(bindStagePath);
         // use the new SQL format for this query so dates/timestamps are parsed correctly
         setUseNewSqlFormat(true);
-      }
-      else
-      {
-        stmtInput.setBindValues(bindValues)
-            .setBindStage(null);
+      } else {
+        stmtInput.setBindValues(bindValues).setBindStage(null);
       }
 
-      if (canceling.get())
-      {
-        logger.debug( "Query cancelled");
+      if (canceling.get()) {
+        logger.debug("Query cancelled");
 
         throw new SFException(ErrorCode.QUERY_CANCELED);
       }
 
       // if timeout is set, start a thread to cancel the request after timeout
       // reached.
-      if (this.queryTimeout > 0)
-      {
+      if (this.queryTimeout > 0) {
         executor = Executors.newScheduledThreadPool(1);
         setTimeBomb(executor);
       }
@@ -466,31 +412,20 @@ public class SFStatement
       StmtUtil.StmtOutput stmtOutput = null;
       boolean sessionRenewed = false;
 
-      do
-      {
+      do {
         sessionRenewed = false;
-        try
-        {
+        try {
           stmtOutput = StmtUtil.execute(stmtInput);
           break;
-        }
-        catch (SnowflakeSQLException ex)
-        {
-          if (ex.getErrorCode() == Constants.SESSION_EXPIRED_GS_CODE)
-          {
-            try
-            {
+        } catch (SnowflakeSQLException ex) {
+          if (ex.getErrorCode() == Constants.SESSION_EXPIRED_GS_CODE) {
+            try {
               // renew the session
               session.renewSession(stmtInput.sessionToken);
-            }
-            catch(SnowflakeReauthenticationRequest ex0)
-            {
-              if (session.isExternalbrowserAuthenticator())
-              {
+            } catch (SnowflakeReauthenticationRequest ex0) {
+              if (session.isExternalbrowserAuthenticator()) {
                 reauthenticate();
-              }
-              else
-              {
+              } else {
                 throw ex0;
               }
             }
@@ -501,26 +436,21 @@ public class SFStatement
             sessionRenewed = true;
 
             logger.debug("Session got renewed, will retry");
-          }
-          else
-            throw ex;
+          } else throw ex;
         }
-      }
-      while(sessionRenewed && !canceling.get());
+      } while (sessionRenewed && !canceling.get());
 
       // Debugging/Testing for incidents
-      if(System.getProperty("snowflake.enable_incident_test1") != null &&
-         System.getProperty("snowflake.enable_incident_test1").equals("true"))
-      {
+      if (System.getProperty("snowflake.enable_incident_test1") != null
+          && System.getProperty("snowflake.enable_incident_test1").equals("true")) {
         SFException sfe =
-            IncidentUtil.generateIncidentWithException(session, this.requestId,
-                null, ErrorCode.STATEMENT_CLOSED);
+            IncidentUtil.generateIncidentWithException(
+                session, this.requestId, null, ErrorCode.STATEMENT_CLOSED);
 
-          throw sfe;
+        throw sfe;
       }
 
-      synchronized (this)
-      {
+      synchronized (this) {
         /*
          * done with the remote execution of the query. set sequenceId to -1
          * and request id to null so that we don't try to abort it upon canceling.
@@ -529,27 +459,21 @@ public class SFStatement
         this.requestId = null;
       }
 
-      if (canceling.get())
-      {
+      if (canceling.get()) {
         // If we are here, this is the context for the initial query that
         // is being canceled. Raise an exception anyway here even if
         // the server fails to abort it.
         throw new SFException(ErrorCode.QUERY_CANCELED);
       }
 
-      logger.debug( "Returning from executeHelper");
+      logger.debug("Returning from executeHelper");
 
       return stmtOutput.getResult();
-    }
-    catch (SFException | SnowflakeSQLException ex)
-    {
+    } catch (SFException | SnowflakeSQLException ex) {
       isClosed = true;
       throw ex;
-    }
-    finally
-    {
-      if (executor != null)
-      {
+    } finally {
+      if (executor != null) {
         executor.shutdownNow();
       }
       // if this query enabled the new SQL format, re-disable it now
@@ -557,8 +481,7 @@ public class SFStatement
     }
   }
 
-  private void reauthenticate() throws SFException, SnowflakeSQLException
-  {
+  private void reauthenticate() throws SFException, SnowflakeSQLException {
     SessionUtil.LoginInput input = new SessionUtil.LoginInput();
     SessionUtil.LoginOutput output = new SessionUtil.LoginOutput();
     output.setSessionToken(session.getSessionToken());
@@ -581,19 +504,16 @@ public class SFStatement
    * @throws SFException if statement is already closed
    */
   private void cancelHelper(String sql, String mediaType)
-      throws SnowflakeSQLException, SFException
-  {
-    synchronized (this)
-    {
-      if (isClosed)
-      {
-        throw new SFException(ErrorCode.INTERNAL_ERROR,
-            "statement already closed");
+      throws SnowflakeSQLException, SFException {
+    synchronized (this) {
+      if (isClosed) {
+        throw new SFException(ErrorCode.INTERNAL_ERROR, "statement already closed");
       }
     }
 
     StmtUtil.StmtInput stmtInput = new StmtUtil.StmtInput();
-    stmtInput.setServerUrl(session.getServerUrl())
+    stmtInput
+        .setServerUrl(session.getServerUrl())
         .setSql(sql)
         .setMediaType(mediaType)
         .setRequestId(requestId)
@@ -602,8 +522,7 @@ public class SFStatement
 
     StmtUtil.cancel(stmtInput);
 
-    synchronized (this)
-    {
+    synchronized (this) {
       /*
        * done with the remote execution of the query. set sequenceId to -1
        * and request id to null so that we don't try to abort it again upon
@@ -615,17 +534,17 @@ public class SFStatement
   }
 
   /**
-   * A method to check if a sql is file upload statement with consideration for
-   * potential comments in front of put keyword.
+   * A method to check if a sql is file upload statement with consideration for potential comments
+   * in front of put keyword.
+   *
    * <p>
+   *
    * @param sql sql statement
    * @return true if the command is upload statement
    */
-  private boolean isFileTransfer(String sql)
-  {
+  private boolean isFileTransfer(String sql) {
     SFStatementType statementType = StmtUtil.checkStageManageCommand(sql);
-    return statementType == SFStatementType.PUT ||
-           statementType == SFStatementType.GET;
+    return statementType == SFStatementType.PUT || statementType == SFStatementType.GET;
   }
 
   /**
@@ -639,12 +558,9 @@ public class SFStatement
    * @throws SFException exception raised from Snowflake components
    * @throws SQLException if SQL error occurs
    */
-  public SFBaseResultSet execute(String sql,
-                                 Map<String, ParameterBindingDTO>
-                                     parametersBinding,
-                                 CallingMethod caller)
-      throws SQLException, SFException
-  {
+  public SFBaseResultSet execute(
+      String sql, Map<String, ParameterBindingDTO> parametersBinding, CallingMethod caller)
+      throws SQLException, SFException {
     sanityCheckQuery(sql);
 
     session.injectedDelay();
@@ -653,19 +569,14 @@ public class SFStatement
 
     String trimmedSql = sql.trim();
 
-    if (trimmedSql.length() >= 20
-        && trimmedSql.toLowerCase().startsWith(
-        "set-sf-property"))
-    {
+    if (trimmedSql.length() >= 20 && trimmedSql.toLowerCase().startsWith("set-sf-property")) {
       executeSetProperty(sql);
       return null;
     }
     return executeQuery(sql, parametersBinding, false, caller);
   }
 
-  private SFBaseResultSet executeFileTransfer(String sql) throws SQLException,
-      SFException
-  {
+  private SFBaseResultSet executeFileTransfer(String sql) throws SQLException, SFException {
     session.injectedDelay();
 
     resetState();
@@ -675,34 +586,29 @@ public class SFStatement
     isFileTransfer = true;
     transferAgent = new SnowflakeFileTransferAgent(sql, session, this);
 
-    try
-    {
+    try {
       transferAgent.execute();
 
       logger.debug("setting result set");
 
-      resultSet = (SFFixedViewResultSet)transferAgent.getResultSet();
+      resultSet = (SFFixedViewResultSet) transferAgent.getResultSet();
       childResults = Collections.emptyList();
 
-      logger.debug("Number of cols: {}",
-                               resultSet.getMetaData().getColumnCount());
+      logger.debug("Number of cols: {}", resultSet.getMetaData().getColumnCount());
       logger.info("Completed transferring data");
       return resultSet;
-    }
-    catch (SQLException ex)
-    {
+    } catch (SQLException ex) {
       logger.debug("Exception: {}", ex.getMessage());
       throw ex;
     }
   }
 
-  public void close() throws SQLException
-  {
+  public void close() throws SQLException {
     logger.debug("public void close()");
 
-    if (requestId != null)
-    {
-      EventUtil.triggerStateTransition(BasicEvent.QueryState.QUERY_ENDED,
+    if (requestId != null) {
+      EventUtil.triggerStateTransition(
+          BasicEvent.QueryState.QUERY_ENDED,
           String.format(QueryState.QUERY_ENDED.getArgString(), requestId));
     }
 
@@ -710,20 +616,16 @@ public class SFStatement
     childResults = null;
     isClosed = true;
 
-    if (httpRequest != null)
-    {
+    if (httpRequest != null) {
       logger.debug("releasing connection for the http request");
 
       httpRequest.releaseConnection();
       httpRequest = null;
     }
 
-    try
-    {
+    try {
       session.getTelemetryClient().sendBatch();
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       logger.warn("Telemetry client failed to send batch metrics.");
     }
 
@@ -731,33 +633,25 @@ public class SFStatement
     transferAgent = null;
   }
 
-  public void cancel() throws SFException, SQLException
-  {
+  public void cancel() throws SFException, SQLException {
     logger.debug("public void cancel()");
 
-    if (canceling.get())
-    {
+    if (canceling.get()) {
       logger.debug("Query is already cancelled");
       return;
     }
 
     canceling.set(true);
 
-    if (isFileTransfer)
-    {
-      if (transferAgent != null)
-      {
+    if (isFileTransfer) {
+      if (transferAgent != null) {
         logger.debug("Cancel file transferring ... ");
         transferAgent.cancel();
       }
-    }
-    else
-    {
-      synchronized (this)
-      {
+    } else {
+      synchronized (this) {
         // the query hasn't been sent to GS yet, just mark the stmt closed
-        if (requestId == null)
-        {
+        if (requestId == null) {
           logger.debug("No remote query outstanding");
 
           return;
@@ -769,13 +663,11 @@ public class SFStatement
     }
   }
 
-  private void resetState()
-  {
+  private void resetState() {
     resultSet = null;
     childResults = null;
 
-    if (httpRequest != null)
-    {
+    if (httpRequest != null) {
       httpRequest.releaseConnection();
       httpRequest = null;
     }
@@ -790,89 +682,71 @@ public class SFStatement
     transferAgent = null;
   }
 
-  public void executeSetProperty(final String sql)
-  {
+  public void executeSetProperty(final String sql) {
     logger.debug("setting property");
 
     // tokenize the sql
     String[] tokens = sql.split("\\s+");
 
-    if (tokens.length < 2)
-    {
+    if (tokens.length < 2) {
       return;
     }
 
-    if ("sort".equalsIgnoreCase(tokens[1]))
-    {
-      if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2]))
-      {
+    if ("sort".equalsIgnoreCase(tokens[1])) {
+      if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2])) {
         logger.debug("setting sort on");
 
         this.session.setSFSessionProperty("sort", true);
-      }
-      else
-      {
+      } else {
         logger.debug("setting sort off");
         this.session.setSFSessionProperty("sort", false);
       }
     }
   }
 
-  protected SFSession getSession()
-  {
+  protected SFSession getSession() {
     return session;
   }
 
-  public void setHasUnsupportedStageBind(boolean hasUnsupportedStageBind)
-  {
+  public void setHasUnsupportedStageBind(boolean hasUnsupportedStageBind) {
     this.hasUnsupportedStageBind = hasUnsupportedStageBind;
   }
 
   // *NOTE* this new SQL format is incomplete. It should only be used under certain circumstances.
-  private void setUseNewSqlFormat(boolean useNewSqlFormat) throws SFException
-  {
+  private void setUseNewSqlFormat(boolean useNewSqlFormat) throws SFException {
     this.addProperty("NEW_SQL_FORMAT", useNewSqlFormat);
   }
 
-  public boolean getMoreResults() throws SQLException
-  {
+  public boolean getMoreResults() throws SQLException {
     return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
   }
 
   /**
    * Sets the result set to the next one, if available.
-   * @param current What to do with the current result.
-   *        One of Statement.CLOSE_CURRENT_RESULT,
-   *               Statement.CLOSE_ALL_RESULTS, or
-   *               Statement.KEEP_CURRENT_RESULT
-   * @return true if there is a next result and it's a result set
-   *         false if there are no more results, or there is a next result
-   *           and it's an update count
+   *
+   * @param current What to do with the current result. One of Statement.CLOSE_CURRENT_RESULT,
+   *     Statement.CLOSE_ALL_RESULTS, or Statement.KEEP_CURRENT_RESULT
+   * @return true if there is a next result and it's a result set false if there are no more
+   *     results, or there is a next result and it's an update count
    * @throws SQLException if something fails while getting the next result
    */
-  public boolean getMoreResults(int current) throws SQLException
-  {
+  public boolean getMoreResults(int current) throws SQLException {
     // clean up current result, if exists
-    if (resultSet != null &&
-        (current == Statement.CLOSE_CURRENT_RESULT ||
-        current == Statement.CLOSE_ALL_RESULTS))
-    {
+    if (resultSet != null
+        && (current == Statement.CLOSE_CURRENT_RESULT || current == Statement.CLOSE_ALL_RESULTS)) {
       resultSet.close();
     }
     resultSet = null;
 
     // verify if more results exist
-    if (childResults == null || childResults.isEmpty())
-    {
+    if (childResults == null || childResults.isEmpty()) {
       return false;
     }
 
     // fetch next result using the query id
     SFChildResult nextResult = childResults.remove(0);
-    try
-    {
-      JsonNode result = StmtUtil.getQueryResultJSON(
-          nextResult.getId(), session);
+    try {
+      JsonNode result = StmtUtil.getQueryResultJSON(nextResult.getId(), session);
       Object sortProperty = session.getSFSessionProperty("sort");
       boolean sortResult = sortProperty != null && (Boolean) sortProperty;
       resultSet = new SFResultSet(result, this, sortResult);
@@ -881,20 +755,16 @@ public class SFStatement
       resultSet.setStatementType(nextResult.getType());
 
       return nextResult.getType().isGenerateResultSet();
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLException(ex);
     }
   }
 
-  public SFBaseResultSet getResultSet()
-  {
+  public SFBaseResultSet getResultSet() {
     return resultSet;
   }
 
-  public boolean hasChildren()
-  {
+  public boolean hasChildren() {
     return !childResults.isEmpty();
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFStatementMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFStatementMetaData.java
@@ -4,17 +4,11 @@
 
 package net.snowflake.client.core;
 
-/**
- * Created by jhuang on 1/21/16.
- */
-
+/** Created by jhuang on 1/21/16. */
 import java.util.Collections;
 
-/**
- * Statement metadata which includes the result metadata and bind information.
- */
-public class SFStatementMetaData
-{
+/** Statement metadata which includes the result metadata and bind information. */
+public class SFStatementMetaData {
   // result metadata
   private SFResultSetMetaData resultSetMetaData;
 
@@ -25,61 +19,56 @@ public class SFStatementMetaData
 
   private final boolean arrayBindSupported;
 
-  SFStatementMetaData(SFResultSetMetaData resultSetMetaData,
-                      SFStatementType statementType,
-                      int numberOfBinds,
-                      boolean arrayBindSupported)
-  {
+  SFStatementMetaData(
+      SFResultSetMetaData resultSetMetaData,
+      SFStatementType statementType,
+      int numberOfBinds,
+      boolean arrayBindSupported) {
     this.resultSetMetaData = resultSetMetaData;
     this.statementType = statementType;
     this.numberOfBinds = numberOfBinds;
     this.arrayBindSupported = arrayBindSupported;
   }
 
-  public SFResultSetMetaData getResultSetMetaData()
-  {
+  public SFResultSetMetaData getResultSetMetaData() {
     return resultSetMetaData;
   }
 
-  public void setResultSetMetaData(SFResultSetMetaData resultSetMetaData)
-  {
+  public void setResultSetMetaData(SFResultSetMetaData resultSetMetaData) {
     this.resultSetMetaData = resultSetMetaData;
   }
 
-  public int getNumberOfBinds()
-  {
+  public int getNumberOfBinds() {
     return numberOfBinds;
   }
 
-  public void setNumberOfBinds(int numberOfBinds)
-  {
+  public void setNumberOfBinds(int numberOfBinds) {
     this.numberOfBinds = numberOfBinds;
   }
 
   /**
    * According to StatementType, to decide whether array binds supported or not
    *
-   * Currently, only INSERT supports array bind
+   * <p>Currently, only INSERT supports array bind
+   *
    * @return true if array binds is supported.
    */
-  public boolean isArrayBindSupported()
-  {
+  public boolean isArrayBindSupported() {
     return this.arrayBindSupported;
   }
 
-  public SFStatementType getStatementType()
-  {
+  public SFStatementType getStatementType() {
     return this.statementType;
   }
 
-  public static SFStatementMetaData emptyMetaData()
-  {
+  public static SFStatementMetaData emptyMetaData() {
     return new SFStatementMetaData(
-        new SFResultSetMetaData(0,
-                                Collections.<String>emptyList(),
-                                Collections.<String>emptyList(),
-                                Collections.<Integer>emptyList(),
-                                null),
+        new SFResultSetMetaData(
+            0,
+            Collections.<String>emptyList(),
+            Collections.<String>emptyList(),
+            Collections.<Integer>emptyList(),
+            null),
         SFStatementType.UNKNOWN,
         0,
         false);

--- a/src/main/java/net/snowflake/client/core/SFStatementType.java
+++ b/src/main/java/net/snowflake/client/core/SFStatementType.java
@@ -10,48 +10,47 @@
 package net.snowflake.client.core;
 
 /**
- * Used to check if the statementType belongs to DDL or DML
- * The enum of each statement type is defined in 
- * com.snowflake.core.Statement.java
+ * Used to check if the statementType belongs to DDL or DML The enum of each statement type is
+ * defined in com.snowflake.core.Statement.java
+ *
  * @author hyu
  */
-public enum SFStatementType
-{
+public enum SFStatementType {
   /**
-   * By default we set query will generate result set, which means executeUpdate
-   * will throw exception. In that way, we have a clear control of what
-   * statements can be executed by executeUpdate
+   * By default we set query will generate result set, which means executeUpdate will throw
+   * exception. In that way, we have a clear control of what statements can be executed by
+   * executeUpdate
    */
-  UNKNOWN        (0x0000, true),
+  UNKNOWN(0x0000, true),
 
   // Server does not have stage related command type
-  PUT            (0x0001, true),
-  GET            (0x0002, true),
-  LIST           (0x0003, true),
-  REMOVE         (0x0004, true),
+  PUT(0x0001, true),
+  GET(0x0002, true),
+  LIST(0x0003, true),
+  REMOVE(0x0004, true),
 
-  SELECT         (0x1000, true),
+  SELECT(0x1000, true),
 
   /** Data Manipulation Language */
-  DML            (0x3000, false),
-  INSERT         (0x3000 + 0x100, false),
-  UPDATE         (0x3000 + 0x200, false),
-  DELETE         (0x3000 + 0x300, false),
-  MERGE          (0x3000 + 0x400, false),
-  MULTI_INSERT   (0x3000 + 0x500, false),
-  COPY           (0x3000 + 0x600, false),
-  UNLOAD         (0x3000 + 0x700, false),
-  RECLUSTER      (0x3000 + 0x800, false),
+  DML(0x3000, false),
+  INSERT(0x3000 + 0x100, false),
+  UPDATE(0x3000 + 0x200, false),
+  DELETE(0x3000 + 0x300, false),
+  MERGE(0x3000 + 0x400, false),
+  MULTI_INSERT(0x3000 + 0x500, false),
+  COPY(0x3000 + 0x600, false),
+  UNLOAD(0x3000 + 0x700, false),
+  RECLUSTER(0x3000 + 0x800, false),
 
-  /** System Command Language (USE, DESCRIBE etc)*/
-  SCL            (0x4000, false),
-  ALTER_SESSION  (0x4000 + 0x100, false),
-  USE            (0x4000 + 0x300, false),
-  USE_DATABASE   (0x4000 + 0x300 + 0x01, false),
-  USE_SCHEMA     (0x4000 + 0x300 + 0x02, false),
-  USE_WAREHOUSE  (0x4000 + 0x300 + 0x03, false),
-  SHOW           (0x4000 + 0x400, true),
-  DESCRIBE       (0x4000 + 0x500, true),
+  /** System Command Language (USE, DESCRIBE etc) */
+  SCL(0x4000, false),
+  ALTER_SESSION(0x4000 + 0x100, false),
+  USE(0x4000 + 0x300, false),
+  USE_DATABASE(0x4000 + 0x300 + 0x01, false),
+  USE_SCHEMA(0x4000 + 0x300 + 0x02, false),
+  USE_WAREHOUSE(0x4000 + 0x300 + 0x03, false),
+  SHOW(0x4000 + 0x400, true),
+  DESCRIBE(0x4000 + 0x500, true),
 
   /** Transaction Command Language (COMMIT, ROLLBACK) */
   TCL(0x5000, false),
@@ -62,80 +61,59 @@ public enum SFStatementType
   private final long statementTypeId;
 
   /**
-   * Used by Statement.executeUpdate to determine if we should return
-   * update counts or throw exception. In general, JDBC should only throw
-   * exception if a result set object is required.
+   * Used by Statement.executeUpdate to determine if we should return update counts or throw
+   * exception. In general, JDBC should only throw exception if a result set object is required.
    */
   private final boolean generateResultSet;
 
   private static final long LEVEL_3_RANGE = 0x1000;
 
-  SFStatementType(long id, boolean generateResultSet)
-  {
+  SFStatementType(long id, boolean generateResultSet) {
     this.statementTypeId = id;
     this.generateResultSet = generateResultSet;
   }
 
-  public static SFStatementType lookUpTypeById(long id)
-  {
-    for (SFStatementType type : SFStatementType.values())
-    {
-      if (type.getStatementTypeId() == id)
-      {
+  public static SFStatementType lookUpTypeById(long id) {
+    for (SFStatementType type : SFStatementType.values()) {
+      if (type.getStatementTypeId() == id) {
         return type;
       }
     }
 
     // if not specific type is found, then return category of statement
-    if (id >= SCL.getStatementTypeId() && id < SCL.getStatementTypeId()
-        + LEVEL_3_RANGE )
-    {
+    if (id >= SCL.getStatementTypeId() && id < SCL.getStatementTypeId() + LEVEL_3_RANGE) {
       return SCL;
-    }
-    else if (id >= TCL.getStatementTypeId() && id < TCL.getStatementTypeId()
-        + LEVEL_3_RANGE )
-    {
+    } else if (id >= TCL.getStatementTypeId() && id < TCL.getStatementTypeId() + LEVEL_3_RANGE) {
       return TCL;
-    }
-    else if (id >= DDL.getStatementTypeId() && id < DDL.getStatementTypeId()
-        + LEVEL_3_RANGE )
-    {
+    } else if (id >= DDL.getStatementTypeId() && id < DDL.getStatementTypeId() + LEVEL_3_RANGE) {
       return DDL;
-    }
-    else
-    {
+    } else {
       return UNKNOWN;
     }
   }
 
-  public long getStatementTypeId()
-  {
+  public long getStatementTypeId() {
     return statementTypeId;
   }
 
-  public boolean isDDL()
-  {
+  public boolean isDDL() {
     return this == DDL;
   }
 
-  public boolean isDML()
-  {
-    return statementTypeId >= DML.getStatementTypeId() &&
-           statementTypeId < DML.getStatementTypeId() + LEVEL_3_RANGE;
+  public boolean isDML() {
+    return statementTypeId >= DML.getStatementTypeId()
+        && statementTypeId < DML.getStatementTypeId() + LEVEL_3_RANGE;
   }
 
-  public boolean isTCL()
-  {
+  public boolean isTCL() {
     return this == TCL;
   }
 
-  public boolean isSCL()
-  {
+  public boolean isSCL() {
     return this == SCL;
   }
 
-  public boolean isGenerateResultSet()
-  {
+  public boolean isGenerateResultSet() {
     return this.generateResultSet;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFTrustManager.java
+++ b/src/main/java/net/snowflake/client/core/SFTrustManager.java
@@ -9,6 +9,42 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Security;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.client.util.SFPair;
@@ -49,180 +85,103 @@ import org.bouncycastle.crypto.digests.SHA1Digest;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.DigestCalculator;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.math.BigInteger;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.security.InvalidKeyException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.Security;
-import java.security.Signature;
-import java.security.SignatureException;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.text.MessageFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-
-
 /**
- * SFTrustManager is a composite of TrustManager of the default JVM
- * TrustManager and Snowflake OCSP revocation status checker. Use this
- * when initializing SSLContext object.
+ * SFTrustManager is a composite of TrustManager of the default JVM TrustManager and Snowflake OCSP
+ * revocation status checker. Use this when initializing SSLContext object.
  *
- * <pre>
- * {@code
+ * <pre>{@code
  * TrustManager[] trustManagers = {new SFTrustManager()};
  * SSLContext sslContext = SSLContext.getInstance("TLS");
  * sslContext.init(null, trustManagers, null);
- * }
- * </pre>
+ * }</pre>
  */
-class SFTrustManager implements X509TrustManager
-{
-  private static final
-  SFLogger LOGGER = SFLoggerFactory.getLogger(SFTrustManager.class);
+class SFTrustManager implements X509TrustManager {
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(SFTrustManager.class);
 
-  private static final ASN1ObjectIdentifier OIDocsp = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1").intern();
+  private static final ASN1ObjectIdentifier OIDocsp =
+      new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1").intern();
 
-  private static final ASN1ObjectIdentifier SHA1RSA = new ASN1ObjectIdentifier("1.2.840.113549.1.1.5").intern();
-  private static final ASN1ObjectIdentifier SHA256RSA = new ASN1ObjectIdentifier("1.2.840.113549.1.1.11").intern();
-  private static final ASN1ObjectIdentifier SHA384RSA = new ASN1ObjectIdentifier("1.2.840.113549.1.1.12").intern();
-  private static final ASN1ObjectIdentifier SHA512RSA = new ASN1ObjectIdentifier("1.2.840.113549.1.1.13").intern();
-  /**
-   * Object mapper for JSON encoding and decoding
-   */
+  private static final ASN1ObjectIdentifier SHA1RSA =
+      new ASN1ObjectIdentifier("1.2.840.113549.1.1.5").intern();
+  private static final ASN1ObjectIdentifier SHA256RSA =
+      new ASN1ObjectIdentifier("1.2.840.113549.1.1.11").intern();
+  private static final ASN1ObjectIdentifier SHA384RSA =
+      new ASN1ObjectIdentifier("1.2.840.113549.1.1.12").intern();
+  private static final ASN1ObjectIdentifier SHA512RSA =
+      new ASN1ObjectIdentifier("1.2.840.113549.1.1.13").intern();
+  /** Object mapper for JSON encoding and decoding */
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  /**
-   * System property name to specify cache directory.
-   */
+  /** System property name to specify cache directory. */
   public static final String CACHE_DIR_PROP = "net.snowflake.jdbc.ocspResponseCacheDir";
 
-  /**
-   * Environment name to specify the cache directory. Used if system property not set.
-   */
+  /** Environment name to specify the cache directory. Used if system property not set. */
   private static final String CACHE_DIR_ENV = "SF_OCSP_RESPONSE_CACHE_DIR";
 
-  /**
-   * OCSP response cache entry expiration time (s)
-   */
+  /** OCSP response cache entry expiration time (s) */
   private static final long CACHE_EXPIRATION_IN_SECONDS = 86400L;
 
-  /**
-   * OCSP response cache lock file expiration time (s)
-   */
+  /** OCSP response cache lock file expiration time (s) */
   private static final long CACHE_FILE_LOCK_EXPIRATION_IN_SECONDS = 60L;
 
-  /**
-   * Default OCSP Cache server host name
-   */
+  /** Default OCSP Cache server host name */
   public static final String DEFAULT_OCSP_CACHE_HOST = "http://ocsp.snowflakecomputing.com";
 
-  /**
-   * OCSP response cache file name. Should be identical to other driver's
-   * cache file name.
-   */
+  /** OCSP response cache file name. Should be identical to other driver's cache file name. */
   public static final String CACHE_FILE_NAME = "ocsp_response_cache.json";
 
-  /**
-   * OCSP response file cache directory
-   */
+  /** OCSP response file cache directory */
   private static final FileCacheManager fileCacheManager;
 
-  static
-  {
-    fileCacheManager = FileCacheManager
-        .builder()
-        .setCacheDirectorySystemProperty(CACHE_DIR_PROP)
-        .setCacheDirectoryEnvironmentVariable(CACHE_DIR_ENV)
-        .setBaseCacheFileName(CACHE_FILE_NAME)
-        .setCacheExpirationInSeconds(CACHE_EXPIRATION_IN_SECONDS)
-        .setCacheFileLockExpirationInSeconds(CACHE_FILE_LOCK_EXPIRATION_IN_SECONDS).build();
+  static {
+    fileCacheManager =
+        FileCacheManager.builder()
+            .setCacheDirectorySystemProperty(CACHE_DIR_PROP)
+            .setCacheDirectoryEnvironmentVariable(CACHE_DIR_ENV)
+            .setBaseCacheFileName(CACHE_FILE_NAME)
+            .setCacheExpirationInSeconds(CACHE_EXPIRATION_IN_SECONDS)
+            .setCacheFileLockExpirationInSeconds(CACHE_FILE_LOCK_EXPIRATION_IN_SECONDS)
+            .build();
   }
 
-  /**
-   * OCSP response cache server URL.
-   */
-  private static String SF_OCSP_RESPONSE_CACHE_SERVER_URL = String.format(
-      "%s/%s", DEFAULT_OCSP_CACHE_HOST, CACHE_FILE_NAME);
+  /** OCSP response cache server URL. */
+  private static String SF_OCSP_RESPONSE_CACHE_SERVER_URL =
+      String.format("%s/%s", DEFAULT_OCSP_CACHE_HOST, CACHE_FILE_NAME);
 
-  /**
-   * OCSP Response Cache server Retry URL pattern
-   */
+  /** OCSP Response Cache server Retry URL pattern */
   private static String SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN;
 
-  /**
-   * Tolerable validity date range ratio.
-   */
+  /** Tolerable validity date range ratio. */
   private static final float TOLERABLE_VALIDITY_RANGE_RATIO = 0.01f;
 
-  /**
-   * Maximum clocktime skew (ms)
-   */
+  /** Maximum clocktime skew (ms) */
   private static final long MAX_CLOCK_SKEW_IN_MILLISECONDS = 900000L;
 
-  /**
-   * Minimum cache warm up time (ms)
-   */
+  /** Minimum cache warm up time (ms) */
   private static final long MIN_CACHE_WARMUP_TIME_IN_MILLISECONDS = 18000000L;
 
-  /**
-   * Maximum retry counter (times)
-   */
+  /** Maximum retry counter (times) */
   private static final int MAX_RETRY_COUNTER = 10;
 
-  /**
-   * Initial sleeping time in retry (ms)
-   */
+  /** Initial sleeping time in retry (ms) */
   private static final long INITIAL_SLEEPING_TIME_IN_MILLISECONDS = 1000L;
-  /**
-   * Maximum sleeping time in retry (ms)
-   */
+  /** Maximum sleeping time in retry (ms) */
   private static final long MAX_SLEEPING_TIME_IN_MILLISECONDS = 16000L;
 
-  /**
-   * Map from signature algorithm ASN1 object to the name.
-   */
+  /** Map from signature algorithm ASN1 object to the name. */
   private static final Map<ASN1ObjectIdentifier, String> SIGNATURE_OID_TO_STRING = new HashMap<>();
 
-  static
-  {
+  static {
     SIGNATURE_OID_TO_STRING.put(SHA1RSA, "SHA1withRSA");
     SIGNATURE_OID_TO_STRING.put(SHA256RSA, "SHA256withRSA");
     SIGNATURE_OID_TO_STRING.put(SHA384RSA, "SHA384withRSA");
     SIGNATURE_OID_TO_STRING.put(SHA512RSA, "SHA512withRSA");
   }
 
-  /**
-   * Map from OCSP response code to a string representation.
-   */
+  /** Map from OCSP response code to a string representation. */
   private static final Map<Integer, String> OCSP_RESPONSE_CODE_TO_STRING = new HashMap<>();
 
-  static
-  {
+  static {
     OCSP_RESPONSE_CODE_TO_STRING.put(OCSPResp.SUCCESSFUL, "successful");
     OCSP_RESPONSE_CODE_TO_STRING.put(OCSPResp.MALFORMED_REQUEST, "malformedRequest");
     OCSP_RESPONSE_CODE_TO_STRING.put(OCSPResp.INTERNAL_ERROR, "internalError");
@@ -231,8 +190,7 @@ class SFTrustManager implements X509TrustManager
     OCSP_RESPONSE_CODE_TO_STRING.put(OCSPResp.UNAUTHORIZED, "unauthorized");
   }
 
-  static
-  {
+  static {
     // Add Bouncy Castle to the security provider. This is required to
     // verify the signature on OCSP response and attached certificates.
     Security.addProvider(new BouncyCastleProvider());
@@ -240,60 +198,47 @@ class SFTrustManager implements X509TrustManager
 
   private static JcaX509CertificateConverter CONVERTER_X509 = new JcaX509CertificateConverter();
 
-  /**
-   * RootCA cache
-   */
+  /** RootCA cache */
   private static Map<Integer, Certificate> ROOT_CA = new HashMap<>();
-  private final static Object ROOT_CA_LOCK = new Object();
 
-  /**
-   * OCSP Response cache
-   */
-  private final static Map<OcspResponseCacheKey, SFPair<Long, OCSPResp>> OCSP_RESPONSE_CACHE = new HashMap<>();
-  private final static Object OCSP_RESPONSE_CACHE_LOCK = new Object();
+  private static final Object ROOT_CA_LOCK = new Object();
+
+  /** OCSP Response cache */
+  private static final Map<OcspResponseCacheKey, SFPair<Long, OCSPResp>> OCSP_RESPONSE_CACHE =
+      new HashMap<>();
+
+  private static final Object OCSP_RESPONSE_CACHE_LOCK = new Object();
   private static boolean WAS_CACHE_UPDATED = false;
   private static boolean WAS_CACHE_READ = false;
 
-  /**
-   * Date and timestamp format
-   */
-  private final static SimpleDateFormat DATE_FORMAT_UTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+  /** Date and timestamp format */
+  private static final SimpleDateFormat DATE_FORMAT_UTC =
+      new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
-  static
-  {
+  static {
     DATE_FORMAT_UTC.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
-  /**
-   * The default JVM Trust manager.
-   */
+  /** The default JVM Trust manager. */
   private final X509TrustManager trustManager;
 
-  /**
-   * Use OCSP response cache server?
-   */
+  /** Use OCSP response cache server? */
   private final boolean useOcspResponseCacheServer;
 
   /**
-   * Constructor with the cache file. If not specified, the default cachefile
-   * is used.
+   * Constructor with the cache file. If not specified, the default cachefile is used.
    *
-   * @param cacheFile                  cache file.
+   * @param cacheFile cache file.
    * @param useOcspResponseCacheServer true if use OCSP response cache server is used.
    */
-  SFTrustManager(File cacheFile, boolean useOcspResponseCacheServer)
-  {
-    this.trustManager = getTrustManager(
-        KeyManagerFactory.getDefaultAlgorithm());
+  SFTrustManager(File cacheFile, boolean useOcspResponseCacheServer) {
+    this.trustManager = getTrustManager(KeyManagerFactory.getDefaultAlgorithm());
 
-    synchronized (OCSP_RESPONSE_CACHE_LOCK)
-    {
-      if (cacheFile != null)
-      {
+    synchronized (OCSP_RESPONSE_CACHE_LOCK) {
+      if (cacheFile != null) {
         fileCacheManager.overrideCacheFile(cacheFile);
       }
-      if (!WAS_CACHE_READ)
-      {
+      if (!WAS_CACHE_READ) {
         // read cache file once
         JsonNode res = fileCacheManager.readCacheFile();
         readJsonStoreCache(res);
@@ -308,112 +253,88 @@ class SFTrustManager implements X509TrustManager
    *
    * @param ocspCacheServerUrl OCSP Cache server URL
    */
-  static void resetOCSPResponseCacherServerURL(String ocspCacheServerUrl)
-  {
-    if (ocspCacheServerUrl == null || SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN != null)
-    {
+  static void resetOCSPResponseCacherServerURL(String ocspCacheServerUrl) {
+    if (ocspCacheServerUrl == null || SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN != null) {
       return;
     }
     SF_OCSP_RESPONSE_CACHE_SERVER_URL = ocspCacheServerUrl;
-    if (!SF_OCSP_RESPONSE_CACHE_SERVER_URL.startsWith(DEFAULT_OCSP_CACHE_HOST))
-    {
-      try
-      {
+    if (!SF_OCSP_RESPONSE_CACHE_SERVER_URL.startsWith(DEFAULT_OCSP_CACHE_HOST)) {
+      try {
         URL url = new URL(SF_OCSP_RESPONSE_CACHE_SERVER_URL);
-        if (url.getPort() > 0)
-        {
+        if (url.getPort() > 0) {
           SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN =
-              String.format("%s://%s:%d/retry/",
-                  url.getProtocol(), url.getHost(), url.getPort()) + "%s/%s";
-        }
-        else
-        {
+              String.format("%s://%s:%d/retry/", url.getProtocol(), url.getHost(), url.getPort())
+                  + "%s/%s";
+        } else {
           SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN =
-              String.format("%s://%s/retry/",
-                  url.getProtocol(), url.getHost()) + "%s/%s";
+              String.format("%s://%s/retry/", url.getProtocol(), url.getHost()) + "%s/%s";
         }
-      }
-      catch (IOException e)
-      {
+      } catch (IOException e) {
         throw new RuntimeException(
             String.format(
                 "Failed to parse SF_OCSP_RESPONSE_CACHE_SERVER_URL: %s",
                 SF_OCSP_RESPONSE_CACHE_SERVER_URL));
       }
-    }
-    else
-    {
+    } else {
       // default OCSP doesn't support retry endpoint yet
       SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN = null;
     }
   }
 
   /**
-   * Get TrustManager for the algorithm.
-   * This is mainly used to get the JVM default trust manager and
-   * cache all of the root CA.
+   * Get TrustManager for the algorithm. This is mainly used to get the JVM default trust manager
+   * and cache all of the root CA.
    *
    * @param algorithm algorithm.
    * @return TrustManager object.
    */
-  private X509TrustManager getTrustManager(String algorithm)
-  {
-    try
-    {
+  private X509TrustManager getTrustManager(String algorithm) {
+    try {
       TrustManagerFactory factory = TrustManagerFactory.getInstance(algorithm);
       factory.init((KeyStore) null);
       X509TrustManager ret = null;
-      for (TrustManager tm : factory.getTrustManagers())
-      {
+      for (TrustManager tm : factory.getTrustManagers()) {
         // Multiple TrustManager may be attached. We just need X509 Trust
         // Manager here.
-        if (tm instanceof X509TrustManager)
-        {
+        if (tm instanceof X509TrustManager) {
           ret = (X509TrustManager) tm;
           break;
         }
       }
-      if (ret == null)
-      {
+      if (ret == null) {
         return null;
       }
-      synchronized (ROOT_CA_LOCK)
-      {
+      synchronized (ROOT_CA_LOCK) {
         // cache root CA certificates for later use.
-        if (ROOT_CA.size() == 0)
-        {
-          for (X509Certificate cert : ret.getAcceptedIssuers())
-          {
+        if (ROOT_CA.size() == 0) {
+          for (X509Certificate cert : ret.getAcceptedIssuers()) {
             Certificate bcCert = Certificate.getInstance(cert.getEncoded());
             ROOT_CA.put(bcCert.getSubject().hashCode(), bcCert);
           }
         }
       }
       return ret;
-    }
-    catch (NoSuchAlgorithmException | KeyStoreException | CertificateEncodingException ex)
-    {
+    } catch (NoSuchAlgorithmException | KeyStoreException | CertificateEncodingException ex) {
       throw new SSLInitializationException(ex.getMessage(), ex);
     }
   }
 
   @Override
-  public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException
-  {
+  public void checkClientTrusted(X509Certificate[] chain, String authType)
+      throws CertificateException {
     // default behavior
     trustManager.checkClientTrusted(chain, authType);
   }
 
   @Override
-  public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException
-  {
+  public void checkServerTrusted(X509Certificate[] chain, String authType)
+      throws CertificateException {
     trustManager.checkServerTrusted(chain, authType);
     this.validateRevocationStatus(chain);
   }
 
   @Override
-  public X509Certificate[] getAcceptedIssuers()
-  {
+  public X509Certificate[] getAcceptedIssuers() {
     return trustManager.getAcceptedIssuers();
   }
 
@@ -423,16 +344,13 @@ class SFTrustManager implements X509TrustManager
    * @param chain chain of certificates attached.
    * @throws CertificateException if any certificate validation fails
    */
-  void validateRevocationStatus(X509Certificate[] chain) throws CertificateException
-  {
+  void validateRevocationStatus(X509Certificate[] chain) throws CertificateException {
     final List<Certificate> bcChain = convertToBouncyCastleCertificate(chain);
     final List<SFPair<Certificate, Certificate>> pairIssuerSubjectList =
         getPairIssuerSubject(bcChain);
-    synchronized (OCSP_RESPONSE_CACHE_LOCK)
-    {
+    synchronized (OCSP_RESPONSE_CACHE_LOCK) {
       boolean isCached = isCached(pairIssuerSubjectList);
-      if (this.useOcspResponseCacheServer && !isCached)
-      {
+      if (this.useOcspResponseCacheServer && !isCached) {
         LOGGER.debug(
             "Downloading OCSP response cache from the server. URL: {}",
             SF_OCSP_RESPONSE_CACHE_SERVER_URL);
@@ -442,8 +360,7 @@ class SFTrustManager implements X509TrustManager
         WAS_CACHE_UPDATED = true;
       }
       executeRevocationStatusChecks(pairIssuerSubjectList);
-      if (WAS_CACHE_UPDATED)
-      {
+      if (WAS_CACHE_UPDATED) {
         JsonNode input = encodeCacheToJSON();
         fileCacheManager.writeCacheFile(input);
         WAS_CACHE_UPDATED = false;
@@ -458,19 +375,13 @@ class SFTrustManager implements X509TrustManager
    * @throws CertificateException raises if any error occurs.
    */
   private void executeRevocationStatusChecks(
-      List<SFPair<Certificate, Certificate>> pairIssuerSubjectList)
-      throws CertificateException
-  {
+      List<SFPair<Certificate, Certificate>> pairIssuerSubjectList) throws CertificateException {
     long currentTimeSecond = new Date().getTime() / 1000L;
-    try
-    {
-      for (SFPair<Certificate, Certificate> pairIssuerSubject : pairIssuerSubjectList)
-      {
+    try {
+      for (SFPair<Certificate, Certificate> pairIssuerSubject : pairIssuerSubjectList) {
         executeOneRevoctionStatusCheck(pairIssuerSubject, currentTimeSecond);
       }
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       LOGGER.debug("Failed to decode CertID. Ignored.");
     }
   }
@@ -480,71 +391,57 @@ class SFTrustManager implements X509TrustManager
    *
    * @param pairIssuerSubject a pair of issuer and subject certificate
    * @param currentTimeSecond the current timestamp
-   * @throws IOException          raises if encoding fails.
+   * @throws IOException raises if encoding fails.
    * @throws CertificateException if certificate exception is raised.
    */
   private void executeOneRevoctionStatusCheck(
       SFPair<Certificate, Certificate> pairIssuerSubject, long currentTimeSecond)
-      throws IOException, CertificateException
-  {
+      throws IOException, CertificateException {
     OCSPReq req = createRequest(pairIssuerSubject);
     CertID cid = req.getRequestList()[0].getCertID().toASN1Primitive();
-    OcspResponseCacheKey keyOcspResponse = new OcspResponseCacheKey(
-        cid.getIssuerNameHash().getEncoded(),
-        cid.getIssuerKeyHash().getEncoded(),
-        cid.getSerialNumber().getValue());
+    OcspResponseCacheKey keyOcspResponse =
+        new OcspResponseCacheKey(
+            cid.getIssuerNameHash().getEncoded(),
+            cid.getIssuerKeyHash().getEncoded(),
+            cid.getSerialNumber().getValue());
 
     long sleepTime = INITIAL_SLEEPING_TIME_IN_MILLISECONDS;
     CertificateException error = null;
     boolean success = false;
-    for (int retry = 0; retry < MAX_RETRY_COUNTER; ++retry)
-    {
+    for (int retry = 0; retry < MAX_RETRY_COUNTER; ++retry) {
       SFPair<Long, OCSPResp> value0 = OCSP_RESPONSE_CACHE.get(keyOcspResponse);
       OCSPResp ocspResp;
-      try
-      {
-        if (value0 == null)
-        {
+      try {
+        if (value0 == null) {
           LOGGER.debug("not hit cache.");
           ocspResp = fetchOcspResponse(pairIssuerSubject, req);
-          OCSP_RESPONSE_CACHE.put(
-              keyOcspResponse, SFPair.of(currentTimeSecond, ocspResp));
+          OCSP_RESPONSE_CACHE.put(keyOcspResponse, SFPair.of(currentTimeSecond, ocspResp));
           WAS_CACHE_UPDATED = true;
-        }
-        else
-        {
+        } else {
           LOGGER.debug("hit cache.");
           ocspResp = value0.right;
         }
-        LOGGER.debug("validating. {}",
-            CertificateIDToString(req.getRequestList()[0].getCertID()));
+        LOGGER.debug("validating. {}", CertificateIDToString(req.getRequestList()[0].getCertID()));
         validateRevocationStatusMain(pairIssuerSubject, ocspResp);
         success = true;
         break;
-      }
-      catch (CertificateException ex)
-      {
-        if (OCSP_RESPONSE_CACHE.containsKey(keyOcspResponse))
-        {
+      } catch (CertificateException ex) {
+        if (OCSP_RESPONSE_CACHE.containsKey(keyOcspResponse)) {
           LOGGER.debug("deleting the invalid OCSP cache.");
           OCSP_RESPONSE_CACHE.remove(keyOcspResponse);
           WAS_CACHE_UPDATED = true;
         }
         error = ex;
-        LOGGER.debug("Retrying {}/{} after sleeping {}(ms)",
-            retry + 1, MAX_RETRY_COUNTER, sleepTime);
-        try
-        {
+        LOGGER.debug(
+            "Retrying {}/{} after sleeping {}(ms)", retry + 1, MAX_RETRY_COUNTER, sleepTime);
+        try {
           Thread.sleep(sleepTime);
           sleepTime = minLong(MAX_SLEEPING_TIME_IN_MILLISECONDS, sleepTime * 2);
-        }
-        catch (InterruptedException ex0)
-        { // nop
+        } catch (InterruptedException ex0) { // nop
         }
       }
     }
-    if (!success)
-    {
+    if (!success) {
       // still not success, raise an error.
       throw error;
     }
@@ -556,58 +453,46 @@ class SFTrustManager implements X509TrustManager
    * @param pairIssuerSubjectList a list of pair of issuer and subject certificates
    * @return true if all of OCSP response are cached else false
    */
-  private boolean isCached(List<SFPair<Certificate, Certificate>> pairIssuerSubjectList)
-  {
+  private boolean isCached(List<SFPair<Certificate, Certificate>> pairIssuerSubjectList) {
     long currentTimeSecond = new Date().getTime() / 1000L;
     boolean isCached = true;
-    try
-    {
-      for (SFPair<Certificate, Certificate> pairIssuerSubject : pairIssuerSubjectList)
-      {
+    try {
+      for (SFPair<Certificate, Certificate> pairIssuerSubject : pairIssuerSubjectList) {
         OCSPReq req = createRequest(pairIssuerSubject);
         CertificateID certificateId = req.getRequestList()[0].getCertID();
         LOGGER.debug(CertificateIDToString(certificateId));
         CertID cid = certificateId.toASN1Primitive();
-        OcspResponseCacheKey k = new OcspResponseCacheKey(
-            cid.getIssuerNameHash().getEncoded(),
-            cid.getIssuerKeyHash().getEncoded(),
-            cid.getSerialNumber().getValue());
+        OcspResponseCacheKey k =
+            new OcspResponseCacheKey(
+                cid.getIssuerNameHash().getEncoded(),
+                cid.getIssuerKeyHash().getEncoded(),
+                cid.getSerialNumber().getValue());
 
         SFPair<Long, OCSPResp> res = OCSP_RESPONSE_CACHE.get(k);
-        if (res == null)
-        {
+        if (res == null) {
           LOGGER.debug("Not all OCSP responses for the certificate is in the cache.");
           isCached = false;
           break;
-        }
-        else if (currentTimeSecond - CACHE_EXPIRATION_IN_SECONDS > res.left)
-        {
+        } else if (currentTimeSecond - CACHE_EXPIRATION_IN_SECONDS > res.left) {
           LOGGER.debug("Cache for CertID expired.");
           isCached = false;
           break;
-        }
-        else
-        {
-          try
-          {
+        } else {
+          try {
             validateRevocationStatusMain(pairIssuerSubject, res.right);
-          }
-          catch (CertificateException ex)
-          {
-            LOGGER.debug("Cache includes invalid OCSPResponse. " +
-                "Will download the OCSP cache from Snowflake OCSP server");
+          } catch (CertificateException ex) {
+            LOGGER.debug(
+                "Cache includes invalid OCSPResponse. "
+                    + "Will download the OCSP cache from Snowflake OCSP server");
             isCached = false;
           }
         }
       }
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       LOGGER.debug("Failed to encode CertID.");
     }
     return isCached;
   }
-
 
   /**
    * CertificateID to string
@@ -615,14 +500,12 @@ class SFTrustManager implements X509TrustManager
    * @param certificateID CertificateID
    * @return a string representation of CertificateID
    */
-  private static String CertificateIDToString(CertificateID certificateID)
-  {
-    return String.format("CertID. NameHash: %s, KeyHash: %s, Serial Number: %s",
+  private static String CertificateIDToString(CertificateID certificateID) {
+    return String.format(
+        "CertID. NameHash: %s, KeyHash: %s, Serial Number: %s",
         byteToHexString(certificateID.getIssuerNameHash()),
         byteToHexString(certificateID.getIssuerKeyHash()),
-        MessageFormat.format("{0,number,#}",
-            certificateID.getSerialNumber()));
-
+        MessageFormat.format("{0,number,#}", certificateID.getSerialNumber()));
   }
 
   /**
@@ -631,9 +514,8 @@ class SFTrustManager implements X509TrustManager
    * @param elem A JSON element
    * @return OcspResponseCacheKey object
    */
-  private static SFPair<OcspResponseCacheKey, SFPair<Long, OCSPResp>>
-  decodeCacheFromJSON(Map.Entry<String, JsonNode> elem) throws IOException
-  {
+  private static SFPair<OcspResponseCacheKey, SFPair<Long, OCSPResp>> decodeCacheFromJSON(
+      Map.Entry<String, JsonNode> elem) throws IOException {
     long currentTimeSecond = new Date().getTime() / 1000;
     byte[] certIdDer = Base64.decodeBase64(elem.getKey());
     DLSequence rawCertId = (DLSequence) ASN1ObjectIdentifier.fromByteArray(certIdDer);
@@ -642,25 +524,21 @@ class SFTrustManager implements X509TrustManager
     byte[] issuerKeyHashDer = ((DEROctetString) rawCertIdArray[2]).getEncoded();
     BigInteger serialNumber = ((ASN1Integer) rawCertIdArray[3]).getValue();
 
-    OcspResponseCacheKey k = new OcspResponseCacheKey(
-        issuerNameHashDer, issuerKeyHashDer, serialNumber);
+    OcspResponseCacheKey k =
+        new OcspResponseCacheKey(issuerNameHashDer, issuerKeyHashDer, serialNumber);
 
     JsonNode ocspRespBase64 = elem.getValue();
-    if (!ocspRespBase64.isArray() || ocspRespBase64.size() != 2)
-    {
+    if (!ocspRespBase64.isArray() || ocspRespBase64.size() != 2) {
       LOGGER.debug("Invalid cache file format.");
       return null;
     }
     long producedAt = ocspRespBase64.get(0).asLong();
     byte[] ocspRespDer = Base64.decodeBase64(ocspRespBase64.get(1).asText());
-    if (currentTimeSecond - CACHE_EXPIRATION_IN_SECONDS <= producedAt)
-    {
+    if (currentTimeSecond - CACHE_EXPIRATION_IN_SECONDS <= producedAt) {
       // add cache
       OCSPResp v0 = new OCSPResp(ocspRespDer);
       return SFPair.of(k, SFPair.of(producedAt, v0));
-    }
-    else
-    {
+    } else {
       // delete cache
       return SFPair.of(k, SFPair.of(producedAt, (OCSPResp) null));
     }
@@ -671,14 +549,11 @@ class SFTrustManager implements X509TrustManager
    *
    * @return JSON object
    */
-  private static ObjectNode encodeCacheToJSON()
-  {
-    try
-    {
+  private static ObjectNode encodeCacheToJSON() {
+    try {
       ObjectNode out = OBJECT_MAPPER.createObjectNode();
       for (Map.Entry<OcspResponseCacheKey, SFPair<Long, OCSPResp>> elem :
-          OCSP_RESPONSE_CACHE.entrySet())
-      {
+          OCSP_RESPONSE_CACHE.entrySet()) {
         OcspResponseCacheKey key = elem.getKey();
         SFPair<Long, OCSPResp> value0 = elem.getValue();
         long currentTimeSecond = value0.left;
@@ -693,14 +568,10 @@ class SFTrustManager implements X509TrustManager
         ArrayNode vout = OBJECT_MAPPER.createArrayNode();
         vout.add(currentTimeSecond);
         vout.add(Base64.encodeBase64String(value.getEncoded()));
-        out.set(
-            Base64.encodeBase64String(cid.toASN1Primitive().getEncoded()),
-            vout);
+        out.set(Base64.encodeBase64String(cid.toASN1Primitive().getEncoded()), vout);
       }
       return out;
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       LOGGER.debug("Failed to encode ASN1 object.");
     }
     return null;
@@ -708,30 +579,24 @@ class SFTrustManager implements X509TrustManager
 
   /**
    * Reads the OCSP response cache from the server.
-   * <p>
-   * Must be synchronized by OCSP_RESPONSE_CACHE_LOCK.
+   *
+   * <p>Must be synchronized by OCSP_RESPONSE_CACHE_LOCK.
    */
-  private static void readOcspResponseCacheServer()
-  {
+  private static void readOcspResponseCacheServer() {
     long sleepTime = INITIAL_SLEEPING_TIME_IN_MILLISECONDS;
     Exception error = null;
-    for (int retry = 0; retry < MAX_RETRY_COUNTER; ++retry)
-    {
-      try
-      {
+    for (int retry = 0; retry < MAX_RETRY_COUNTER; ++retry) {
+      try {
         HttpClient client = getHttpClient();
         URI uri = new URI(SF_OCSP_RESPONSE_CACHE_SERVER_URL);
         HttpGet get = new HttpGet(uri);
         HttpResponse response = client.execute(get);
 
-        if (response == null || response.getStatusLine().getStatusCode() != HttpStatus.SC_OK)
-        {
+        if (response == null || response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
           throw new IOException(
               String.format(
-                  "Failed to get the OCSP response from the OCSP " +
-                      "cache server: HTTP: %d",
-                  response != null ? response.getStatusLine().getStatusCode() :
-                      -1));
+                  "Failed to get the OCSP response from the OCSP " + "cache server: HTTP: %d",
+                  response != null ? response.getStatusLine().getStatusCode() : -1));
         }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -740,55 +605,41 @@ class SFTrustManager implements X509TrustManager
         readJsonStoreCache(m);
         LOGGER.debug("Successfully downloaded OCSP cache from the server.");
         return;
-      }
-      catch (IOException | URISyntaxException ex)
-      {
+      } catch (IOException | URISyntaxException ex) {
         error = ex;
-        LOGGER.debug("Retrying {}/{} after sleeping {}(ms)",
-            retry + 1, MAX_RETRY_COUNTER, sleepTime);
-        try
-        {
+        LOGGER.debug(
+            "Retrying {}/{} after sleeping {}(ms)", retry + 1, MAX_RETRY_COUNTER, sleepTime);
+        try {
           Thread.sleep(sleepTime);
           sleepTime = minLong(MAX_SLEEPING_TIME_IN_MILLISECONDS, sleepTime * 2);
-        }
-        catch (InterruptedException ex0)
-        { // nop
+        } catch (InterruptedException ex0) { // nop
         }
       }
     }
     LOGGER.debug(
-        "Failed to read the OCSP response cache from the server. " +
-            "Server: {}, Err: {}", SF_OCSP_RESPONSE_CACHE_SERVER_URL, error);
+        "Failed to read the OCSP response cache from the server. " + "Server: {}, Err: {}",
+        SF_OCSP_RESPONSE_CACHE_SERVER_URL,
+        error);
   }
 
-  private static void readJsonStoreCache(JsonNode m)
-  {
-    if (m == null || !m.getNodeType().equals(JsonNodeType.OBJECT))
-    {
+  private static void readJsonStoreCache(JsonNode m) {
+    if (m == null || !m.getNodeType().equals(JsonNodeType.OBJECT)) {
       LOGGER.debug("Invalid cache file format.");
       return;
     }
-    try
-    {
-      for (Iterator<Map.Entry<String, JsonNode>> itr = m.fields(); itr.hasNext(); )
-      {
-        SFPair<OcspResponseCacheKey, SFPair<Long, OCSPResp>> ky =
-            decodeCacheFromJSON(itr.next());
-        if (ky != null && ky.right != null && ky.right.right != null)
-        {
+    try {
+      for (Iterator<Map.Entry<String, JsonNode>> itr = m.fields(); itr.hasNext(); ) {
+        SFPair<OcspResponseCacheKey, SFPair<Long, OCSPResp>> ky = decodeCacheFromJSON(itr.next());
+        if (ky != null && ky.right != null && ky.right.right != null) {
           // valid range. cache the result in memory
           OCSP_RESPONSE_CACHE.put(ky.left, ky.right);
-        }
-        else if (ky != null && OCSP_RESPONSE_CACHE.containsKey(ky.left))
-        {
+        } else if (ky != null && OCSP_RESPONSE_CACHE.containsKey(ky.left)) {
           // delete it from the cache if no OCSP response is back.
           OCSP_RESPONSE_CACHE.remove(ky.left);
           WAS_CACHE_UPDATED = true;
         }
       }
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       LOGGER.debug("Failed to decode the cache file");
     }
   }
@@ -797,86 +648,73 @@ class SFTrustManager implements X509TrustManager
    * Fetches OCSP response from OCSP server
    *
    * @param pairIssuerSubject a pair of issuer and subject certificates
-   * @param req               OCSP Request object
+   * @param req OCSP Request object
    * @return OCSP Response object
    * @throws CertificateEncodingException if any other error occurs
    */
   private OCSPResp fetchOcspResponse(
       SFPair<Certificate, Certificate> pairIssuerSubject, OCSPReq req)
-      throws CertificateEncodingException
-  {
-    try
-    {
+      throws CertificateEncodingException {
+    try {
       byte[] ocspReqDer = req.getEncoded();
       String ocspReqDerBase64 = Base64.encodeBase64String(ocspReqDer);
 
       Set<String> ocspUrls = getOcspUrls(pairIssuerSubject.right);
       String ocspUrlStr = ocspUrls.iterator().next(); // first one
       URL url;
-      if (SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN != null)
-      {
+      if (SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN != null) {
         URL ocspUrl = new URL(ocspUrlStr);
-        url = new URL(String.format(
-            SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN,
-                ocspUrl.getHost(), ocspReqDerBase64));
-      }
-      else
-      {
+        url =
+            new URL(
+                String.format(
+                    SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN,
+                    ocspUrl.getHost(),
+                    ocspReqDerBase64));
+      } else {
         url = new URL(String.format("%s/%s", ocspUrlStr, ocspReqDerBase64));
       }
-      LOGGER.debug(
-          "not hit cache. Fetching OCSP response from CA OCSP server. {}", url.toString());
+      LOGGER.debug("not hit cache. Fetching OCSP response from CA OCSP server. {}", url.toString());
 
       long sleepTime = INITIAL_SLEEPING_TIME_IN_MILLISECONDS;
       boolean success = false;
       HttpResponse response = null;
 
-      for (int retry = 0; retry < MAX_RETRY_COUNTER; ++retry)
-      {
+      for (int retry = 0; retry < MAX_RETRY_COUNTER; ++retry) {
         HttpClient client = getHttpClient();
         HttpGet get = new HttpGet(url.toString());
         response = client.execute(get);
-        if (response != null && response.getStatusLine().getStatusCode() == HttpStatus.SC_OK)
-        {
+        if (response != null && response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
           success = true;
           LOGGER.debug(
-              "Successfully downloaded OCSP response from CA server. " +
-                  "URL: {}", url.toString());
+              "Successfully downloaded OCSP response from CA server. " + "URL: {}", url.toString());
           break;
         }
-        LOGGER.debug("Retrying {}/{} after sleeping {}(ms)",
-            retry + 1, MAX_RETRY_COUNTER, sleepTime);
-        try
-        {
+        LOGGER.debug(
+            "Retrying {}/{} after sleeping {}(ms)", retry + 1, MAX_RETRY_COUNTER, sleepTime);
+        try {
           Thread.sleep(sleepTime);
           sleepTime = minLong(MAX_SLEEPING_TIME_IN_MILLISECONDS, sleepTime * 2);
-        }
-        catch (InterruptedException ex0)
-        { // nop
+        } catch (InterruptedException ex0) { // nop
         }
       }
-      if (!success)
-      {
+      if (!success) {
         throw new CertificateEncodingException(
             String.format(
                 "Failed to get OCSP response. StatusCode: %d, URL: %s",
-                response == null ? null : response.getStatusLine().getStatusCode(),
-                ocspUrlStr));
+                response == null ? null : response.getStatusLine().getStatusCode(), ocspUrlStr));
       }
       ByteArrayOutputStream out = new ByteArrayOutputStream();
       IOUtils.copy(response.getEntity().getContent(), out);
       OCSPResp ocspResp = new OCSPResp(out.toByteArray());
-      if (ocspResp.getStatus() != OCSPResp.SUCCESSFUL)
-      {
+      if (ocspResp.getStatus() != OCSPResp.SUCCESSFUL) {
         throw new CertificateEncodingException(
-            String.format("Failed to get OCSP response. Status: %s",
+            String.format(
+                "Failed to get OCSP response. Status: %s",
                 OCSP_RESPONSE_CODE_TO_STRING.get(ocspResp.getStatus())));
       }
 
       return ocspResp;
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       throw new CertificateEncodingException("Failed to encode object.", ex);
     }
   }
@@ -885,40 +723,33 @@ class SFTrustManager implements X509TrustManager
    * Validates the certificate revocation status
    *
    * @param pairIssuerSubject a pair of issuer and subject certificates
-   * @param ocspResp          OCSP Response object
+   * @param ocspResp OCSP Response object
    * @throws CertificateException raises if any other error occurs
    */
   private void validateRevocationStatusMain(
-      SFPair<Certificate, Certificate> pairIssuerSubject,
-      OCSPResp ocspResp) throws CertificateException
-  {
-    try
-    {
+      SFPair<Certificate, Certificate> pairIssuerSubject, OCSPResp ocspResp)
+      throws CertificateException {
+    try {
       Date currentTime = new Date();
       BasicOCSPResp basicOcspResp = (BasicOCSPResp) (ocspResp.getResponseObject());
       X509CertificateHolder[] attachedCerts = basicOcspResp.getCerts();
       X509CertificateHolder signVerifyCert;
-      if (attachedCerts.length > 0)
-      {
+      if (attachedCerts.length > 0) {
         LOGGER.debug(
-            "Certificate is attached for verification. " +
-                "Verifying it by the issuer certificate.");
+            "Certificate is attached for verification. "
+                + "Verifying it by the issuer certificate.");
         signVerifyCert = attachedCerts[0];
         verifySignature(
             new X509CertificateHolder(pairIssuerSubject.left.getEncoded()),
             signVerifyCert.getSignature(),
             CONVERTER_X509.getCertificate(signVerifyCert).getTBSCertificate(),
             signVerifyCert.getSignatureAlgorithm());
+        LOGGER.debug("Verifying OCSP signature by the attached certificate public key.");
+      } else {
         LOGGER.debug(
-            "Verifying OCSP signature by the attached certificate public key."
-        );
-      }
-      else
-      {
-        LOGGER.debug("Certificate is NOT attached for verification. " +
-            "Verifying OCSP signature by the issuer public key.");
-        signVerifyCert = new X509CertificateHolder(
-            pairIssuerSubject.left.getEncoded());
+            "Certificate is NOT attached for verification. "
+                + "Verifying OCSP signature by the issuer public key.");
+        signVerifyCert = new X509CertificateHolder(pairIssuerSubject.left.getEncoded());
       }
       verifySignature(
           signVerifyCert,
@@ -927,44 +758,36 @@ class SFTrustManager implements X509TrustManager
           basicOcspResp.getSignatureAlgorithmID());
 
       validateBasicOcspResponse(currentTime, basicOcspResp);
-    }
-    catch (IOException | OCSPException ex)
-    {
-      throw new CertificateEncodingException(
-          "Failed to check revocation status.", ex);
+    } catch (IOException | OCSPException ex) {
+      throw new CertificateEncodingException("Failed to check revocation status.", ex);
     }
   }
 
   /**
    * Validates OCSP Basic OCSP response.
    *
-   * @param currentTime   the current timestamp.
+   * @param currentTime the current timestamp.
    * @param basicOcspResp BasicOcspResponse data.
    * @throws CertificateEncodingException raises if any failure occurs.
    */
-  private void validateBasicOcspResponse(
-      Date currentTime, BasicOCSPResp basicOcspResp)
-      throws CertificateEncodingException
-  {
-    for (SingleResp singleResps : basicOcspResp.getResponses())
-    {
+  private void validateBasicOcspResponse(Date currentTime, BasicOCSPResp basicOcspResp)
+      throws CertificateEncodingException {
+    for (SingleResp singleResps : basicOcspResp.getResponses()) {
       Date thisUpdate = singleResps.getThisUpdate();
       Date nextUpdate = singleResps.getNextUpdate();
-      LOGGER.debug("Current Time: {}, This Update: {}, Next Update: {}",
-          currentTime, thisUpdate, nextUpdate);
+      LOGGER.debug(
+          "Current Time: {}, This Update: {}, Next Update: {}",
+          currentTime,
+          thisUpdate,
+          nextUpdate);
       CertificateStatus certStatus = singleResps.getCertStatus();
-      if (certStatus != CertificateStatus.GOOD)
-      {
-        if (certStatus instanceof RevokedStatus)
-        {
+      if (certStatus != CertificateStatus.GOOD) {
+        if (certStatus instanceof RevokedStatus) {
           RevokedStatus status = (RevokedStatus) certStatus;
           int reason;
-          try
-          {
+          try {
             reason = status.getRevocationReason();
-          }
-          catch (IllegalStateException ex)
-          {
+          } catch (IllegalStateException ex) {
             reason = -1;
           }
           Date revocationTime = status.getRevocationTime();
@@ -972,20 +795,17 @@ class SFTrustManager implements X509TrustManager
               String.format(
                   "The certificate has been revoked. Reason: %d, Time: %s",
                   reason, DATE_FORMAT_UTC.format(revocationTime)));
-        }
-        else
-        {
+        } else {
           // Unknown status
           throw new CertificateEncodingException(
               "Failed to validate the certificate for UNKNOWN reason.");
         }
       }
-      if (!isValidityRange(currentTime, thisUpdate, nextUpdate))
-      {
+      if (!isValidityRange(currentTime, thisUpdate, nextUpdate)) {
         throw new CertificateEncodingException(
             String.format(
-                "The validity is out of range: " +
-                    "Current Time: %s, This Update: %s, Next Update: %s",
+                "The validity is out of range: "
+                    + "Current Time: %s, This Update: %s, Next Update: %s",
                 DATE_FORMAT_UTC.format(currentTime),
                 DATE_FORMAT_UTC.format(thisUpdate),
                 DATE_FORMAT_UTC.format(nextUpdate)));
@@ -998,41 +818,37 @@ class SFTrustManager implements X509TrustManager
    * Verifies the signature of the data
    *
    * @param cert a certificate for public key.
-   * @param sig  signature in a byte array.
+   * @param sig signature in a byte array.
    * @param data data in a byte array.
-   * @param idf  algorithm identifier object.
+   * @param idf algorithm identifier object.
    * @throws CertificateException raises if the verification fails.
    */
   private static void verifySignature(
-      X509CertificateHolder cert,
-      byte[] sig, byte[] data, AlgorithmIdentifier idf) throws CertificateException
-  {
-    try
-    {
+      X509CertificateHolder cert, byte[] sig, byte[] data, AlgorithmIdentifier idf)
+      throws CertificateException {
+    try {
       String algorithm = SIGNATURE_OID_TO_STRING.get(idf.getAlgorithm());
-      if (algorithm == null)
-      {
+      if (algorithm == null) {
         throw new NoSuchAlgorithmException(
             String.format("Unsupported signature OID. OID: %s", idf));
       }
-      Signature signer = Signature.getInstance(
-          algorithm, BouncyCastleProvider.PROVIDER_NAME);
+      Signature signer = Signature.getInstance(algorithm, BouncyCastleProvider.PROVIDER_NAME);
 
       X509Certificate c = CONVERTER_X509.getCertificate(cert);
       signer.initVerify(c.getPublicKey());
       signer.update(data);
-      if (!signer.verify(sig))
-      {
+      if (!signer.verify(sig)) {
         throw new CertificateEncodingException(
-            String.format("Failed to verify the signature. Potentially the " +
-                "data was not generated by by the cert, %s", cert.getSubject()));
+            String.format(
+                "Failed to verify the signature. Potentially the "
+                    + "data was not generated by by the cert, %s",
+                cert.getSubject()));
       }
-    }
-    catch (NoSuchAlgorithmException | NoSuchProviderException |
-        InvalidKeyException | SignatureException ex)
-    {
-      throw new CertificateEncodingException(
-          "Failed to verify the signature.", ex);
+    } catch (NoSuchAlgorithmException
+        | NoSuchProviderException
+        | InvalidKeyException
+        | SignatureException ex) {
+      throw new CertificateEncodingException("Failed to verify the signature.", ex);
     }
   }
 
@@ -1042,12 +858,10 @@ class SFTrustManager implements X509TrustManager
    * @param bytes a byte array
    * @return a string in hexadecimal code
    */
-  private static String byteToHexString(byte[] bytes)
-  {
+  private static String byteToHexString(byte[] bytes) {
     final char[] hexArray = "0123456789ABCDEF".toCharArray();
     char[] hexChars = new char[bytes.length * 2];
-    for (int j = 0; j < bytes.length; j++)
-    {
+    for (int j = 0; j < bytes.length; j++) {
       int v = bytes[j] & 0xFF;
       hexChars[j * 2] = hexArray[v >>> 4];
       hexChars[j * 2 + 1] = hexArray[v & 0x0F];
@@ -1061,27 +875,21 @@ class SFTrustManager implements X509TrustManager
    * @param pairIssuerSubject a pair of issuer and subject certificates
    * @return OCSPReq object
    */
-  private OCSPReq createRequest(
-      SFPair<Certificate, Certificate> pairIssuerSubject)
-  {
+  private OCSPReq createRequest(SFPair<Certificate, Certificate> pairIssuerSubject) {
     Certificate issuer = pairIssuerSubject.left;
     Certificate subject = pairIssuerSubject.right;
     OCSPReqBuilder gen = new OCSPReqBuilder();
-    try
-    {
+    try {
       DigestCalculator digest = new SHA1DigestCalculator();
       X509CertificateHolder certHolder = new X509CertificateHolder(issuer.getEncoded());
-      CertificateID certId = new CertificateID(
-          digest, certHolder, subject.getSerialNumber().getValue());
+      CertificateID certId =
+          new CertificateID(digest, certHolder, subject.getSerialNumber().getValue());
       gen.addRequest(certId);
       return gen.build();
-    }
-    catch (OCSPException | IOException ex)
-    {
+    } catch (OCSPException | IOException ex) {
       throw new RuntimeException("Failed to build a OCSPReq.");
     }
   }
-
 
   /**
    * Converts X509Certificate to Bouncy Castle Certificate
@@ -1089,18 +897,12 @@ class SFTrustManager implements X509TrustManager
    * @param chain an array of X509Certificate
    * @return a list of Bouncy Castle Certificate
    */
-  private List<Certificate> convertToBouncyCastleCertificate(
-      X509Certificate[] chain)
-  {
+  private List<Certificate> convertToBouncyCastleCertificate(X509Certificate[] chain) {
     final List<Certificate> bcChain = new ArrayList<>();
-    for (X509Certificate cert : chain)
-    {
-      try
-      {
+    for (X509Certificate cert : chain) {
+      try {
         bcChain.add(Certificate.getInstance(cert.getEncoded()));
-      }
-      catch (CertificateEncodingException ex)
-      {
+      } catch (CertificateEncodingException ex) {
         throw new RuntimeException("Failed to decode the certificate DER data");
       }
     }
@@ -1113,30 +915,21 @@ class SFTrustManager implements X509TrustManager
    * @param bcChain a list of bouncy castle Certificate
    * @return a list of paif of Issuer and Subject certificates
    */
-  private List<SFPair<Certificate, Certificate>> getPairIssuerSubject(
-      List<Certificate> bcChain)
-  {
+  private List<SFPair<Certificate, Certificate>> getPairIssuerSubject(List<Certificate> bcChain) {
     List<SFPair<Certificate, Certificate>> pairIssuerSubject = new ArrayList<>();
-    for (int i = 0, len = bcChain.size(); i < len; ++i)
-    {
+    for (int i = 0, len = bcChain.size(); i < len; ++i) {
       Certificate bcCert = bcChain.get(i);
-      if (bcCert.getIssuer().equals(bcCert.getSubject()))
-      {
+      if (bcCert.getIssuer().equals(bcCert.getSubject())) {
         continue; // skipping ROOT CA
       }
-      if (i < len - 1)
-      {
+      if (i < len - 1) {
         pairIssuerSubject.add(SFPair.of(bcChain.get(i + 1), bcChain.get(i)));
-      }
-      else
-      {
-        synchronized (ROOT_CA_LOCK)
-        {
+      } else {
+        synchronized (ROOT_CA_LOCK) {
           // no root CA certificate is attached in the certificate chain, so
           // getting one from the root CA from JVM.
           Certificate issuer = ROOT_CA.get(bcCert.getIssuer().hashCode());
-          if (issuer == null)
-          {
+          if (issuer == null) {
             throw new RuntimeException("Failed to find the root CA.");
           }
           pairIssuerSubject.add(SFPair.of(issuer, bcChain.get(i)));
@@ -1152,32 +945,25 @@ class SFTrustManager implements X509TrustManager
    * @param bcCert Bouncy Castle Certificate
    * @return a set of OCSP URLs
    */
-  private Set<String> getOcspUrls(Certificate bcCert)
-  {
+  private Set<String> getOcspUrls(Certificate bcCert) {
     TBSCertificate bcTbsCert = bcCert.getTBSCertificate();
     Extensions bcExts = bcTbsCert.getExtensions();
-    if (bcExts == null)
-    {
+    if (bcExts == null) {
       throw new RuntimeException("Failed to get Tbs Certificate.");
     }
 
     Set<String> ocsp = new HashSet<>();
-    for (Enumeration en = bcExts.oids(); en.hasMoreElements(); )
-    {
+    for (Enumeration en = bcExts.oids(); en.hasMoreElements(); ) {
       ASN1ObjectIdentifier oid = (ASN1ObjectIdentifier) en.nextElement();
       Extension bcExt = bcExts.getExtension(oid);
-      if (bcExt.getExtnId() == Extension.authorityInfoAccess)
-      {
+      if (bcExt.getExtnId() == Extension.authorityInfoAccess) {
         // OCSP URLS are included in authorityInfoAccess
         DLSequence seq = (DLSequence) bcExt.getParsedValue();
-        for (ASN1Encodable asn : seq)
-        {
+        for (ASN1Encodable asn : seq) {
           ASN1Encodable[] pairOfAsn = ((DLSequence) asn).toArray();
-          if (pairOfAsn.length == 2)
-          {
+          if (pairOfAsn.length == 2) {
             ASN1ObjectIdentifier key = (ASN1ObjectIdentifier) pairOfAsn[0];
-            if (key == OIDocsp)
-            {
+            if (key == OIDocsp) {
               // ensure OCSP and not CRL
               GeneralName gn = GeneralName.getInstance(pairOfAsn[1]);
               ocsp.add(gn.getName().toString());
@@ -1194,117 +980,100 @@ class SFTrustManager implements X509TrustManager
    *
    * @return HttpClient
    */
-  private static HttpClient getHttpClient()
-  {
+  private static HttpClient getHttpClient() {
     // using the default HTTP client
     return HttpUtil.getHttpClient();
   }
 
-  private static long minLong(long v1, long v2)
-  {
+  private static long minLong(long v1, long v2) {
     return v1 < v2 ? v1 : v2;
   }
 
-  private static long maxLong(long v1, long v2)
-  {
+  private static long maxLong(long v1, long v2) {
     return v1 > v2 ? v1 : v2;
   }
 
   /**
    * Calculates the tolerable validity time beyond the next update.
-   * <p>
-   * Sometimes CA's OCSP response update is delayed beyond the clock skew
-   * as the update is not populated to all OCSP servers for certain period.
+   *
+   * <p>Sometimes CA's OCSP response update is delayed beyond the clock skew as the update is not
+   * populated to all OCSP servers for certain period.
    *
    * @param thisUpdate the last update
    * @param nextUpdate the next update
    * @return the tolerable validity beyond the next update.
    */
-  private static long calculateTolerableVadility(Date thisUpdate, Date nextUpdate)
-  {
-    return maxLong((long) ((float) (nextUpdate.getTime() - thisUpdate.getTime()) *
-        TOLERABLE_VALIDITY_RANGE_RATIO), MIN_CACHE_WARMUP_TIME_IN_MILLISECONDS);
+  private static long calculateTolerableVadility(Date thisUpdate, Date nextUpdate) {
+    return maxLong(
+        (long)
+            ((float) (nextUpdate.getTime() - thisUpdate.getTime())
+                * TOLERABLE_VALIDITY_RANGE_RATIO),
+        MIN_CACHE_WARMUP_TIME_IN_MILLISECONDS);
   }
 
   /**
    * Checks the validity
    *
    * @param currentTime the current time
-   * @param thisUpdate  the last update timestamp
-   * @param nextUpdate  the next update timestamp
+   * @param thisUpdate the last update timestamp
+   * @param nextUpdate the next update timestamp
    * @return true if valid or false
    */
-  private static boolean isValidityRange(Date currentTime, Date thisUpdate, Date nextUpdate)
-  {
+  private static boolean isValidityRange(Date currentTime, Date thisUpdate, Date nextUpdate) {
     long tolerableValidity = calculateTolerableVadility(thisUpdate, nextUpdate);
-    return thisUpdate.getTime() - MAX_CLOCK_SKEW_IN_MILLISECONDS <= currentTime.getTime() &&
-        currentTime.getTime() <= nextUpdate.getTime() + tolerableValidity;
+    return thisUpdate.getTime() - MAX_CLOCK_SKEW_IN_MILLISECONDS <= currentTime.getTime()
+        && currentTime.getTime() <= nextUpdate.getTime() + tolerableValidity;
   }
 
-  /**
-   * OCSP response cache key object
-   */
-  static class OcspResponseCacheKey
-  {
+  /** OCSP response cache key object */
+  static class OcspResponseCacheKey {
     final byte[] nameHash;
     final byte[] keyHash;
     final BigInteger serialNumber;
 
-    OcspResponseCacheKey(byte[] nameHash, byte[] keyHash, BigInteger serialNumber)
-    {
+    OcspResponseCacheKey(byte[] nameHash, byte[] keyHash, BigInteger serialNumber) {
       this.nameHash = nameHash;
       this.keyHash = keyHash;
       this.serialNumber = serialNumber;
     }
 
-    public int hashCode()
-    {
+    public int hashCode() {
       int ret = Arrays.hashCode(this.nameHash) * 37;
       ret = ret * 10 + Arrays.hashCode(this.keyHash) * 37;
       ret = ret * 10 + this.serialNumber.hashCode();
       return ret;
     }
 
-    public boolean equals(Object obj)
-    {
-      if (!(obj instanceof OcspResponseCacheKey))
-      {
+    public boolean equals(Object obj) {
+      if (!(obj instanceof OcspResponseCacheKey)) {
         return false;
       }
       OcspResponseCacheKey target = (OcspResponseCacheKey) obj;
-      return Arrays.equals(this.nameHash, target.nameHash) &&
-          Arrays.equals(this.keyHash, target.keyHash) &&
-          this.serialNumber.equals(target.serialNumber);
+      return Arrays.equals(this.nameHash, target.nameHash)
+          && Arrays.equals(this.keyHash, target.keyHash)
+          && this.serialNumber.equals(target.serialNumber);
     }
 
-    public String toString()
-    {
+    public String toString() {
       return String.format(
           "OcspResponseCacheKey: NameHash: %s, KeyHash: %s, SerialNumber: %s",
-          byteToHexString(nameHash), byteToHexString(keyHash),
-          serialNumber.toString());
+          byteToHexString(nameHash), byteToHexString(keyHash), serialNumber.toString());
     }
   }
 
-  /**
-   * SHA1 Digest Calculator used in OCSP Req.
-   */
-  static class SHA1DigestCalculator implements DigestCalculator
-  {
+  /** SHA1 Digest Calculator used in OCSP Req. */
+  static class SHA1DigestCalculator implements DigestCalculator {
     private ByteArrayOutputStream bOut = new ByteArrayOutputStream();
 
-    public AlgorithmIdentifier getAlgorithmIdentifier()
-    {
+    public AlgorithmIdentifier getAlgorithmIdentifier() {
       return new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1);
     }
 
-    public OutputStream getOutputStream()
-    {
+    public OutputStream getOutputStream() {
       return bOut;
     }
 
-    public byte[] getDigest()
-    {
+    public byte[] getDigest() {
       byte[] bytes = bOut.toByteArray();
       bOut.reset();
       Digest sha1 = new SHA1Digest();
@@ -1314,5 +1083,4 @@ class SFTrustManager implements X509TrustManager
       return digest;
     }
   }
-
 }

--- a/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
@@ -6,19 +6,6 @@ package net.snowflake.client.core;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.common.core.ClientAuthnDTO;
-import net.snowflake.common.core.ClientAuthnParameter;
-import net.snowflake.common.core.SqlState;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.entity.StringEntity;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -37,22 +24,28 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.ClientAuthnDTO;
+import net.snowflake.common.core.ClientAuthnParameter;
+import net.snowflake.common.core.SqlState;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.StringEntity;
 
 /**
- * SAML 2.0 Compliant service/application federated authentication
- * 1. Query GS to obtain IDP SSO url
- * 2. Listen a localhost port to accept Saml response
- * 3. Open a browser in the backend so that the user can type IdP username
- * and password.
- * 4. Return token and proof key to the GS to gain access.
+ * SAML 2.0 Compliant service/application federated authentication 1. Query GS to obtain IDP SSO url
+ * 2. Listen a localhost port to accept Saml response 3. Open a browser in the backend so that the
+ * user can type IdP username and password. 4. Return token and proof key to the GS to gain access.
  */
-public class SessionUtilExternalBrowser
-{
-  static final SFLogger logger = SFLoggerFactory.getLogger(
-      SessionUtilExternalBrowser.class);
+public class SessionUtilExternalBrowser {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SessionUtilExternalBrowser.class);
 
-  public interface AuthExternalBrowserHandlers
-  {
+  public interface AuthExternalBrowserHandlers {
     // build a HTTP post object
     HttpPost build(URI uri);
 
@@ -63,52 +56,38 @@ public class SessionUtilExternalBrowser
     void output(String msg);
   }
 
-  static class DefaultAuthExternalBrowserHandlers implements AuthExternalBrowserHandlers
-  {
+  static class DefaultAuthExternalBrowserHandlers implements AuthExternalBrowserHandlers {
     @Override
-    public HttpPost build(URI uri)
-    {
+    public HttpPost build(URI uri) {
       return new HttpPost(uri);
     }
 
     @Override
-    public void openBrowser(String ssoUrl) throws SFException
-    {
-      try
-      {
+    public void openBrowser(String ssoUrl) throws SFException {
+      try {
         // start web browser
-        if (java.awt.Desktop.isDesktopSupported())
-        {
+        if (java.awt.Desktop.isDesktopSupported()) {
           URI uri = new URI(ssoUrl);
           java.awt.Desktop.getDesktop().browse(uri);
-        }
-        else
-        {
+        } else {
           Runtime runtime = Runtime.getRuntime();
           Constants.OS os = Constants.getOS();
-          if (os == Constants.OS.MAC)
-          {
+          if (os == Constants.OS.MAC) {
             runtime.exec("open " + ssoUrl);
-          }
-          else
-          {
+          } else {
             // linux?
             runtime.exec("xdg-open " + ssoUrl);
           }
         }
-      }
-      catch (URISyntaxException | IOException ex)
-      {
+      } catch (URISyntaxException | IOException ex) {
         throw new SFException(ex, ErrorCode.NETWORK_ERROR, ex.getMessage());
       }
     }
 
     @Override
-    public void output(String msg)
-    {
+    public void output(String msg) {
       System.out.println(msg);
     }
-
   }
 
   private final ObjectMapper mapper;
@@ -126,19 +105,16 @@ public class SessionUtilExternalBrowser
   private static final String PREFIX_USER_AGENT = "USER-AGENT: ";
   private static Charset UTF8_CHARSET;
 
-  static
-  {
+  static {
     UTF8_CHARSET = Charset.forName("UTF-8");
   }
 
-  public static SessionUtilExternalBrowser createInstance(SessionUtil.LoginInput loginInput)
-  {
-    return new SessionUtilExternalBrowser(
-        loginInput, new DefaultAuthExternalBrowserHandlers());
+  public static SessionUtilExternalBrowser createInstance(SessionUtil.LoginInput loginInput) {
+    return new SessionUtilExternalBrowser(loginInput, new DefaultAuthExternalBrowserHandlers());
   }
 
-  public SessionUtilExternalBrowser(SessionUtil.LoginInput loginInput, AuthExternalBrowserHandlers handlers)
-  {
+  public SessionUtilExternalBrowser(
+      SessionUtil.LoginInput loginInput, AuthExternalBrowserHandlers handlers) {
     this.mapper = new ObjectMapper();
     this.loginInput = loginInput;
     this.handlers = handlers;
@@ -152,17 +128,13 @@ public class SessionUtilExternalBrowser
    * @return port number
    * @throws SFException raised if an error occurs.
    */
-  protected ServerSocket getServerSocket() throws SFException
-  {
-    try
-    {
+  protected ServerSocket getServerSocket() throws SFException {
+    try {
       return new ServerSocket(
           0, // free port
           0, // default number of connections
           InetAddress.getByName("localhost"));
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       throw new SFException(ex, ErrorCode.NETWORK_ERROR, ex.getMessage());
     }
   }
@@ -173,8 +145,7 @@ public class SessionUtilExternalBrowser
    * @param ssocket server socket
    * @return port number
    */
-  protected int getLocalPort(ServerSocket ssocket)
-  {
+  protected int getLocalPort(ServerSocket ssocket) {
     return ssocket.getLocalPort();
   }
 
@@ -182,13 +153,11 @@ public class SessionUtilExternalBrowser
    * Gets SSO URL and proof key
    *
    * @return SSO URL.
-   * @throws SFException           if Snowflake error occurs
+   * @throws SFException if Snowflake error occurs
    * @throws SnowflakeSQLException if Snowflake SQL error occurs
    */
-  private String getSSOUrl(int port) throws SFException, SnowflakeSQLException
-  {
-    try
-    {
+  private String getSSOUrl(int port) throws SFException, SnowflakeSQLException {
+    try {
       String serverUrl = loginInput.getServerUrl();
       String authenticator = loginInput.getAuthenticator();
 
@@ -202,15 +171,11 @@ public class SessionUtilExternalBrowser
       Map<String, Object> data = new HashMap<>();
 
       data.put(ClientAuthnParameter.AUTHENTICATOR.name(), authenticator);
-      data.put(ClientAuthnParameter.ACCOUNT_NAME.name(),
-          loginInput.getAccountName());
-      data.put(ClientAuthnParameter.LOGIN_NAME.name(),
-          loginInput.getUserName());
-      data.put(ClientAuthnParameter.BROWSER_MODE_REDIRECT_PORT.name(),
-          Integer.toString(port));
+      data.put(ClientAuthnParameter.ACCOUNT_NAME.name(), loginInput.getAccountName());
+      data.put(ClientAuthnParameter.LOGIN_NAME.name(), loginInput.getUserName());
+      data.put(ClientAuthnParameter.BROWSER_MODE_REDIRECT_PORT.name(), Integer.toString(port));
       data.put(ClientAuthnParameter.CLIENT_APP_ID.name(), loginInput.getAppId());
-      data.put(ClientAuthnParameter.CLIENT_APP_VERSION.name(),
-          loginInput.getAppVersion());
+      data.put(ClientAuthnParameter.CLIENT_APP_VERSION.name(), loginInput.getAppVersion());
 
       authnData.setData(data);
       String json = mapper.writeValueAsString(authnData);
@@ -222,8 +187,8 @@ public class SessionUtilExternalBrowser
 
       postRequest.addHeader("accept", "application/json");
 
-      String theString = HttpUtil.executeRequest(postRequest,
-          loginInput.getLoginTimeout(), 0, null);
+      String theString =
+          HttpUtil.executeRequest(postRequest, loginInput.getLoginTimeout(), 0, null);
 
       logger.debug("authenticator-request response: {}", theString);
 
@@ -231,8 +196,7 @@ public class SessionUtilExternalBrowser
       JsonNode jsonNode = mapper.readTree(theString);
 
       // check the success field first
-      if (!jsonNode.path("success").asBoolean())
-      {
+      if (!jsonNode.path("success").asBoolean()) {
         logger.debug("response = {}", theString);
         String errorCode = jsonNode.path("code").asText();
         throw new SnowflakeSQLException(
@@ -246,9 +210,7 @@ public class SessionUtilExternalBrowser
       // session token is in the data field of the returned json response
       this.proofKey = dataNode.path("proofKey").asText();
       return dataNode.path("ssoUrl").asText();
-    }
-    catch (IOException | URISyntaxException ex)
-    {
+    } catch (IOException | URISyntaxException ex) {
       throw new SFException(ex, ErrorCode.NETWORK_ERROR, ex.getMessage());
     }
   }
@@ -256,151 +218,114 @@ public class SessionUtilExternalBrowser
   /**
    * Authenticate
    *
-   * @throws SFException           if any error occurs
+   * @throws SFException if any error occurs
    * @throws SnowflakeSQLException if any error occurs
    */
-  void authenticate() throws SFException, SnowflakeSQLException
-  {
+  void authenticate() throws SFException, SnowflakeSQLException {
     ServerSocket ssocket = this.getServerSocket();
-    try
-    {
+    try {
       // main procedure
       int port = this.getLocalPort(ssocket);
       logger.debug("Listening localhost:{}", port);
       String ssoUrl = getSSOUrl(port);
       this.handlers.output(
-          "Initiating login request with your identity provider. A " +
-              "browser window should have opened for you to complete the " +
-              "login. If you can't see it, check existing browser windows, " +
-              "or your OS settings. Press CTRL+C to abort and try again...");
+          "Initiating login request with your identity provider. A "
+              + "browser window should have opened for you to complete the "
+              + "login. If you can't see it, check existing browser windows, "
+              + "or your OS settings. Press CTRL+C to abort and try again...");
       this.handlers.openBrowser(ssoUrl);
 
-      while (true)
-      {
+      while (true) {
         Socket socket = ssocket.accept(); // start accepting the request
-        try
-        {
-          BufferedReader in = new BufferedReader(
-              new InputStreamReader(socket.getInputStream(), UTF8_CHARSET));
+        try {
+          BufferedReader in =
+              new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF8_CHARSET));
           char[] buf = new char[16384];
           int strLen = in.read(buf);
           String[] rets = new String(buf, 0, strLen).split("\r\n");
-          if (!processOptions(rets, socket))
-          {
+          if (!processOptions(rets, socket)) {
             processSamlToken(rets, socket);
             break;
           }
-        }
-        finally
-        {
+        } finally {
           socket.close();
         }
       }
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       throw new SFException(ex, ErrorCode.NETWORK_ERROR, ex.getMessage());
-    }
-    finally
-    {
-      try
-      {
+    } finally {
+      try {
         ssocket.close();
-      }
-      catch (IOException ex)
-      {
+      } catch (IOException ex) {
         throw new SFException(ex, ErrorCode.NETWORK_ERROR, ex.getMessage());
       }
     }
   }
 
-  private boolean processOptions(String[] rets, Socket socket) throws IOException
-  {
+  private boolean processOptions(String[] rets, Socket socket) throws IOException {
     String targetLine = null;
     String userAgent = null;
     String requestedHeaderLine = null;
-    for (String line : rets)
-    {
-      if (line.length() > PREFIX_OPTIONS.length() &&
-          line.substring(0, PREFIX_OPTIONS.length()).equalsIgnoreCase(PREFIX_OPTIONS))
-      {
+    for (String line : rets) {
+      if (line.length() > PREFIX_OPTIONS.length()
+          && line.substring(0, PREFIX_OPTIONS.length()).equalsIgnoreCase(PREFIX_OPTIONS)) {
         targetLine = line;
-      }
-      else if (line.length() > PREFIX_USER_AGENT.length() &&
-          line.substring(0, PREFIX_USER_AGENT.length()).equalsIgnoreCase(PREFIX_USER_AGENT))
-      {
+      } else if (line.length() > PREFIX_USER_AGENT.length()
+          && line.substring(0, PREFIX_USER_AGENT.length()).equalsIgnoreCase(PREFIX_USER_AGENT)) {
         userAgent = line;
-      }
-      else if (line.startsWith("Access-Control-Request-Method"))
-      {
+      } else if (line.startsWith("Access-Control-Request-Method")) {
         String[] kv = line.split(":");
-        if (kv.length != 2)
-        {
-          logger.error(
-              "no value for HTTP header: Access-Control-Request-Method. line={}", line);
+        if (kv.length != 2) {
+          logger.error("no value for HTTP header: Access-Control-Request-Method. line={}", line);
           return false;
         }
-        if (!kv[1].trim().contains("POST"))
-        {
+        if (!kv[1].trim().contains("POST")) {
           return false;
         }
-      }
-      else if (line.startsWith("Access-Control-Request-Headers"))
-      {
+      } else if (line.startsWith("Access-Control-Request-Headers")) {
         String[] kv = line.split(":");
-        if (kv.length != 2)
-        {
-          logger.error(
-              "no value for HTTP header: Access-Control-Request-Method. line={}", line);
+        if (kv.length != 2) {
+          logger.error("no value for HTTP header: Access-Control-Request-Method. line={}", line);
           return false;
         }
         requestedHeaderLine = kv[1].trim();
-      }
-      else if (line.startsWith("Origin"))
-      {
+      } else if (line.startsWith("Origin")) {
         String[] kv = line.split(":");
-        if (kv.length < 2)
-        {
-          logger.error(
-              "no value for HTTP header: Origin. line={}", line);
+        if (kv.length < 2) {
+          logger.error("no value for HTTP header: Origin. line={}", line);
           return false;
         }
         this.origin = line.substring(line.indexOf(':') + 1).trim();
       }
     }
-    if (userAgent != null)
-    {
+    if (userAgent != null) {
       logger.debug("{}", userAgent);
     }
-    if (Strings.isNullOrEmpty(targetLine) ||
-        Strings.isNullOrEmpty(requestedHeaderLine) ||
-        Strings.isNullOrEmpty(this.origin))
-    {
+    if (Strings.isNullOrEmpty(targetLine)
+        || Strings.isNullOrEmpty(requestedHeaderLine)
+        || Strings.isNullOrEmpty(this.origin)) {
       return false;
     }
     returnToBrowserForOptions(requestedHeaderLine, socket);
     return true;
   }
 
-  private void returnToBrowserForOptions(String requestedHeader, Socket socket) throws IOException
-  {
+  private void returnToBrowserForOptions(String requestedHeader, Socket socket) throws IOException {
     PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
     SimpleDateFormat fmt = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss");
     fmt.setTimeZone(TimeZone.getTimeZone("UTC"));
     String[] content = {
-        "HTTP/1.1 200 OK",
-        String.format("Date: %s", fmt.format(new Date()) + " GMT"),
-        "Access-Control-Allow-Methods: POST, GET",
-        String.format("Access-Control-Allow-Headers: %s", requestedHeader),
-        "Access-Control-Max-Age: 86400",
-        String.format("Access-Control-Allow-Origin: %s", this.origin),
-        "",
-        ""
+      "HTTP/1.1 200 OK",
+      String.format("Date: %s", fmt.format(new Date()) + " GMT"),
+      "Access-Control-Allow-Methods: POST, GET",
+      String.format("Access-Control-Allow-Headers: %s", requestedHeader),
+      "Access-Control-Max-Age: 86400",
+      String.format("Access-Control-Allow-Origin: %s", this.origin),
+      "",
+      ""
     };
-    for (int i = 0; i < content.length; ++i)
-    {
-      if (i > 0)
-      {
+    for (int i = 0; i < content.length; ++i) {
+      if (i > 0) {
         out.print("\r\n");
       }
       out.print(content[i]);
@@ -415,105 +340,82 @@ public class SessionUtilExternalBrowser
    * @throws IOException if any IO error occurs
    * @throws SFException if a HTTP request from browser is invalid
    */
-  private void processSamlToken(String[] rets, Socket socket) throws IOException, SFException
-  {
+  private void processSamlToken(String[] rets, Socket socket) throws IOException, SFException {
     String targetLine = null;
     String userAgent = null;
     boolean isPost = false;
-    for (String line : rets)
-    {
-      if (line.length() > PREFIX_GET.length() &&
-          line.substring(0, PREFIX_GET.length()).equalsIgnoreCase(PREFIX_GET))
-      {
+    for (String line : rets) {
+      if (line.length() > PREFIX_GET.length()
+          && line.substring(0, PREFIX_GET.length()).equalsIgnoreCase(PREFIX_GET)) {
         targetLine = line;
-      }
-      else if (line.length() > PREFIX_POST.length() &&
-          line.substring(0, PREFIX_POST.length()).equalsIgnoreCase(PREFIX_POST))
-      {
+      } else if (line.length() > PREFIX_POST.length()
+          && line.substring(0, PREFIX_POST.length()).equalsIgnoreCase(PREFIX_POST)) {
         targetLine = rets[rets.length - 1];
         isPost = true;
-      }
-      else if (line.length() > PREFIX_USER_AGENT.length() &&
-          line.substring(0, PREFIX_USER_AGENT.length()).equalsIgnoreCase(PREFIX_USER_AGENT))
-      {
+      } else if (line.length() > PREFIX_USER_AGENT.length()
+          && line.substring(0, PREFIX_USER_AGENT.length()).equalsIgnoreCase(PREFIX_USER_AGENT)) {
         userAgent = line;
       }
     }
-    if (targetLine == null)
-    {
-      throw new SFException(ErrorCode.NETWORK_ERROR,
-          "Invalid HTTP request. No token is given from the browser.");
+    if (targetLine == null) {
+      throw new SFException(
+          ErrorCode.NETWORK_ERROR, "Invalid HTTP request. No token is given from the browser.");
     }
-    if (userAgent != null)
-    {
+    if (userAgent != null) {
       logger.debug("{}", userAgent);
     }
 
-    try
-    {
+    try {
       // attempt to get JSON response
       extractJsonTokenFromPostRequest(targetLine);
-    }
-    catch (IOException ex)
-    {
-      String parameters = isPost ?
-          extractTokenFromPostRequest(targetLine) :
-          extractTokenFromGetRequest(targetLine);
-      try
-      {
+    } catch (IOException ex) {
+      String parameters =
+          isPost ? extractTokenFromPostRequest(targetLine) : extractTokenFromGetRequest(targetLine);
+      try {
         URI inputParameter = new URI(parameters);
-        for (NameValuePair urlParam : URLEncodedUtils.parse(
-            inputParameter, UTF8_CHARSET))
-        {
-          if ("token".equals(urlParam.getName()))
-          {
+        for (NameValuePair urlParam : URLEncodedUtils.parse(inputParameter, UTF8_CHARSET)) {
+          if ("token".equals(urlParam.getName())) {
             this.token = urlParam.getValue();
             break;
           }
         }
-      }
-      catch (URISyntaxException ex0)
-      {
-        throw new SFException(ErrorCode.NETWORK_ERROR,
+      } catch (URISyntaxException ex0) {
+        throw new SFException(
+            ErrorCode.NETWORK_ERROR,
             String.format(
                 "Invalid HTTP request. No token is given from the browser. %s, err: %s",
                 targetLine, ex0));
       }
     }
-    if (this.token == null)
-    {
-      throw new SFException(ErrorCode.NETWORK_ERROR,
+    if (this.token == null) {
+      throw new SFException(
+          ErrorCode.NETWORK_ERROR,
           String.format(
-              "Invalid HTTP request. No token is given from the browser: %s",
-              targetLine));
+              "Invalid HTTP request. No token is given from the browser: %s", targetLine));
     }
 
     returnToBrowser(socket);
   }
 
-  private void extractJsonTokenFromPostRequest(String targetLine) throws IOException
-  {
+  private void extractJsonTokenFromPostRequest(String targetLine) throws IOException {
     JsonNode jsonNode = mapper.readTree(targetLine);
     this.token = jsonNode.get("token").asText();
     this.consentCacheIdToken = jsonNode.get("consent").asBoolean();
   }
 
-  private String extractTokenFromPostRequest(String targetLine)
-  {
+  private String extractTokenFromPostRequest(String targetLine) {
     return "/?" + targetLine;
   }
 
-  private String extractTokenFromGetRequest(String targetLine) throws SFException
-  {
+  private String extractTokenFromGetRequest(String targetLine) throws SFException {
     String[] elems = targetLine.split("\\s");
-    if (elems.length != 3 ||
-        !elems[0].toLowerCase(Locale.US).equalsIgnoreCase("GET") ||
-        !elems[2].startsWith("HTTP/1."))
-    {
-      throw new SFException(ErrorCode.NETWORK_ERROR,
+    if (elems.length != 3
+        || !elems[0].toLowerCase(Locale.US).equalsIgnoreCase("GET")
+        || !elems[2].startsWith("HTTP/1.")) {
+      throw new SFException(
+          ErrorCode.NETWORK_ERROR,
           String.format(
-              "Invalid HTTP request. No token is given from the browser: %s",
-              targetLine));
+              "Invalid HTTP request. No token is given from the browser: %s", targetLine));
     }
     return elems[1];
   }
@@ -524,41 +426,33 @@ public class SessionUtilExternalBrowser
    * @param socket client socket
    * @throws IOException if any IO error occurs
    */
-  private void returnToBrowser(Socket socket) throws IOException
-  {
+  private void returnToBrowser(Socket socket) throws IOException {
     PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
 
     List<String> content = new ArrayList<>();
     content.add("HTTP/1.0 200 OK");
     content.add("Content-Type: text/html");
     String responseText;
-    if (this.origin != null)
-    {
-      content.add(
-          String.format("Access-Control-Allow-Origin: %s", this.origin));
+    if (this.origin != null) {
+      content.add(String.format("Access-Control-Allow-Origin: %s", this.origin));
       content.add("Vary: Accept-Encoding, Origin");
       Map<String, Object> data = new HashMap<>();
       data.put("consent", this.consentCacheIdToken);
       responseText = mapper.writeValueAsString(data);
-    }
-    else
-    {
+    } else {
       responseText =
-          "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"/>" +
-              "<title>SAML Response for Snowflake</title></head>" +
-              "<body>Your identity was confirmed and propagated to " +
-              "Snowflake JDBC driver. You can close this window now and go back " +
-              "where you started from.</body></html>";
-
+          "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"/>"
+              + "<title>SAML Response for Snowflake</title></head>"
+              + "<body>Your identity was confirmed and propagated to "
+              + "Snowflake JDBC driver. You can close this window now and go back "
+              + "where you started from.</body></html>";
     }
     content.add(String.format("Content-Length: %s", responseText.length()));
     content.add("");
     content.add(responseText);
 
-    for (int i = 0; i < content.size(); ++i)
-    {
-      if (i > 0)
-      {
+    for (int i = 0; i < content.size(); ++i) {
+      if (i > 0) {
         out.print("\r\n");
       }
       out.print(content.get(i));
@@ -571,28 +465,26 @@ public class SessionUtilExternalBrowser
    *
    * @return SAML token
    */
-  String getToken()
-  {
+  String getToken() {
     return this.token;
   }
 
   /**
-   * Returns proofkey provided in the first roundtrip with GS and
-   * back to GS in the last login-request authentication.
+   * Returns proofkey provided in the first roundtrip with GS and back to GS in the last
+   * login-request authentication.
    *
    * @return proofkey
    */
-  String getProofKey()
-  {
+  String getProofKey() {
     return this.proofKey;
   }
 
   /**
    * True if the user consented to cache id token
+   *
    * @return true or false
    */
-  boolean isConsentCacheIdToken()
-  {
+  boolean isConsentCacheIdToken() {
     return this.consentCacheIdToken;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
@@ -10,9 +10,6 @@ import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import net.snowflake.client.jdbc.ErrorCode;
-import org.apache.commons.codec.binary.Base64;
-
 import java.security.KeyFactory;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -22,66 +19,58 @@ import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Date;
+import net.snowflake.client.jdbc.ErrorCode;
+import org.apache.commons.codec.binary.Base64;
 
-/**
- * Class used to compute jwt token for key pair authentication
- * Created by hyu on 1/16/18.
- */
-class SessionUtilKeyPair
-{
+/** Class used to compute jwt token for key pair authentication Created by hyu on 1/16/18. */
+class SessionUtilKeyPair {
   // user name in upper case
-  final private String userName;
+  private final String userName;
 
   // account name in upper case
-  final private String accountName;
+  private final String accountName;
 
-  final private PrivateKey privateKey;
+  private final PrivateKey privateKey;
 
-  final private PublicKey publicKey;
+  private final PublicKey publicKey;
 
-  static private final String ISSUER_FMT = "%s.%s.%s";
+  private static final String ISSUER_FMT = "%s.%s.%s";
 
-  static private final String SUBJECT_FMT = "%s.%s";
+  private static final String SUBJECT_FMT = "%s.%s";
 
-  SessionUtilKeyPair(PrivateKey privateKey,
-                     String accountName,
-                     String userName) throws SFException
-  {
+  SessionUtilKeyPair(PrivateKey privateKey, String accountName, String userName)
+      throws SFException {
     this.userName = userName.toUpperCase();
     this.accountName = accountName.toUpperCase();
     this.privateKey = privateKey;
 
     // construct public key from raw bytes
-    if (privateKey instanceof RSAPrivateCrtKey)
-    {
-      RSAPrivateCrtKey rsaPrivateCrtKey = (RSAPrivateCrtKey)privateKey;
-      RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(
-          rsaPrivateCrtKey.getModulus(), rsaPrivateCrtKey.getPublicExponent());
+    if (privateKey instanceof RSAPrivateCrtKey) {
+      RSAPrivateCrtKey rsaPrivateCrtKey = (RSAPrivateCrtKey) privateKey;
+      RSAPublicKeySpec rsaPublicKeySpec =
+          new RSAPublicKeySpec(rsaPrivateCrtKey.getModulus(), rsaPrivateCrtKey.getPublicExponent());
 
-      try
-      {
-        this.publicKey = KeyFactory.getInstance("RSA")
-                                   .generatePublic(rsaPublicKeySpec);
+      try {
+        this.publicKey = KeyFactory.getInstance("RSA").generatePublic(rsaPublicKeySpec);
+      } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+        throw new SFException(e, ErrorCode.INTERNAL_ERROR, "Error retrieving public key");
       }
-      catch(NoSuchAlgorithmException | InvalidKeySpecException e)
-      {
-        throw new SFException(e, ErrorCode.INTERNAL_ERROR,
-            "Error retrieving public key");
-      }
-    }
-    else
-    {
-      throw new SFException(ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
+    } else {
+      throw new SFException(
+          ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
           "Please use java.security.interfaces.RSAPrivateCrtKey.class");
     }
   }
 
-  public String issueJwtToken() throws SFException
-  {
+  public String issueJwtToken() throws SFException {
     JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder();
     String sub = String.format(SUBJECT_FMT, this.accountName, this.userName);
-    String iss = String.format(ISSUER_FMT, this.accountName, this.userName,
-        this.calculatePublicKeyFingerprint(this.publicKey));
+    String iss =
+        String.format(
+            ISSUER_FMT,
+            this.accountName,
+            this.userName,
+            this.calculatePublicKeyFingerprint(this.publicKey));
 
     // iat is now
     Date iat = new Date(System.currentTimeMillis());
@@ -89,41 +78,28 @@ class SessionUtilKeyPair
     // expiration is 60 seconds later
     Date exp = new Date(iat.getTime() + 60L * 1000);
 
-    JWTClaimsSet claimsSet = builder.issuer(iss)
-                                    .subject(sub)
-                                    .issueTime(iat)
-                                    .expirationTime(exp)
-                                    .build();
+    JWTClaimsSet claimsSet =
+        builder.issuer(iss).subject(sub).issueTime(iat).expirationTime(exp).build();
 
-    SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256),
-        claimsSet);
+    SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), claimsSet);
     JWSSigner signer = new RSASSASigner(this.privateKey);
 
-    try
-    {
+    try {
       signedJWT.sign(signer);
-    }
-    catch(JOSEException e)
-    {
+    } catch (JOSEException e) {
       throw new SFException(e, ErrorCode.FAILED_TO_GENERATE_JWT);
     }
 
     return signedJWT.serialize();
   }
 
-  private String calculatePublicKeyFingerprint(PublicKey publicKey)
-      throws SFException
-  {
-    try
-    {
+  private String calculatePublicKeyFingerprint(PublicKey publicKey) throws SFException {
+    try {
       MessageDigest md = MessageDigest.getInstance("SHA-256");
       byte[] sha256Hash = md.digest(publicKey.getEncoded());
       return "SHA256:" + Base64.encodeBase64String(sha256Hash);
-    }
-    catch (NoSuchAlgorithmException e)
-    {
-      throw new SFException(e, ErrorCode.INTERNAL_ERROR,
-          "Error when calculating fingerprint");
+    } catch (NoSuchAlgorithmException e) {
+      throw new SFException(e, ErrorCode.INTERNAL_ERROR, "Error when calculating fingerprint");
     }
   }
 }

--- a/src/main/java/net/snowflake/client/core/StmtUtil.java
+++ b/src/main/java/net/snowflake/client/core/StmtUtil.java
@@ -8,23 +8,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import net.snowflake.client.core.BasicEvent.QueryState;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.SnowflakeUtil;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.common.api.QueryInProgressResponse;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -34,12 +17,23 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPOutputStream;
+import net.snowflake.client.core.BasicEvent.QueryState;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.api.QueryInProgressResponse;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.StringEntity;
 
-/**
- * Created by jhuang on 1/28/16.
- */
-public class StmtUtil
-{
+/** Created by jhuang on 1/28/16. */
+public class StmtUtil {
   static final EventHandler eventHandler = EventUtil.getEventHandlerInstance();
 
   static final ObjectMapper mapper = new ObjectMapper();
@@ -68,11 +62,8 @@ public class StmtUtil
 
   static final SFLogger logger = SFLoggerFactory.getLogger(StmtUtil.class);
 
-  /**
-   * Input for executing a statement on server
-   */
-  static class StmtInput
-  {
+  /** Input for executing a statement on server */
+  static class StmtInput {
     String sql;
 
     // default to snowflake (a special json format for snowflake query result
@@ -105,148 +96,121 @@ public class StmtUtil
 
     public StmtInput() {};
 
-    public StmtInput setSql(String sql)
-    {
+    public StmtInput setSql(String sql) {
       this.sql = sql;
       return this;
     }
 
-    public StmtInput setMediaType(String mediaType)
-    {
+    public StmtInput setMediaType(String mediaType) {
       this.mediaType = mediaType;
       return this;
     }
 
-    public StmtInput setParametersMap(Map<String, Object> parametersMap)
-    {
+    public StmtInput setParametersMap(Map<String, Object> parametersMap) {
       this.parametersMap = parametersMap;
       return this;
     }
 
-
-    public StmtInput setBindValues(Map<String, ParameterBindingDTO> bindValues)
-    {
+    public StmtInput setBindValues(Map<String, ParameterBindingDTO> bindValues) {
       this.bindValues = bindValues;
       return this;
     }
 
-    public StmtInput setBindStage(String bindStage)
-    {
+    public StmtInput setBindStage(String bindStage) {
       this.bindStage = bindStage;
       return this;
     }
 
-    public StmtInput setDescribeOnly(boolean describeOnly)
-    {
+    public StmtInput setDescribeOnly(boolean describeOnly) {
       this.describeOnly = describeOnly;
       return this;
     }
 
-    public StmtInput setInternal(boolean internal)
-    {
+    public StmtInput setInternal(boolean internal) {
       this.internal = internal;
       return this;
     }
 
-    public StmtInput setServerUrl(String serverUrl)
-    {
+    public StmtInput setServerUrl(String serverUrl) {
       this.serverUrl = serverUrl;
       return this;
     }
 
-    public StmtInput setRequestId(String requestId)
-    {
+    public StmtInput setRequestId(String requestId) {
       this.requestId = requestId;
       return this;
     }
 
-    public StmtInput setSequenceId(int sequenceId)
-    {
+    public StmtInput setSequenceId(int sequenceId) {
       this.sequenceId = sequenceId;
       return this;
     }
 
-    public StmtInput parametersMap(Map<String, Object> parametersMap)
-    {
+    public StmtInput parametersMap(Map<String, Object> parametersMap) {
       this.parametersMap = parametersMap;
       return this;
     }
 
-    public StmtInput setSessionToken(String sessionToken)
-    {
+    public StmtInput setSessionToken(String sessionToken) {
       this.sessionToken = sessionToken;
       return this;
     }
 
-    public StmtInput setNetworkTimeoutInMillis(int networkTimeoutInMillis)
-    {
+    public StmtInput setNetworkTimeoutInMillis(int networkTimeoutInMillis) {
       this.networkTimeoutInMillis = networkTimeoutInMillis;
       return this;
     }
 
-    public StmtInput setInjectSocketTimeout(int injectSocketTimeout)
-    {
+    public StmtInput setInjectSocketTimeout(int injectSocketTimeout) {
       this.injectSocketTimeout = injectSocketTimeout;
       return this;
     }
 
-    public StmtInput setInjectClientPause(int injectClientPause)
-    {
+    public StmtInput setInjectClientPause(int injectClientPause) {
       this.injectClientPause = injectClientPause;
       return this;
     }
 
-    public StmtInput setCanceling(AtomicBoolean canceling)
-    {
+    public StmtInput setCanceling(AtomicBoolean canceling) {
       this.canceling = canceling;
       return this;
     }
 
-    public StmtInput setRetry(boolean retry)
-    {
+    public StmtInput setRetry(boolean retry) {
       this.retry = retry;
       return this;
     }
 
-    public StmtInput setCombineDescribe(boolean combineDescribe)
-    {
+    public StmtInput setCombineDescribe(boolean combineDescribe) {
       this.combineDescribe = combineDescribe;
       return this;
     }
 
-    public StmtInput setDescribedJobId(String describedJobId)
-    {
+    public StmtInput setDescribedJobId(String describedJobId) {
       this.describedJobId = describedJobId;
       return this;
     }
 
-    public StmtInput setQuerySubmissionTime(long querySubmissionTime)
-    {
+    public StmtInput setQuerySubmissionTime(long querySubmissionTime) {
       this.querySubmissionTime = querySubmissionTime;
       return this;
     }
 
-    public StmtInput setServiceName(String serviceName)
-    {
+    public StmtInput setServiceName(String serviceName) {
       this.serviceName = serviceName;
       return this;
     }
   }
 
-  /**
-   * Output for running a statement on server
-   */
-  static public class StmtOutput
-  {
+  /** Output for running a statement on server */
+  public static class StmtOutput {
     JsonNode result;
 
-    public StmtOutput(JsonNode result)
-    {
+    public StmtOutput(JsonNode result) {
       this.result = result;
     }
 
-    public JsonNode getResult()
-    {
+    public JsonNode getResult() {
       return result;
     }
   }
@@ -254,86 +218,74 @@ public class StmtUtil
   /**
    * Execute a statement
    *
-   * side effect: stmtInput.prevGetResultURL is set if we have started ping
-   * pong and receives an exception from session token expiration so that
-   * during retry we don't retry the query submission, but continue the
-   * ping pong process.
+   * <p>side effect: stmtInput.prevGetResultURL is set if we have started ping pong and receives an
+   * exception from session token expiration so that during retry we don't retry the query
+   * submission, but continue the ping pong process.
    *
    * @param stmtInput input statement
    * @return StmtOutput output statement
-   *
    * @throws SFException exception raised from Snowflake components
    * @throws SnowflakeSQLException exception raised from Snowflake components
    */
-  public static StmtOutput execute(StmtInput stmtInput) throws SFException,
-      SnowflakeSQLException
-  {
+  public static StmtOutput execute(StmtInput stmtInput) throws SFException, SnowflakeSQLException {
     HttpPost httpRequest = null;
 
-    AssertUtil.assertTrue(stmtInput.serverUrl != null,
-        "Missing server url for statement execution");
+    AssertUtil.assertTrue(
+        stmtInput.serverUrl != null, "Missing server url for statement execution");
 
-    AssertUtil.assertTrue(stmtInput.sql != null,
-        "Missing sql for statement execution");
+    AssertUtil.assertTrue(stmtInput.sql != null, "Missing sql for statement execution");
 
-    AssertUtil.assertTrue(stmtInput.requestId != null,
-        "Missing request id for statement execution");
+    AssertUtil.assertTrue(
+        stmtInput.requestId != null, "Missing request id for statement execution");
 
-    AssertUtil.assertTrue(stmtInput.sequenceId >=0,
-        "Negative sequence id for statement execution");
+    AssertUtil.assertTrue(
+        stmtInput.sequenceId >= 0, "Negative sequence id for statement execution");
 
-    AssertUtil.assertTrue(stmtInput.mediaType != null,
-        "Missing media type for statement execution");
+    AssertUtil.assertTrue(
+        stmtInput.mediaType != null, "Missing media type for statement execution");
 
-    try
-    {
+    try {
       String resultAsString = null;
 
       // SNOW-20443: if we are retrying and there is get result URL, we
       // don't need to execute the query again
-      if (stmtInput.retry && stmtInput.prevGetResultURL != null)
-      {
+      if (stmtInput.retry && stmtInput.prevGetResultURL != null) {
         logger.debug(
-            "retrying statement execution with get result URL: {}",
-            stmtInput.prevGetResultURL);
-      }
-      else
-      {
+            "retrying statement execution with get result URL: {}", stmtInput.prevGetResultURL);
+      } else {
         URIBuilder uriBuilder = new URIBuilder(stmtInput.serverUrl);
 
         uriBuilder.setPath(SF_PATH_QUERY_V1);
         uriBuilder.addParameter(SF_QUERY_REQUEST_ID, stmtInput.requestId);
 
-        if (stmtInput.combineDescribe)
-        {
+        if (stmtInput.combineDescribe) {
           uriBuilder.addParameter(SF_QUERY_COMBINE_DESCRIBE_EXECUTE, "true");
         }
 
         httpRequest = new HttpPost(uriBuilder.build());
 
         /**
-         * sequence id is only needed for old query API, when old query API
-         * is deprecated, we can remove sequence id.
+         * sequence id is only needed for old query API, when old query API is deprecated, we can
+         * remove sequence id.
          */
-        QueryExecDTO sqlJsonBody = new QueryExecDTO(
-            stmtInput.sql,
-            stmtInput.describeOnly,
-            stmtInput.sequenceId,
-            stmtInput.bindValues,
-            stmtInput.bindStage,
-            stmtInput.parametersMap,
-            stmtInput.querySubmissionTime,
-            stmtInput.describeOnly || stmtInput.internal);
+        QueryExecDTO sqlJsonBody =
+            new QueryExecDTO(
+                stmtInput.sql,
+                stmtInput.describeOnly,
+                stmtInput.sequenceId,
+                stmtInput.bindValues,
+                stmtInput.bindStage,
+                stmtInput.parametersMap,
+                stmtInput.querySubmissionTime,
+                stmtInput.describeOnly || stmtInput.internal);
 
-        if (stmtInput.combineDescribe && !stmtInput.describeOnly)
-        {
+        if (stmtInput.combineDescribe && !stmtInput.describeOnly) {
           sqlJsonBody.setDescribedJobId(stmtInput.describedJobId);
         }
 
         String json = mapper.writeValueAsString(sqlJsonBody);
 
-        if (logger.isDebugEnabled())
-        {
+        if (logger.isDebugEnabled()) {
           logger.debug("JSON: {}", json);
         }
 
@@ -350,149 +302,124 @@ public class StmtUtil
 
         httpRequest.addHeader("accept", stmtInput.mediaType);
 
-        httpRequest.setHeader(SF_HEADER_AUTHORIZATION,
-            SF_HEADER_SNOWFLAKE_AUTHTYPE + " " + SF_HEADER_TOKEN_TAG
-                + "=\"" + stmtInput.sessionToken + "\"");
+        httpRequest.setHeader(
+            SF_HEADER_AUTHORIZATION,
+            SF_HEADER_SNOWFLAKE_AUTHTYPE
+                + " "
+                + SF_HEADER_TOKEN_TAG
+                + "=\""
+                + stmtInput.sessionToken
+                + "\"");
 
         setServiceNameHeader(stmtInput, httpRequest);
-        eventHandler.triggerStateTransition(BasicEvent.QueryState.SENDING_QUERY,
+        eventHandler.triggerStateTransition(
+            BasicEvent.QueryState.SENDING_QUERY,
             String.format(QueryState.SENDING_QUERY.getArgString(), stmtInput.requestId));
 
         resultAsString =
-            HttpUtil.executeRequest(httpRequest,
-                                    stmtInput.networkTimeoutInMillis / 1000,
-                                    stmtInput.injectSocketTimeout,
-                                    stmtInput.canceling,
-                                    true // include retry parameters
-                                  );
+            HttpUtil.executeRequest(
+                httpRequest,
+                stmtInput.networkTimeoutInMillis / 1000,
+                stmtInput.injectSocketTimeout,
+                stmtInput.canceling,
+                true // include retry parameters
+                );
       }
 
       return pollForOutput(resultAsString, stmtInput, httpRequest);
-    }
-    catch (Exception ex)
-    {
-      if (!(ex instanceof SnowflakeSQLException))
-      {
-        if (ex instanceof IOException)
-        {
+    } catch (Exception ex) {
+      if (!(ex instanceof SnowflakeSQLException)) {
+        if (ex instanceof IOException) {
           logger.error("IOException encountered", ex);
 
           // network error
-          throw new SFException(ex, ErrorCode.NETWORK_ERROR,
-              "Exception encountered when executing statement: " +
-                  ex.getLocalizedMessage());
-        }
-        else
-        {
+          throw new SFException(
+              ex,
+              ErrorCode.NETWORK_ERROR,
+              "Exception encountered when executing statement: " + ex.getLocalizedMessage());
+        } else {
           logger.error("Exception encountered", ex);
 
           // raise internal exception if this is not a snowflake exception
-          throw new SFException(ex, ErrorCode.INTERNAL_ERROR,
-              ex.getLocalizedMessage());
+          throw new SFException(ex, ErrorCode.INTERNAL_ERROR, ex.getLocalizedMessage());
         }
-      }
-      else
-      {
+      } else {
         throw (SnowflakeSQLException) ex;
       }
-    }
-    finally
-    {
+    } finally {
       // we can release the http connection now
-      if (httpRequest != null)
-      {
+      if (httpRequest != null) {
         httpRequest.releaseConnection();
       }
     }
   }
 
-  private static void setServiceNameHeader(StmtInput stmtInput, HttpRequestBase httpRequest)
-  {
-    if (!Strings.isNullOrEmpty(stmtInput.serviceName))
-    {
-      httpRequest.setHeader(
-          SessionUtil.SF_HEADER_SERVICE_NAME, stmtInput.serviceName);
+  private static void setServiceNameHeader(StmtInput stmtInput, HttpRequestBase httpRequest) {
+    if (!Strings.isNullOrEmpty(stmtInput.serviceName)) {
+      httpRequest.setHeader(SessionUtil.SF_HEADER_SERVICE_NAME, stmtInput.serviceName);
     }
   }
 
-  private static StmtOutput pollForOutput(String resultAsString,
-                                          StmtInput stmtInput,
-                                          HttpPost httpRequest)
-      throws SFException, SnowflakeSQLException
-  {
+  private static StmtOutput pollForOutput(
+      String resultAsString, StmtInput stmtInput, HttpPost httpRequest)
+      throws SFException, SnowflakeSQLException {
     /**
      * Check response for error or for ping pong response
      *
-     * For ping-pong: want to make sure our connection is not silently dropped
-     * by middle players (e.g load balancer/VPN timeout) between client and GS
+     * <p>For ping-pong: want to make sure our connection is not silently dropped by middle players
+     * (e.g load balancer/VPN timeout) between client and GS
      */
     JsonNode pingPongResponseJson;
     boolean queryInProgress;
     boolean firstResponse = !stmtInput.retry;
-    String previousGetResultPath =
-        (stmtInput.retry ? stmtInput.prevGetResultURL : null);
+    String previousGetResultPath = (stmtInput.retry ? stmtInput.prevGetResultURL : null);
     int retries = 0;
     final int MAX_RETRIES = 3;
 
-    do
-    {
+    do {
       pingPongResponseJson = null;
 
-      if (resultAsString != null)
-      {
-        try
-        {
+      if (resultAsString != null) {
+        try {
           pingPongResponseJson = mapper.readTree(resultAsString);
-        }
-        catch (Exception ex)
-        {
-          logger.error("Bad result json: {}, " +
-                  "JSON parsing exception: {}, http request: {}",
-              resultAsString, ex.getLocalizedMessage(),
+        } catch (Exception ex) {
+          logger.error(
+              "Bad result json: {}, " + "JSON parsing exception: {}, http request: {}",
+              resultAsString,
+              ex.getLocalizedMessage(),
               httpRequest);
 
           logger.error("Exception stack trace", ex);
         }
       }
 
-      eventHandler.triggerStateTransition(BasicEvent.QueryState.WAITING_FOR_RESULT,
-          "{requestId: " + stmtInput.requestId + "," +
-              "pingNumber: " + retries + "}");
+      eventHandler.triggerStateTransition(
+          BasicEvent.QueryState.WAITING_FOR_RESULT,
+          "{requestId: " + stmtInput.requestId + "," + "pingNumber: " + retries + "}");
 
-      if (pingPongResponseJson == null)
-      {
-        /**
-         * Retry for bad response for server.
-         * But we don't want to retry too many times
-         */
-        if (retries >= MAX_RETRIES)
-        {
+      if (pingPongResponseJson == null) {
+        /** Retry for bad response for server. But we don't want to retry too many times */
+        if (retries >= MAX_RETRIES) {
           throw IncidentUtil.generateIncidentWithException(
               stmtInput.sessionToken,
-              stmtInput.serverUrl, stmtInput.requestId, null,
-              ErrorCode.BAD_RESPONSE, resultAsString);
-        }
-        else
-        {
-          logger.info("Will retry get result. Retry count: {}",
-              retries);
+              stmtInput.serverUrl,
+              stmtInput.requestId,
+              null,
+              ErrorCode.BAD_RESPONSE,
+              resultAsString);
+        } else {
+          logger.info("Will retry get result. Retry count: {}", retries);
 
           retries++;
         }
-      }
-      else
-        retries = 0; // reset retry counter after a successful response
+      } else retries = 0; // reset retry counter after a successful response
 
       // trace the response if requested
-      if (logger.isDebugEnabled())
-      {
-        try
-        {
+      if (logger.isDebugEnabled()) {
+        try {
           String json = mapper.writeValueAsString(resultAsString);
           logger.debug("Response: {}", json);
-        }
-        catch(JsonProcessingException ex)
-        {
+        } catch (JsonProcessingException ex) {
           logger.debug("Response: {}", resultAsString);
         }
       }
@@ -504,71 +431,57 @@ public class StmtUtil
       }
 
       // check the response code to see if it is a progress report response
-      if (pingPongResponseJson != null &&
-          !QueryInProgressResponse.QUERY_IN_PROGRESS_CODE.equals(
+      if (pingPongResponseJson != null
+          && !QueryInProgressResponse.QUERY_IN_PROGRESS_CODE.equals(
               pingPongResponseJson.path("code").asText())
           && !QueryInProgressResponse.QUERY_IN_PROGRESS_ASYNC_CODE.equals(
-          pingPongResponseJson.path("code").asText()))
-      {
+              pingPongResponseJson.path("code").asText())) {
         queryInProgress = false;
-      }
-      else
-      {
+      } else {
         queryInProgress = true;
 
-        if (firstResponse)
-        {
+        if (firstResponse) {
           // sleep some time to simulate client pause. The purpose is to
           // simulate client pause before trying to fetch result so that
           // we can test query behavior related to disconnected client
-          if (stmtInput.injectClientPause != 0)
-          {
-            logger.debug(
-                "inject client pause for {} seconds",
-                stmtInput.injectClientPause);
-            try
-            {
+          if (stmtInput.injectClientPause != 0) {
+            logger.debug("inject client pause for {} seconds", stmtInput.injectClientPause);
+            try {
               Thread.sleep(stmtInput.injectClientPause * 1000);
-            }
-            catch (InterruptedException ex)
-            {
+            } catch (InterruptedException ex) {
               logger.warn("exception encountered while injecting pause");
             }
           }
         }
 
-        resultAsString = getQueryResult(pingPongResponseJson,
-            previousGetResultPath,
-            stmtInput);
+        resultAsString = getQueryResult(pingPongResponseJson, previousGetResultPath, stmtInput);
 
         // save the previous get result path in case we run into session
         // expiration
-        if (pingPongResponseJson != null)
-        {
-          previousGetResultPath = pingPongResponseJson.path("data").
-              path("getResultUrl").asText();
+        if (pingPongResponseJson != null) {
+          previousGetResultPath = pingPongResponseJson.path("data").path("getResultUrl").asText();
           stmtInput.prevGetResultURL = previousGetResultPath;
         }
       }
 
       // not first response any more
-      if (firstResponse)
-        firstResponse = false;
-    }
-    while (queryInProgress);
+      if (firstResponse) firstResponse = false;
+    } while (queryInProgress);
 
     logger.debug("Returning result");
 
-    eventHandler.triggerStateTransition(BasicEvent.QueryState.PROCESSING_RESULT,
+    eventHandler.triggerStateTransition(
+        BasicEvent.QueryState.PROCESSING_RESULT,
         String.format(QueryState.PROCESSING_RESULT.getArgString(), stmtInput.requestId));
 
     return new StmtOutput(pingPongResponseJson);
   }
 
-
   /**
    * Issue get-result call to get query result given an in-progress response.
+   *
    * <p>
+   *
    * @param inProgressResponse In progress response in JSON form
    * @param previousGetResultPath previous get results path
    * @param stmtInput input statement
@@ -576,111 +489,98 @@ public class StmtUtil
    * @throws SFException exception raised from Snowflake components
    * @throws SnowflakeSQLException exception raised from Snowflake components
    */
-  static protected String getQueryResult(JsonNode inProgressResponse,
-                                        String previousGetResultPath,
-                                        StmtInput stmtInput)
-      throws SFException, SnowflakeSQLException
-  {
+  protected static String getQueryResult(
+      JsonNode inProgressResponse, String previousGetResultPath, StmtInput stmtInput)
+      throws SFException, SnowflakeSQLException {
     String getResultPath = null;
 
     // get result url better not be empty
-    if (inProgressResponse == null ||
-        inProgressResponse.path("data").path("getResultUrl").isMissingNode())
-    {
-      if (previousGetResultPath == null)
-      {
-        throw new SFException(ErrorCode.INTERNAL_ERROR,
-            "No query response or missing get result URL");
-      }
-      else
-      {
-        logger.debug("No query response or missing get result URL, " +
-            "use previous get result URL: {}", previousGetResultPath);
+    if (inProgressResponse == null
+        || inProgressResponse.path("data").path("getResultUrl").isMissingNode()) {
+      if (previousGetResultPath == null) {
+        throw new SFException(
+            ErrorCode.INTERNAL_ERROR, "No query response or missing get result URL");
+      } else {
+        logger.debug(
+            "No query response or missing get result URL, " + "use previous get result URL: {}",
+            previousGetResultPath);
         getResultPath = previousGetResultPath;
       }
+    } else {
+      getResultPath = inProgressResponse.path("data").path("getResultUrl").asText();
     }
-    else
-    {
-      getResultPath = inProgressResponse.path("data").path("getResultUrl").
-          asText();
-    }
-    return getQueryResult(
-        getResultPath,
-        stmtInput
-    );
+    return getQueryResult(getResultPath, stmtInput);
   }
 
   /**
    * Issue get-result call to get query result given an in-progress response.
+   *
    * <p>
+   *
    * @param getResultPath path to results
    * @param stmtInput object with context information
    * @return results in string form
    * @throws SFException exception raised from Snowflake components
    * @throws SnowflakeSQLException exception raised from Snowflake components
    */
-  static protected String getQueryResult(String getResultPath,
-                                         StmtInput stmtInput)
-      throws SFException, SnowflakeSQLException
-  {
+  protected static String getQueryResult(String getResultPath, StmtInput stmtInput)
+      throws SFException, SnowflakeSQLException {
     HttpGet httpRequest = null;
     logger.debug("get query result: {}", getResultPath);
 
-    try
-    {
+    try {
       URIBuilder uriBuilder = new URIBuilder(stmtInput.serverUrl);
 
       uriBuilder.setPath(getResultPath);
 
-      uriBuilder.addParameter(SF_QUERY_REQUEST_ID,
-          UUID.randomUUID().toString());
+      uriBuilder.addParameter(SF_QUERY_REQUEST_ID, UUID.randomUUID().toString());
 
       httpRequest = new HttpGet(uriBuilder.build());
 
       httpRequest.addHeader("accept", stmtInput.mediaType);
 
-      httpRequest.setHeader(SF_HEADER_AUTHORIZATION,
-          SF_HEADER_SNOWFLAKE_AUTHTYPE + " " + SF_HEADER_TOKEN_TAG
-              + "=\"" + stmtInput.sessionToken + "\"");
+      httpRequest.setHeader(
+          SF_HEADER_AUTHORIZATION,
+          SF_HEADER_SNOWFLAKE_AUTHTYPE
+              + " "
+              + SF_HEADER_TOKEN_TAG
+              + "=\""
+              + stmtInput.sessionToken
+              + "\"");
 
       setServiceNameHeader(stmtInput, httpRequest);
 
-      return HttpUtil.executeRequest(httpRequest,
-          stmtInput.networkTimeoutInMillis/1000,
-          0,
-          stmtInput.canceling);
-    }
-    catch (URISyntaxException | IOException ex)
-    {
-      logger.error("Exception encountered when getting result for "
-          + httpRequest, ex);
+      return HttpUtil.executeRequest(
+          httpRequest, stmtInput.networkTimeoutInMillis / 1000, 0, stmtInput.canceling);
+    } catch (URISyntaxException | IOException ex) {
+      logger.error("Exception encountered when getting result for " + httpRequest, ex);
 
       // raise internal exception if this is not a snowflake exception
-      throw new SFException(ex, ErrorCode.INTERNAL_ERROR,
-          ex.getLocalizedMessage());
+      throw new SFException(ex, ErrorCode.INTERNAL_ERROR, ex.getLocalizedMessage());
     }
   }
 
   /**
    * Issue get-result call to get query result given an in progress response.
+   *
    * <p>
+   *
    * @param queryId id of query to get results for
    * @param session the current session
    * @return results in JSON
    * @throws SFException exception raised from Snowflake components
    * @throws SnowflakeSQLException exception raised from Snowflake components
    */
-  static protected JsonNode getQueryResultJSON(String queryId,
-                                               SFSession session)
-      throws SFException, SnowflakeSQLException
-  {
+  protected static JsonNode getQueryResultJSON(String queryId, SFSession session)
+      throws SFException, SnowflakeSQLException {
     String getResultPath = String.format(SF_PATH_QUERY_RESULT, queryId);
-    StmtInput stmtInput = new StmtInput()
-        .setServerUrl(session.getServerUrl())
-        .setSessionToken(session.getSessionToken())
-        .setNetworkTimeoutInMillis(session.getNetworkTimeoutInMilli())
-        .setMediaType(SF_MEDIA_TYPE)
-        .setServiceName(session.getServiceName());
+    StmtInput stmtInput =
+        new StmtInput()
+            .setServerUrl(session.getServerUrl())
+            .setSessionToken(session.getSessionToken())
+            .setNetworkTimeoutInMillis(session.getNetworkTimeoutInMilli())
+            .setMediaType(SF_MEDIA_TYPE)
+            .setServiceName(session.getServiceName());
 
     String resultAsString = getQueryResult(getResultPath, stmtInput);
 
@@ -695,28 +595,24 @@ public class StmtUtil
    * @throws SFException if there is an internal exception
    * @throws SnowflakeSQLException if failed to cancel the statement
    */
-  public static void cancel(StmtInput stmtInput) throws SFException,
-      SnowflakeSQLException
-  {
+  public static void cancel(StmtInput stmtInput) throws SFException, SnowflakeSQLException {
     HttpPost httpRequest = null;
 
-    AssertUtil.assertTrue(stmtInput.serverUrl != null,
-        "Missing server url for statement execution");
+    AssertUtil.assertTrue(
+        stmtInput.serverUrl != null, "Missing server url for statement execution");
 
-    AssertUtil.assertTrue(stmtInput.sql != null,
-        "Missing sql for statement execution");
+    AssertUtil.assertTrue(stmtInput.sql != null, "Missing sql for statement execution");
 
-    AssertUtil.assertTrue(stmtInput.mediaType != null,
-        "Missing media type for statement execution");
+    AssertUtil.assertTrue(
+        stmtInput.mediaType != null, "Missing media type for statement execution");
 
-    AssertUtil.assertTrue(stmtInput.requestId != null,
-        "Missing request id for statement execution");
+    AssertUtil.assertTrue(
+        stmtInput.requestId != null, "Missing request id for statement execution");
 
-    AssertUtil.assertTrue(stmtInput.sessionToken != null,
-        "Missing session token for statement execution");
+    AssertUtil.assertTrue(
+        stmtInput.sessionToken != null, "Missing session token for statement execution");
 
-    try
-    {
+    try {
       URIBuilder uriBuilder = new URIBuilder(stmtInput.serverUrl);
 
       logger.debug("Aborting query: {}", stmtInput.sql);
@@ -744,16 +640,19 @@ public class StmtUtil
 
       httpRequest.addHeader("accept", stmtInput.mediaType);
 
-      httpRequest.setHeader(SF_HEADER_AUTHORIZATION,
-          SF_HEADER_SNOWFLAKE_AUTHTYPE + " " + SF_HEADER_TOKEN_TAG
-              + "=\"" + stmtInput.sessionToken + "\"");
+      httpRequest.setHeader(
+          SF_HEADER_AUTHORIZATION,
+          SF_HEADER_SNOWFLAKE_AUTHTYPE
+              + " "
+              + SF_HEADER_TOKEN_TAG
+              + "=\""
+              + stmtInput.sessionToken
+              + "\"");
 
       setServiceNameHeader(stmtInput, httpRequest);
 
       String jsonString =
-          HttpUtil.executeRequest(httpRequest,
-                                  SF_CANCELING_RETRY_TIMEOUT_IN_MILLIS,
-                                  0, null);
+          HttpUtil.executeRequest(httpRequest, SF_CANCELING_RETRY_TIMEOUT_IN_MILLIS, 0, null);
 
       // trace the response if requested
       logger.debug("Json response: {}", jsonString);
@@ -763,17 +662,11 @@ public class StmtUtil
 
       // raise server side error as an exception if any
       SnowflakeUtil.checkErrorAndThrowException(rootNode);
-    }
-    catch (URISyntaxException | IOException ex)
-    {
-      logger.error(
-                 "Exception encountered when canceling " + httpRequest,
-                 ex);
+    } catch (URISyntaxException | IOException ex) {
+      logger.error("Exception encountered when canceling " + httpRequest, ex);
 
       // raise internal exception if this is not a snowflake exception
-      throw new SFException(ex,
-                            ErrorCode.INTERNAL_ERROR,
-                            ex.getLocalizedMessage());
+      throw new SFException(ex, ErrorCode.INTERNAL_ERROR, ex.getLocalizedMessage());
     }
   }
 
@@ -781,79 +674,53 @@ public class StmtUtil
    * A simple function to check if the statement is related to manipulate stage.
    *
    * @param sql a SQL statement/command
-   * @return PUT/GET/LIST/RM if statment belongs to one of them, otherwise
-   *         return NULL
+   * @return PUT/GET/LIST/RM if statment belongs to one of them, otherwise return NULL
    */
-  static public SFStatementType checkStageManageCommand(String sql)
-  {
-    if (sql == null)
-    {
+  public static SFStatementType checkStageManageCommand(String sql) {
+    if (sql == null) {
       return null;
     }
 
     String trimmedSql = sql.trim();
 
     // skip commenting prefixed with //
-    while (trimmedSql.startsWith("//"))
-    {
+    while (trimmedSql.startsWith("//")) {
       logger.debug("skipping // comments in: \n{}", trimmedSql);
 
-      if (trimmedSql.indexOf('\n') > 0)
-      {
+      if (trimmedSql.indexOf('\n') > 0) {
         trimmedSql = trimmedSql.substring(trimmedSql.indexOf('\n'));
         trimmedSql = trimmedSql.trim();
-      }
-      else
-      {
+      } else {
         break;
       }
 
-      logger.debug( "New sql after skipping // comments: \n{}",
-          trimmedSql);
-
+      logger.debug("New sql after skipping // comments: \n{}", trimmedSql);
     }
 
     // skip commenting enclosed with /* */
-    while (trimmedSql.startsWith("/*"))
-    {
-      logger.debug( "skipping /* */ comments in: \n{}", trimmedSql);
+    while (trimmedSql.startsWith("/*")) {
+      logger.debug("skipping /* */ comments in: \n{}", trimmedSql);
 
-      if (trimmedSql.indexOf("*/") > 0)
-      {
+      if (trimmedSql.indexOf("*/") > 0) {
         trimmedSql = trimmedSql.substring(trimmedSql.indexOf("*/") + 2);
         trimmedSql = trimmedSql.trim();
-      }
-      else
-      {
+      } else {
         break;
-
       }
-      logger.debug( "New sql after skipping /* */ comments: \n{}", trimmedSql);
-
+      logger.debug("New sql after skipping /* */ comments: \n{}", trimmedSql);
     }
 
     trimmedSql = trimmedSql.toLowerCase();
 
-    if (trimmedSql.startsWith("put "))
-    {
+    if (trimmedSql.startsWith("put ")) {
       return SFStatementType.PUT;
-    }
-    else if (trimmedSql.startsWith("get "))
-    {
+    } else if (trimmedSql.startsWith("get ")) {
       return SFStatementType.GET;
-    }
-    else if (trimmedSql.startsWith("ls ") ||
-             trimmedSql.startsWith("list "))
-    {
+    } else if (trimmedSql.startsWith("ls ") || trimmedSql.startsWith("list ")) {
       return SFStatementType.LIST;
-    }
-    else if (trimmedSql.startsWith("rm ") ||
-            trimmedSql.startsWith("remove "))
-    {
+    } else if (trimmedSql.startsWith("rm ") || trimmedSql.startsWith("remove ")) {
       return SFStatementType.REMOVE;
-    }
-    else
-    {
+    } else {
       return null;
     }
   }

--- a/src/main/java/net/snowflake/client/core/bind/BindException.java
+++ b/src/main/java/net/snowflake/client/core/bind/BindException.java
@@ -6,26 +6,22 @@ package net.snowflake.client.core.bind;
 
 import net.snowflake.client.jdbc.telemetry.TelemetryField;
 
-public class BindException extends Exception
-{
-  public enum Type
-  {
+public class BindException extends Exception {
+  public enum Type {
     SERIALIZATION(TelemetryField.FAILED_BIND_SERIALIZATION),
     UPLOAD(TelemetryField.FAILED_BIND_UPLOAD),
-    OTHER(TelemetryField.FAILED_BIND_OTHER)
-    ;
+    OTHER(TelemetryField.FAILED_BIND_OTHER);
 
     public final TelemetryField field;
-    Type(TelemetryField field)
-    {
+
+    Type(TelemetryField field) {
       this.field = field;
     }
   }
 
   public final Type type;
 
-  public BindException(String msg, Type type)
-  {
+  public BindException(String msg, Type type) {
     super(msg);
     this.type = type;
   }

--- a/src/main/java/net/snowflake/client/core/bind/BindUploader.java
+++ b/src/main/java/net/snowflake/client/core/bind/BindUploader.java
@@ -4,15 +4,7 @@
 
 package net.snowflake.client.core.bind;
 
-import net.snowflake.client.core.ParameterBindingDTO;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.core.SFStatement;
-import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
-import net.snowflake.client.jdbc.SnowflakeType;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.Closeable;
 import java.io.File;
@@ -32,37 +24,49 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.zip.GZIPOutputStream;
+import net.snowflake.client.core.ParameterBindingDTO;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.core.SFStatement;
+import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
+import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-public class BindUploader implements Closeable
-{
+public class BindUploader implements Closeable {
   private static final SFLogger logger = SFLoggerFactory.getLogger(BindUploader.class);
 
   private static final String PREFIX = "binding_";
 
   private static final String STAGE_NAME = "SYSTEM$BIND";
 
-  // Date binds are saved as millis, timestamp binds are saved as nanos (and times are not supported)
+  // Date binds are saved as millis, timestamp binds are saved as nanos (and times are not
+  // supported)
   private static final String DATE_FORMAT = "ES3";
   private static final String TS_FORMAT = "YYYY-MM-DD HH24:MI:SS.FF9 TZH:TZM";
 
-  private static final String CREATE_STAGE_STMT = "CREATE TEMPORARY STAGE "
-      + STAGE_NAME
-      + " file_format=("
-      + " type=csv"
-      + " date_format=" + DATE_FORMAT
-      + " timestamp_format='" + TS_FORMAT + "'"
-      + " field_optionally_enclosed_by='\"'"
-      + ")";
+  private static final String CREATE_STAGE_STMT =
+      "CREATE TEMPORARY STAGE "
+          + STAGE_NAME
+          + " file_format=("
+          + " type=csv"
+          + " date_format="
+          + DATE_FORMAT
+          + " timestamp_format='"
+          + TS_FORMAT
+          + "'"
+          + " field_optionally_enclosed_by='\"'"
+          + ")";
 
-  private static final String PUT_STMT = "PUT"
-      + " 'file://%s%s*'"           // argument 1: folder, argument 2: separator
-      + " '%s'"                     // argument 3: stage path
-      + " parallel=10"              // upload chunks in parallel
-      + " overwrite=true"           // skip file existence check
-      + " auto_compress=false"      // we compress already
-      + " source_compression=gzip"; //   (with gzip)
+  private static final String PUT_STMT =
+      "PUT"
+          + " 'file://%s%s*'" // argument 1: folder, argument 2: separator
+          + " '%s'" // argument 3: stage path
+          + " parallel=10" // upload chunks in parallel
+          + " overwrite=true" // skip file existence check
+          + " auto_compress=false" // we compress already
+          + " source_compression=gzip"; //   (with gzip)
 
   private static final int PUT_RETRY_COUNT = 3;
 
@@ -83,62 +87,52 @@ public class BindUploader implements Closeable
 
   private final DateFormat timestampFormat;
 
-  static class ColumnTypeDataPair
-  {
+  static class ColumnTypeDataPair {
     public String type;
     public List<String> data;
 
-    ColumnTypeDataPair(String type, List<String> data)
-    {
+    ColumnTypeDataPair(String type, List<String> data) {
       this.type = type;
       this.data = data;
     }
   }
 
   /**
-   * Create a new BindUploader which will write binds to the *existing*
-   * bindDir and upload them to the given stageDir
+   * Create a new BindUploader which will write binds to the *existing* bindDir and upload them to
+   * the given stageDir
    *
-   * @param session  the session to use for uploading binds
+   * @param session the session to use for uploading binds
    * @param stageDir the stage path to upload to
-   * @param bindDir  the local directory to serialize binds to
+   * @param bindDir the local directory to serialize binds to
    */
-  private BindUploader(SFSession session, String stageDir, Path bindDir)
-  {
+  private BindUploader(SFSession session, String stageDir, Path bindDir) {
     this.session = session;
     this.stagePath = "@" + STAGE_NAME + "/" + stageDir;
     this.bindDir = bindDir;
     Calendar calendarUTC = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendarUTC.clear();
 
-    this.timestampFormat = new SimpleDateFormat(
-        "yyyy-MM-dd HH:mm:ss.");
+    this.timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.");
     this.timestampFormat.setCalendar(calendarUTC);
   }
 
-  private synchronized String synchronizedTimestampFormat(String o)
-  {
+  private synchronized String synchronizedTimestampFormat(String o) {
     boolean isNegative = o.length() > 0 && o.charAt(0) == '-';
     String inpString = o;
-    if (isNegative)
-    {
+    if (isNegative) {
       inpString = o.substring(1);
     }
 
     long sec;
     int nano;
-    if (inpString.length() < 10)
-    {
+    if (inpString.length() < 10) {
       sec = 0;
       nano = Integer.parseInt(inpString);
-    }
-    else
-    {
+    } else {
       sec = Long.parseLong(inpString.substring(0, inpString.length() - 9));
       nano = Integer.parseInt(inpString.substring(inpString.length() - 9));
     }
-    if (isNegative)
-    {
+    if (isNegative) {
       // adjust the timestamp
       sec = -1 * sec - 1L;
       nano = 1000000000 - nano;
@@ -148,26 +142,23 @@ public class BindUploader implements Closeable
   }
 
   /**
-   * Create a new BindUploader which will upload to the given stage path
-   * Ensure temporary directory for file writing exists
+   * Create a new BindUploader which will upload to the given stage path Ensure temporary directory
+   * for file writing exists
    *
-   * @param session  the session to use for uploading binds
+   * @param session the session to use for uploading binds
    * @param stageDir the stage path to upload to
    * @return BindUploader instance
    * @throws BindException if temporary directory could not be created
    */
-  public synchronized static BindUploader newInstance(SFSession session, String stageDir)
-      throws BindException
-  {
-    try
-    {
+  public static synchronized BindUploader newInstance(SFSession session, String stageDir)
+      throws BindException {
+    try {
       Path bindDir = Files.createTempDirectory(PREFIX);
       return new BindUploader(session, stageDir, bindDir);
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       throw new BindException(
-          String.format("Failed to create temporary directory: %s", ex.getMessage()), BindException.Type.OTHER);
+          String.format("Failed to create temporary directory: %s", ex.getMessage()),
+          BindException.Type.OTHER);
     }
   }
 
@@ -175,13 +166,10 @@ public class BindUploader implements Closeable
    * Upload the bindValues to stage
    *
    * @param bindValues the bind map to upload
-   * @throws BindException if the bind map could not be serialized or upload
-   *                       fails
+   * @throws BindException if the bind map could not be serialized or upload fails
    */
-  public void upload(Map<String, ParameterBindingDTO> bindValues) throws BindException
-  {
-    if (!closed)
-    {
+  public void upload(Map<String, ParameterBindingDTO> bindValues) throws BindException {
+    if (!closed) {
       serializeBinds(bindValues);
       putBinds();
     }
@@ -193,56 +181,49 @@ public class BindUploader implements Closeable
    * @param bindValues the bind map to serialize
    * @throws BindException if bind map improperly formed or writing binds fails
    */
-  private void serializeBinds(Map<String, ParameterBindingDTO> bindValues) throws BindException
-  {
+  private void serializeBinds(Map<String, ParameterBindingDTO> bindValues) throws BindException {
     List<ColumnTypeDataPair> columns = getColumnValues(bindValues);
     List<String[]> rows = buildRows(columns);
     writeRowsToCSV(rows);
   }
 
   /**
-   * Convert bind map to a list of values for each column
-   * Perform necessary type casts and invariant checks
+   * Convert bind map to a list of values for each column Perform necessary type casts and invariant
+   * checks
    *
    * @param bindValues the bind map to convert
    * @return list of values for each column
    * @throws BindException if bind map is improperly formed
    */
-  private List<ColumnTypeDataPair> getColumnValues(Map<String, ParameterBindingDTO> bindValues) throws BindException
-  {
+  private List<ColumnTypeDataPair> getColumnValues(Map<String, ParameterBindingDTO> bindValues)
+      throws BindException {
     List<ColumnTypeDataPair> columns = new ArrayList<>(bindValues.size());
-    for (int i = 1; i <= bindValues.size(); i++)
-    {
+    for (int i = 1; i <= bindValues.size(); i++) {
       // bindValues should have n entries with string keys 1 ... n and list values
       String key = Integer.toString(i);
-      if (!bindValues.containsKey(key))
-      {
+      if (!bindValues.containsKey(key)) {
         throw new BindException(
-            String.format("Bind map with %d columns should contain key \"%d\"", bindValues.size(), i), BindException.Type.SERIALIZATION);
+            String.format(
+                "Bind map with %d columns should contain key \"%d\"", bindValues.size(), i),
+            BindException.Type.SERIALIZATION);
       }
 
       ParameterBindingDTO value = bindValues.get(key);
-      try
-      {
+      try {
         String type = value.getType();
         List<String> list = (List<String>) value.getValue();
         List<String> convertedList = new ArrayList<>(list.size());
-        if ("TIMESTAMP_LTZ".equals(type) || "TIMESTAMP_NTZ".equals(type))
-        {
-          for (int j = 0, len = list.size(); j < len; ++j)
-          {
+        if ("TIMESTAMP_LTZ".equals(type) || "TIMESTAMP_NTZ".equals(type)) {
+          for (int j = 0, len = list.size(); j < len; ++j) {
             convertedList.add(synchronizedTimestampFormat(list.get(j)));
           }
-        }
-        else
-        {
+        } else {
           convertedList = list;
         }
         columns.add(i - 1, new ColumnTypeDataPair(type, convertedList));
-      }
-      catch (ClassCastException ex)
-      {
-        throw new BindException("Value in binding DTO could not be cast to a list", BindException.Type.SERIALIZATION);
+      } catch (ClassCastException ex) {
+        throw new BindException(
+            "Value in binding DTO could not be cast to a list", BindException.Type.SERIALIZATION);
       }
     }
     return columns;
@@ -255,34 +236,31 @@ public class BindUploader implements Closeable
    * @return list of rows
    * @throws BindException if columns improperly formed
    */
-  private List<String[]> buildRows(List<ColumnTypeDataPair> columns) throws BindException
-  {
+  private List<String[]> buildRows(List<ColumnTypeDataPair> columns) throws BindException {
     List<String[]> rows = new ArrayList<>();
 
     int numColumns = columns.size();
     // columns should have binds
-    if (columns.get(0).data.isEmpty())
-    {
+    if (columns.get(0).data.isEmpty()) {
       throw new BindException("No binds found in first column", BindException.Type.SERIALIZATION);
     }
 
     int numRows = columns.get(0).data.size();
     // every column should have the same number of binds
-    for (int i = 0; i < numColumns; i++)
-    {
+    for (int i = 0; i < numColumns; i++) {
       int iNumRows = columns.get(i).data.size();
-      if (columns.get(i).data.size() != numRows)
-      {
+      if (columns.get(i).data.size() != numRows) {
         throw new BindException(
-            String.format("Column %d has a different number of binds (%d) than column 1 (%d)", i, iNumRows, numRows), BindException.Type.SERIALIZATION);
+            String.format(
+                "Column %d has a different number of binds (%d) than column 1 (%d)",
+                i, iNumRows, numRows),
+            BindException.Type.SERIALIZATION);
       }
     }
 
-    for (int rowIdx = 0; rowIdx < numRows; rowIdx++)
-    {
+    for (int rowIdx = 0; rowIdx < numRows; rowIdx++) {
       String[] row = new String[numColumns];
-      for (int colIdx = 0; colIdx < numColumns; colIdx++)
-      {
+      for (int colIdx = 0; colIdx < numColumns; colIdx++) {
         row[colIdx] = columns.get(colIdx).data.get(rowIdx);
       }
       rows.add(row);
@@ -297,32 +275,27 @@ public class BindUploader implements Closeable
    * @param rows the list of rows to write out to a file
    * @throws BindException if exception occurs while writing rows out
    */
-  private void writeRowsToCSV(List<String[]> rows) throws BindException
-  {
+  private void writeRowsToCSV(List<String[]> rows) throws BindException {
     int numBytes = 0;
     int rowNum = 0;
     int fileCount = 0;
 
-    while (rowNum < rows.size())
-    {
+    while (rowNum < rows.size()) {
       File file = getFile(++fileCount);
 
-      try (OutputStream out = openFile(file))
-      {
+      try (OutputStream out = openFile(file)) {
         // until we reach the last row or the file is too big, write to the file
         numBytes = 0;
-        while (numBytes < fileSize && rowNum < rows.size())
-        {
+        while (numBytes < fileSize && rowNum < rows.size()) {
           byte[] csv = createCSVRecord(rows.get(rowNum));
           numBytes += csv.length;
           out.write(csv);
           rowNum++;
         }
-      }
-      catch (IOException ex)
-      {
+      } catch (IOException ex) {
         throw new BindException(
-            String.format("Exception encountered while writing to file: %s", ex.getMessage()), BindException.Type.SERIALIZATION);
+            String.format("Exception encountered while writing to file: %s", ex.getMessage()),
+            BindException.Type.SERIALIZATION);
       }
     }
   }
@@ -333,8 +306,7 @@ public class BindUploader implements Closeable
    * @param fileNum the number to use as the file name
    * @return
    */
-  private File getFile(int fileNum)
-  {
+  private File getFile(int fileNum) {
     return bindDir.resolve(Integer.toString(fileNum)).toFile();
   }
 
@@ -345,32 +317,26 @@ public class BindUploader implements Closeable
    * @return output stream
    * @throws BindException
    */
-  private OutputStream openFile(File file) throws BindException
-  {
-    try
-    {
+  private OutputStream openFile(File file) throws BindException {
+    try {
       return new GZIPOutputStream(new FileOutputStream(file));
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       throw new BindException(
-          String.format("Failed to create output file %s: %s", file.toString(), ex.getMessage()), BindException.Type.SERIALIZATION);
+          String.format("Failed to create output file %s: %s", file.toString(), ex.getMessage()),
+          BindException.Type.SERIALIZATION);
     }
   }
 
   /**
-   * Serialize row to a csv
-   * Duplicated from StreamLoader class
+   * Serialize row to a csv Duplicated from StreamLoader class
    *
    * @param data the row to create a csv record from
    * @return serialized csv for row
    */
-  private byte[] createCSVRecord(String[] data)
-  {
+  private byte[] createCSVRecord(String[] data) {
     StringBuilder sb = new StringBuilder(1024);
 
-    for (int i = 0; i < data.length; ++i)
-    {
+    for (int i = 0; i < data.length; ++i) {
       if (i > 0) sb.append(',');
       sb.append(SnowflakeType.escapeForCSV(data[i]));
     }
@@ -381,12 +347,11 @@ public class BindUploader implements Closeable
   /**
    * Build PUT statement string. Handle filesystem differences and escaping backslashes.
    *
-   * @param bindDir   the local directory which contains files with binds
+   * @param bindDir the local directory which contains files with binds
    * @param stagePath the stage path to upload to
    * @return put statement for files in bindDir to stagePath
    */
-  private String getPutStmt(String bindDir, String stagePath)
-  {
+  private String getPutStmt(String bindDir, String stagePath) {
     return String.format(PUT_STMT, bindDir, File.separator, stagePath)
         .replaceAll("\\\\", "\\\\\\\\");
   }
@@ -396,33 +361,30 @@ public class BindUploader implements Closeable
    *
    * @throws BindException if uploading the binds fails
    */
-  private void putBinds() throws BindException
-  {
+  private void putBinds() throws BindException {
     createStageIfNeeded();
 
     String putStatement = getPutStmt(bindDir.toString(), stagePath);
 
-    for (int i = 0; i < PUT_RETRY_COUNT; i++)
-    {
-      try
-      {
+    for (int i = 0; i < PUT_RETRY_COUNT; i++) {
+      try {
         SFStatement statement = new SFStatement(session);
         SFBaseResultSet putResult = statement.execute(putStatement, null, null);
         putResult.next();
 
         // metadata is 0-based, result set is 1-based
-        int column = putResult.getMetaData().getColumnIndex(
-            SnowflakeFileTransferAgent.UploadColumns.status.name()) + 1;
+        int column =
+            putResult
+                    .getMetaData()
+                    .getColumnIndex(SnowflakeFileTransferAgent.UploadColumns.status.name())
+                + 1;
         String status = putResult.getString(column);
 
-        if (SnowflakeFileTransferAgent.ResultStatus.UPLOADED.name().equals(status))
-        {
+        if (SnowflakeFileTransferAgent.ResultStatus.UPLOADED.name().equals(status)) {
           return; // success!
         }
         logger.warn("PUT statement failed. The response had status %s.", status);
-      }
-      catch (SFException | SQLException ex)
-      {
+      } catch (SFException | SQLException ex) {
         logger.warn("Exception encountered during PUT operation. ", ex);
       }
     }
@@ -432,35 +394,29 @@ public class BindUploader implements Closeable
   }
 
   /**
-   * Check whether the session's temporary stage has been created, and create it
-   * if not.
+   * Check whether the session's temporary stage has been created, and create it if not.
    *
    * @throws BindException if creating the stage fails
    */
-  private void createStageIfNeeded() throws BindException
-  {
-    if (session.getArrayBindStage() != null)
-    {
+  private void createStageIfNeeded() throws BindException {
+    if (session.getArrayBindStage() != null) {
       return;
     }
-    synchronized (session)
-    {
+    synchronized (session) {
       // another thread may have created the session by the time we enter this block
-      if (session.getArrayBindStage() == null)
-      {
-        try
-        {
+      if (session.getArrayBindStage() == null) {
+        try {
           SFStatement statement = new SFStatement(session);
           statement.execute(CREATE_STAGE_STMT, null, null);
           session.setArrayBindStage(STAGE_NAME);
-        }
-        catch (SFException | SQLException ex)
-        {
+        } catch (SFException | SQLException ex) {
           // to avoid repeated failures to create stage, disable array bind stage
           // optimization if we fail to create stage for some reason
           session.setArrayBindStageThreshold(0);
           throw new BindException(
-              String.format("Failed to create temporary stage for array binds. %s", ex.getMessage()), BindException.Type.UPLOAD);
+              String.format(
+                  "Failed to create temporary stage for array binds. %s", ex.getMessage()),
+              BindException.Type.UPLOAD);
         }
       }
     }
@@ -468,32 +424,23 @@ public class BindUploader implements Closeable
 
   /**
    * Close uploader, deleting the local temporary directory
-   * <p>
-   * This class can be used in a try-with-resources statement, which ensures that
-   * the temporary directory is cleaned up even when exceptions occur
+   *
+   * <p>This class can be used in a try-with-resources statement, which ensures that the temporary
+   * directory is cleaned up even when exceptions occur
    */
   @Override
-  public void close()
-  {
-    if (!closed)
-    {
-      try
-      {
-        if (Files.isDirectory(bindDir))
-        {
-          for (String fileName : bindDir.toFile().list())
-          {
+  public void close() {
+    if (!closed) {
+      try {
+        if (Files.isDirectory(bindDir)) {
+          for (String fileName : bindDir.toFile().list()) {
             Files.delete(bindDir.resolve(fileName));
           }
           Files.delete(bindDir);
         }
-      }
-      catch (IOException ex)
-      {
+      } catch (IOException ex) {
         logger.warn("Exception encountered while trying to clean local directory. ", ex);
-      }
-      finally
-      {
+      } finally {
         closed = true;
       }
     }
@@ -504,8 +451,7 @@ public class BindUploader implements Closeable
    *
    * @param fileSize size in bytes
    */
-  public void setFileSize(int fileSize)
-  {
+  public void setFileSize(int fileSize) {
     this.fileSize = fileSize;
   }
 
@@ -514,8 +460,7 @@ public class BindUploader implements Closeable
    *
    * @return the stage path
    */
-  public String getStagePath()
-  {
+  public String getStagePath() {
     return this.stagePath;
   }
 
@@ -524,8 +469,7 @@ public class BindUploader implements Closeable
    *
    * @return the local path
    */
-  public Path getBindDir()
-  {
+  public Path getBindDir() {
     return this.bindDir;
   }
 
@@ -533,17 +477,13 @@ public class BindUploader implements Closeable
    * Compute the number of array bind values in the given bind map
    *
    * @param bindValues the bind map
-   * @return 0 if bindValues is null, has no binds, or is not an array bind
-   * n otherwise, where n is the number of binds in the array bind
+   * @return 0 if bindValues is null, has no binds, or is not an array bind n otherwise, where n is
+   *     the number of binds in the array bind
    */
-  public static int arrayBindValueCount(Map<String, ParameterBindingDTO> bindValues)
-  {
-    if (!isArrayBind(bindValues))
-    {
+  public static int arrayBindValueCount(Map<String, ParameterBindingDTO> bindValues) {
+    if (!isArrayBind(bindValues)) {
       return 0;
-    }
-    else
-    {
+    } else {
       ParameterBindingDTO bindSample = bindValues.values().iterator().next();
       List<String> bindSampleValues = (List<String>) bindSample.getValue();
       return bindValues.size() * bindSampleValues.size();
@@ -556,10 +496,8 @@ public class BindUploader implements Closeable
    * @param bindValues the bind map
    * @return whether the bind map uses array binds
    */
-  public static boolean isArrayBind(Map<String, ParameterBindingDTO> bindValues)
-  {
-    if (bindValues == null || bindValues.size() == 0)
-    {
+  public static boolean isArrayBind(Map<String, ParameterBindingDTO> bindValues) {
+    if (bindValues == null || bindValues.size() == 0) {
       return false;
     }
     ParameterBindingDTO bindSample = bindValues.values().iterator().next();

--- a/src/main/java/net/snowflake/client/jdbc/DBMetadataResultSetMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/DBMetadataResultSetMetadata.java
@@ -6,21 +6,17 @@ package net.snowflake.client.jdbc;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
 
 /**
- * For function call getTables/getSchemas, we returned resultset.
- * We stored these resultSetMetadata here
+ * For function call getTables/getSchemas, we returned resultset. We stored these resultSetMetadata
+ * here
  *
- * Created by hyu on 12/15/16.
+ * <p>Created by hyu on 12/15/16.
  */
-public enum DBMetadataResultSetMetadata
-{
-  GET_CATALOGS(
-      Arrays.asList("TABLE_CAT"),
-      Arrays.asList("TEXT"),
-      Arrays.asList(Types.VARCHAR)),
+public enum DBMetadataResultSetMetadata {
+  GET_CATALOGS(Arrays.asList("TABLE_CAT"), Arrays.asList("TEXT"), Arrays.asList(Types.VARCHAR)),
 
   GET_SCHEMAS(
       Arrays.asList("TABLE_SCHEM", "TABLE_CATALOG"),
@@ -28,41 +24,85 @@ public enum DBMetadataResultSetMetadata
       Arrays.asList(Types.VARCHAR, Types.VARCHAR)),
 
   GET_TABLES(
-      Arrays.asList("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME",
-          "TABLE_TYPE", "REMARKS", "TYPE_CAT", "TYPE_SCHEM",
-          "TYPE_NAME", "SELF_REFERENCING_COL_NAME",
+      Arrays.asList(
+          "TABLE_CAT",
+          "TABLE_SCHEM",
+          "TABLE_NAME",
+          "TABLE_TYPE",
+          "REMARKS",
+          "TYPE_CAT",
+          "TYPE_SCHEM",
+          "TYPE_NAME",
+          "SELF_REFERENCING_COL_NAME",
           "REF_GENERATION"),
-      Arrays.asList("TEXT", "TEXT", "TEXT", "TEXT", "TEXT",
-          "TEXT", "TEXT", "TEXT", "TEXT", "TEXT"),
-      Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-          Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-          Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
+      Arrays.asList("TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT"),
+      Arrays.asList(
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
           Types.VARCHAR)),
 
   GET_COLUMNS(
-      Arrays.asList("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME",
-          "COLUMN_NAME", "DATA_TYPE", "TYPE_NAME",
-          "COLUMN_SIZE", "BUFFER_LENGTH",
-          "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS",
+      Arrays.asList(
+          "TABLE_CAT",
+          "TABLE_SCHEM",
+          "TABLE_NAME",
+          "COLUMN_NAME",
+          "DATA_TYPE",
+          "TYPE_NAME",
+          "COLUMN_SIZE",
+          "BUFFER_LENGTH",
+          "DECIMAL_DIGITS",
+          "NUM_PREC_RADIX",
+          "NULLABLE",
+          "REMARKS",
           "COLUMN_DEF",
-          "SQL_DATA_TYPE", "SQL_DATETIME_SUB",
-          "CHAR_OCTET_LENGTH", "ORDINAL_POSITION",
-          "IS_NULLABLE", "SCOPE_CATALOG", "SCOPE_SCHEMA",
-          "SCOPE_TABLE", "SOURCE_DATA_TYPE",
-          "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN"),
-      Arrays.asList("TEXT", "TEXT", "TEXT", "TEXT", "INTEGER",
-           "TEXT", "INTEGER", "INTEGER", "INTEGER", "INTEGER",
-           "INTEGER", "TEXT", "TEXT", "INTEGER", "INTEGER",
-           "INTEGER", "INTEGER", "TEXT", "TEXT",
-           "TEXT", "TEXT", "SHORT", "TEXT", "TEXT"),
-      Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-                    Types.VARCHAR, Types.INTEGER, Types.VARCHAR,
-                    Types.INTEGER, Types.INTEGER, Types.INTEGER,
-                    Types.INTEGER, Types.INTEGER, Types.VARCHAR,
-                    Types.VARCHAR, Types.INTEGER, Types.INTEGER,
-                    Types.INTEGER, Types.INTEGER, Types.VARCHAR,
-                    Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-                    Types.SMALLINT, Types.VARCHAR, Types.VARCHAR)),
+          "SQL_DATA_TYPE",
+          "SQL_DATETIME_SUB",
+          "CHAR_OCTET_LENGTH",
+          "ORDINAL_POSITION",
+          "IS_NULLABLE",
+          "SCOPE_CATALOG",
+          "SCOPE_SCHEMA",
+          "SCOPE_TABLE",
+          "SOURCE_DATA_TYPE",
+          "IS_AUTOINCREMENT",
+          "IS_GENERATEDCOLUMN"),
+      Arrays.asList(
+          "TEXT", "TEXT", "TEXT", "TEXT", "INTEGER", "TEXT", "INTEGER", "INTEGER", "INTEGER",
+          "INTEGER", "INTEGER", "TEXT", "TEXT", "INTEGER", "INTEGER", "INTEGER", "INTEGER", "TEXT",
+          "TEXT", "TEXT", "TEXT", "SHORT", "TEXT", "TEXT"),
+      Arrays.asList(
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.INTEGER,
+          Types.VARCHAR,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.SMALLINT,
+          Types.VARCHAR,
+          Types.VARCHAR)),
 
   GET_COLUMNS_EXTENDED_SET(
       GET_COLUMNS,
@@ -71,50 +111,109 @@ public enum DBMetadataResultSetMetadata
       Collections.singletonList(Types.VARCHAR)),
 
   GET_PRIMARY_KEYS(
-      Arrays.asList("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME",
-          "COLUMN_NAME", "KEY_SEQ", "PK_NAME"),
+      Arrays.asList("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "KEY_SEQ", "PK_NAME"),
       Arrays.asList("TEXT", "TEXT", "TEXT", "TEXT", "INTEGER", "TEXT"),
-      Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-          Types.VARCHAR, Types.SMALLINT, Types.VARCHAR)),
-
-  GET_FOREIGN_KEYS(
-      Arrays.asList("PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME",
-          "PKCOLUMN_NAME", "FKTABLE_CAT", "FKTABLE_SCHEM",
-          "FKTABLE_NAME", "FKCOLUMN_NAME", "KEY_SEQ",
-          "UPDATE_RULE", "DELETE_RULE", "FK_NAME",
-          "PK_NAME", "DEFERRABILITY"),
-      Arrays.asList("TEXT", "TEXT", "TEXT", "TEXT", "TEXT",
-          "TEXT", "TEXT", "TEXT", "SHORT", "SHORT",
-          "SHORT", "TEXT", "TEXT", "SHORT"),
-      Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-          Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-          Types.VARCHAR, Types.VARCHAR, Types.SMALLINT,
-          Types.SMALLINT, Types.SMALLINT, Types.VARCHAR,
-          Types.VARCHAR, Types.SMALLINT)),
-
-  GET_FUNCTIONS(
-      Arrays.asList("FUNCTION_CAT", "FUNCTION_SCHEM",
-          "FUNCTION_NAME", "REMARKS", "FUNCTION_TYPE", "SPECIFIC_NAME"),
-      Arrays.asList("TEXT", "TEXT", "TEXT", "TEXT", "SHORT", "TEXT"),
-      Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-                Types.VARCHAR, Types.SMALLINT, Types.VARCHAR)),
-
-  GET_FUNCTION_COLUMNS(
-      Arrays.asList("FUNCTION_CAT", "FUNCTION_SCHEM", "FUNCTION_NAME",
-          "COLUMN_NAME", "COLUMN_TYPE", "DATA_TYPE", "TYPE_NAME", "PRECISION",
-          "LENGTH", "SCALE", "RADIX", "NULLABLE", "REMARKS", "CHAR_OCTET_LENGTH",
-          "ORDINAL_POSITION", "IS_NULLABLE", "SPECIFIC_NAME"),
-      Arrays.asList("TEXT", "TEXT", "TEXT", "TEXT", "SHORT", "INTEGER", "TEXT",
-          "INTEGER", "INTEGER", "SHORT", "SHORT", "SHORT", "TEXT", "INTEGER",
-          "INTEGER", "TEXT", "TEXT"),
-      Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-          Types.SMALLINT, Types.INTEGER, Types.VARCHAR, Types.INTEGER,
-          Types.INTEGER, Types.SMALLINT, Types.SMALLINT, Types.SMALLINT,
-          Types.VARCHAR, Types.INTEGER, Types.INTEGER, Types.VARCHAR,
+      Arrays.asList(
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.SMALLINT,
           Types.VARCHAR)),
 
-  ;
+  GET_FOREIGN_KEYS(
+      Arrays.asList(
+          "PKTABLE_CAT",
+          "PKTABLE_SCHEM",
+          "PKTABLE_NAME",
+          "PKCOLUMN_NAME",
+          "FKTABLE_CAT",
+          "FKTABLE_SCHEM",
+          "FKTABLE_NAME",
+          "FKCOLUMN_NAME",
+          "KEY_SEQ",
+          "UPDATE_RULE",
+          "DELETE_RULE",
+          "FK_NAME",
+          "PK_NAME",
+          "DEFERRABILITY"),
+      Arrays.asList(
+          "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "SHORT", "SHORT", "SHORT",
+          "TEXT", "TEXT", "SHORT"),
+      Arrays.asList(
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.SMALLINT,
+          Types.SMALLINT,
+          Types.SMALLINT,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.SMALLINT)),
 
+  GET_FUNCTIONS(
+      Arrays.asList(
+          "FUNCTION_CAT",
+          "FUNCTION_SCHEM",
+          "FUNCTION_NAME",
+          "REMARKS",
+          "FUNCTION_TYPE",
+          "SPECIFIC_NAME"),
+      Arrays.asList("TEXT", "TEXT", "TEXT", "TEXT", "SHORT", "TEXT"),
+      Arrays.asList(
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.SMALLINT,
+          Types.VARCHAR)),
+
+  GET_FUNCTION_COLUMNS(
+      Arrays.asList(
+          "FUNCTION_CAT",
+          "FUNCTION_SCHEM",
+          "FUNCTION_NAME",
+          "COLUMN_NAME",
+          "COLUMN_TYPE",
+          "DATA_TYPE",
+          "TYPE_NAME",
+          "PRECISION",
+          "LENGTH",
+          "SCALE",
+          "RADIX",
+          "NULLABLE",
+          "REMARKS",
+          "CHAR_OCTET_LENGTH",
+          "ORDINAL_POSITION",
+          "IS_NULLABLE",
+          "SPECIFIC_NAME"),
+      Arrays.asList(
+          "TEXT", "TEXT", "TEXT", "TEXT", "SHORT", "INTEGER", "TEXT", "INTEGER", "INTEGER", "SHORT",
+          "SHORT", "SHORT", "TEXT", "INTEGER", "INTEGER", "TEXT", "TEXT"),
+      Arrays.asList(
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.VARCHAR,
+          Types.SMALLINT,
+          Types.INTEGER,
+          Types.VARCHAR,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.SMALLINT,
+          Types.SMALLINT,
+          Types.SMALLINT,
+          Types.VARCHAR,
+          Types.INTEGER,
+          Types.INTEGER,
+          Types.VARCHAR,
+          Types.VARCHAR)),
+  ;
 
   private List<String> columnNames;
 
@@ -122,20 +221,18 @@ public enum DBMetadataResultSetMetadata
 
   private List<Integer> columnTypes;
 
-  DBMetadataResultSetMetadata(List<String> columnNames,
-                              List<String> columnTypeNames,
-                              List<Integer> columnTypes)
-  {
+  DBMetadataResultSetMetadata(
+      List<String> columnNames, List<String> columnTypeNames, List<Integer> columnTypes) {
     this.columnNames = columnNames;
     this.columnTypeNames = columnTypeNames;
     this.columnTypes = columnTypes;
   }
 
-  DBMetadataResultSetMetadata(DBMetadataResultSetMetadata base,
-                              List<String> additionalColumnNames,
-                              List<String> additionalColumnTypeNames,
-                              List<Integer> additionalColumnTypes)
-  {
+  DBMetadataResultSetMetadata(
+      DBMetadataResultSetMetadata base,
+      List<String> additionalColumnNames,
+      List<String> additionalColumnTypeNames,
+      List<Integer> additionalColumnTypes) {
     this.columnNames = new ArrayList<>(base.getColumnNames());
     this.columnTypeNames = new ArrayList<>(base.getColumnTypeNames());
     this.columnTypes = new ArrayList<>(base.getColumnTypes());
@@ -144,18 +241,15 @@ public enum DBMetadataResultSetMetadata
     columnTypes.addAll(additionalColumnTypes);
   }
 
-  public List<String> getColumnNames()
-  {
+  public List<String> getColumnNames() {
     return columnNames;
   }
 
-  public List<String> getColumnTypeNames()
-  {
+  public List<String> getColumnTypeNames() {
     return columnTypeNames;
   }
 
-  public List<Integer> getColumnTypes()
-  {
+  public List<Integer> getColumnTypes() {
     return columnTypes;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/ErrorCode.java
+++ b/src/main/java/net/snowflake/client/jdbc/ErrorCode.java
@@ -6,27 +6,20 @@ package net.snowflake.client.jdbc;
 
 import net.snowflake.common.core.SqlState;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Internal JDBC driver error codes
  *
  * @author jhuang
  */
-public enum ErrorCode
-{
+public enum ErrorCode {
 
   /**
    * Error codes partitioning:
    *
-   * 0NNNNN: GS SQL error codes
-   * 1NNNNN: XP error codes
-   * 2NNNNN: JDBC driver error codes
-   * 3NNNNN: GS generic error codes
-   * 4NNNNN: Node.js driver error codes
+   * <p>0NNNNN: GS SQL error codes 1NNNNN: XP error codes 2NNNNN: JDBC driver error codes 3NNNNN: GS
+   * generic error codes 4NNNNN: Node.js driver error codes
    *
-   * N can be any digits from 0 to 9.
+   * <p>N can be any digits from 0 to 9.
    */
   INTERNAL_ERROR(200001, SqlState.INTERNAL_ERROR),
   CONNECTION_ERROR(200002, SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
@@ -37,8 +30,7 @@ public enum ErrorCode
   FAIL_LIST_FILES(200007, SqlState.DATA_EXCEPTION),
   FILE_NOT_FOUND(200008, SqlState.DATA_EXCEPTION),
   FILE_IS_DIRECTORY(200009, SqlState.DATA_EXCEPTION),
-  DUPLICATE_CONNECTION_PROPERTY_SPECIFIED(200010,
-      SqlState.DATA_EXCEPTION),
+  DUPLICATE_CONNECTION_PROPERTY_SPECIFIED(200010, SqlState.DATA_EXCEPTION),
   MISSING_USERNAME(200011, SqlState.INVALID_AUTHORIZATION_SPECIFICATION),
   MISSING_PASSWORD(200012, SqlState.INVALID_AUTHORIZATION_SPECIFICATION),
   S3_OPERATION_ERROR(200013, SqlState.SYSTEM_ERROR),
@@ -56,8 +48,7 @@ public enum ErrorCode
   STATEMENT_ALREADY_RUNNING_QUERY(200025, SqlState.FEATURE_NOT_SUPPORTED),
   MISSING_SERVER_URL(200026, SqlState.INVALID_AUTHORIZATION_SPECIFICATION),
   TOO_MANY_SESSION_PARAMETERS(200027, SqlState.FEATURE_NOT_SUPPORTED),
-  MISSING_CONNECTION_PROPERTY(200028,
-      SqlState.INVALID_AUTHORIZATION_SPECIFICATION),
+  MISSING_CONNECTION_PROPERTY(200028, SqlState.INVALID_AUTHORIZATION_SPECIFICATION),
   INVALID_CONNECTION_URL(200029, SqlState.INVALID_AUTHORIZATION_SPECIFICATION),
   DUPLICATE_STATEMENT_PARAMETER_SPECIFIED(200030, SqlState.DATA_EXCEPTION),
   TOO_MANY_STATEMENT_PARAMETERS(200031, SqlState.FEATURE_NOT_SUPPORTED),
@@ -68,15 +59,12 @@ public enum ErrorCode
   INVALID_STATE(200036, SqlState.FEATURE_NOT_SUPPORTED),
   RESULTSET_ALREADY_CLOSED(200037, SqlState.FEATURE_NOT_SUPPORTED),
   INVALID_VALUE_CONVERT(200038, SqlState.FEATURE_NOT_SUPPORTED),
-  IDP_CONNECTION_ERROR(200039,
-                       SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
-  IDP_INCORRECT_DESTINATION(200040,
-                       SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+  IDP_CONNECTION_ERROR(200039, SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+  IDP_INCORRECT_DESTINATION(200040, SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
   CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP(200041, SqlState.WARNING),
-  UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API(200042,
-      SqlState.FEATURE_NOT_SUPPORTED),
+  UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API(200042, SqlState.FEATURE_NOT_SUPPORTED),
   STATEMENT_PREPARE_FAILURE(200043, SqlState.FEATURE_NOT_SUPPORTED),
-   AZURE_SERVICE_ERROR(200044, SqlState.SYSTEM_ERROR),
+  AZURE_SERVICE_ERROR(200044, SqlState.SYSTEM_ERROR),
 
   INVALID_OR_UNSUPPORTED_PRIVATE_KEY(200045, SqlState.SYNTAX_ERROR),
   FAILED_TO_GENERATE_JWT(200046, SqlState.SYNTAX_ERROR),
@@ -86,42 +74,36 @@ public enum ErrorCode
   CHILD_RESULT_IDS_AND_TYPES_DIFFERENT_SIZES(200050, SqlState.INTERNAL_ERROR),
   ;
 
-  public final static String errorMessageResource =
-  "net.snowflake.client.jdbc.jdbc_error_messages";
+  public static final String errorMessageResource = "net.snowflake.client.jdbc.jdbc_error_messages";
+
+  /** Snowflake internal message associated to the error. */
+  private final Integer messageCode;
+
+  private final String sqlState;
 
   /**
-   * Snowflake internal message associated to the error.
-   */
-  final private Integer messageCode;
-
-  final private String sqlState;
-
-  /**
-   * Construct a new error code specification given Snowflake internal error
-   * code and SQL state error code.
-   * <p/>
+   * Construct a new error code specification given Snowflake internal error code and SQL state
+   * error code.
+   *
+   * <p>
+   *
    * @param messageCode
    */
-  ErrorCode(Integer messageCode, String sqlState)
-  {
+  ErrorCode(Integer messageCode, String sqlState) {
     this.messageCode = messageCode;
     this.sqlState = sqlState;
   }
 
-  public Integer getMessageCode()
-  {
+  public Integer getMessageCode() {
     return messageCode;
   }
 
-  public String getSqlState()
-  {
+  public String getSqlState() {
     return sqlState;
   }
 
   @Override
-  public String toString()
-  {
-    return "ErrorCode{" + "messageCode=" + messageCode + ", sqlState=" +
-        sqlState + '}';
+  public String toString() {
+    return "ErrorCode{" + "messageCode=" + messageCode + ", sqlState=" + sqlState + '}';
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/FileBackedOutputStream.java
+++ b/src/main/java/net/snowflake/client/jdbc/FileBackedOutputStream.java
@@ -17,10 +17,7 @@
 package net.snowflake.client.jdbc;
 
 import com.google.common.annotations.Beta;
-import com.google.common.annotations.VisibleForTesting;
-
 import com.google.common.io.ByteSource;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -31,12 +28,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * An {@link OutputStream} that starts buffering to a byte array, but
- * switches to file buffering once the data reaches a configurable size.
+ * An {@link OutputStream} that starts buffering to a byte array, but switches to file buffering
+ * once the data reaches a configurable size.
  *
  * <p>This class is thread-safe.
  *
- * Adapted by Snowflake to return File object when file is spilled to disk.
+ * <p>Adapted by Snowflake to return File object when file is spilled to disk.
  *
  * @author Chris Nokleberg
  * @since 1.0
@@ -63,35 +60,28 @@ public final class FileBackedOutputStream extends OutputStream {
     }
   }
 
-  /**
-   * @return the file holding the data (possibly null).
-   */
+  /** @return the file holding the data (possibly null). */
   public synchronized File getFile() {
     return file;
   }
 
   /**
-   * Creates a new instance that uses the given file threshold, and does
-   * not reset the data when the {@link ByteSource} returned by
-   * {@link #asByteSource} is finalized.
+   * Creates a new instance that uses the given file threshold, and does not reset the data when the
+   * {@link ByteSource} returned by {@link #asByteSource} is finalized.
    *
-   * @param fileThreshold the number of bytes before the stream should
-   *     switch to buffering to a file
+   * @param fileThreshold the number of bytes before the stream should switch to buffering to a file
    */
   public FileBackedOutputStream(int fileThreshold) {
     this(fileThreshold, false);
   }
 
   /**
-   * Creates a new instance that uses the given file threshold, and
-   * optionally resets the data when the {@link ByteSource} returned
-   * by {@link #asByteSource} is finalized.
+   * Creates a new instance that uses the given file threshold, and optionally resets the data when
+   * the {@link ByteSource} returned by {@link #asByteSource} is finalized.
    *
-   * @param fileThreshold the number of bytes before the stream should
-   *     switch to buffering to a file
-   * @param resetOnFinalize if true, the {@link #reset} method will
-   *     be called when the {@link ByteSource} returned by {@link
-   *     #asByteSource} is finalized
+   * @param fileThreshold the number of bytes before the stream should switch to buffering to a file
+   * @param resetOnFinalize if true, the {@link #reset} method will be called when the {@link
+   *     ByteSource} returned by {@link #asByteSource} is finalized
    */
   public FileBackedOutputStream(int fileThreshold, boolean resetOnFinalize) {
     this.fileThreshold = fileThreshold;
@@ -100,34 +90,35 @@ public final class FileBackedOutputStream extends OutputStream {
     out = memory;
 
     if (resetOnFinalize) {
-      source = new ByteSource() {
-        @Override
-        public InputStream openStream() throws IOException {
-          return openInputStream();
-        }
+      source =
+          new ByteSource() {
+            @Override
+            public InputStream openStream() throws IOException {
+              return openInputStream();
+            }
 
-        @Override protected void finalize() {
-          try {
-            reset();
-          } catch (Throwable t) {
-            t.printStackTrace(System.err);
-          }
-        }
-      };
+            @Override
+            protected void finalize() {
+              try {
+                reset();
+              } catch (Throwable t) {
+                t.printStackTrace(System.err);
+              }
+            }
+          };
     } else {
-      source = new ByteSource() {
-        @Override
-        public InputStream openStream() throws IOException {
-          return openInputStream();
-        }
-      };
+      source =
+          new ByteSource() {
+            @Override
+            public InputStream openStream() throws IOException {
+              return openInputStream();
+            }
+          };
     }
   }
 
   /**
-   * @return a readable {@link ByteSource} view of the data that has been
-   * written to this stream.
-   *
+   * @return a readable {@link ByteSource} view of the data that has been written to this stream.
    * @since 15.0
    */
   public ByteSource asByteSource() {
@@ -138,15 +129,13 @@ public final class FileBackedOutputStream extends OutputStream {
     if (file != null) {
       return new FileInputStream(file);
     } else {
-      return new ByteArrayInputStream(
-          memory.getBuffer(), 0, memory.getCount());
+      return new ByteArrayInputStream(memory.getBuffer(), 0, memory.getCount());
     }
   }
 
   /**
-   * Calls {@link #close} if not already closed, and then resets this
-   * object back to its initial state, for reuse. If data was buffered
-   * to a file, it will be deleted.
+   * Calls {@link #close} if not already closed, and then resets this object back to its initial
+   * state, for reuse. If data was buffered to a file, it will be deleted.
    *
    * @throws IOException if an I/O error occurred while deleting the file buffer
    */
@@ -170,32 +159,36 @@ public final class FileBackedOutputStream extends OutputStream {
     }
   }
 
-  @Override public synchronized void write(int b) throws IOException {
+  @Override
+  public synchronized void write(int b) throws IOException {
     update(1);
     out.write(b);
   }
 
-  @Override public synchronized void write(byte[] b) throws IOException {
+  @Override
+  public synchronized void write(byte[] b) throws IOException {
     write(b, 0, b.length);
   }
 
-  @Override public synchronized void write(byte[] b, int off, int len)
-      throws IOException {
+  @Override
+  public synchronized void write(byte[] b, int off, int len) throws IOException {
     update(len);
     out.write(b, off, len);
   }
 
-  @Override public synchronized void close() throws IOException {
+  @Override
+  public synchronized void close() throws IOException {
     out.close();
   }
 
-  @Override public synchronized void flush() throws IOException {
+  @Override
+  public synchronized void flush() throws IOException {
     out.flush();
   }
 
   /**
-   * Checks if writing {@code len} bytes would go over threshold, and
-   * switches to file buffering if so.
+   * Checks if writing {@code len} bytes would go over threshold, and switches to file buffering if
+   * so.
    */
   private void update(int len) throws IOException {
     if (file == null && (memory.getCount() + len > fileThreshold)) {

--- a/src/main/java/net/snowflake/client/jdbc/MatDesc.java
+++ b/src/main/java/net/snowflake/client/jdbc/MatDesc.java
@@ -10,118 +10,88 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * A class to handle S3 material descriptor metadata entries (matdesc).
+ *
  * @author ffunke
  */
-public class MatDesc
-{
-  /**
-   * MatDesc key for query ID
-   */
+public class MatDesc {
+  /** MatDesc key for query ID */
   public static String QUERY_ID = "queryId";
 
-  /**
-   * MatDesc key for stage master key ID
-   */
+  /** MatDesc key for stage master key ID */
   public static String SMK_ID = "smkId";
 
-  /**
-   * MatDesc key for the length of the key in bits
-   */
+  /** MatDesc key for the length of the key in bits */
   public static String KEY_SIZE = "keySize";
-  
-  /**
-   * If key size is not explicitly specified, assume DEFAULT_KEY_SIZE
-   */
+
+  /** If key size is not explicitly specified, assume DEFAULT_KEY_SIZE */
   public static int DEFAULT_KEY_SIZE = 256;
 
+  /** The JSON parser for matdesc entries */
+  private static final ObjectMapper mapper = new ObjectMapper();
 
-  /**
-   * The JSON parser for matdesc entries
-   */
-  private final static ObjectMapper mapper = new ObjectMapper();
+  /** The Stage Master Key ID */
+  private final long smkId;
 
-  /**
-   * The Stage Master Key ID
-   */
-  final private long smkId;
+  /** The query ID */
+  private final String queryId;
 
-  /**
-   * The query ID
-   */
-  final private String queryId;
+  /** The key length in bits */
+  private final int keySize;
 
-  /**
-   * The key length in bits
-   */
-  final private int keySize;
-
-  public MatDesc(long smkId, String queryId, int keySize)
-  {
+  public MatDesc(long smkId, String queryId, int keySize) {
     this.smkId = smkId;
     this.queryId = queryId;
     this.keySize = keySize;
   }
 
-  public MatDesc(long smkId, String queryId)
-  {
+  public MatDesc(long smkId, String queryId) {
     this(smkId, queryId, DEFAULT_KEY_SIZE);
   }
 
-  public long getSmkId()
-  {
+  public long getSmkId() {
     return this.smkId;
   }
 
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return this.queryId;
   }
 
-  public int getKeySize()
-  {
+  public int getKeySize() {
     return this.keySize;
   }
 
   /**
    * Try to parse the material descriptor string.
+   *
    * @param matdesc string
    * @return The material description or null
    */
-  public static MatDesc parse(String matdesc)
-  {
-    if (matdesc == null)
-      return null;
-    try
-    {
+  public static MatDesc parse(String matdesc) {
+    if (matdesc == null) return null;
+    try {
       JsonNode jsonNode = mapper.readTree(matdesc);
       JsonNode queryIdNode = jsonNode.path(QUERY_ID);
-      if (queryIdNode.isMissingNode() || queryIdNode.isNull())
-      {
+      if (queryIdNode.isMissingNode() || queryIdNode.isNull()) {
         return null;
       }
       JsonNode smkIdNode = jsonNode.path(SMK_ID);
-      if (smkIdNode.isMissingNode() || smkIdNode.isNull())
-      {
+      if (smkIdNode.isMissingNode() || smkIdNode.isNull()) {
         return null;
       }
       String queryId = queryIdNode.asText();
       long smkId = smkIdNode.asLong();
       JsonNode keySizeNode = jsonNode.path(KEY_SIZE);
-      if (!keySizeNode.isMissingNode() && !keySizeNode.isNull())
-      {
+      if (!keySizeNode.isMissingNode() && !keySizeNode.isNull()) {
         return new MatDesc(smkId, queryId, keySizeNode.asInt());
       }
       return new MatDesc(smkId, queryId);
-    }
-    catch (Exception ex)
-    {
+    } catch (Exception ex) {
       return null;
     }
   }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
     ObjectNode obj = mapper.createObjectNode();
     obj.put(QUERY_ID, this.queryId);
     obj.put(SMK_ID, Long.toString(this.smkId));

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -4,10 +4,8 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.common.core.SqlState;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URL;
@@ -27,21 +25,21 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
-import java.sql.Types;
 import java.util.TimeZone;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SqlState;
 
 /**
  * Base class for query result set and metadata result set
  *
  * @author jhuang
  */
-abstract class SnowflakeBaseResultSet implements ResultSet
-{
+abstract class SnowflakeBaseResultSet implements ResultSet {
 
   static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeBaseResultSet.class);
 
@@ -60,22 +58,20 @@ abstract class SnowflakeBaseResultSet implements ResultSet
   private int fetchSize = 0;
 
   @Override
-  abstract public boolean next() throws SQLException;
+  public abstract boolean next() throws SQLException;
 
   @Override
-  abstract public void close() throws SQLException;
+  public abstract void close() throws SQLException;
 
   @Override
-  public boolean wasNull() throws SQLException
-  {
+  public boolean wasNull() throws SQLException {
     logger.debug("public boolean wasNull() returning {}", wasNull);
 
     return wasNull;
   }
 
   @Override
-  public String getString(int columnIndex) throws SQLException
-  {
+  public String getString(int columnIndex) throws SQLException {
     logger.debug("public String getString(int columnIndex)");
 
     // Column index starts from 1, not 0.
@@ -85,179 +81,134 @@ abstract class SnowflakeBaseResultSet implements ResultSet
   }
 
   @Override
-  public boolean getBoolean(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public boolean getBoolean(int columnIndex)");
+  public boolean getBoolean(int columnIndex) throws SQLException {
+    logger.debug("public boolean getBoolean(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return false;
+    if (obj == null) return false;
 
-    if (obj instanceof String)
-    {
-      if (obj.toString().equals("1"))
-      {
+    if (obj instanceof String) {
+      if (obj.toString().equals("1")) {
         return Boolean.TRUE;
       }
       return Boolean.FALSE;
-    }
-    else
-    {
+    } else {
       return ((Boolean) obj).booleanValue();
     }
   }
 
   @Override
-  public byte getByte(int columnIndex) throws SQLException
-  {
+  public byte getByte(int columnIndex) throws SQLException {
     logger.debug("public byte getByte(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public short getShort(int columnIndex) throws SQLException
-  {
+  public short getShort(int columnIndex) throws SQLException {
     logger.debug("public short getShort(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    if (obj instanceof String)
-    {
+    if (obj instanceof String) {
       return (Short.valueOf((String) obj)).shortValue();
-    }
-    else
-    {
+    } else {
       return ((Number) obj).shortValue();
     }
   }
 
   @Override
-  public int getInt(int columnIndex) throws SQLException
-  {
+  public int getInt(int columnIndex) throws SQLException {
     logger.debug("public int getInt(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    if (obj instanceof String)
-    {
+    if (obj instanceof String) {
       return (Integer.valueOf((String) obj)).intValue();
-    }
-    else
-    {
+    } else {
       return ((Number) obj).intValue();
     }
-
   }
 
   @Override
-  public long getLong(int columnIndex) throws SQLException
-  {
+  public long getLong(int columnIndex) throws SQLException {
     logger.debug("public long getLong(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    try
-    {
-      if (obj instanceof String)
-      {
+    try {
+      if (obj instanceof String) {
         return (Long.valueOf((String) obj)).longValue();
-      }
-      else
-      {
+      } else {
         return ((Number) obj).longValue();
       }
-    }
-    catch (NumberFormatException nfe)
-    {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                      "Invalid long: " + (String) obj);
+    } catch (NumberFormatException nfe) {
+      throw new SnowflakeSQLException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Invalid long: " + (String) obj);
     }
   }
 
   @Override
-  public float getFloat(int columnIndex) throws SQLException
-  {
+  public float getFloat(int columnIndex) throws SQLException {
     logger.debug("public float getFloat(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    if (obj instanceof String)
-    {
+    if (obj instanceof String) {
       return (Float.valueOf((String) obj)).floatValue();
-    }
-    else
-    {
+    } else {
       return ((Number) obj).floatValue();
     }
   }
 
   @Override
-  public double getDouble(int columnIndex) throws SQLException
-  {
+  public double getDouble(int columnIndex) throws SQLException {
     logger.debug("public double getDouble(int columnIndex)");
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
     // snow-11974: null for getDouble should return 0
-    if (obj == null)
-      return 0;
+    if (obj == null) return 0;
 
-    if (obj instanceof String)
-    {
+    if (obj instanceof String) {
       return (Double.valueOf((String) obj)).doubleValue();
-    }
-    else
-    {
+    } else {
       return ((Number) obj).doubleValue();
     }
   }
 
-  /**
-   * @deprecated
-   */
+  /** @deprecated */
   @Override
-  public BigDecimal getBigDecimal(int columnIndex, int scale)
-          throws SQLException
-  {
-    logger.debug(
-               "public BigDecimal getBigDecimal(int columnIndex, int scale)");
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+    logger.debug("public BigDecimal getBigDecimal(int columnIndex, int scale)");
 
     BigDecimal value = null;
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
-    if (obj instanceof String)
-    {
+    if (obj instanceof String) {
       value = new BigDecimal((String) obj);
-    }
-    else
-    {
+    } else {
       value = new BigDecimal(obj.toString());
     }
 
@@ -267,300 +218,240 @@ abstract class SnowflakeBaseResultSet implements ResultSet
   }
 
   @Override
-  abstract public byte[] getBytes(int columnIndex) throws SQLException;
+  public abstract byte[] getBytes(int columnIndex) throws SQLException;
 
-  abstract public Date getDate(int columnIndex, TimeZone tz) throws SQLException;
+  public abstract Date getDate(int columnIndex, TimeZone tz) throws SQLException;
 
   @Override
-  public Date getDate(int columnIndex) throws SQLException
-  {
+  public Date getDate(int columnIndex) throws SQLException {
     return getDate(columnIndex, TimeZone.getDefault());
   }
 
   @Override
-  abstract public Time getTime(int columnIndex) throws SQLException;
+  public abstract Time getTime(int columnIndex) throws SQLException;
 
   @Override
-  public Timestamp getTimestamp(int columnIndex) throws SQLException
-  {
+  public Timestamp getTimestamp(int columnIndex) throws SQLException {
     return getTimestamp(columnIndex, TimeZone.getDefault());
   }
 
-  abstract public Timestamp getTimestamp(int columnIndex, TimeZone tz)
-      throws SQLException;
+  public abstract Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SQLException;
 
   /**
-   * Parse seconds since epoch with both seconds and fractional seconds after
-   * decimal point (e.g 123.456 with a scale of 3) to a representation with
-   * fractions normalized to an integer (e.g. 123456)
+   * Parse seconds since epoch with both seconds and fractional seconds after decimal point (e.g
+   * 123.456 with a scale of 3) to a representation with fractions normalized to an integer (e.g.
+   * 123456)
+   *
    * @param secondsSinceEpochStr
    * @param scale
-   * @return a BigDecimal containing the number of fractional seconds since
-   * epoch.
+   * @return a BigDecimal containing the number of fractional seconds since epoch.
    */
-  private BigDecimal parseSecondsSinceEpoch(String secondsSinceEpochStr,
-                                                       int scale)
-  {
-      // seconds since epoch has both seconds and fractional seconds after decimal
-      // point. Ex: 134567890.12345678
-      // Note: can actually contain timezone in the lowest part
-      // Example: obj is e.g. "123.456" (scale=3)
-      //          Then, secondsSinceEpoch is 123.456
-      BigDecimal secondsSinceEpoch = new BigDecimal(secondsSinceEpochStr);
+  private BigDecimal parseSecondsSinceEpoch(String secondsSinceEpochStr, int scale) {
+    // seconds since epoch has both seconds and fractional seconds after decimal
+    // point. Ex: 134567890.12345678
+    // Note: can actually contain timezone in the lowest part
+    // Example: obj is e.g. "123.456" (scale=3)
+    //          Then, secondsSinceEpoch is 123.456
+    BigDecimal secondsSinceEpoch = new BigDecimal(secondsSinceEpochStr);
 
-      // Representation with fractions normalized to an integer
-      // Note: can actually contain timezone in the lowest part
-      // Example: fractionsSinceEpoch is 123456
-      return secondsSinceEpoch.scaleByPowerOfTen(scale);
+    // Representation with fractions normalized to an integer
+    // Note: can actually contain timezone in the lowest part
+    // Example: fractionsSinceEpoch is 123456
+    return secondsSinceEpoch.scaleByPowerOfTen(scale);
   }
 
   @Override
-  public InputStream getAsciiStream(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public InputStream getAsciiStream(int columnIndex)");
+  public InputStream getAsciiStream(int columnIndex) throws SQLException {
+    logger.debug("public InputStream getAsciiStream(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
-  /**
-   * @deprecated
-   */
+  /** @deprecated */
   @Override
-  public InputStream getUnicodeStream(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public InputStream getUnicodeStream(int columnIndex)");
+  public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+    logger.debug("public InputStream getUnicodeStream(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public InputStream getBinaryStream(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public InputStream getBinaryStream(int columnIndex)");
+  public InputStream getBinaryStream(int columnIndex) throws SQLException {
+    logger.debug("public InputStream getBinaryStream(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public String getString(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public String getString(String columnLabel)");
+  public String getString(String columnLabel) throws SQLException {
+    logger.debug("public String getString(String columnLabel)");
 
     return getString(findColumn(columnLabel));
   }
 
   @Override
-  public boolean getBoolean(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public boolean getBoolean(String columnLabel)");
+  public boolean getBoolean(String columnLabel) throws SQLException {
+    logger.debug("public boolean getBoolean(String columnLabel)");
 
     return getBoolean(findColumn(columnLabel));
   }
 
   @Override
-  public byte getByte(String columnLabel) throws SQLException
-  {
+  public byte getByte(String columnLabel) throws SQLException {
     logger.debug("public byte getByte(String columnLabel)");
 
     return getByte(findColumn(columnLabel));
   }
 
   @Override
-  public short getShort(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public short getShort(String columnLabel)");
+  public short getShort(String columnLabel) throws SQLException {
+    logger.debug("public short getShort(String columnLabel)");
 
     return getShort(findColumn(columnLabel));
   }
 
   @Override
-  public int getInt(String columnLabel) throws SQLException
-  {
+  public int getInt(String columnLabel) throws SQLException {
     logger.debug("public int getInt(String columnLabel)");
 
     return getInt(findColumn(columnLabel));
   }
 
   @Override
-  public long getLong(String columnLabel) throws SQLException
-  {
+  public long getLong(String columnLabel) throws SQLException {
     logger.debug("public long getLong(String columnLabel)");
 
     return getLong(findColumn(columnLabel));
   }
 
   @Override
-  public float getFloat(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public float getFloat(String columnLabel)");
+  public float getFloat(String columnLabel) throws SQLException {
+    logger.debug("public float getFloat(String columnLabel)");
 
     return getFloat(findColumn(columnLabel));
   }
 
   @Override
-  public double getDouble(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public double getDouble(String columnLabel)");
+  public double getDouble(String columnLabel) throws SQLException {
+    logger.debug("public double getDouble(String columnLabel)");
 
     return getDouble(findColumn(columnLabel));
   }
 
-  /**
-   * @deprecated
-   */
+  /** @deprecated */
   @Override
-  public BigDecimal getBigDecimal(String columnLabel, int scale)
-          throws SQLException
-  {
-    logger.debug(
-               "public BigDecimal getBigDecimal(String columnLabel, "
-               + "int scale)");
+  public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+    logger.debug("public BigDecimal getBigDecimal(String columnLabel, " + "int scale)");
 
     return getBigDecimal(findColumn(columnLabel), scale);
   }
 
   @Override
-  public byte[] getBytes(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public byte[] getBytes(String columnLabel)");
+  public byte[] getBytes(String columnLabel) throws SQLException {
+    logger.debug("public byte[] getBytes(String columnLabel)");
 
     return getBytes(findColumn(columnLabel));
   }
 
   @Override
-  public Date getDate(String columnLabel) throws SQLException
-  {
+  public Date getDate(String columnLabel) throws SQLException {
     logger.debug("public Date getDate(String columnLabel)");
 
     return getDate(findColumn(columnLabel));
   }
 
   @Override
-  public Time getTime(String columnLabel) throws SQLException
-  {
+  public Time getTime(String columnLabel) throws SQLException {
     logger.debug("public Time getTime(String columnLabel)");
 
     return getTime(findColumn(columnLabel));
   }
 
   @Override
-  public Timestamp getTimestamp(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public Timestamp getTimestamp(String columnLabel)");
+  public Timestamp getTimestamp(String columnLabel) throws SQLException {
+    logger.debug("public Timestamp getTimestamp(String columnLabel)");
 
     return getTimestamp(findColumn(columnLabel));
   }
 
   @Override
-  public InputStream getAsciiStream(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public InputStream getAsciiStream(String columnLabel)");
+  public InputStream getAsciiStream(String columnLabel) throws SQLException {
+    logger.debug("public InputStream getAsciiStream(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
-  /**
-   * @deprecated
-   */
+  /** @deprecated */
   @Override
-  public InputStream getUnicodeStream(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public InputStream getUnicodeStream(String columnLabel)");
+  public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+    logger.debug("public InputStream getUnicodeStream(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public InputStream getBinaryStream(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public InputStream getBinaryStream(String columnLabel)");
+  public InputStream getBinaryStream(String columnLabel) throws SQLException {
+    logger.debug("public InputStream getBinaryStream(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public SQLWarning getWarnings() throws SQLException
-  {
+  public SQLWarning getWarnings() throws SQLException {
     logger.debug("public SQLWarning getWarnings()");
 
     return null;
   }
 
   @Override
-  public void clearWarnings() throws SQLException
-  {
+  public void clearWarnings() throws SQLException {
     logger.debug("public void clearWarnings()");
 
     // do nothing since warnings are not tracked
   }
 
   @Override
-  public String getCursorName() throws SQLException
-  {
+  public String getCursorName() throws SQLException {
     logger.debug("public String getCursorName()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public ResultSetMetaData getMetaData() throws SQLException
-  {
+  public ResultSetMetaData getMetaData() throws SQLException {
     logger.debug("public ResultSetMetaData getMetaData()");
 
     return resultSetMetaData;
   }
 
-  protected Object getObjectInternal(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public Object getObjectInternal(int columnIndex)");
+  protected Object getObjectInternal(int columnIndex) throws SQLException {
+    logger.debug("public Object getObjectInternal(int columnIndex)");
 
-    if (nextRow == null)
-    {
+    if (nextRow == null) {
       throw new SQLException("No row found.");
     }
 
-    if (columnIndex > nextRow.length)
-    {
+    if (columnIndex > nextRow.length) {
       throw new SQLException("Invalid column index: " + columnIndex);
     }
 
     wasNull = nextRow[columnIndex - 1] == null;
 
-    logger.debug(
-               "Returning column: " + columnIndex + ": "
-               + nextRow[columnIndex - 1]);
+    logger.debug("Returning column: " + columnIndex + ": " + nextRow[columnIndex - 1]);
 
     return nextRow[columnIndex - 1];
   }
 
   @Override
-  public Object getObject(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public Object getObject(int columnIndex)");
+  public Object getObject(int columnIndex) throws SQLException {
+    logger.debug("public Object getObject(int columnIndex)");
 
     int type = resultSetMetaData.getColumnType(columnIndex);
 
     Object internalObj = getObjectInternal(columnIndex);
-    if (internalObj == null)
-      return null;
+    if (internalObj == null) return null;
 
-    switch(type)
-    {
+    switch (type) {
       case Types.VARCHAR:
       case Types.CHAR:
         return getString(columnIndex);
@@ -599,70 +490,53 @@ abstract class SnowflakeBaseResultSet implements ResultSet
   }
 
   @Override
-  public Object getObject(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public Object getObject(String columnLabel)");
+  public Object getObject(String columnLabel) throws SQLException {
+    logger.debug("public Object getObject(String columnLabel)");
 
     return getObject(findColumn(columnLabel));
   }
 
   @Override
-  public int findColumn(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public int findColumn(String columnLabel)");
+  public int findColumn(String columnLabel) throws SQLException {
+    logger.debug("public int findColumn(String columnLabel)");
 
     int columnIndex = resultSetMetaData.getColumnIndex(columnLabel);
 
-    if (columnIndex == -1)
-    {
+    if (columnIndex == -1) {
       throw new SQLException("Column not found: " + columnLabel);
-    }
-    else
-    {
+    } else {
       return ++columnIndex;
     }
   }
 
   @Override
-  public Reader getCharacterStream(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public Reader getCharacterStream(int columnIndex)");
+  public Reader getCharacterStream(int columnIndex) throws SQLException {
+    logger.debug("public Reader getCharacterStream(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Reader getCharacterStream(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public Reader getCharacterStream(String columnLabel)");
+  public Reader getCharacterStream(String columnLabel) throws SQLException {
+    logger.debug("public Reader getCharacterStream(String columnLabel)");
 
     return getCharacterStream(findColumn(columnLabel));
   }
 
   @Override
-  public BigDecimal getBigDecimal(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public BigDecimal getBigDecimal(int columnIndex)");
+  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+    logger.debug("public BigDecimal getBigDecimal(int columnIndex)");
 
     BigDecimal value = null;
 
     // Column index starts from 1, not 0.
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj == null)
-      return null;
+    if (obj == null) return null;
 
-    if (obj instanceof String)
-    {
+    if (obj instanceof String) {
       value = new BigDecimal((String) obj);
-    }
-    else
-    {
+    } else {
       value = new BigDecimal(obj.toString());
     }
 
@@ -670,155 +544,133 @@ abstract class SnowflakeBaseResultSet implements ResultSet
   }
 
   @Override
-  public BigDecimal getBigDecimal(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public BigDecimal getBigDecimal(String columnLabel)");
+  public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+    logger.debug("public BigDecimal getBigDecimal(String columnLabel)");
 
     return getBigDecimal(findColumn(columnLabel));
   }
 
   @Override
-  public boolean isBeforeFirst() throws SQLException
-  {
+  public boolean isBeforeFirst() throws SQLException {
     logger.debug("public boolean isBeforeFirst()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isAfterLast() throws SQLException
-  {
+  public boolean isAfterLast() throws SQLException {
     logger.debug("public boolean isAfterLast()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isFirst() throws SQLException
-  {
+  public boolean isFirst() throws SQLException {
     logger.debug("public boolean isFirst()");
 
     return row == 1;
   }
 
   @Override
-  public boolean isLast() throws SQLException
-  {
+  public boolean isLast() throws SQLException {
     logger.debug("public boolean isLast()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void beforeFirst() throws SQLException
-  {
+  public void beforeFirst() throws SQLException {
     logger.debug("public void beforeFirst()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void afterLast() throws SQLException
-  {
+  public void afterLast() throws SQLException {
     logger.debug("public void afterLast()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean first() throws SQLException
-  {
+  public boolean first() throws SQLException {
     logger.debug("public boolean first()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean last() throws SQLException
-  {
+  public boolean last() throws SQLException {
     logger.debug("public boolean last()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getRow() throws SQLException
-  {
+  public int getRow() throws SQLException {
     logger.debug("public int getRow()");
 
     return row;
   }
 
   @Override
-  public boolean absolute(int row) throws SQLException
-  {
+  public boolean absolute(int row) throws SQLException {
     logger.debug("public boolean absolute(int row)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean relative(int rows) throws SQLException
-  {
+  public boolean relative(int rows) throws SQLException {
     logger.debug("public boolean relative(int rows)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean previous() throws SQLException
-  {
+  public boolean previous() throws SQLException {
     logger.debug("public boolean previous()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setFetchDirection(int direction) throws SQLException
-  {
-    logger.debug(
-               "public void setFetchDirection(int direction)");
+  public void setFetchDirection(int direction) throws SQLException {
+    logger.debug("public void setFetchDirection(int direction)");
 
-    if (direction != ResultSet.FETCH_FORWARD)
-      throw new SQLFeatureNotSupportedException();
+    if (direction != ResultSet.FETCH_FORWARD) throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getFetchDirection() throws SQLException
-  {
+  public int getFetchDirection() throws SQLException {
     logger.debug("public int getFetchDirection()");
 
     return ResultSet.FETCH_FORWARD;
   }
 
   @Override
-  public void setFetchSize(int rows) throws SQLException
-  {
+  public void setFetchSize(int rows) throws SQLException {
     logger.debug("public void setFetchSize(int rows)");
 
     this.fetchSize = rows;
   }
 
   @Override
-  public int getFetchSize() throws SQLException
-  {
+  public int getFetchSize() throws SQLException {
     logger.debug("public int getFetchSize()");
 
     return this.fetchSize;
   }
 
   @Override
-  public int getType() throws SQLException
-  {
+  public int getType() throws SQLException {
     logger.debug("public int getType()");
 
     return ResultSet.TYPE_FORWARD_ONLY;
   }
 
   @Override
-  public int getConcurrency() throws SQLException
-  {
+  public int getConcurrency() throws SQLException {
     logger.debug("public int getConcurrency()");
 
     throw new SQLFeatureNotSupportedException(
@@ -828,1193 +680,908 @@ abstract class SnowflakeBaseResultSet implements ResultSet
   }
 
   @Override
-  public boolean rowUpdated() throws SQLException
-  {
+  public boolean rowUpdated() throws SQLException {
     logger.debug("public boolean rowUpdated()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean rowInserted() throws SQLException
-  {
+  public boolean rowInserted() throws SQLException {
     logger.debug("public boolean rowInserted()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean rowDeleted() throws SQLException
-  {
+  public boolean rowDeleted() throws SQLException {
     logger.debug("public boolean rowDeleted()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNull(int columnIndex) throws SQLException
-  {
+  public void updateNull(int columnIndex) throws SQLException {
     logger.debug("public void updateNull(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBoolean(int columnIndex, boolean x) throws SQLException
-  {
-    logger.debug(
-               "public void updateBoolean(int columnIndex, boolean x)");
+  public void updateBoolean(int columnIndex, boolean x) throws SQLException {
+    logger.debug("public void updateBoolean(int columnIndex, boolean x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateByte(int columnIndex, byte x) throws SQLException
-  {
-    logger.debug(
-               "public void updateByte(int columnIndex, byte x)");
+  public void updateByte(int columnIndex, byte x) throws SQLException {
+    logger.debug("public void updateByte(int columnIndex, byte x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateShort(int columnIndex, short x) throws SQLException
-  {
-    logger.debug(
-               "public void updateShort(int columnIndex, short x)");
+  public void updateShort(int columnIndex, short x) throws SQLException {
+    logger.debug("public void updateShort(int columnIndex, short x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateInt(int columnIndex, int x) throws SQLException
-  {
-    logger.debug(
-               "public void updateInt(int columnIndex, int x)");
+  public void updateInt(int columnIndex, int x) throws SQLException {
+    logger.debug("public void updateInt(int columnIndex, int x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateLong(int columnIndex, long x) throws SQLException
-  {
-    logger.debug(
-               "public void updateLong(int columnIndex, long x)");
+  public void updateLong(int columnIndex, long x) throws SQLException {
+    logger.debug("public void updateLong(int columnIndex, long x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateFloat(int columnIndex, float x) throws SQLException
-  {
-    logger.debug(
-               "public void updateFloat(int columnIndex, float x)");
+  public void updateFloat(int columnIndex, float x) throws SQLException {
+    logger.debug("public void updateFloat(int columnIndex, float x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateDouble(int columnIndex, double x) throws SQLException
-  {
-    logger.debug(
-               "public void updateDouble(int columnIndex, double x)");
+  public void updateDouble(int columnIndex, double x) throws SQLException {
+    logger.debug("public void updateDouble(int columnIndex, double x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBigDecimal(int columnIndex, BigDecimal x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateBigDecimal(int columnIndex, BigDecimal x)");
+  public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+    logger.debug("public void updateBigDecimal(int columnIndex, BigDecimal x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateString(int columnIndex, String x) throws SQLException
-  {
-    logger.debug(
-               "public void updateString(int columnIndex, String x)");
+  public void updateString(int columnIndex, String x) throws SQLException {
+    logger.debug("public void updateString(int columnIndex, String x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBytes(int columnIndex, byte[] x) throws SQLException
-  {
-    logger.debug(
-               "public void updateBytes(int columnIndex, byte[] x)");
+  public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+    logger.debug("public void updateBytes(int columnIndex, byte[] x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateDate(int columnIndex, Date x) throws SQLException
-  {
-    logger.debug(
-               "public void updateDate(int columnIndex, Date x)");
+  public void updateDate(int columnIndex, Date x) throws SQLException {
+    logger.debug("public void updateDate(int columnIndex, Date x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateTime(int columnIndex, Time x) throws SQLException
-  {
-    logger.debug(
-               "public void updateTime(int columnIndex, Time x)");
+  public void updateTime(int columnIndex, Time x) throws SQLException {
+    logger.debug("public void updateTime(int columnIndex, Time x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException
-  {
-    logger.debug(
-               "public void updateTimestamp(int columnIndex, Timestamp x)");
+  public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+    logger.debug("public void updateTimestamp(int columnIndex, Timestamp x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateAsciiStream(int columnIndex, InputStream x, int length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateAsciiStream(int columnIndex, "
-               + "InputStream x, int length)");
+  public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+    logger.debug("public void updateAsciiStream(int columnIndex, " + "InputStream x, int length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBinaryStream(int columnIndex, InputStream x, int length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateBinaryStream(int columnIndex, "
-               + "InputStream x, int length)");
+  public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+    logger.debug("public void updateBinaryStream(int columnIndex, " + "InputStream x, int length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateCharacterStream(int columnIndex, Reader x, int length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateCharacterStream(int columnIndex, "
-               + "Reader x, int length)");
+  public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+    logger.debug("public void updateCharacterStream(int columnIndex, " + "Reader x, int length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateObject(int columnIndex, Object x, int scaleOrLength)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateObject(int columnIndex, Object x, "
-               + "int scaleOrLength)");
+  public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+    logger.debug("public void updateObject(int columnIndex, Object x, " + "int scaleOrLength)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateObject(int columnIndex, Object x) throws SQLException
-  {
-    logger.debug(
-               "public void updateObject(int columnIndex, Object x)");
+  public void updateObject(int columnIndex, Object x) throws SQLException {
+    logger.debug("public void updateObject(int columnIndex, Object x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNull(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public void updateNull(String columnLabel)");
+  public void updateNull(String columnLabel) throws SQLException {
+    logger.debug("public void updateNull(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBoolean(String columnLabel, boolean x) throws SQLException
-  {
-    logger.debug(
-               "public void updateBoolean(String columnLabel, boolean x)");
+  public void updateBoolean(String columnLabel, boolean x) throws SQLException {
+    logger.debug("public void updateBoolean(String columnLabel, boolean x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateByte(String columnLabel, byte x) throws SQLException
-  {
-    logger.debug(
-               "public void updateByte(String columnLabel, byte x)");
+  public void updateByte(String columnLabel, byte x) throws SQLException {
+    logger.debug("public void updateByte(String columnLabel, byte x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateShort(String columnLabel, short x) throws SQLException
-  {
-    logger.debug(
-               "public void updateShort(String columnLabel, short x)");
+  public void updateShort(String columnLabel, short x) throws SQLException {
+    logger.debug("public void updateShort(String columnLabel, short x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateInt(String columnLabel, int x) throws SQLException
-  {
-    logger.debug(
-               "public void updateInt(String columnLabel, int x)");
+  public void updateInt(String columnLabel, int x) throws SQLException {
+    logger.debug("public void updateInt(String columnLabel, int x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateLong(String columnLabel, long x) throws SQLException
-  {
-    logger.debug(
-               "public void updateLong(String columnLabel, long x)");
+  public void updateLong(String columnLabel, long x) throws SQLException {
+    logger.debug("public void updateLong(String columnLabel, long x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateFloat(String columnLabel, float x) throws SQLException
-  {
-    logger.debug(
-               "public void updateFloat(String columnLabel, float x)");
+  public void updateFloat(String columnLabel, float x) throws SQLException {
+    logger.debug("public void updateFloat(String columnLabel, float x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateDouble(String columnLabel, double x) throws SQLException
-  {
-    logger.debug(
-               "public void updateDouble(String columnLabel, double x)");
+  public void updateDouble(String columnLabel, double x) throws SQLException {
+    logger.debug("public void updateDouble(String columnLabel, double x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBigDecimal(String columnLabel, BigDecimal x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateBigDecimal(String columnLabel, "
-               + "BigDecimal x)");
+  public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+    logger.debug("public void updateBigDecimal(String columnLabel, " + "BigDecimal x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateString(String columnLabel, String x) throws SQLException
-  {
-    logger.debug(
-               "public void updateString(String columnLabel, String x)");
+  public void updateString(String columnLabel, String x) throws SQLException {
+    logger.debug("public void updateString(String columnLabel, String x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBytes(String columnLabel, byte[] x) throws SQLException
-  {
-    logger.debug(
-               "public void updateBytes(String columnLabel, byte[] x)");
+  public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+    logger.debug("public void updateBytes(String columnLabel, byte[] x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateDate(String columnLabel, Date x) throws SQLException
-  {
-    logger.debug(
-               "public void updateDate(String columnLabel, Date x)");
+  public void updateDate(String columnLabel, Date x) throws SQLException {
+    logger.debug("public void updateDate(String columnLabel, Date x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateTime(String columnLabel, Time x) throws SQLException
-  {
-    logger.debug(
-               "public void updateTime(String columnLabel, Time x)");
+  public void updateTime(String columnLabel, Time x) throws SQLException {
+    logger.debug("public void updateTime(String columnLabel, Time x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateTimestamp(String columnLabel, Timestamp x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateTimestamp(String columnLabel, Timestamp x)");
+  public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+    logger.debug("public void updateTimestamp(String columnLabel, Timestamp x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateAsciiStream(String columnLabel, InputStream x, int length)
-          throws SQLException
-  {
+  public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
     logger.debug(
-               "public void updateAsciiStream(String columnLabel, "
-               + "InputStream x, int length)");
+        "public void updateAsciiStream(String columnLabel, " + "InputStream x, int length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void updateBinaryStream(String columnLabel, InputStream x, int length)
-          throws SQLException
-  {
+      throws SQLException {
     logger.debug(
-               "public void updateBinaryStream(String columnLabel, "
-               + "InputStream x, int length)");
+        "public void updateBinaryStream(String columnLabel, " + "InputStream x, int length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateCharacterStream(String columnLabel, Reader reader,
-                                    int length) throws SQLException
-  {
+  public void updateCharacterStream(String columnLabel, Reader reader, int length)
+      throws SQLException {
     logger.debug(
-               "public void updateCharacterStream(String columnLabel, "
-               + "Reader reader,int length)");
+        "public void updateCharacterStream(String columnLabel, " + "Reader reader,int length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateObject(String columnLabel, Object x, int scaleOrLength)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateObject(String columnLabel, Object x, "
-               + "int scaleOrLength)");
+  public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+    logger.debug("public void updateObject(String columnLabel, Object x, " + "int scaleOrLength)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateObject(String columnLabel, Object x) throws SQLException
-  {
-    logger.debug(
-               "public void updateObject(String columnLabel, Object x)");
+  public void updateObject(String columnLabel, Object x) throws SQLException {
+    logger.debug("public void updateObject(String columnLabel, Object x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void insertRow() throws SQLException
-  {
+  public void insertRow() throws SQLException {
     logger.debug("public void insertRow()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateRow() throws SQLException
-  {
+  public void updateRow() throws SQLException {
     logger.debug("public void updateRow()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void deleteRow() throws SQLException
-  {
+  public void deleteRow() throws SQLException {
     logger.debug("public void deleteRow()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void refreshRow() throws SQLException
-  {
+  public void refreshRow() throws SQLException {
     logger.debug("public void refreshRow()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void cancelRowUpdates() throws SQLException
-  {
+  public void cancelRowUpdates() throws SQLException {
     logger.debug("public void cancelRowUpdates()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void moveToInsertRow() throws SQLException
-  {
+  public void moveToInsertRow() throws SQLException {
     logger.debug("public void moveToInsertRow()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void moveToCurrentRow() throws SQLException
-  {
+  public void moveToCurrentRow() throws SQLException {
     logger.debug("public void moveToCurrentRow()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Statement getStatement() throws SQLException
-  {
+  public Statement getStatement() throws SQLException {
     logger.debug("public Statement getStatement()");
 
     return statement;
   }
 
   @Override
-  public Object getObject(int columnIndex,
-                          Map<String, Class<?>> map) throws SQLException
-  {
-    logger.debug(
-               "public Object getObject(int columnIndex, Map<String, "
-               + "Class<?>> map)");
+  public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
+    logger.debug("public Object getObject(int columnIndex, Map<String, " + "Class<?>> map)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Ref getRef(int columnIndex) throws SQLException
-  {
+  public Ref getRef(int columnIndex) throws SQLException {
     logger.debug("public Ref getRef(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Blob getBlob(int columnIndex) throws SQLException
-  {
+  public Blob getBlob(int columnIndex) throws SQLException {
     logger.debug("public Blob getBlob(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Clob getClob(int columnIndex) throws SQLException
-  {
+  public Clob getClob(int columnIndex) throws SQLException {
     logger.debug("public Clob getClob(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Array getArray(int columnIndex) throws SQLException
-  {
+  public Array getArray(int columnIndex) throws SQLException {
     logger.debug("public Array getArray(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Object getObject(String columnLabel,
-                          Map<String, Class<?>> map) throws SQLException
-  {
-    logger.debug(
-               "public Object getObject(String columnLabel, "
-               + "Map<String, Class<?>> map)");
+  public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
+    logger.debug("public Object getObject(String columnLabel, " + "Map<String, Class<?>> map)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Ref getRef(String columnLabel) throws SQLException
-  {
+  public Ref getRef(String columnLabel) throws SQLException {
     logger.debug("public Ref getRef(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Blob getBlob(String columnLabel) throws SQLException
-  {
+  public Blob getBlob(String columnLabel) throws SQLException {
     logger.debug("public Blob getBlob(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Clob getClob(String columnLabel) throws SQLException
-  {
+  public Clob getClob(String columnLabel) throws SQLException {
     logger.debug("public Clob getClob(String columnLabel)");
 
     return new SnowflakeClob(getString(columnLabel));
   }
 
   @Override
-  public Array getArray(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public Array getArray(String columnLabel)");
+  public Array getArray(String columnLabel) throws SQLException {
+    logger.debug("public Array getArray(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Date getDate(int columnIndex, Calendar cal) throws SQLException
-  {
-    logger.debug(
-               "public Date getDate(int columnIndex, Calendar cal)");
+  public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    logger.debug("public Date getDate(int columnIndex, Calendar cal)");
 
     return getDate(columnIndex, cal.getTimeZone());
   }
 
   @Override
-  public Date getDate(String columnLabel, Calendar cal) throws SQLException
-  {
-    logger.debug(
-               "public Date getDate(String columnLabel, Calendar cal)");
+  public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    logger.debug("public Date getDate(String columnLabel, Calendar cal)");
 
     return getDate(findColumn(columnLabel), cal.getTimeZone());
   }
 
   @Override
-  public Time getTime(int columnIndex, Calendar cal) throws SQLException
-  {
-    logger.debug(
-               "public Time getTime(int columnIndex, Calendar cal)");
+  public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    logger.debug("public Time getTime(int columnIndex, Calendar cal)");
 
     return getTime(columnIndex);
   }
 
   @Override
-  public Time getTime(String columnLabel, Calendar cal) throws SQLException
-  {
-    logger.debug(
-               "public Time getTime(String columnLabel, Calendar cal)");
+  public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    logger.debug("public Time getTime(String columnLabel, Calendar cal)");
 
     return getTime(columnLabel);
   }
 
   @Override
-  public Timestamp getTimestamp(int columnIndex, Calendar cal)
-          throws SQLException
-  {
-    logger.debug(
-               "public Timestamp getTimestamp(int columnIndex, Calendar cal)");
+  public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    logger.debug("public Timestamp getTimestamp(int columnIndex, Calendar cal)");
 
     return getTimestamp(columnIndex, cal.getTimeZone());
   }
 
   @Override
-  public Timestamp getTimestamp(String columnLabel, Calendar cal)
-          throws SQLException
-  {
-    logger.debug(
-               "public Timestamp getTimestamp(String columnLabel, "
-               + "Calendar cal)");
+  public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    logger.debug("public Timestamp getTimestamp(String columnLabel, " + "Calendar cal)");
 
     return getTimestamp(findColumn(columnLabel), cal.getTimeZone());
   }
 
   @Override
-  public URL getURL(int columnIndex) throws SQLException
-  {
+  public URL getURL(int columnIndex) throws SQLException {
     logger.debug("public URL getURL(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public URL getURL(String columnLabel) throws SQLException
-  {
+  public URL getURL(String columnLabel) throws SQLException {
     logger.debug("public URL getURL(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateRef(int columnIndex, Ref x) throws SQLException
-  {
-    logger.debug(
-               "public void updateRef(int columnIndex, Ref x)");
+  public void updateRef(int columnIndex, Ref x) throws SQLException {
+    logger.debug("public void updateRef(int columnIndex, Ref x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateRef(String columnLabel, Ref x) throws SQLException
-  {
-    logger.debug(
-               "public void updateRef(String columnLabel, Ref x)");
+  public void updateRef(String columnLabel, Ref x) throws SQLException {
+    logger.debug("public void updateRef(String columnLabel, Ref x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBlob(int columnIndex, Blob x) throws SQLException
-  {
-    logger.debug(
-               "public void updateBlob(int columnIndex, Blob x)");
+  public void updateBlob(int columnIndex, Blob x) throws SQLException {
+    logger.debug("public void updateBlob(int columnIndex, Blob x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBlob(String columnLabel, Blob x) throws SQLException
-  {
-    logger.debug(
-               "public void updateBlob(String columnLabel, Blob x)");
+  public void updateBlob(String columnLabel, Blob x) throws SQLException {
+    logger.debug("public void updateBlob(String columnLabel, Blob x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateClob(int columnIndex, Clob x) throws SQLException
-  {
-    logger.debug(
-               "public void updateClob(int columnIndex, Clob x)");
+  public void updateClob(int columnIndex, Clob x) throws SQLException {
+    logger.debug("public void updateClob(int columnIndex, Clob x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateClob(String columnLabel, Clob x) throws SQLException
-  {
-    logger.debug(
-               "public void updateClob(String columnLabel, Clob x)");
+  public void updateClob(String columnLabel, Clob x) throws SQLException {
+    logger.debug("public void updateClob(String columnLabel, Clob x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateArray(int columnIndex, Array x) throws SQLException
-  {
-    logger.debug(
-               "public void updateArray(int columnIndex, Array x)");
+  public void updateArray(int columnIndex, Array x) throws SQLException {
+    logger.debug("public void updateArray(int columnIndex, Array x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateArray(String columnLabel, Array x) throws SQLException
-  {
-    logger.debug(
-               "public void updateArray(String columnLabel, Array x)");
+  public void updateArray(String columnLabel, Array x) throws SQLException {
+    logger.debug("public void updateArray(String columnLabel, Array x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public RowId getRowId(int columnIndex) throws SQLException
-  {
+  public RowId getRowId(int columnIndex) throws SQLException {
     logger.debug("public RowId getRowId(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public RowId getRowId(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public RowId getRowId(String columnLabel)");
+  public RowId getRowId(String columnLabel) throws SQLException {
+    logger.debug("public RowId getRowId(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateRowId(int columnIndex, RowId x) throws SQLException
-  {
-    logger.debug(
-               "public void updateRowId(int columnIndex, RowId x)");
+  public void updateRowId(int columnIndex, RowId x) throws SQLException {
+    logger.debug("public void updateRowId(int columnIndex, RowId x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateRowId(String columnLabel, RowId x) throws SQLException
-  {
-    logger.debug(
-               "public void updateRowId(String columnLabel, RowId x)");
+  public void updateRowId(String columnLabel, RowId x) throws SQLException {
+    logger.debug("public void updateRowId(String columnLabel, RowId x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getHoldability() throws SQLException
-  {
+  public int getHoldability() throws SQLException {
     logger.debug("public int getHoldability()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isClosed() throws SQLException
-  {
+  public boolean isClosed() throws SQLException {
     logger.debug("public boolean isClosed()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNString(int columnIndex, String nString) throws SQLException
-  {
-    logger.debug(
-               "public void updateNString(int columnIndex, String nString)");
+  public void updateNString(int columnIndex, String nString) throws SQLException {
+    logger.debug("public void updateNString(int columnIndex, String nString)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNString(String columnLabel, String nString)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateNString(String columnLabel, String nString)");
+  public void updateNString(String columnLabel, String nString) throws SQLException {
+    logger.debug("public void updateNString(String columnLabel, String nString)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNClob(int columnIndex, NClob nClob) throws SQLException
-  {
-    logger.debug(
-               "public void updateNClob(int columnIndex, NClob nClob)");
+  public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+    logger.debug("public void updateNClob(int columnIndex, NClob nClob)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNClob(String columnLabel, NClob nClob) throws SQLException
-  {
-    logger.debug(
-               "public void updateNClob(String columnLabel, NClob nClob)");
+  public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+    logger.debug("public void updateNClob(String columnLabel, NClob nClob)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public NClob getNClob(int columnIndex) throws SQLException
-  {
+  public NClob getNClob(int columnIndex) throws SQLException {
     logger.debug("public NClob getNClob(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public NClob getNClob(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public NClob getNClob(String columnLabel)");
+  public NClob getNClob(String columnLabel) throws SQLException {
+    logger.debug("public NClob getNClob(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public SQLXML getSQLXML(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public SQLXML getSQLXML(int columnIndex)");
+  public SQLXML getSQLXML(int columnIndex) throws SQLException {
+    logger.debug("public SQLXML getSQLXML(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public SQLXML getSQLXML(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public SQLXML getSQLXML(String columnLabel)");
+  public SQLXML getSQLXML(String columnLabel) throws SQLException {
+    logger.debug("public SQLXML getSQLXML(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateSQLXML(int columnIndex, SQLXML xmlObject)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateSQLXML(int columnIndex, SQLXML xmlObject)");
+  public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
+    logger.debug("public void updateSQLXML(int columnIndex, SQLXML xmlObject)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateSQLXML(String columnLabel, SQLXML xmlObject)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateSQLXML(String columnLabel, SQLXML xmlObject)");
+  public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
+    logger.debug("public void updateSQLXML(String columnLabel, SQLXML xmlObject)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public String getNString(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public String getNString(int columnIndex)");
+  public String getNString(int columnIndex) throws SQLException {
+    logger.debug("public String getNString(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public String getNString(String columnLabel) throws SQLException
-  {
-    logger.debug(
-               "public String getNString(String columnLabel)");
+  public String getNString(String columnLabel) throws SQLException {
+    logger.debug("public String getNString(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Reader getNCharacterStream(int columnIndex) throws SQLException
-  {
-    logger.debug(
-               "public Reader getNCharacterStream(int columnIndex)");
+  public Reader getNCharacterStream(int columnIndex) throws SQLException {
+    logger.debug("public Reader getNCharacterStream(int columnIndex)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Reader getNCharacterStream(String columnLabel) throws SQLException
-  {
-    logger.debug(
-                "public Reader getNCharacterStream(String columnLabel)");
+  public Reader getNCharacterStream(String columnLabel) throws SQLException {
+    logger.debug("public Reader getNCharacterStream(String columnLabel)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNCharacterStream(int columnIndex, Reader x, long length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateNCharacterStream(int columnIndex, "
-               + "Reader x, long length)");
+  public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+    logger.debug("public void updateNCharacterStream(int columnIndex, " + "Reader x, long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNCharacterStream(String columnLabel, Reader reader,
-                                     long length) throws SQLException
-  {
+  public void updateNCharacterStream(String columnLabel, Reader reader, long length)
+      throws SQLException {
     logger.debug(
-               "public void updateNCharacterStream(String columnLabel, "
-               + "Reader reader,long length)");
+        "public void updateNCharacterStream(String columnLabel, " + "Reader reader,long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateAsciiStream(int columnIndex, InputStream x, long length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateAsciiStream(int columnIndex, "
-               + "InputStream x, long length)");
+  public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
+    logger.debug("public void updateAsciiStream(int columnIndex, " + "InputStream x, long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBinaryStream(int columnIndex, InputStream x, long length)
-          throws SQLException
-  {
+  public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
     logger.debug(
-               "public void updateBinaryStream(int columnIndex, "
-               + "InputStream x, long length)");
+        "public void updateBinaryStream(int columnIndex, " + "InputStream x, long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateCharacterStream(int columnIndex, Reader x, long length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateCharacterStream(int columnIndex, Reader x, "
-               + "long length)");
+  public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+    logger.debug("public void updateCharacterStream(int columnIndex, Reader x, " + "long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void updateAsciiStream(String columnLabel, InputStream x, long length)
-          throws SQLException
-  {
+      throws SQLException {
     logger.debug(
-               "public void updateAsciiStream(String columnLabel, "
-               + "InputStream x, long length)");
+        "public void updateAsciiStream(String columnLabel, " + "InputStream x, long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void updateBinaryStream(String columnLabel, InputStream x, long length)
-          throws SQLException
-  {
+      throws SQLException {
     logger.debug(
-               "public void updateBinaryStream(String columnLabel, "
-               + "InputStream x, long length)");
+        "public void updateBinaryStream(String columnLabel, " + "InputStream x, long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateCharacterStream(String columnLabel, Reader reader,
-                                    long length) throws SQLException
-  {
+  public void updateCharacterStream(String columnLabel, Reader reader, long length)
+      throws SQLException {
     logger.debug(
-               "public void updateCharacterStream(String columnLabel, "
-               + "Reader reader,long length)");
+        "public void updateCharacterStream(String columnLabel, " + "Reader reader,long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void updateBlob(int columnIndex, InputStream inputStream, long length)
-          throws SQLException
-  {
+      throws SQLException {
     logger.debug(
-               "public void updateBlob(int columnIndex, InputStream "
-               + "inputStream, long length)");
+        "public void updateBlob(int columnIndex, InputStream " + "inputStream, long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBlob(String columnLabel, InputStream inputStream,
-                         long length) throws SQLException
-  {
+  public void updateBlob(String columnLabel, InputStream inputStream, long length)
+      throws SQLException {
     logger.debug(
-               "public void updateBlob(String columnLabel, "
-               + "InputStream inputStream,long length)");
+        "public void updateBlob(String columnLabel, " + "InputStream inputStream,long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateClob(int columnIndex, Reader reader, long length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateClob(int columnIndex, Reader reader, "
-               + "long length)");
+  public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
+    logger.debug("public void updateClob(int columnIndex, Reader reader, " + "long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateClob(String columnLabel, Reader reader, long length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateClob(String columnLabel, Reader reader, "
-               + "long length)");
+  public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
+    logger.debug("public void updateClob(String columnLabel, Reader reader, " + "long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNClob(int columnIndex, Reader reader, long length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateNClob(int columnIndex, Reader reader, "
-               + "long length)");
+  public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
+    logger.debug("public void updateNClob(int columnIndex, Reader reader, " + "long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNClob(String columnLabel, Reader reader, long length)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateNClob(String columnLabel, Reader reader, "
-               + "long length)");
+  public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
+    logger.debug("public void updateNClob(String columnLabel, Reader reader, " + "long length)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNCharacterStream(int columnIndex, Reader x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateNCharacterStream(int columnIndex, Reader x)");
+  public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
+    logger.debug("public void updateNCharacterStream(int columnIndex, Reader x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNCharacterStream(String columnLabel, Reader reader)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateNCharacterStream(String columnLabel, "
-               + "Reader reader)");
+  public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
+    logger.debug("public void updateNCharacterStream(String columnLabel, " + "Reader reader)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateAsciiStream(int columnIndex, InputStream x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateAsciiStream(int columnIndex, InputStream x)");
+  public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
+    logger.debug("public void updateAsciiStream(int columnIndex, InputStream x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBinaryStream(int columnIndex, InputStream x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateBinaryStream(int columnIndex, InputStream x)");
+  public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
+    logger.debug("public void updateBinaryStream(int columnIndex, InputStream x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateCharacterStream(int columnIndex, Reader x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateCharacterStream(int columnIndex, Reader x)");
+  public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
+    logger.debug("public void updateCharacterStream(int columnIndex, Reader x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateAsciiStream(String columnLabel, InputStream x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateAsciiStream(String columnLabel, InputStream x)");
+  public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
+    logger.debug("public void updateAsciiStream(String columnLabel, InputStream x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBinaryStream(String columnLabel, InputStream x)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateBinaryStream(String columnLabel, InputStream x)");
+  public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
+    logger.debug("public void updateBinaryStream(String columnLabel, InputStream x)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateCharacterStream(String columnLabel, Reader reader)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateCharacterStream(String columnLabel, "
-               + "Reader reader)");
+  public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
+    logger.debug("public void updateCharacterStream(String columnLabel, " + "Reader reader)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBlob(int columnIndex, InputStream inputStream)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateBlob(int columnIndex, InputStream inputStream)");
+  public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
+    logger.debug("public void updateBlob(int columnIndex, InputStream inputStream)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateBlob(String columnLabel, InputStream inputStream)
-          throws SQLException
-  {
-    logger.debug(
-               "public void updateBlob(String columnLabel, InputStream "
-               + "inputStream)");
+  public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
+    logger.debug("public void updateBlob(String columnLabel, InputStream " + "inputStream)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateClob(int columnIndex, Reader reader) throws SQLException
-  {
-    logger.debug(
-               "public void updateClob(int columnIndex, Reader reader)");
+  public void updateClob(int columnIndex, Reader reader) throws SQLException {
+    logger.debug("public void updateClob(int columnIndex, Reader reader)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateClob(String columnLabel, Reader reader) throws SQLException
-  {
-    logger.debug(
-               "public void updateClob(String columnLabel, Reader reader)");
+  public void updateClob(String columnLabel, Reader reader) throws SQLException {
+    logger.debug("public void updateClob(String columnLabel, Reader reader)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNClob(int columnIndex, Reader reader) throws SQLException
-  {
-    logger.debug(
-               "public void updateNClob(int columnIndex, Reader reader)");
+  public void updateNClob(int columnIndex, Reader reader) throws SQLException {
+    logger.debug("public void updateNClob(int columnIndex, Reader reader)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void updateNClob(String columnLabel, Reader reader) throws SQLException
-  {
-    logger.debug(
-               "public void updateNClob(String columnLabel, Reader reader)");
+  public void updateNClob(String columnLabel, Reader reader) throws SQLException {
+    logger.debug("public void updateNClob(String columnLabel, Reader reader)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
-  //@Override
-  public <T> T getObject(int columnIndex,
-                         Class<T> type) throws SQLException
-  {
-    logger.debug(
-               "public <T> T getObject(int columnIndex,Class<T> type)");
+  // @Override
+  public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+    logger.debug("public <T> T getObject(int columnIndex,Class<T> type)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
-  //@Override
-  public <T> T getObject(String columnLabel,
-                         Class<T> type) throws SQLException
-  {
-    logger.debug(
-               "public <T> T getObject(String columnLabel,Class<T> type)");
+  // @Override
+  public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+    logger.debug("public <T> T getObject(String columnLabel,Class<T> type)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public <T> T unwrap(
-          Class<T> iface) throws SQLException
-  {
+  public <T> T unwrap(Class<T> iface) throws SQLException {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isWrapperFor(
-          Class<?> iface) throws SQLException
-  {
-    logger.debug(
-               "public boolean isWrapperFor(Class<?> iface)");
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     throw new SQLFeatureNotSupportedException();
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
@@ -1,9 +1,5 @@
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-
-import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -11,12 +7,12 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.logging.Logger;
+import javax.sql.DataSource;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 
-/**
- * Created by hyu on 5/11/17.
- */
-public class SnowflakeBasicDataSource implements DataSource
-{
+/** Created by hyu on 5/11/17. */
+public class SnowflakeBasicDataSource implements DataSource {
   private String url;
 
   private String serverName;
@@ -29,168 +25,134 @@ public class SnowflakeBasicDataSource implements DataSource
 
   private Properties properties = new Properties();
 
-  static final
-  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeBasicDataSource.class);
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeBasicDataSource.class);
 
   static {
     try {
       Class.forName("net.snowflake.client.jdbc.SnowflakeDriver");
     } catch (ClassNotFoundException e) {
-      throw new IllegalStateException("Unable to load " +
-          "net.snowflake.client.jdbc.SnowflakeDriver. " +
-          "Please check if you have proper Snowflake JDBC " +
-          "Driver jar on the classpath", e);
+      throw new IllegalStateException(
+          "Unable to load "
+              + "net.snowflake.client.jdbc.SnowflakeDriver. "
+              + "Please check if you have proper Snowflake JDBC "
+              + "Driver jar on the classpath",
+          e);
     }
   }
 
   @Override
-  public Connection getConnection() throws SQLException
-  {
+  public Connection getConnection() throws SQLException {
     return getConnection(user, password);
   }
 
   @Override
-  public Connection getConnection(String username, String password)
-      throws SQLException
-  {
+  public Connection getConnection(String username, String password) throws SQLException {
     properties.put("user", username);
     properties.put("password", password);
 
-    try
-    {
+    try {
       Connection con = DriverManager.getConnection(getUrl(), properties);
-      if (logger.isTraceEnabled())
-      {
-        logger.trace("Created a connection for {} at {}",
-            user, getUrl());
+      if (logger.isTraceEnabled()) {
+        logger.trace("Created a connection for {} at {}", user, getUrl());
       }
       return con;
-    }
-    catch (SQLException e)
-    {
-      logger.error("Failed to create a connection for {} at {}: {}",
-          user, getUrl(), e);
+    } catch (SQLException e) {
+      logger.error("Failed to create a connection for {} at {}: {}", user, getUrl(), e);
       throw e;
     }
   }
 
   @Override
-  public PrintWriter getLogWriter() throws SQLException
-  {
-   throw new SQLFeatureNotSupportedException();
-  }
-
-  @Override
-  public void setLogWriter(PrintWriter out) throws SQLException
-  {
+  public PrintWriter getLogWriter() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getLoginTimeout() throws SQLException
-  {
-    try
-    {
+  public void setLogWriter(PrintWriter out) throws SQLException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  @Override
+  public int getLoginTimeout() throws SQLException {
+    try {
       return Integer.parseInt(properties.getProperty("loginTimeout"));
-    }
-    catch(NumberFormatException e)
-    {
+    } catch (NumberFormatException e) {
       return 0;
     }
   }
 
   @Override
-  public void setLoginTimeout(int seconds) throws SQLException
-  {
+  public void setLoginTimeout(int seconds) throws SQLException {
     properties.put("loginTimeout", Integer.toString(seconds));
   }
 
   @Override
-  public Logger getParentLogger() throws SQLFeatureNotSupportedException
-  {
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface)
-  {
+  public boolean isWrapperFor(Class<?> iface) {
     return false;
   }
 
   @Override
-  public <T> T unwrap(Class<T> iface)
-  {
+  public <T> T unwrap(Class<T> iface) {
     return null;
   }
 
-  public void setUrl(String url)
-  {
+  public void setUrl(String url) {
     this.url = url;
   }
 
-  public void setDatabaseName(String databaseName)
-  {
+  public void setDatabaseName(String databaseName) {
     properties.put("db", databaseName);
   }
 
-  public void setSchema(String schema)
-  {
+  public void setSchema(String schema) {
     properties.put("schema", schema);
   }
 
-  public void setWarehouse(String warehouse)
-  {
+  public void setWarehouse(String warehouse) {
     properties.put("warehouse", warehouse);
   }
 
-  public void setRole(String role)
-  {
+  public void setRole(String role) {
     properties.put("role", role);
   }
 
-  public void setUser(String user)
-  {
+  public void setUser(String user) {
     this.user = user;
   }
 
-  public void setServerName(String serverName)
-  {
+  public void setServerName(String serverName) {
     this.serverName = serverName;
   }
 
-  public void setPassword(String password)
-  {
+  public void setPassword(String password) {
     this.password = password;
   }
 
-  public void setPortNumber(int portNumber)
-  {
+  public void setPortNumber(int portNumber) {
     this.portNumber = portNumber;
   }
 
-  public void setAccount(String account)
-  {
+  public void setAccount(String account) {
     this.properties.put("account", account);
   }
 
-  public void setSsl(boolean ssl)
-  {
+  public void setSsl(boolean ssl) {
     this.properties.put("ssl", String.valueOf(ssl));
   }
-  
-  public void setAuthenticator(String authenticator)
-  {
+
+  public void setAuthenticator(String authenticator) {
     this.properties.put("authenticator", authenticator);
   }
 
-  public String getUrl()
-  {
-    if (url != null)
-    {
+  public String getUrl() {
+    if (url != null) {
       return url;
-    }
-    else
-    {
+    } else {
       // generate url;
       StringBuilder url = new StringBuilder(100);
       url.append("jdbc:snowflake://");

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -10,18 +10,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.jdbc.SnowflakeResultChunk.DownloadState;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.common.core.SqlState;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,21 +32,29 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPInputStream;
+import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.jdbc.SnowflakeResultChunk.DownloadState;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SqlState;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 /**
  * Class for managing async download of offline result chunks
  *
- * Created by jhuang on 11/12/14.
+ * <p>Created by jhuang on 11/12/14.
  */
-public class SnowflakeChunkDownloader
-{
+public class SnowflakeChunkDownloader {
   // SSE-C algorithm header
-  private static final String SSE_C_ALGORITHM =
-      "x-amz-server-side-encryption-customer-algorithm";
+  private static final String SSE_C_ALGORITHM = "x-amz-server-side-encryption-customer-algorithm";
 
   // SSE-C customer key header
-  private static final String SSE_C_KEY =
-      "x-amz-server-side-encryption-customer-key";
+  private static final String SSE_C_KEY = "x-amz-server-side-encryption-customer-key";
 
   // SSE-C algorithm value
   private static final String SSE_C_AES = "AES256";
@@ -67,13 +63,12 @@ public class SnowflakeChunkDownloader
   private static final ObjectMapper mapper = new ObjectMapper();
 
   /** a shared JSON parser factory. */
-  private static final JsonFactory jsonFactory  = new MappingJsonFactory();
+  private static final JsonFactory jsonFactory = new MappingJsonFactory();
 
-  private static final SFLogger logger =
-      SFLoggerFactory.getLogger(SnowflakeChunkDownloader.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeChunkDownloader.class);
 
-  private SnowflakeResultChunk.ResultChunkDataCache chunkDataCache
-      = new SnowflakeResultChunk.ResultChunkDataCache();
+  private SnowflakeResultChunk.ResultChunkDataCache chunkDataCache =
+      new SnowflakeResultChunk.ResultChunkDataCache();
   private List<SnowflakeResultChunk> chunks = null;
 
   // index of next chunk to be consumed (it may not be ready yet)
@@ -120,7 +115,7 @@ public class SnowflakeChunkDownloader
   private long BASE_WAITING_MS = 50;
   private long WAITING_SECS_MULTIPLIER = 2;
   // the maximum waiting time
-  private long MAX_WAITING_MS = 30*1000;
+  private long MAX_WAITING_MS = 30 * 1000;
   // the default jitter ratio 10%
   private long WAITING_JITTER_RATIO = 10;
   /** Timeout that main thread wait for downloading */
@@ -134,43 +129,36 @@ public class SnowflakeChunkDownloader
    * @return new thread pool
    */
   private static ThreadPoolExecutor createChunkDownloaderExecutorService(
-      final String threadNamePrefix, final int parallel)
-  {
-    ThreadFactory threadFactory = new ThreadFactory() {
-      private int threadCount = 1;
+      final String threadNamePrefix, final int parallel) {
+    ThreadFactory threadFactory =
+        new ThreadFactory() {
+          private int threadCount = 1;
 
-      public Thread newThread(final Runnable r)
-      {
-        final Thread thread = new Thread(r);
-        thread.setName(threadNamePrefix + threadCount++);
+          public Thread newThread(final Runnable r) {
+            final Thread thread = new Thread(r);
+            thread.setName(threadNamePrefix + threadCount++);
 
-        thread.setUncaughtExceptionHandler(
-            new Thread.UncaughtExceptionHandler()
-            {
-              public void uncaughtException(Thread t, Throwable e)
-              {
-                logger.error(
-                           "uncaughtException in thread: " + t + " {}",
-                           e);
-              }
-            });
+            thread.setUncaughtExceptionHandler(
+                new Thread.UncaughtExceptionHandler() {
+                  public void uncaughtException(Thread t, Throwable e) {
+                    logger.error("uncaughtException in thread: " + t + " {}", e);
+                  }
+                });
 
-        thread.setDaemon(true);
+            thread.setDaemon(true);
 
-        return thread;
-      }
-    };
-    return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallel,
-                                                             threadFactory);
+            return thread;
+          }
+        };
+    return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallel, threadFactory);
   }
 
-  public class Metrics
-  {
+  public class Metrics {
     public final long millisWaiting;
     public final long millisDownloading;
     public final long millisParsing;
-    private Metrics()
-    {
+
+    private Metrics() {
       SnowflakeChunkDownloader outer = SnowflakeChunkDownloader.this;
       millisWaiting = outer.numberMillisWaitingForChunks;
       millisDownloading = outer.totalMillisDownloadingChunks.get();
@@ -180,6 +168,7 @@ public class SnowflakeChunkDownloader
 
   /**
    * Constructor to initialize downloader
+   *
    * @param colCount number of columns to expect
    * @param chunksData JSON object contains all the chunk information
    * @param prefetchThreads number of prefetch threads
@@ -190,46 +179,41 @@ public class SnowflakeChunkDownloader
    * @param memoryLimit memory limit for chunk buffer
    * @param efficientChunkStorage use new efficient storage format
    */
-  public SnowflakeChunkDownloader(int colCount,
-                                  JsonNode chunksData,
-                                  int prefetchThreads,
-                                  String qrmk,
-                                  JsonNode chunkHeaders,
-                                  int networkTimeoutInMilli,
-                                  boolean useJsonParser,
-                                  long memoryLimit,
-                                  boolean efficientChunkStorage)
-  throws SnowflakeSQLException
-  {
+  public SnowflakeChunkDownloader(
+      int colCount,
+      JsonNode chunksData,
+      int prefetchThreads,
+      String qrmk,
+      JsonNode chunkHeaders,
+      int networkTimeoutInMilli,
+      boolean useJsonParser,
+      long memoryLimit,
+      boolean efficientChunkStorage)
+      throws SnowflakeSQLException {
     this.qrmk = qrmk;
     this.networkTimeoutInMilli = networkTimeoutInMilli;
     this.prefetchSlots = prefetchThreads * 2;
     this.useJsonParser = useJsonParser;
     this.memoryLimit = memoryLimit;
-    logger.debug( "qrmk = {}", qrmk);
+    logger.debug("qrmk = {}", qrmk);
 
-    if (chunkHeaders != null && !chunkHeaders.isMissingNode())
-    {
+    if (chunkHeaders != null && !chunkHeaders.isMissingNode()) {
       chunkHeadersMap = new HashMap<>(2);
 
-      Iterator<Map.Entry<String, JsonNode>> chunkHeadersIter =
-      chunkHeaders.fields();
+      Iterator<Map.Entry<String, JsonNode>> chunkHeadersIter = chunkHeaders.fields();
 
-      while (chunkHeadersIter.hasNext())
-      {
+      while (chunkHeadersIter.hasNext()) {
         Map.Entry<String, JsonNode> chunkHeader = chunkHeadersIter.next();
 
-        logger.debug("add header key={}, value={}",
-                               new Object[]{chunkHeader.getKey(),
-                               chunkHeader.getValue().asText()});
-        chunkHeadersMap.put(chunkHeader.getKey(),
-                            chunkHeader.getValue().asText());
+        logger.debug(
+            "add header key={}, value={}",
+            new Object[] {chunkHeader.getKey(), chunkHeader.getValue().asText()});
+        chunkHeadersMap.put(chunkHeader.getKey(), chunkHeader.getValue().asText());
       }
     }
 
     // no chunk data
-    if (chunksData == null)
-    {
+    if (chunksData == null) {
       logger.debug("no chunk data");
       return;
     }
@@ -240,8 +224,7 @@ public class SnowflakeChunkDownloader
     chunks = new ArrayList<>(numChunks);
 
     // initialize chunks with url and row count
-    for (int idx = 0; idx < numChunks; idx++)
-    {
+    for (int idx = 0; idx < numChunks; idx++) {
       JsonNode chunkNode = chunksData.get(idx);
 
       SnowflakeResultChunk chunk =
@@ -252,8 +235,8 @@ public class SnowflakeChunkDownloader
               chunkNode.path("uncompressedSize").asInt(),
               efficientChunkStorage);
 
-      logger.debug("add chunk, url={} rowCount={}",
-          new Object[]{chunk.getUrl(), chunk.getRowCount()});
+      logger.debug(
+          "add chunk, url={} rowCount={}", new Object[] {chunk.getUrl(), chunk.getRowCount()});
 
       chunks.add(chunk);
     }
@@ -261,79 +244,77 @@ public class SnowflakeChunkDownloader
     int effectiveThreads = Math.min(prefetchThreads, numChunks);
 
     logger.debug(
-	       "#chunks: {} #threads:{} #slots:{} -> pool:{}", 
-		   numChunks, prefetchThreads, prefetchSlots, effectiveThreads);
+        "#chunks: {} #threads:{} #slots:{} -> pool:{}",
+        numChunks,
+        prefetchThreads,
+        prefetchSlots,
+        effectiveThreads);
 
     // create thread pool
-    executor =
-        createChunkDownloaderExecutorService("result-chunk-downloader-",
-                                             effectiveThreads);
+    executor = createChunkDownloaderExecutorService("result-chunk-downloader-", effectiveThreads);
 
     startNextDownloaders();
   }
 
-  /**
-   * Submit download chunk tasks to executor.
-   * Number depends on thread and memory limit
-   */
-  private void startNextDownloaders() throws SnowflakeSQLException
-  {
+  /** Submit download chunk tasks to executor. Number depends on thread and memory limit */
+  private void startNextDownloaders() throws SnowflakeSQLException {
     // start downloading chunks up to number of slots
-    logger.debug("Submit {} chunks to be pre-fetched",
-               Math.min(prefetchSlots, chunks.size()));
+    logger.debug("Submit {} chunks to be pre-fetched", Math.min(prefetchSlots, chunks.size()));
 
     long waitingTime = BASE_WAITING_MS;
 
     // submit the chunks to be downloaded up to the prefetch slot capacity
     // and limited by memory
-    while (nextChunkToDownload - nextChunkToConsume < prefetchSlots &&
-        nextChunkToDownload < chunks.size())
-    {
+    while (nextChunkToDownload - nextChunkToConsume < prefetchSlots
+        && nextChunkToDownload < chunks.size()) {
       // check if memory limit allows more prefetching
       final SnowflakeResultChunk nextChunk = chunks.get(nextChunkToDownload);
       final long neededChunkMemory = nextChunk.computeNeededChunkMemory();
 
       // each time only one thread can enter this block
-      synchronized (currentMemoryUsage)
-      {
+      synchronized (currentMemoryUsage) {
         // make sure memoryLimit > neededChunkMemory; otherwise, the thread hangs
-        if (neededChunkMemory > memoryLimit)
-        {
-          logger.debug("{}: reset memoryLimit from {} MB to current chunk size {} MB",
+        if (neededChunkMemory > memoryLimit) {
+          logger.debug(
+              "{}: reset memoryLimit from {} MB to current chunk size {} MB",
               Thread.currentThread().getName(),
-              memoryLimit/1024/1024,
-              neededChunkMemory/1024/1024);
+              memoryLimit / 1024 / 1024,
+              neededChunkMemory / 1024 / 1024);
           memoryLimit = neededChunkMemory;
         }
 
         // no memory allocate when memory is not enough for prefetch
-        if (currentMemoryUsage + neededChunkMemory > memoryLimit &&
-            nextChunkToDownload - nextChunkToConsume > 0)
-        {
+        if (currentMemoryUsage + neededChunkMemory > memoryLimit
+            && nextChunkToDownload - nextChunkToConsume > 0) {
           break;
         }
 
         // only allocate memory when the future usage is less than the limit
-        if (currentMemoryUsage + neededChunkMemory <= memoryLimit)
-        {
+        if (currentMemoryUsage + neededChunkMemory <= memoryLimit) {
           nextChunk.tryReuse(chunkDataCache);
 
           currentMemoryUsage += neededChunkMemory;
-          logger.debug("{}: currentMemoryUsage in MB: {}, nextD: {}, nextC: {}, allocated: {} ",
+          logger.debug(
+              "{}: currentMemoryUsage in MB: {}, nextD: {}, nextC: {}, allocated: {} ",
               Thread.currentThread().getName(),
-              currentMemoryUsage/1024/1024,
+              currentMemoryUsage / 1024 / 1024,
               nextChunkToDownload,
               nextChunkToConsume,
               neededChunkMemory);
 
-          logger.debug("submit chunk #{} for downloading, url={}",
-              this.nextChunkToDownload, nextChunk.getUrl());
+          logger.debug(
+              "submit chunk #{} for downloading, url={}",
+              this.nextChunkToDownload,
+              nextChunk.getUrl());
 
-          executor.submit(getDownloadChunkCallable(this,
-              nextChunk,
-              qrmk, nextChunkToDownload,
-              chunkHeadersMap,
-              networkTimeoutInMilli));
+          executor.submit(
+              getDownloadChunkCallable(
+                  this,
+                  nextChunk,
+                  qrmk,
+                  nextChunkToDownload,
+                  chunkHeadersMap,
+                  networkTimeoutInMilli));
 
           // increment next chunk to download
           nextChunkToDownload++;
@@ -345,21 +326,21 @@ public class SnowflakeChunkDownloader
       }
 
       // waiting when nextChunkToDownload is equal to nextChunkToConsume but reach memory limit
-      try{
+      try {
         waitingTime *= WAITING_SECS_MULTIPLIER;
-        waitingTime = waitingTime > MAX_WAITING_MS ? MAX_WAITING_MS: waitingTime;
-        long jitter = ThreadLocalRandom.current().nextLong(0, waitingTime/WAITING_JITTER_RATIO);
+        waitingTime = waitingTime > MAX_WAITING_MS ? MAX_WAITING_MS : waitingTime;
+        long jitter = ThreadLocalRandom.current().nextLong(0, waitingTime / WAITING_JITTER_RATIO);
         waitingTime += jitter;
-        logger.debug("{} waiting for {}s: currentMemoryUsage in MB: {}, needed: {}, nextD: {}, nextC: {} ",
+        logger.debug(
+            "{} waiting for {}s: currentMemoryUsage in MB: {}, needed: {}, nextD: {}, nextC: {} ",
             Thread.currentThread().getName(),
-            waitingTime/1000.0,
-            currentMemoryUsage/1024/1024,
-            neededChunkMemory/1024/1024,
+            waitingTime / 1000.0,
+            currentMemoryUsage / 1024 / 1024,
+            neededChunkMemory / 1024 / 1024,
             nextChunkToDownload,
             nextChunkToConsume);
         Thread.sleep(waitingTime);
-      } catch (InterruptedException ie)
-      {
+      } catch (InterruptedException ie) {
         throw new SnowflakeSQLException(
             SqlState.INTERNAL_ERROR,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
@@ -372,55 +353,46 @@ public class SnowflakeChunkDownloader
     chunkDataCache.clear();
   }
 
-  private void releaseCurrentMemoryUsage(int chunk)
-  {
-    synchronized (currentMemoryUsage)
-    {
+  private void releaseCurrentMemoryUsage(int chunk) {
+    synchronized (currentMemoryUsage) {
       // has to be before reusing the memory
       currentMemoryUsage -= chunks.get(chunk).computeNeededChunkMemory();
-      logger.debug("{}: currentMemoryUsage in MB: {}, released: {}, chunk: {}",
+      logger.debug(
+          "{}: currentMemoryUsage in MB: {}, released: {}, chunk: {}",
           Thread.currentThread().getName(),
-          currentMemoryUsage/1024/1024,
+          currentMemoryUsage / 1024 / 1024,
           chunks.get(chunk).computeNeededChunkMemory(),
           chunk);
     }
   }
 
   /**
-   *
    * The method does the following:
    *
-   * 1. free the previous chunk data and submit a new chunk to be downloaded
+   * <p>1. free the previous chunk data and submit a new chunk to be downloaded
    *
-   * 2. get next chunk to consume, if it is not ready for consumption,
-   * it waits until it is ready
+   * <p>2. get next chunk to consume, if it is not ready for consumption, it waits until it is ready
    *
    * @return next SnowflakeResultChunk to be consumed
    * @throws InterruptedException if downloading thread was interrupted
    * @throws SnowflakeSQLException if downloader encountered an error
    */
-  public SnowflakeResultChunk getNextChunkToConsume() throws InterruptedException,
-                                                      SnowflakeSQLException
-  {
+  public SnowflakeResultChunk getNextChunkToConsume()
+      throws InterruptedException, SnowflakeSQLException {
     // free previous chunk data and submit a new chunk for downloading
-    if (this.nextChunkToConsume > 0)
-    {
+    if (this.nextChunkToConsume > 0) {
       int prevChunk = this.nextChunkToConsume - 1;
 
       // free the chunk data for previous chunk
-      logger.debug("free chunk data for chunk #{}",
-                 prevChunk);
+      logger.debug("free chunk data for chunk #{}", prevChunk);
 
       releaseCurrentMemoryUsage(prevChunk);
 
-      if (this.nextChunkToDownload < this.chunks.size())
-      {
+      if (this.nextChunkToDownload < this.chunks.size()) {
         // Reuse the set of object to avoid reallocation
         // It is important to do this BEFORE starting the next download
         chunkDataCache.add(this.chunks.get(prevChunk));
-      }
-      else
-      {
+      } else {
         // clear the cache if we don't need it anymore
         chunkDataCache.clear();
       }
@@ -430,8 +402,7 @@ public class SnowflakeChunkDownloader
     }
 
     // if no more chunks, return null
-    if (this.nextChunkToConsume >= this.chunks.size())
-    {
+    if (this.nextChunkToConsume >= this.chunks.size()) {
       logger.debug("no more chunk");
       return null;
     }
@@ -441,83 +412,70 @@ public class SnowflakeChunkDownloader
 
     SnowflakeResultChunk currentChunk = this.chunks.get(nextChunkToConsume);
 
-    if (currentChunk.getDownloadState() == DownloadState.SUCCESS)
-    {
+    if (currentChunk.getDownloadState() == DownloadState.SUCCESS) {
       logger.debug("chunk #{} is ready to consume", nextChunkToConsume);
       nextChunkToConsume++;
-      if (nextChunkToConsume == this.chunks.size())
-      {
+      if (nextChunkToConsume == this.chunks.size()) {
         // make sure to release the last chunk
-        releaseCurrentMemoryUsage(nextChunkToConsume-1);
+        releaseCurrentMemoryUsage(nextChunkToConsume - 1);
       }
       return currentChunk;
-    }
-    else
-    {
+    } else {
       // the chunk we want to consume is not ready yet, wait for it
-      try
-      {
-        logger.debug("chunk #{} is not ready to consume",
-                   nextChunkToConsume);
+      try {
+        logger.debug("chunk #{} is not ready to consume", nextChunkToConsume);
 
         currentChunk.getLock().lock();
         logger.debug("consumer get lock to check chunk state");
 
-        while (currentChunk.getDownloadState() != DownloadState.SUCCESS &&
-            currentChunk.getDownloadState() != DownloadState.FAILURE)
-        {
-          logger.debug("wait for chunk #{} to be ready, current"
-                  + "chunk state is: {}",
-              new Object[]{nextChunkToConsume, currentChunk.getDownloadState()});
+        while (currentChunk.getDownloadState() != DownloadState.SUCCESS
+            && currentChunk.getDownloadState() != DownloadState.FAILURE) {
+          logger.debug(
+              "wait for chunk #{} to be ready, current" + "chunk state is: {}",
+              new Object[] {nextChunkToConsume, currentChunk.getDownloadState()});
 
           long startTime = System.currentTimeMillis();
-          if(!currentChunk.getDownloadCondition().await(downloadedConditionTimeoutInSeconds, TimeUnit.SECONDS))
-          {
+          if (!currentChunk
+              .getDownloadCondition()
+              .await(downloadedConditionTimeoutInSeconds, TimeUnit.SECONDS)) {
             currentChunk.setDownloadState(DownloadState.FAILURE);
-            currentChunk.setDownloadError(String.format("Timeout waiting for the download of chunk #%d" +
-                "(Total chunks: %d)", nextChunkToConsume, this.chunks.size()));
+            currentChunk.setDownloadError(
+                String.format(
+                    "Timeout waiting for the download of chunk #%d" + "(Total chunks: %d)",
+                    nextChunkToConsume, this.chunks.size()));
           }
-          this.numberMillisWaitingForChunks +=
-              (System.currentTimeMillis() - startTime);
+          this.numberMillisWaitingForChunks += (System.currentTimeMillis() - startTime);
 
-          logger.debug(
-              "woken up from waiting for chunk #{} to be ready",
-                     nextChunkToConsume);
+          logger.debug("woken up from waiting for chunk #{} to be ready", nextChunkToConsume);
         }
 
         // downloader thread encountered an error
-        if (currentChunk.getDownloadState() == DownloadState.FAILURE)
-        {
-          logger.error("downloader encountered error: {}",
-              currentChunk.getDownloadError());
+        if (currentChunk.getDownloadState() == DownloadState.FAILURE) {
+          logger.error("downloader encountered error: {}", currentChunk.getDownloadError());
 
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+          throw new SnowflakeSQLException(
+              SqlState.INTERNAL_ERROR,
               ErrorCode.INTERNAL_ERROR.getMessageCode(),
               currentChunk.getDownloadError());
         }
 
-        logger.debug("chunk #{} is ready to consume",
-                   nextChunkToConsume);
+        logger.debug("chunk #{} is ready to consume", nextChunkToConsume);
 
         nextChunkToConsume++;
 
         // next chunk to consume is ready for consumption
         return currentChunk;
-      }
-      finally
-      {
+      } finally {
         logger.debug("consumer free lock");
 
         boolean terminateDownloader = (currentChunk.getDownloadState() == DownloadState.FAILURE);
         // release the unlock always
         currentChunk.getLock().unlock();
-        if (nextChunkToConsume == this.chunks.size())
-        {
+        if (nextChunkToConsume == this.chunks.size()) {
           // make sure to release the last chunk
-          releaseCurrentMemoryUsage(nextChunkToConsume-1);
+          releaseCurrentMemoryUsage(nextChunkToConsume - 1);
         }
-        if (terminateDownloader)
-        {
+        if (terminateDownloader) {
           logger.debug("Download result fail. Shut down the chunk downloader");
           terminate();
         }
@@ -527,22 +485,23 @@ public class SnowflakeChunkDownloader
 
   /**
    * terminate the downloader
+   *
    * @return chunk downloader metrics collected over instance lifetime
    */
-  public Metrics terminate()
-  {
-    if (!terminated)
-    {
+  public Metrics terminate() {
+    if (!terminated) {
 
-      logger.debug("Total milliseconds waiting for chunks: {}, " +
-              "Total memory used: {}, total download time: {} millisec, " +
-              "total parsing time: {} milliseconds, total chunks: {}",
+      logger.debug(
+          "Total milliseconds waiting for chunks: {}, "
+              + "Total memory used: {}, total download time: {} millisec, "
+              + "total parsing time: {} milliseconds, total chunks: {}",
           numberMillisWaitingForChunks,
-          Runtime.getRuntime().totalMemory(), totalMillisDownloadingChunks.get(),
-          totalMillisParsingChunks.get(), chunks.size());
+          Runtime.getRuntime().totalMemory(),
+          totalMillisDownloadingChunks.get(),
+          totalMillisParsingChunks.get(),
+          chunks.size());
 
-      if (executor != null)
-      {
+      if (executor != null) {
         executor.shutdownNow();
         executor = null;
       }
@@ -557,30 +516,30 @@ public class SnowflakeChunkDownloader
 
   /**
    * add download time
+   *
    * @param downloadTime Time for downloading a single chunk
    */
-  private void addDownloadTime(long downloadTime)
-  {
+  private void addDownloadTime(long downloadTime) {
     this.totalMillisDownloadingChunks.addAndGet(downloadTime);
   }
 
   /**
    * add parsing time
+   *
    * @param parsingTime Time for parsing a single chunk
    */
-  private void addParsingTime(long parsingTime)
-  {
+  private void addParsingTime(long parsingTime) {
     this.totalMillisParsingChunks.addAndGet(parsingTime);
   }
 
   /**
    * Create a download callable that will be run in download thread
+   *
    * @param downloader object to download the chunk
-   * @param resultChunk object contains information about the chunk will
-   *                    be downloaded
+   * @param resultChunk object contains information about the chunk will be downloaded
    * @param qrmk Query Result Master Key
-   * @param chunkIndex the index of the chunk which will be downloaded in array
-   *                   chunks. This is mainly for logging purpose
+   * @param chunkIndex the index of the chunk which will be downloaded in array chunks. This is
+   *     mainly for logging purpose
    * @param chunkHeadersMap contains headers needed to be added when downloading from s3
    * @param networkTimeoutInMilli network timeout
    * @return A callable responsible for downloading chunk
@@ -588,29 +547,23 @@ public class SnowflakeChunkDownloader
   private static Callable<Void> getDownloadChunkCallable(
       final SnowflakeChunkDownloader downloader,
       final SnowflakeResultChunk resultChunk,
-      final String qrmk, final int chunkIndex,
+      final String qrmk,
+      final int chunkIndex,
       final Map<String, String> chunkHeadersMap,
-      final int networkTimeoutInMilli)
-  {
-    return new Callable<Void> ()
-    {
-      public Void call() throws Exception
-      {
-        try
-        {
+      final int networkTimeoutInMilli) {
+    return new Callable<Void>() {
+      public Void call() throws Exception {
+        try {
           // set the chunk state to be in progress
-          try
-          {
+          try {
             resultChunk.getLock().lock();
             resultChunk.setDownloadState(DownloadState.IN_PROGRESS);
-          }
-          finally
-          {
+          } finally {
             resultChunk.getLock().unlock();
           }
 
-          logger.debug("Downloading chunk {}, url={}",
-                                 new Object[]{chunkIndex, resultChunk.getUrl()});
+          logger.debug(
+              "Downloading chunk {}, url={}", new Object[] {chunkIndex, resultChunk.getUrl()});
 
           long startTime = System.currentTimeMillis();
 
@@ -620,50 +573,39 @@ public class SnowflakeChunkDownloader
            * return error if we don't get a response or the response code
            * means failure.
            */
-          if (response == null
-              || response.getStatusLine().getStatusCode() != 200)
-          {
-            logger.error( "Error fetching chunk from: {}",
-                resultChunk.getUrl());
+          if (response == null || response.getStatusLine().getStatusCode() != 200) {
+            logger.error("Error fetching chunk from: {}", resultChunk.getUrl());
 
             SnowflakeUtil.logResponseDetails(response, logger);
 
-            throw new SnowflakeSQLException(SqlState.IO_ERROR,
-                ErrorCode.NETWORK_ERROR
-                    .getMessageCode(),
+            throw new SnowflakeSQLException(
+                SqlState.IO_ERROR,
+                ErrorCode.NETWORK_ERROR.getMessageCode(),
                 "Error encountered when downloading a result chunk: HTTP "
                     + "status="
                     + ((response != null)
-                    ? response.getStatusLine().getStatusCode()
-                    : "null response"));
+                        ? response.getStatusLine().getStatusCode()
+                        : "null response"));
           }
 
           InputStream jsonInputStream;
           final HttpEntity entity = response.getEntity();
-          try
-          {
+          try {
             // read the chunk data
-            InputStream is =
-                  new HttpUtil.HttpInputStream(entity.getContent());
+            InputStream is = new HttpUtil.HttpInputStream(entity.getContent());
 
             // Determine the format of the response, if it is not
             // either plain text or gzip, raise an error.
             Header encoding = response.getFirstHeader("Content-Encoding");
-            if (encoding != null)
-            {
-              if (encoding.getValue().equalsIgnoreCase("gzip"))
-              {
+            if (encoding != null) {
+              if (encoding.getValue().equalsIgnoreCase("gzip")) {
                 /* specify buffer size for GZIPInputStream */
                 is = new GZIPInputStream(is, 65536);
-              }
-              else
-              {
-                throw
-                    new SnowflakeSQLException(
-                        SqlState.INTERNAL_ERROR,
-                        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                        "Exception: unexpected compression got " +
-                            encoding.getValue());
+              } else {
+                throw new SnowflakeSQLException(
+                    SqlState.INTERNAL_ERROR,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    "Exception: unexpected compression got " + encoding.getValue());
               }
             }
 
@@ -674,18 +616,13 @@ public class SnowflakeChunkDownloader
             // no buffering as json parser does it internally
             jsonInputStream =
                 new SequenceInputStream(
-                    Collections.enumeration(Arrays.asList(
-                        new ByteArrayInputStream("[".getBytes(
-                            StandardCharsets.UTF_8)),
-                        is,
-                        new ByteArrayInputStream("]".getBytes(
-                            StandardCharsets.UTF_8)))));
-          }
-          catch (Exception ex)
-          {
-            logger.error(
-                       "Failed to uncompress data: {}",
-                       response);
+                    Collections.enumeration(
+                        Arrays.asList(
+                            new ByteArrayInputStream("[".getBytes(StandardCharsets.UTF_8)),
+                            is,
+                            new ByteArrayInputStream("]".getBytes(StandardCharsets.UTF_8)))));
+          } catch (Exception ex) {
+            logger.error("Failed to uncompress data: {}", response);
 
             throw ex;
           }
@@ -702,32 +639,26 @@ public class SnowflakeChunkDownloader
           JsonNode resultData = null;
 
           // parse the result json
-          try
-          {
-            if (downloader.useJsonParser)
-            {
-              parseJsonToChunk(jsonInputStream,resultChunk);
-            }
-            else
-            {
+          try {
+            if (downloader.useJsonParser) {
+              parseJsonToChunk(jsonInputStream, resultChunk);
+            } else {
               // Use Jackson deserialization if not using JsonParser
               // tokenization.
               resultData = mapper.readTree(jsonInputStream);
             }
-          }
-          catch (Exception ex)
-          {
-            logger.error( "Exception when parsing result", ex);
+          } catch (Exception ex) {
+            logger.error("Exception when parsing result", ex);
 
-            throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR
-                    .getMessageCode(),
-                "Exception: " +
-                    ex.getLocalizedMessage() +
-                    "\nBad result json: " + response.toString());
-          }
-          finally
-          {
+            throw new SnowflakeSQLException(
+                ex,
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                "Exception: "
+                    + ex.getLocalizedMessage()
+                    + "\nBad result json: "
+                    + response.toString());
+          } finally {
             // close the buffer reader will close underlying stream
             jsonInputStream.close();
           }
@@ -740,72 +671,55 @@ public class SnowflakeChunkDownloader
           resultChunk.setResultData(resultData);
 
           logger.debug(
-                   "Finished preparing chunk data for {}, " +
-                    "total download time={}ms, total parse time={}ms",
-                     resultChunk.getUrl(),
-                     resultChunk.getDownloadTime(),
-                     resultChunk.getParseTime());
+              "Finished preparing chunk data for {}, "
+                  + "total download time={}ms, total parse time={}ms",
+              resultChunk.getUrl(),
+              resultChunk.getDownloadTime(),
+              resultChunk.getParseTime());
 
-          try
-          {
+          try {
             resultChunk.getLock().lock();
-            logger.debug(
-                "get lock to change the chunk to be ready to consume");
+            logger.debug("get lock to change the chunk to be ready to consume");
 
-            logger.debug(
-                "wake up consumer if it is waiting for a chunk to be "
-                    + "ready");
+            logger.debug("wake up consumer if it is waiting for a chunk to be " + "ready");
 
             resultChunk.setDownloadState(DownloadState.SUCCESS);
             resultChunk.getDownloadCondition().signal();
-          }
-          finally
-          {
-            logger.debug(
-                "Downloaded chunk {}, free lock", chunkIndex);
+          } finally {
+            logger.debug("Downloaded chunk {}, free lock", chunkIndex);
 
             resultChunk.getLock().unlock();
           }
-        }
-        catch (Throwable ex)
-        {
-          try
-          {
+        } catch (Throwable ex) {
+          try {
             logger.debug("get lock to set chunk download error");
             resultChunk.getLock().lock();
 
             resultChunk.setDownloadState(DownloadState.FAILURE);
             resultChunk.setDownloadError(ex.getLocalizedMessage());
 
-            logger.debug(
-                "wake up consumer if it is waiting for a chunk to be ready");
+            logger.debug("wake up consumer if it is waiting for a chunk to be ready");
 
             resultChunk.getDownloadCondition().signal();
-          }
-          finally
-          {
-            logger.debug("Failed to download chunk {}, free lock",
-                chunkIndex);
+          } finally {
+            logger.debug("Failed to download chunk {}, free lock", chunkIndex);
             resultChunk.getLock().unlock();
           }
 
           logger.error(
-                     "Exception encountered ({}:{}) fetching chunk from: {}",
-                     new Object[]{
-                         ex.getClass().getName(),
-                         ex.getLocalizedMessage(),
-                         resultChunk.getUrl()});
+              "Exception encountered ({}:{}) fetching chunk from: {}",
+              new Object[] {
+                ex.getClass().getName(), ex.getLocalizedMessage(), resultChunk.getUrl()
+              });
 
-          logger.error( "Exception: ", ex);
+          logger.error("Exception: ", ex);
         }
 
         return null;
       }
 
-      private void parseJsonToChunk(InputStream jsonInputStream,
-                                    SnowflakeResultChunk resultChunk)
-          throws IOException, SnowflakeSQLException
-      {
+      private void parseJsonToChunk(InputStream jsonInputStream, SnowflakeResultChunk resultChunk)
+          throws IOException, SnowflakeSQLException {
         /*
          * This is a hand-written customized parser that
          * handle.
@@ -818,26 +732,21 @@ public class SnowflakeChunkDownloader
          * The number of rows is known and the number of expected columns
          * is also known.
          */
-        try (JsonParser jp = jsonFactory.createParser(new InputStreamReader(jsonInputStream, "UTF-8")))
-        {
+        try (JsonParser jp =
+            jsonFactory.createParser(new InputStreamReader(jsonInputStream, "UTF-8"))) {
           JsonToken currentToken;
 
           // Get the first token and make sure it is the start of an array
           currentToken = jp.nextToken();
-          if (currentToken != JsonToken.START_ARRAY)
-          {
-            throw
-                new SnowflakeSQLException(
-                    SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                    "Exception1: expected '[' " +
-                        "got " +
-                        currentToken.asString());
+          if (currentToken != JsonToken.START_ARRAY) {
+            throw new SnowflakeSQLException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                "Exception1: expected '[' " + "got " + currentToken.asString());
           }
 
           // For all the rows...
-          while (jp.nextToken() != JsonToken.END_ARRAY)
-          {
+          while (jp.nextToken() != JsonToken.END_ARRAY) {
             // Position to the current row in the result
             resultChunk.addRow(mapper.readValue(jp, Object[].class));
           }
@@ -845,24 +754,20 @@ public class SnowflakeChunkDownloader
         }
       }
 
-      private HttpResponse getResultChunk(String chunkUrl) throws URISyntaxException, IOException, SnowflakeSQLException
-      {
+      private HttpResponse getResultChunk(String chunkUrl)
+          throws URISyntaxException, IOException, SnowflakeSQLException {
         URIBuilder uriBuilder = new URIBuilder(chunkUrl);
 
         HttpGet httpRequest = new HttpGet(uriBuilder.build());
 
-        if (chunkHeadersMap != null && chunkHeadersMap.size() != 0)
-        {
-          for (Map.Entry<String, String> entry : chunkHeadersMap.entrySet())
-          {
-            logger.debug("Adding header key={}, value={}",
-                       entry.getKey(), entry.getValue());
+        if (chunkHeadersMap != null && chunkHeadersMap.size() != 0) {
+          for (Map.Entry<String, String> entry : chunkHeadersMap.entrySet()) {
+            logger.debug("Adding header key={}, value={}", entry.getKey(), entry.getValue());
             httpRequest.addHeader(entry.getKey(), entry.getValue());
           }
         }
         // Add SSE-C headers
-        else if (qrmk != null)
-        {
+        else if (qrmk != null) {
           httpRequest.addHeader(SSE_C_ALGORITHM, SSE_C_AES);
           httpRequest.addHeader(SSE_C_KEY, qrmk);
           logger.debug("Adding SSE-C headers");
@@ -870,23 +775,23 @@ public class SnowflakeChunkDownloader
 
         logger.debug("Fetching result: {}", resultChunk.getUrl());
 
-        //TODO move this s3 request to HttpUtil class. In theory, upper layer
-        //TODO does not need to know about http client
+        // TODO move this s3 request to HttpUtil class. In theory, upper layer
+        // TODO does not need to know about http client
         CloseableHttpClient httpClient = HttpUtil.getHttpClient();
 
         // fetch the result chunk
         HttpResponse response =
-            RestRequest.execute(httpClient,
-                                httpRequest,
-                                networkTimeoutInMilli / 1000, // retry timeout
-                                0, // no socketime injection
-                                null, // no canceling
-                                false, // no cookie
-                                false, // no retry
-                                false); // no request_guid
+            RestRequest.execute(
+                httpClient,
+                httpRequest,
+                networkTimeoutInMilli / 1000, // retry timeout
+                0, // no socketime injection
+                null, // no canceling
+                false, // no cookie
+                false, // no retry
+                false); // no request_guid
 
-        logger.debug("Call returned for URL: {}",
-                               chunkUrl);
+        logger.debug("Call returned for URL: {}", chunkUrl);
         return response;
       }
     };

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeClob.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeClob.java
@@ -10,50 +10,38 @@ import java.io.Writer;
 import java.sql.Clob;
 import java.sql.SQLException;
 
-/**
- * A simple Clob implementation using String
- */
-public class SnowflakeClob implements Clob
-{
+/** A simple Clob implementation using String */
+public class SnowflakeClob implements Clob {
   private StringBuffer buffer;
 
-  private class StringBufferWriter extends Writer
-  {
+  private class StringBufferWriter extends Writer {
     private StringBuffer main;
     private StringBuffer current;
     private int offset;
-    /**
-     *
-     */
-    public StringBufferWriter(StringBuffer buffer, int pos)
-    {
+    /** */
+    public StringBufferWriter(StringBuffer buffer, int pos) {
       super();
       this.main = buffer;
       this.current = new StringBuffer();
-      this.offset = pos-1;
+      this.offset = pos - 1;
     }
 
     @Override
-    public void write(final char[] cbuf, final int off, final int len) throws IOException
-    {
-      for (int i = 0; i < len; i++)
-      {
-        this.current.append(cbuf[off+i]);
+    public void write(final char[] cbuf, final int off, final int len) throws IOException {
+      for (int i = 0; i < len; i++) {
+        this.current.append(cbuf[off + i]);
       }
     }
 
     @Override
-    public void flush() throws IOException
-    {
+    public void flush() throws IOException {
       this.main.append(this.current);
       this.current.delete(0, this.current.length());
     }
 
     @Override
-    public void close() throws IOException
-    {
-      if(this.current == null)
-      {
+    public void close() throws IOException {
+      if (this.current == null) {
         throw new IOException();
       }
       flush();
@@ -61,164 +49,132 @@ public class SnowflakeClob implements Clob
     }
   }
 
-  private class StringBufferOutputStream extends OutputStream
-  {
+  private class StringBufferOutputStream extends OutputStream {
     private StringBuffer buffer;
     private int offset;
-    /**
-     *
-     */
-    public StringBufferOutputStream(StringBuffer buffer, int pos)
-    {
+    /** */
+    public StringBufferOutputStream(StringBuffer buffer, int pos) {
       super();
       this.buffer = buffer;
-      this.offset = pos-1;
+      this.offset = pos - 1;
     }
 
     /*
      * @see java.io.OutputStream#write(int)
      */
-    public void write(int c) throws IOException
-    {
-      if(this.offset >= this.buffer.length())
-      {
-        buffer.append((char)c);
-      }
-      else
-      {
-        buffer.replace(this.offset, this.offset+1, Integer.toString(c));
+    public void write(int c) throws IOException {
+      if (this.offset >= this.buffer.length()) {
+        buffer.append((char) c);
+      } else {
+        buffer.replace(this.offset, this.offset + 1, Integer.toString(c));
       }
     }
 
-    public String toString()
-    {
+    public String toString() {
       return buffer.toString();
     }
 
-    public void clear()
-    {
+    public void clear() {
       buffer.delete(0, buffer.length());
     }
   }
 
-  public SnowflakeClob()
-  {
+  public SnowflakeClob() {
     buffer = new StringBuffer();
   }
 
-  public SnowflakeClob(String content)
-  {
+  public SnowflakeClob(String content) {
     buffer = new StringBuffer(content);
   }
 
   @Override
-  public long length() throws SQLException
-  {
+  public long length() throws SQLException {
     return buffer.length();
   }
 
   @Override
-  public String getSubString(final long pos, final int length) throws SQLException
-  {
-    if (pos < 1 || length < 0)
-    {
+  public String getSubString(final long pos, final int length) throws SQLException {
+    if (pos < 1 || length < 0) {
       throw new SQLException();
     }
-    return buffer.substring((int)pos-0, (int)pos-0+length);
+    return buffer.substring((int) pos - 0, (int) pos - 0 + length);
   }
 
   @Override
-  public Reader getCharacterStream() throws SQLException
-  {
+  public Reader getCharacterStream() throws SQLException {
     return new StringReader(buffer.toString());
   }
 
   @Override
-  public InputStream getAsciiStream() throws SQLException
-  {
+  public InputStream getAsciiStream() throws SQLException {
     return new ByteArrayInputStream(buffer.toString().getBytes());
   }
 
   @Override
-  public long position(final String searchstr, final long start) throws SQLException
-  {
-    if (start < 1 )
-    {
+  public long position(final String searchstr, final long start) throws SQLException {
+    if (start < 1) {
       throw new SQLException();
     }
-    return (long) buffer.lastIndexOf(searchstr, (int)start-1);
+    return (long) buffer.lastIndexOf(searchstr, (int) start - 1);
   }
 
   @Override
-  public long position(final Clob searchstr, final long start) throws SQLException
-  {
-    if (start < 1 )
-    {
+  public long position(final Clob searchstr, final long start) throws SQLException {
+    if (start < 1) {
       throw new SQLException();
     }
-    return (long) buffer.lastIndexOf(searchstr.toString(), (int)start-1);
+    return (long) buffer.lastIndexOf(searchstr.toString(), (int) start - 1);
   }
 
   @Override
-  public int setString(final long pos, final String str) throws SQLException
-  {
-    if (pos < 1 )
-    {
+  public int setString(final long pos, final String str) throws SQLException {
+    if (pos < 1) {
       throw new SQLException();
     }
-    buffer.insert((int)pos-1, str);
+    buffer.insert((int) pos - 1, str);
     return str.length();
   }
 
   @Override
-  public int setString(final long pos, final String str, final int offset,
-                       final int len) throws SQLException
-  {
-    if (pos < 1 )
-    {
+  public int setString(final long pos, final String str, final int offset, final int len)
+      throws SQLException {
+    if (pos < 1) {
       throw new SQLException();
     }
     String substring = str.substring(offset, len);
-    buffer.insert((int)pos-1, substring);
+    buffer.insert((int) pos - 1, substring);
     return substring.length();
   }
 
   @Override
-  public OutputStream setAsciiStream(final long pos) throws SQLException
-  {
-    return new StringBufferOutputStream(buffer, (int)pos);
+  public OutputStream setAsciiStream(final long pos) throws SQLException {
+    return new StringBufferOutputStream(buffer, (int) pos);
   }
 
   @Override
-  public Writer setCharacterStream(final long pos) throws SQLException
-  {
+  public Writer setCharacterStream(final long pos) throws SQLException {
     return new StringBufferWriter(buffer, (int) pos);
   }
 
   @Override
-  public void truncate(final long len) throws SQLException
-  {
-    if (buffer.length() > len)
-    {
-      buffer.delete((int)len, buffer.length());
+  public void truncate(final long len) throws SQLException {
+    if (buffer.length() > len) {
+      buffer.delete((int) len, buffer.length());
     }
   }
 
   @Override
-  public void free() throws SQLException
-  {
+  public void free() throws SQLException {
     buffer = new StringBuffer();
   }
 
   @Override
-  public Reader getCharacterStream(final long pos, final long length) throws SQLException
-  {
-    return new StringReader(buffer.substring((int)pos-1, (int)pos-1+(int)length));
+  public Reader getCharacterStream(final long pos, final long length) throws SQLException {
+    return new StringReader(buffer.substring((int) pos - 1, (int) pos - 1 + (int) length));
   }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
     return buffer.toString();
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeColumnMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeColumnMetadata.java
@@ -4,12 +4,8 @@
 
 package net.snowflake.client.jdbc;
 
-/**
- *
- * @author jhuang
- */
-public class SnowflakeColumnMetadata
-{
+/** @author jhuang */
+public class SnowflakeColumnMetadata {
   private String name;
   private String typeName;
   private int type;
@@ -23,12 +19,19 @@ public class SnowflakeColumnMetadata
   private String columnSrcSchema;
   private String columnSrcDatabase;
 
-  public SnowflakeColumnMetadata(String name, int type, boolean nullable,
-                                 int length, int precision, int scale,
-                                 String typeName, boolean fixed, 
-                                 SnowflakeType base, String columnSrcDatabase,
-                                 String columnSrcSchema, String columnSrcTable)
-  {
+  public SnowflakeColumnMetadata(
+      String name,
+      int type,
+      boolean nullable,
+      int length,
+      int precision,
+      int scale,
+      String typeName,
+      boolean fixed,
+      SnowflakeType base,
+      String columnSrcDatabase,
+      String columnSrcSchema,
+      String columnSrcTable) {
     this.name = name;
     this.type = type;
     this.nullable = nullable;
@@ -43,107 +46,87 @@ public class SnowflakeColumnMetadata
     this.columnSrcTable = columnSrcTable;
   }
 
-  public String getName()
-  {
+  public String getName() {
     return name;
   }
 
-  public void setName(String name)
-  {
+  public void setName(String name) {
     this.name = name;
   }
 
-  public int getType()
-  {
+  public int getType() {
     return type;
   }
 
-  public void setType(int type)
-  {
+  public void setType(int type) {
     this.type = type;
   }
 
-  public boolean isNullable()
-  {
+  public boolean isNullable() {
     return nullable;
   }
 
-  public void setNullable(boolean nullable)
-  {
+  public void setNullable(boolean nullable) {
     this.nullable = nullable;
   }
 
-  public int getLength()
-  {
+  public int getLength() {
     return length;
   }
 
-  public void setLength(int length)
-  {
+  public void setLength(int length) {
     this.length = length;
   }
 
-  public int getPrecision()
-  {
+  public int getPrecision() {
     return precision;
   }
 
-  public void setPrecision(int precision)
-  {
+  public void setPrecision(int precision) {
     this.precision = precision;
   }
 
-  public int getScale()
-  {
+  public int getScale() {
     return scale;
   }
 
-  public void setScale(int scale)
-  {
+  public void setScale(int scale) {
     this.scale = scale;
   }
 
-  public String getTypeName()
-  {
+  public String getTypeName() {
     return typeName;
   }
 
-  public void setTypeName(String typeName)
-  {
+  public void setTypeName(String typeName) {
     this.typeName = typeName;
   }
 
-  public boolean isFixed()
-  {
+  public boolean isFixed() {
     return fixed;
   }
 
-  public void setFixed(boolean fixed)
-  {
+  public void setFixed(boolean fixed) {
     this.fixed = fixed;
   }
 
   public SnowflakeType getBase() {
     return this.base;
   }
-  
-  public String getColumnSrcTable()
-  {
+
+  public String getColumnSrcTable() {
     return this.columnSrcTable;
   }
 
-  public String getColumnSrcSchema()
-  {
+  public String getColumnSrcSchema() {
     return this.columnSrcSchema;
   }
 
-  public String getColumnSrcDatabase()
-  {
+  public String getColumnSrcDatabase() {
     return this.columnSrcDatabase;
   }
 
-  public String toString()
-  {
+  public String toString() {
     StringBuilder sBuilder = new StringBuilder();
 
     sBuilder.append("name=").append(name);

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -4,14 +4,7 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.core.SFSessionProperty;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.common.core.LoginInfoDTO;
-import net.snowflake.common.core.ResourceBundleManager;
-import net.snowflake.common.core.SqlState;
+import static net.snowflake.client.core.SessionUtil.JVM_PARAMS_TO_PARAMS;
 
 import java.io.InputStream;
 import java.sql.Array;
@@ -40,19 +33,23 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static net.snowflake.client.core.SessionUtil.JVM_PARAMS_TO_PARAMS;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.LoginInfoDTO;
+import net.snowflake.common.core.ResourceBundleManager;
+import net.snowflake.common.core.SqlState;
 
 /**
  * Snowflake connection implementation
  *
  * @author jhuang
  */
-public class SnowflakeConnectionV1 implements Connection
-{
+public class SnowflakeConnectionV1 implements Connection {
 
-  static private final
-  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionV1.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionV1.class);
 
   private static final String JDBC_PROTOCOL_PREFIX = "jdbc:snowflake";
 
@@ -75,29 +72,27 @@ public class SnowflakeConnectionV1 implements Connection
   private int databaseMinorVersion = 0;
 
   /**
-   * Amount of seconds a user is willing to tolerate for establishing the
-   * connection with database. In our case, it means the first login
-   * request to get authorization token.
-   * <p>
-   * A value of 0 means no timeout.
-   * <p>
-   * Default: to login timeout in driver manager if set or 60 seconds
+   * Amount of seconds a user is willing to tolerate for establishing the connection with database.
+   * In our case, it means the first login request to get authorization token.
+   *
+   * <p>A value of 0 means no timeout.
+   *
+   * <p>Default: to login timeout in driver manager if set or 60 seconds
    */
-  private int loginTimeout = (DriverManager.getLoginTimeout() > 0) ?
-      DriverManager.getLoginTimeout() : 60;
+  private int loginTimeout =
+      (DriverManager.getLoginTimeout() > 0) ? DriverManager.getLoginTimeout() : 60;
 
   /**
-   * Amount of milliseconds a user is willing to tolerate for network related
-   * issues (e.g. HTTP 503/504) or database transient issues (e.g. GS
-   * not responding)
-   * <p>
-   * A value of 0 means no timeout
-   * <p>
-   * Default: 300 seconds
+   * Amount of milliseconds a user is willing to tolerate for network related issues (e.g. HTTP
+   * 503/504) or database transient issues (e.g. GS not responding)
+   *
+   * <p>A value of 0 means no timeout
+   *
+   * <p>Default: 300 seconds
    */
   private int networkTimeoutInMilli = 0; // in milliseconds
 
-  static private final ResourceBundleManager errorResourceBundleManager =
+  private static final ResourceBundleManager errorResourceBundleManager =
       ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
 
   private Properties clientInfo = new Properties();
@@ -107,7 +102,7 @@ public class SnowflakeConnectionV1 implements Connection
   // TODO setTransactionIsolation doesn't do anything.
   private int transactionIsolation = Connection.TRANSACTION_NONE;
 
-  //--- Simulated failures for testing
+  // --- Simulated failures for testing
 
   // whether we try to simulate a socket timeout (a default value of 0 means
   // no simulation). The value is in milliseconds
@@ -117,7 +112,7 @@ public class SnowflakeConnectionV1 implements Connection
   // call ( a default value of 0 means no pause). The value is in seconds
   private int injectClientPause = 0;
 
-  //Generate exception while uploading file with a given name
+  // Generate exception while uploading file with a given name
   private String injectFileUploadFailure = null;
 
   private SFSession sfSession;
@@ -125,20 +120,16 @@ public class SnowflakeConnectionV1 implements Connection
   /**
    * A connection will establish a session token from snowflake
    *
-   * @param url  server url used to create snowflake connection
+   * @param url server url used to create snowflake connection
    * @param info properties about the snowflake connection
-   * @throws java.sql.SQLException if failed to create a snowflake connection
-   *                               i.e. username or password not specified
+   * @throws java.sql.SQLException if failed to create a snowflake connection i.e. username or
+   *     password not specified
    */
-  public SnowflakeConnectionV1(String url,
-                               Properties info)
-      throws SQLException
-  {
+  public SnowflakeConnectionV1(String url, Properties info) throws SQLException {
     // open connection to GS
     sfSession = new SFSession();
 
-    try
-    {
+    try {
       // pass the parameters to sfSession
       initSessionProperties(url, info);
 
@@ -149,11 +140,9 @@ public class SnowflakeConnectionV1 implements Connection
       databaseMajorVersion = sfSession.getDatabaseMajorVersion();
       databaseMinorVersion = sfSession.getDatabaseMinorVersion();
       newClientForUpdate = sfSession.getNewClientForUpdate();
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(), ex.getSqlState(),
-          ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
 
     appendWarnings(sfSession.getSqlWarnings());
@@ -162,61 +151,54 @@ public class SnowflakeConnectionV1 implements Connection
   }
 
   /**
-   * Processes parameters given in the connection string. This extracts
-   * accountName, databaseName, schemaName from
-   * the URL if it is specified there, where the URL is of the form:
+   * Processes parameters given in the connection string. This extracts accountName, databaseName,
+   * schemaName from the URL if it is specified there, where the URL is of the form:
    *
-   * jdbc:snowflake://host:port/?user=v&password=v&account=v&
+   * <p>jdbc:snowflake://host:port/?user=v&password=v&account=v&
    * db=v&schema=v&ssl=v&[passcode=v|passcodeInPassword=on]
+   *
    * @param url
    * @param info
    */
-  static Map<String, Object> mergeProperties(String url, Properties info)
-  {
+  static Map<String, Object> mergeProperties(String url, Properties info) {
     final Map<String, Object> properties = new HashMap<>();
 
     // first deal with url
     int queryParamsIndex = url.indexOf("?");
 
-    String serverUrl = queryParamsIndex > 0 ? url.substring(0, queryParamsIndex)
-        : url;
-    String queryParams = queryParamsIndex > 0 ? url.substring(queryParamsIndex + 1)
-        : null;
+    String serverUrl = queryParamsIndex > 0 ? url.substring(0, queryParamsIndex) : url;
+    String queryParams = queryParamsIndex > 0 ? url.substring(queryParamsIndex + 1) : null;
 
-    if (queryParams != null && !queryParams.isEmpty())
-    {
+    if (queryParams != null && !queryParams.isEmpty()) {
       String[] entries = queryParams.split("&");
 
-      for (String entry : entries)
-      {
+      for (String entry : entries) {
         int sep = entry.indexOf("=");
-        if (sep > 0)
-        {
+        if (sep > 0) {
           String key = entry.substring(0, sep).toUpperCase();
           properties.put(key, entry.substring(sep + 1));
         }
       }
     }
 
-    for (Map.Entry<Object, Object> entry : info.entrySet())
-    {
+    for (Map.Entry<Object, Object> entry : info.entrySet()) {
       properties.put(entry.getKey().toString().toUpperCase(), entry.getValue());
     }
 
     boolean sslOn = getBooleanTrueByDefault(properties.get("SSL"));
 
-    serverUrl = serverUrl.replace(JDBC_PROTOCOL_PREFIX,
-        sslOn ? SSL_NATIVE_PROTOCOL : NATIVE_PROTOCOL);
+    serverUrl =
+        serverUrl.replace(JDBC_PROTOCOL_PREFIX, sslOn ? SSL_NATIVE_PROTOCOL : NATIVE_PROTOCOL);
 
     properties.put("SERVERURL", serverUrl);
     properties.remove("SSL");
 
-    if (properties.get("ACCOUNT") == null && serverUrl != null &&
-          serverUrl.indexOf(".") > 0 &&
-          serverUrl.indexOf("://") > 0)
-    {
-      String accountName = serverUrl.substring(serverUrl.indexOf("://") + 3,
-          serverUrl.indexOf("."));
+    if (properties.get("ACCOUNT") == null
+        && serverUrl != null
+        && serverUrl.indexOf(".") > 0
+        && serverUrl.indexOf("://") > 0) {
+      String accountName =
+          serverUrl.substring(serverUrl.indexOf("://") + 3, serverUrl.indexOf("."));
 
       logger.debug("set account name to {}", accountName);
       properties.put("ACCOUNT", accountName);
@@ -225,63 +207,51 @@ public class SnowflakeConnectionV1 implements Connection
     return properties;
   }
 
-  void initSessionProperties(String url, Properties info) throws SFException
-  {
+  void initSessionProperties(String url, Properties info) throws SFException {
     Map<String, Object> properties = mergeProperties(url, info);
 
-    for (Map.Entry<String, Object> property : properties.entrySet())
-    {
+    for (Map.Entry<String, Object> property : properties.entrySet()) {
       sfSession.addProperty(property.getKey(), property.getValue());
     }
 
     // populate app id and version
     sfSession.addProperty(SFSessionProperty.APP_ID, LoginInfoDTO.SF_JDBC_APP_ID);
-    sfSession.addProperty(SFSessionProperty.APP_VERSION,
-          SnowflakeDriver.implementVersion);
+    sfSession.addProperty(SFSessionProperty.APP_VERSION, SnowflakeDriver.implementVersion);
 
     // Set the corresponding session parameters to the JVM properties
-    for (Map.Entry<String, String> entry: JVM_PARAMS_TO_PARAMS.entrySet())
-    {
+    for (Map.Entry<String, String> entry : JVM_PARAMS_TO_PARAMS.entrySet()) {
       String value = System.getProperty(entry.getKey());
-      if (value != null && !sfSession.containProperty(entry.getValue()))
-      {
+      if (value != null && !sfSession.containProperty(entry.getValue())) {
         sfSession.addProperty(entry.getValue(), value);
       }
     }
   }
 
-  private static boolean getBooleanTrueByDefault(Object value)
-  {
-    if (value instanceof String)
-    {
-      final String value0 = (String)value;
+  private static boolean getBooleanTrueByDefault(Object value) {
+    if (value instanceof String) {
+      final String value0 = (String) value;
       return !("off".equalsIgnoreCase(value0) || "false".equalsIgnoreCase(value0));
-    }
-    else if (value instanceof Boolean)
-    {
-      return (boolean)value;
+    } else if (value instanceof Boolean) {
+      return (boolean) value;
     }
     return true;
   }
 
   /**
-   * Execute a statement where the result isn't needed, and the statement is
-   * closed before this method returns
+   * Execute a statement where the result isn't needed, and the statement is closed before this
+   * method returns
    *
    * @param stmtText text of the statement
    * @throws java.sql.SQLException exception thrown it the statement fails to execute
    */
-  private void executeImmediate(String stmtText) throws SQLException
-  {
+  private void executeImmediate(String stmtText) throws SQLException {
     // execute the statement and auto-close it as well
-    try (final Statement statement = this.createStatement();)
-    {
+    try (final Statement statement = this.createStatement(); ) {
       statement.execute(stmtText);
     }
   }
 
-  public String getNewClientForUpdate()
-  {
+  public String getNewClientForUpdate() {
     return newClientForUpdate;
   }
 
@@ -292,8 +262,7 @@ public class SnowflakeConnectionV1 implements Connection
    * @throws java.sql.SQLException if failed to create a snowflake statement
    */
   @Override
-  public Statement createStatement() throws SQLException
-  {
+  public Statement createStatement() throws SQLException {
     Statement statement = new SnowflakeStatementV1(this);
     return statement;
   }
@@ -304,34 +273,27 @@ public class SnowflakeConnectionV1 implements Connection
    * @throws java.sql.SQLException failed to close the connection
    */
   @Override
-  public void close() throws SQLException
-  {
+  public void close() throws SQLException {
     logger.debug(" public void close() throws SQLException");
 
-    if (isClosed)
-    {
+    if (isClosed) {
       return;
     }
 
-    try
-    {
-      if (sfSession != null)
-      {
+    try {
+      if (sfSession != null) {
         sfSession.close();
         sfSession = null;
       }
       isClosed = true;
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public boolean isClosed() throws SQLException
-  {
+  public boolean isClosed() throws SQLException {
     logger.debug(" public boolean isClosed() throws SQLException");
 
     return isClosed;
@@ -344,82 +306,56 @@ public class SnowflakeConnectionV1 implements Connection
    * @throws java.sql.SQLException f
    */
   @Override
-  public DatabaseMetaData getMetaData() throws SQLException
-  {
-    logger.debug(
-        " public DatabaseMetaData getMetaData() throws SQLException");
+  public DatabaseMetaData getMetaData() throws SQLException {
+    logger.debug(" public DatabaseMetaData getMetaData() throws SQLException");
 
     return new SnowflakeDatabaseMetaData(this);
   }
 
   @Override
-  public CallableStatement prepareCall(String sql) throws SQLException
-  {
-    logger.debug(
-        " public CallableStatement prepareCall(String sql) throws "
-            + "SQLException");
+  public CallableStatement prepareCall(String sql) throws SQLException {
+    logger.debug(" public CallableStatement prepareCall(String sql) throws " + "SQLException");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public CallableStatement prepareCall(String sql, int resultSetType,
-                                       int resultSetConcurrency)
-      throws SQLException
-  {
-    logger.debug(
-        " public CallableStatement prepareCall(String sql, int "
-            + "resultSetType,");
+  public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
+      throws SQLException {
+    logger.debug(" public CallableStatement prepareCall(String sql, int " + "resultSetType,");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public CallableStatement prepareCall(String sql, int resultSetType,
-                                       int resultSetConcurrency,
-                                       int resultSetHoldability)
-      throws SQLException
-  {
-    logger.debug(
-        " public CallableStatement prepareCall(String sql, int "
-            + "resultSetType,");
+  public CallableStatement prepareCall(
+      String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+      throws SQLException {
+    logger.debug(" public CallableStatement prepareCall(String sql, int " + "resultSetType,");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public String nativeSQL(String sql) throws SQLException
-  {
-    logger.debug(
-        " public String nativeSQL(String sql) throws SQLException");
+  public String nativeSQL(String sql) throws SQLException {
+    logger.debug(" public String nativeSQL(String sql) throws SQLException");
 
     return sql;
   }
 
   @Override
-  public void setAutoCommit(boolean isAutoCommit) throws SQLException
-  {
-    logger.debug(
-        " public void setAutoCommit(boolean isAutoCommit) throws "
-            + "SQLException");
+  public void setAutoCommit(boolean isAutoCommit) throws SQLException {
+    logger.debug(" public void setAutoCommit(boolean isAutoCommit) throws " + "SQLException");
 
-    try
-    {
-      this.executeImmediate("alter session set autocommit=" +
-          Boolean.toString(isAutoCommit));
-    }
-    catch (SnowflakeSQLException sse)
-    {
+    try {
+      this.executeImmediate("alter session set autocommit=" + Boolean.toString(isAutoCommit));
+    } catch (SnowflakeSQLException sse) {
       // check whether this is the autocommit api unsupported exception
-      if (sse.getSQLState().equals(SqlState.FEATURE_NOT_SUPPORTED))
-      {
+      if (sse.getSQLState().equals(SqlState.FEATURE_NOT_SUPPORTED)) {
         // autocommit api support has not yet been enabled in this session/account
         // do nothing for backward compatibility
-        logger.debug("Autocommit API is not supported for this " +
-            "connection.");
-      }
-      else
-      {
+        logger.debug("Autocommit API is not supported for this " + "connection.");
+      } else {
         // this is a different exception, rethrow it
         throw sse;
       }
@@ -427,37 +363,30 @@ public class SnowflakeConnectionV1 implements Connection
   }
 
   /**
-   * Look up the GS metadata using sql command,
-   * provide a list of column names
-   * and return these column values in the row one of result set
+   * Look up the GS metadata using sql command, provide a list of column names and return these
+   * column values in the row one of result set
    *
    * @param querySQL,
    * @param columnNames
    * @return
    * @throws SQLException
    */
-  private List<String> queryGSMetaData(String querySQL, List<String> columnNames) throws SQLException
-  {
+  private List<String> queryGSMetaData(String querySQL, List<String> columnNames)
+      throws SQLException {
     // try with auto-closing statement resource
-    try (Statement statement = this.createStatement())
-    {
+    try (Statement statement = this.createStatement()) {
       statement.execute(querySQL);
 
       // handle the case where the result set is not what is expected
       // try with auto-closing resultset resource
-      try (ResultSet rs = statement.getResultSet())
-      {
-        if (rs != null && rs.next())
-        {
+      try (ResultSet rs = statement.getResultSet()) {
+        if (rs != null && rs.next()) {
           List<String> columnValues = new ArrayList<>();
-          for (String columnName : columnNames)
-          {
+          for (String columnName : columnNames) {
             columnValues.add(rs.getString(columnName));
           }
           return columnValues;
-        }
-        else
-        {
+        } else {
           // returned no results or an error
           throw new SQLException(
               errorResourceBundleManager.getLocalizedMessage(
@@ -468,17 +397,14 @@ public class SnowflakeConnectionV1 implements Connection
   }
 
   @Override
-  public boolean getAutoCommit() throws SQLException
-  {
-    logger.debug(
-        " public boolean getAutoCommit() throws SQLException");
+  public boolean getAutoCommit() throws SQLException {
+    logger.debug(" public boolean getAutoCommit() throws SQLException");
 
     return sfSession.getAutoCommit();
   }
 
   @Override
-  public void commit() throws SQLException
-  {
+  public void commit() throws SQLException {
     logger.debug(" public void commit() throws SQLException");
 
     // commit
@@ -486,8 +412,7 @@ public class SnowflakeConnectionV1 implements Connection
   }
 
   @Override
-  public void rollback() throws SQLException
-  {
+  public void rollback() throws SQLException {
     logger.debug(" public void rollback() throws SQLException");
 
     // rollback
@@ -495,65 +420,49 @@ public class SnowflakeConnectionV1 implements Connection
   }
 
   @Override
-  public void rollback(Savepoint savepoint) throws SQLException
-  {
-    logger.debug(
-        " public void rollback(Savepoint savepoint) throws "
-            + "SQLException");
+  public void rollback(Savepoint savepoint) throws SQLException {
+    logger.debug(" public void rollback(Savepoint savepoint) throws " + "SQLException");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setReadOnly(boolean readOnly) throws SQLException
-  {
-    logger.debug(
-        " public void setReadOnly(boolean readOnly) throws "
-            + "SQLException");
+  public void setReadOnly(boolean readOnly) throws SQLException {
+    logger.debug(" public void setReadOnly(boolean readOnly) throws " + "SQLException");
 
-    if (readOnly)
-    {
+    if (readOnly) {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public boolean isReadOnly() throws SQLException
-  {
+  public boolean isReadOnly() throws SQLException {
     logger.debug(" public boolean isReadOnly() throws SQLException");
 
     return false;
   }
 
   @Override
-  public void setCatalog(String catalog) throws SQLException
-  {
-    logger.debug(
-        " public void setCatalog(String catalog) throws SQLException");
+  public void setCatalog(String catalog) throws SQLException {
+    logger.debug(" public void setCatalog(String catalog) throws SQLException");
 
     // switch db by running "use db"
     this.executeImmediate("use database \"" + catalog + "\"");
   }
 
   @Override
-  public String getCatalog() throws SQLException
-  {
+  public String getCatalog() throws SQLException {
     return sfSession.getDatabase();
   }
 
   @Override
-  public void setTransactionIsolation(int level) throws SQLException
-  {
+  public void setTransactionIsolation(int level) throws SQLException {
     logger.debug(
-        " public void setTransactionIsolation(int level) "
-            + "throws SQLException. level = {}", level);
-    if (level == Connection.TRANSACTION_NONE
-        || level == Connection.TRANSACTION_READ_COMMITTED)
-    {
+        " public void setTransactionIsolation(int level) " + "throws SQLException. level = {}",
+        level);
+    if (level == Connection.TRANSACTION_NONE || level == Connection.TRANSACTION_READ_COMMITTED) {
       this.transactionIsolation = level;
-    }
-    else
-    {
+    } else {
       throw new SQLFeatureNotSupportedException(
           "Transaction Isolation " + Integer.toString(level) + " not supported.",
           ErrorCode.FEATURE_UNSUPPORTED.getSqlState(),
@@ -562,26 +471,21 @@ public class SnowflakeConnectionV1 implements Connection
   }
 
   @Override
-  public int getTransactionIsolation() throws SQLException
-  {
-    logger.debug(
-        " public int getTransactionIsolation() throws SQLException");
+  public int getTransactionIsolation() throws SQLException {
+    logger.debug(" public int getTransactionIsolation() throws SQLException");
 
     return this.transactionIsolation;
   }
 
   @Override
-  public SQLWarning getWarnings() throws SQLException
-  {
-    logger.debug(
-        " public SQLWarning getWarnings() throws SQLException");
+  public SQLWarning getWarnings() throws SQLException {
+    logger.debug(" public SQLWarning getWarnings() throws SQLException");
 
     return sqlWarnings;
   }
 
   @Override
-  public void clearWarnings() throws SQLException
-  {
+  public void clearWarnings() throws SQLException {
     logger.debug(" public void clearWarnings() throws SQLException");
 
     sfSession.clearSqlWarnings();
@@ -590,98 +494,74 @@ public class SnowflakeConnectionV1 implements Connection
 
   @Override
   public Statement createStatement(int resultSetType, int resultSetConcurrency)
-      throws SQLException
-  {
+      throws SQLException {
     logger.debug(
-        " public Statement createStatement(int resultSetType, "
-            + "int resultSetConcurrency)");
+        " public Statement createStatement(int resultSetType, " + "int resultSetConcurrency)");
 
-    logger.debug("resultSetType=" + resultSetType +
-        "; resultSetConcurrency=" + resultSetConcurrency);
+    logger.debug(
+        "resultSetType=" + resultSetType + "; resultSetConcurrency=" + resultSetConcurrency);
 
     if (resultSetType != ResultSet.TYPE_FORWARD_ONLY
-        || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY)
-    {
+        || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY) {
       throw new SQLFeatureNotSupportedException();
     }
     return createStatement();
   }
 
   @Override
-  public Statement createStatement(int resultSetType, int resultSetConcurrency,
-                                   int resultSetHoldability)
-      throws SQLException
-  {
+  public Statement createStatement(
+      int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
     logger.debug(
-        " public Statement createStatement(int resultSetType, "
-            + "int resultSetConcurrency,");
+        " public Statement createStatement(int resultSetType, " + "int resultSetConcurrency,");
 
-    if (resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT)
-    {
+    if (resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
       throw new SQLFeatureNotSupportedException();
     }
     return createStatement(resultSetType, resultSetConcurrency);
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql) throws SQLException
-  {
-    logger.debug(
-        " public PreparedStatement prepareStatement(String sql) "
-            + "throws SQLException");
+  public PreparedStatement prepareStatement(String sql) throws SQLException {
+    logger.debug(" public PreparedStatement prepareStatement(String sql) " + "throws SQLException");
 
     return prepareStatement(sql, false);
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
-      throws SQLException
-  {
+  public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
     logger.debug(
-        " public PreparedStatement prepareStatement(String sql, "
-            + "int autoGeneratedKeys)");
+        " public PreparedStatement prepareStatement(String sql, " + "int autoGeneratedKeys)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int[] columnIndexes)
-      throws SQLException
-  {
+  public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
     logger.debug(
-        " public PreparedStatement prepareStatement(String sql, "
-            + "int[] columnIndexes)");
+        " public PreparedStatement prepareStatement(String sql, " + "int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, String[] columnNames)
-      throws SQLException
-  {
+  public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
     logger.debug(
-        " public PreparedStatement prepareStatement(String sql, "
-            + "String[] columnNames)");
+        " public PreparedStatement prepareStatement(String sql, " + "String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int resultSetType,
-                                            int resultSetConcurrency)
-      throws SQLException
-  {
-    logger.debug(
-        " public PreparedStatement prepareStatement(String sql, "
-            + "int resultSetType,");
+  public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency)
+      throws SQLException {
+    logger.debug(" public PreparedStatement prepareStatement(String sql, " + "int resultSetType,");
 
     if (resultSetType != ResultSet.TYPE_FORWARD_ONLY
-        || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY)
-    {
+        || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY) {
       logger.error(
-          "result set type ({}) or result set concurrency ({}) "
-              + "not supported",
-          resultSetType, resultSetConcurrency);
+          "result set type ({}) or result set concurrency ({}) " + "not supported",
+          resultSetType,
+          resultSetConcurrency);
 
       throw new SQLFeatureNotSupportedException();
     }
@@ -689,391 +569,312 @@ public class SnowflakeConnectionV1 implements Connection
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int resultSetType,
-                                            int resultSetConcurrency,
-                                            int resultSetHoldability)
-      throws SQLException
-  {
-    logger.debug(
-        " public PreparedStatement prepareStatement(String sql, "
-            + "int resultSetType,");
+  public PreparedStatement prepareStatement(
+      String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+      throws SQLException {
+    logger.debug(" public PreparedStatement prepareStatement(String sql, " + "int resultSetType,");
 
-    if (resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT)
-    {
+    if (resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
       throw new SQLFeatureNotSupportedException();
     }
     return prepareStatement(sql, resultSetType, resultSetConcurrency);
   }
 
-  public PreparedStatement prepareStatement(String sql, boolean skipParsing)
-      throws SQLException
-  {
+  public PreparedStatement prepareStatement(String sql, boolean skipParsing) throws SQLException {
     logger.debug(
-        " public PreparedStatement prepareStatement(String sql, "
-            + "boolean skipParsing)");
+        " public PreparedStatement prepareStatement(String sql, " + "boolean skipParsing)");
     return new SnowflakePreparedStatementV1(this, sql, skipParsing);
   }
 
   @Override
-  public Map<String, Class<?>> getTypeMap() throws SQLException
-  {
+  public Map<String, Class<?>> getTypeMap() throws SQLException {
     return Collections.emptyMap(); // nop
   }
 
   @Override
-  public void setTypeMap(Map<String, Class<?>> map) throws SQLException
-  {
+  public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setHoldability(int holdability) throws SQLException
-  {
+  public void setHoldability(int holdability) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getHoldability() throws SQLException
-  {
+  public int getHoldability() throws SQLException {
     return ResultSet.CLOSE_CURSORS_AT_COMMIT; // nop
   }
 
   @Override
-  public Savepoint setSavepoint() throws SQLException
-  {
+  public Savepoint setSavepoint() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Savepoint setSavepoint(String name) throws SQLException
-  {
+  public Savepoint setSavepoint(String name) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void releaseSavepoint(Savepoint savepoint) throws SQLException
-  {
+  public void releaseSavepoint(Savepoint savepoint) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Blob createBlob() throws SQLException
-  {
+  public Blob createBlob() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Clob createClob() throws SQLException
-  {
+  public Clob createClob() throws SQLException {
     return new SnowflakeClob();
   }
 
   @Override
-  public NClob createNClob() throws SQLException
-  {
+  public NClob createNClob() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public SQLXML createSQLXML() throws SQLException
-  {
+  public SQLXML createSQLXML() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isValid(int timeout) throws SQLException
-  {
+  public boolean isValid(int timeout) throws SQLException {
     // TODO: run query here or ping
     return !isClosed;
   }
 
   @Override
-  public void setClientInfo(Properties properties)
-      throws SQLClientInfoException
-  {
-    logger.debug(
-        " public void setClientInfo(Properties properties)");
+  public void setClientInfo(Properties properties) throws SQLClientInfoException {
+    logger.debug(" public void setClientInfo(Properties properties)");
 
-    if (this.clientInfo == null)
-      this.clientInfo = new Properties();
+    if (this.clientInfo == null) this.clientInfo = new Properties();
 
     // make a copy, don't point to the properties directly since we don't
     // own it.
     this.clientInfo.clear();
     this.clientInfo.putAll(properties);
 
-    if (sfSession != null)
-      sfSession.setClientInfo(properties);
+    if (sfSession != null) sfSession.setClientInfo(properties);
   }
 
   @Override
-  public void setClientInfo(String name, String value)
-      throws SQLClientInfoException
-  {
+  public void setClientInfo(String name, String value) throws SQLClientInfoException {
     logger.debug(" public void setClientInfo(String name, String value)");
 
-    if (this.clientInfo == null)
-      this.clientInfo = new Properties();
+    if (this.clientInfo == null) this.clientInfo = new Properties();
 
     this.clientInfo.setProperty(name, value);
 
-    if (sfSession != null)
-      sfSession.setClientInfo(name, value);
+    if (sfSession != null) sfSession.setClientInfo(name, value);
   }
 
   @Override
-  public Properties getClientInfo() throws SQLException
-  {
-    logger.debug(
-        " public Properties getClientInfo() throws SQLException");
+  public Properties getClientInfo() throws SQLException {
+    logger.debug(" public Properties getClientInfo() throws SQLException");
 
-    if (sfSession != null)
-      return sfSession.getClientInfo();
+    if (sfSession != null) return sfSession.getClientInfo();
 
-    if (this.clientInfo != null)
-    {
+    if (this.clientInfo != null) {
       // defensive copy to avoid client from changing the properties
       // directly w/o going through the API
       Properties copy = new Properties();
       copy.putAll(this.clientInfo);
 
       return copy;
-    }
-    else
-      return null;
+    } else return null;
   }
 
   @Override
-  public String getClientInfo(String name)
-  {
-    if (sfSession != null)
-      return sfSession.getClientInfo(name);
+  public String getClientInfo(String name) {
+    if (sfSession != null) return sfSession.getClientInfo(name);
 
     logger.debug(" public String getClientInfo(String name)");
 
-    if (this.clientInfo != null)
-      return this.clientInfo.getProperty(name);
-    else
-      return null;
+    if (this.clientInfo != null) return this.clientInfo.getProperty(name);
+    else return null;
   }
 
   @Override
-  public Array createArrayOf(String typeName, Object[] elements)
-      throws SQLException
-  {
-    logger.debug(
-        " public Array createArrayOf(String typeName, Object[] "
-            + "elements)");
+  public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+    logger.debug(" public Array createArrayOf(String typeName, Object[] " + "elements)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Struct createStruct(String typeName, Object[] attributes)
-      throws SQLException
-  {
-    logger.debug(
-        " public Struct createStruct(String typeName, Object[] "
-            + "attributes)");
+  public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+    logger.debug(" public Struct createStruct(String typeName, Object[] " + "attributes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setSchema(String schema) throws SQLException
-  {
-    logger.debug(
-        " public void setSchema(String schema) throws SQLException");
+  public void setSchema(String schema) throws SQLException {
+    logger.debug(" public void setSchema(String schema) throws SQLException");
 
     String databaseName = getCatalog();
 
     // switch schema by running "use db.schema"
-    if (databaseName == null)
-    {
+    if (databaseName == null) {
       this.executeImmediate("use schema \"" + schema + "\"");
-    }
-    else
-    {
+    } else {
       this.executeImmediate("use schema \"" + databaseName + "\".\"" + schema + "\"");
     }
   }
 
   @Override
-  public String getSchema() throws SQLException
-  {
+  public String getSchema() throws SQLException {
     return sfSession.getSchema();
   }
 
   @Override
-  public void abort(Executor executor) throws SQLException
-  {
-    logger.debug(
-        " public void abort(Executor executor) throws SQLException");
+  public void abort(Executor executor) throws SQLException {
+    logger.debug(" public void abort(Executor executor) throws SQLException");
 
     close();
   }
 
   @Override
-  public void setNetworkTimeout(Executor executor, int milliseconds)
-      throws SQLException
-  {
-    logger.debug(
-        " public void setNetworkTimeout(Executor executor, int "
-            + "milliseconds)");
+  public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+    logger.debug(" public void setNetworkTimeout(Executor executor, int " + "milliseconds)");
 
     networkTimeoutInMilli = milliseconds;
   }
 
   @Override
-  public int getNetworkTimeout() throws SQLException
-  {
-    logger.debug(
-        " public int getNetworkTimeout() throws SQLException");
+  public int getNetworkTimeout() throws SQLException {
+    logger.debug(" public int getNetworkTimeout() throws SQLException");
 
     return networkTimeoutInMilli;
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException
-  {
-    logger.debug(
-        " public boolean isWrapperFor(Class<?> iface) throws "
-            + "SQLException");
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    logger.debug(" public boolean isWrapperFor(Class<?> iface) throws " + "SQLException");
 
     return iface.isInstance(this);
   }
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException
-  {
-    logger.debug(
-        " public <T> T unwrap(Class<T> iface) throws SQLException");
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    logger.debug(" public <T> T unwrap(Class<T> iface) throws SQLException");
 
-
-    if (!iface.isInstance(this))
-    {
-      throw new RuntimeException(this.getClass().getName()
-          + " not unwrappable from " + iface.getName());
+    if (!iface.isInstance(this)) {
+      throw new RuntimeException(
+          this.getClass().getName() + " not unwrappable from " + iface.getName());
     }
     return (T) this;
   }
 
-  public static int getMajorVersion()
-  {
+  public static int getMajorVersion() {
     return SnowflakeDriver.majorVersion;
   }
 
-  public static int getMinorVersion()
-  {
+  public static int getMinorVersion() {
     return SnowflakeDriver.minorVersion;
   }
 
-  public int getDatabaseMajorVersion()
-  {
+  public int getDatabaseMajorVersion() {
     return databaseMajorVersion;
   }
 
-  public int getDatabaseMinorVersion()
-  {
+  public int getDatabaseMinorVersion() {
     return databaseMinorVersion;
   }
 
-  public String getDatabaseVersion()
-  {
+  public String getDatabaseVersion() {
     return databaseVersion;
   }
 
   /**
-   * Method to put data from a stream at a stage location. The data will be
-   * uploaded as one file. No splitting is done in this method.
-   * <p>
-   * Stream size must match the total size of data in the input stream unless
-   * compressData parameter is set to true.
-   * <p>
-   * caller is responsible for passing the correct size for the data in the
-   * stream and releasing the inputStream after the method is called.
+   * Method to put data from a stream at a stage location. The data will be uploaded as one file. No
+   * splitting is done in this method.
    *
-   * @param stageName    stage name: e.g. ~ or table name or stage name
-   * @param destPrefix   path prefix under which the data should be uploaded on the stage
-   * @param inputStream  input stream from which the data will be uploaded
+   * <p>Stream size must match the total size of data in the input stream unless compressData
+   * parameter is set to true.
+   *
+   * <p>caller is responsible for passing the correct size for the data in the stream and releasing
+   * the inputStream after the method is called.
+   *
+   * @param stageName stage name: e.g. ~ or table name or stage name
+   * @param destPrefix path prefix under which the data should be uploaded on the stage
+   * @param inputStream input stream from which the data will be uploaded
    * @param destFileName destination file name to use
-   * @param streamSize   data size in the stream
+   * @param streamSize data size in the stream
    * @throws java.sql.SQLException failed to put data from a stream at stage
    */
-  public void uploadStream(String stageName,
-                           String destPrefix,
-                           InputStream inputStream,
-                           String destFileName,
-                           long streamSize)
-      throws SQLException
-  {
-    uploadStreamInternal(stageName, destPrefix, inputStream,
-        destFileName, streamSize, false);
+  public void uploadStream(
+      String stageName,
+      String destPrefix,
+      InputStream inputStream,
+      String destFileName,
+      long streamSize)
+      throws SQLException {
+    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, streamSize, false);
   }
 
   /**
-   * Method to compress data from a stream and upload it at a stage location.
-   * The data will be uploaded as one file. No splitting is done in this method.
-   * <p>
-   * caller is responsible for releasing the inputStream after the method is
-   * called.
+   * Method to compress data from a stream and upload it at a stage location. The data will be
+   * uploaded as one file. No splitting is done in this method.
    *
-   * @param stageName    stage name: e.g. ~ or table name or stage name
-   * @param destPrefix   path prefix under which the data should be uploaded on the stage
-   * @param inputStream  input stream from which the data will be uploaded
+   * <p>caller is responsible for releasing the inputStream after the method is called.
+   *
+   * @param stageName stage name: e.g. ~ or table name or stage name
+   * @param destPrefix path prefix under which the data should be uploaded on the stage
+   * @param inputStream input stream from which the data will be uploaded
    * @param destFileName destination file name to use
    * @throws java.sql.SQLException failed to compress and put data from a stream at stage
    */
-  public void compressAndUploadStream(String stageName,
-                                      String destPrefix,
-                                      InputStream inputStream,
-                                      String destFileName)
-      throws SQLException
-  {
-    uploadStreamInternal(stageName, destPrefix, inputStream,
-        destFileName, 0, true);
+  public void compressAndUploadStream(
+      String stageName, String destPrefix, InputStream inputStream, String destFileName)
+      throws SQLException {
+    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, 0, true);
   }
 
   /**
-   * Method to put data from a stream at a stage location. The data will be
-   * uploaded as one file. No splitting is done in this method.
-   * <p>
-   * Stream size must match the total size of data in the input stream unless
-   * compressData parameter is set to true.
-   * <p>
-   * caller is responsible for passing the correct size for the data in the
-   * stream and releasing the inputStream after the method is called.
+   * Method to put data from a stream at a stage location. The data will be uploaded as one file. No
+   * splitting is done in this method.
    *
-   * @param stageName    stage name: e.g. ~ or table name or stage name
-   * @param destPrefix   path prefix under which the data should be uploaded on the stage
-   * @param inputStream  input stream from which the data will be uploaded
+   * <p>Stream size must match the total size of data in the input stream unless compressData
+   * parameter is set to true.
+   *
+   * <p>caller is responsible for passing the correct size for the data in the stream and releasing
+   * the inputStream after the method is called.
+   *
+   * @param stageName stage name: e.g. ~ or table name or stage name
+   * @param destPrefix path prefix under which the data should be uploaded on the stage
+   * @param inputStream input stream from which the data will be uploaded
    * @param destFileName destination file name to use
-   * @param streamSize   data size in the stream
+   * @param streamSize data size in the stream
    * @param compressData whether compression is requested fore uploading data
    * @throws java.sql.SQLException
    */
-  private void uploadStreamInternal(String stageName,
-                                    String destPrefix,
-                                    InputStream inputStream,
-                                    String destFileName,
-                                    long streamSize,
-                                    boolean compressData)
-      throws SQLException
-  {
-    logger.debug("upload data from stream: stageName={}" +
-            ", destPrefix={}, destFileName={}",
-            stageName, destPrefix, destFileName);
+  private void uploadStreamInternal(
+      String stageName,
+      String destPrefix,
+      InputStream inputStream,
+      String destFileName,
+      long streamSize,
+      boolean compressData)
+      throws SQLException {
+    logger.debug(
+        "upload data from stream: stageName={}" + ", destPrefix={}, destFileName={}",
+        stageName,
+        destPrefix,
+        destFileName);
 
     if (stageName == null)
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "stage name is null");
+      throw new SnowflakeSQLException(
+          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), "stage name is null");
 
     if (destFileName == null)
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "stage name is null");
+      throw new SnowflakeSQLException(
+          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), "stage name is null");
 
     SnowflakeStatementV1 stmt = new SnowflakeStatementV1(this);
 
@@ -1083,21 +884,18 @@ public class SnowflakeConnectionV1 implements Connection
     putCommand.append("put file:///tmp/placeholder ");
 
     // add stage name
-    if (!stageName.startsWith("@"))
-      putCommand.append("@");
+    if (!stageName.startsWith("@")) putCommand.append("@");
     putCommand.append(stageName);
 
     // add dest prefix
-    if (destPrefix != null)
-    {
-      if (!destPrefix.startsWith("/"))
-        putCommand.append("/");
+    if (destPrefix != null) {
+      if (!destPrefix.startsWith("/")) putCommand.append("/");
       putCommand.append(destPrefix);
     }
 
     SnowflakeFileTransferAgent transferAgent = null;
-    transferAgent = new SnowflakeFileTransferAgent(putCommand.toString(),
-        sfSession, stmt.getSfStatement());
+    transferAgent =
+        new SnowflakeFileTransferAgent(putCommand.toString(), sfSession, stmt.getSfStatement());
 
     transferAgent.setSourceStream(inputStream);
     transferAgent.setDestFileNameForStreamSource(destFileName);
@@ -1109,72 +907,52 @@ public class SnowflakeConnectionV1 implements Connection
     stmt.close();
   }
 
-  public void setInjectedDelay(int delay)
-  {
-    if (sfSession != null)
-      sfSession.setInjectedDelay(delay);
+  public void setInjectedDelay(int delay) {
+    if (sfSession != null) sfSession.setInjectedDelay(delay);
 
     this._injectedDelay.set(delay);
   }
 
-  void injectedDelay()
-  {
+  void injectedDelay() {
 
     int d = _injectedDelay.get();
 
-    if (d != 0)
-    {
+    if (d != 0) {
       _injectedDelay.set(0);
-      try
-      {
+      try {
         logger.trace("delayed for {}", d);
 
         Thread.sleep(d);
-      }
-      catch (InterruptedException ex)
-      {
+      } catch (InterruptedException ex) {
       }
     }
   }
 
-  public void setInjectFileUploadFailure(String fileToFail)
-  {
-    if (sfSession != null)
-      sfSession.setInjectFileUploadFailure(fileToFail);
+  public void setInjectFileUploadFailure(String fileToFail) {
+    if (sfSession != null) sfSession.setInjectFileUploadFailure(fileToFail);
 
     this.injectFileUploadFailure = fileToFail;
   }
 
-
-  public String getInjectFileUploadFailure()
-  {
+  public String getInjectFileUploadFailure() {
     return this.injectFileUploadFailure;
   }
 
-  public SFSession getSfSession()
-  {
+  public SFSession getSfSession() {
     return sfSession;
   }
 
-  private void appendWarning(SQLWarning w)
-  {
-    if (sqlWarnings == null)
-    {
+  private void appendWarning(SQLWarning w) {
+    if (sqlWarnings == null) {
       sqlWarnings = w;
-    }
-    else
-    {
+    } else {
       sqlWarnings.setNextWarning(w);
     }
   }
 
-  private void appendWarnings(List<SFException> warnings)
-  {
-    for (SFException e : warnings)
-    {
-      appendWarning(new SQLWarning(e.getMessage(),
-                                   e.getSqlState(),
-                                   e.getVendorCode()));
+  private void appendWarnings(List<SFException> warnings) {
+    for (SFException e : warnings) {
+      appendWarning(new SQLWarning(e.getMessage(), e.getSqlState(), e.getVendorCode()));
     }
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1355,8 +1355,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
                   }
                 }
 
-                statement.close();
-                statement = null;
+                if (statement != null) {
+                  statement.close();
+                  statement = null;
+                }
 
                 return false;
               }
@@ -1395,8 +1397,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
                   return true;
                 }
 
-                statement.close();
-                statement = null;
+                if (statement != null) {
+                  statement.close();
+                  statement = null;
+                }
 
                 return false;
               }
@@ -1654,8 +1658,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
                   }
                 }
 
-                statement.close();
-                statement = null;
+                if (statement != null) {
+                  statement.close();
+                  statement = null;
+                }
                 return false;
               }
             };
@@ -1823,8 +1829,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
           }
         }
 
-        statement.close();
-        statement = null;
+        if (statement != null) {
+          statement.close();
+          statement = null;
+        }
 
         return false;
       }
@@ -1990,8 +1998,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
           }
         }
 
-        statement.close();
-        statement = null;
+        if (statement != null) {
+          statement.close();
+          statement = null;
+        }
 
         return false;
       }
@@ -2542,8 +2552,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
           }
         }
 
-        statement.close();
-        statement = null;
+        if (statement != null) {
+          statement.close();
+          statement = null;
+        }
 
         return false;
       }
@@ -2670,8 +2682,12 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
             return true;
           }
         }
-        statement.close();
-        statement = null;
+
+        if (statement != null) {
+          statement.close();
+          statement = null;
+        }
+
         return false;
       }
     };

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaDataResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaDataResultSet.java
@@ -4,8 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.SFSession;
-
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.ResultSet;
@@ -15,33 +13,25 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.TimeZone;
-
-import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.core.SFSession;
 import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 
-/**
- *
- * @author jhuang
- */
-class SnowflakeDatabaseMetaDataResultSet extends
-        SnowflakeBaseResultSet
-{
+/** @author jhuang */
+class SnowflakeDatabaseMetaDataResultSet extends SnowflakeBaseResultSet {
   protected ResultSet showObjectResultSet;
   protected Statement statement;
   protected Object[][] rows;
 
-  static final SFLogger logger = SFLoggerFactory.getLogger(
-          SnowflakeDatabaseMetaDataResultSet.class);
+  static final SFLogger logger =
+      SFLoggerFactory.getLogger(SnowflakeDatabaseMetaDataResultSet.class);
 
-  /**
-   * Used for creating an empty result set
-   */
-  public SnowflakeDatabaseMetaDataResultSet()
-  {
-  }
+  /** Used for creating an empty result set */
+  public SnowflakeDatabaseMetaDataResultSet() {}
 
   /**
    * DatabaseMetadataResultSet based on result from show command
+   *
    * @param columnNames column names
    * @param columnTypeNames column type names
    * @param columnTypes column types
@@ -49,31 +39,29 @@ class SnowflakeDatabaseMetaDataResultSet extends
    * @param statement show command statement
    * @throws SQLException if failed to construct snowflake database metadata result set
    */
- 	public SnowflakeDatabaseMetaDataResultSet(
-          final List<String> columnNames,
-          final List<String> columnTypeNames,
-          final List<Integer> columnTypes,
-          final ResultSet showObjectResultSet,
-          final Statement statement)
-          throws SQLException
-  {
+  public SnowflakeDatabaseMetaDataResultSet(
+      final List<String> columnNames,
+      final List<String> columnTypeNames,
+      final List<Integer> columnTypes,
+      final ResultSet showObjectResultSet,
+      final Statement statement)
+      throws SQLException {
     this.showObjectResultSet = showObjectResultSet;
 
-    SFSession session = ((SnowflakeConnectionV1)statement.getConnection()).getSfSession();
+    SFSession session = ((SnowflakeConnectionV1) statement.getConnection()).getSfSession();
 
-    this.resultSetMetaData = new SnowflakeResultSetMetaData(columnNames.size(),
-                                                            columnNames,
-                                                            columnTypeNames,
-                                                            columnTypes,
-                                                            session);
+    this.resultSetMetaData =
+        new SnowflakeResultSetMetaData(
+            columnNames.size(), columnNames, columnTypeNames, columnTypes, session);
 
     this.nextRow = new Object[columnNames.size()];
 
     this.statement = statement;
- 	}
+  }
 
   /**
    * DatabaseMetadataResultSet based on a constant rowset.
+   *
    * @param columnNames column name
    * @param columnTypeNames column types name
    * @param columnTypes column type
@@ -81,57 +69,58 @@ class SnowflakeDatabaseMetaDataResultSet extends
    * @param statement show command statement
    * @throws SQLException if failed to construct snowflake database metadata result set
    */
- 	public SnowflakeDatabaseMetaDataResultSet(
-          final List<String> columnNames,
-          final List<String> columnTypeNames,
-          final List<Integer> columnTypes,
-          final Object[][] rows,
-          final Statement statement)
-          throws SQLException
-  {
+  public SnowflakeDatabaseMetaDataResultSet(
+      final List<String> columnNames,
+      final List<String> columnTypeNames,
+      final List<Integer> columnTypes,
+      final Object[][] rows,
+      final Statement statement)
+      throws SQLException {
     this.rows = rows;
-    
-    SFSession session = ((SnowflakeConnectionV1)statement.getConnection()).getSfSession();
 
-    this.resultSetMetaData = new SnowflakeResultSetMetaData(columnNames.size(),
-                                                            columnNames,
-                                                            columnTypeNames,
-                                                            columnTypes,
-                                                            session);
+    SFSession session = ((SnowflakeConnectionV1) statement.getConnection()).getSfSession();
+
+    this.resultSetMetaData =
+        new SnowflakeResultSetMetaData(
+            columnNames.size(), columnNames, columnTypeNames, columnTypes, session);
 
     this.nextRow = new Object[columnNames.size()];
 
     this.statement = statement;
- 	}
-
- 	public SnowflakeDatabaseMetaDataResultSet(DBMetadataResultSetMetadata metadataType,
-                                            ResultSet resultSet,
-                                            Statement statement) throws SQLException
-  {
-    this(metadataType.getColumnNames(), metadataType.getColumnTypeNames(),
-        metadataType.getColumnTypes(), resultSet, statement);
   }
 
-  public SnowflakeDatabaseMetaDataResultSet(DBMetadataResultSetMetadata metadataType,
-                                            Object[][] rows,
-                                            Statement statement) throws SQLException
-  {
-    this(metadataType.getColumnNames(), metadataType.getColumnTypeNames(),
-        metadataType.getColumnTypes(), rows, statement);
+  public SnowflakeDatabaseMetaDataResultSet(
+      DBMetadataResultSetMetadata metadataType, ResultSet resultSet, Statement statement)
+      throws SQLException {
+    this(
+        metadataType.getColumnNames(),
+        metadataType.getColumnTypeNames(),
+        metadataType.getColumnTypes(),
+        resultSet,
+        statement);
+  }
+
+  public SnowflakeDatabaseMetaDataResultSet(
+      DBMetadataResultSetMetadata metadataType, Object[][] rows, Statement statement)
+      throws SQLException {
+    this(
+        metadataType.getColumnNames(),
+        metadataType.getColumnTypeNames(),
+        metadataType.getColumnTypes(),
+        rows,
+        statement);
   }
 
   @Override
-  public boolean next() throws SQLException
-  {
+  public boolean next() throws SQLException {
     logger.debug("public boolean next()");
 
-    if (row < rows.length)
-    {
+    if (row < rows.length) {
       nextRow = rows[row++];
       return true;
     }
 
-    if(statement != null) {
+    if (statement != null) {
       statement.close();
       statement = null;
     }
@@ -140,80 +129,61 @@ class SnowflakeDatabaseMetaDataResultSet extends
   }
 
   @Override
-  public void close() throws SQLException
-  {
-    if(statement != null)
-    {
+  public void close() throws SQLException {
+    if (statement != null) {
       statement.close();
       statement = null;
     }
   }
 
   @Override
-  public byte[] getBytes(int columnIndex) throws SQLException
-  {
+  public byte[] getBytes(int columnIndex) throws SQLException {
     String str = this.getString(columnIndex);
-    if (str != null)
-    {
+    if (str != null) {
       return str.getBytes(StandardCharsets.UTF_8);
-    }
-    else
-    {
+    } else {
       throw new SQLException("Cannot get bytes on null column");
     }
   }
 
   @Override
-  public Time getTime(int columnIndex) throws SQLException
-  {
+  public Time getTime(int columnIndex) throws SQLException {
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj instanceof Time)
-    {
-      return (Time)obj;
-    }
-    else
-    {
-      throw new SnowflakeSQLException(ErrorCode.INVALID_VALUE_CONVERT,
-          obj.getClass().getName(), "TIME", obj);
+    if (obj instanceof Time) {
+      return (Time) obj;
+    } else {
+      throw new SnowflakeSQLException(
+          ErrorCode.INVALID_VALUE_CONVERT, obj.getClass().getName(), "TIME", obj);
     }
   }
 
   @Override
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SQLException
-  {
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SQLException {
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj instanceof Timestamp)
-    {
-      return (Timestamp)obj;
-    }
-    else
-    {
-      throw new SnowflakeSQLException(ErrorCode.INVALID_VALUE_CONVERT,
-          obj.getClass().getName(), "TIMESTAMP", obj);
+    if (obj instanceof Timestamp) {
+      return (Timestamp) obj;
+    } else {
+      throw new SnowflakeSQLException(
+          ErrorCode.INVALID_VALUE_CONVERT, obj.getClass().getName(), "TIMESTAMP", obj);
     }
   }
 
   @Override
-  public Date getDate(int columnIndex, TimeZone tz) throws SQLException
-  {
+  public Date getDate(int columnIndex, TimeZone tz) throws SQLException {
     Object obj = getObjectInternal(columnIndex);
 
-    if (obj instanceof Date)
-    {
-      return (Date)obj;
-    }
-    else
-    {
-      throw new SnowflakeSQLException(ErrorCode.INVALID_VALUE_CONVERT,
-          obj.getClass().getName(), "DATE", obj);
+    if (obj instanceof Date) {
+      return (Date) obj;
+    } else {
+      throw new SnowflakeSQLException(
+          ErrorCode.INVALID_VALUE_CONVERT, obj.getClass().getName(), "DATE", obj);
     }
   }
 
   static ResultSet getEmptyResultSet(DBMetadataResultSetMetadata metadataType, Statement statement)
-      throws SQLException
-  {
-    return new SnowflakeDatabaseMetaDataResultSet(metadataType, new Object[][]{}, statement);
+      throws SQLException {
+    return new SnowflakeDatabaseMetaDataResultSet(metadataType, new Object[][] {}, statement);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -4,11 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.common.core.ResourceBundleManager;
-import net.snowflake.client.core.EventHandler;
-import net.snowflake.client.core.EventUtil;
-import net.snowflake.common.core.SqlState;
-
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
@@ -22,40 +17,38 @@ import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
-import java.util.logging.Handler;
 import java.util.logging.FileHandler;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import java.util.regex.Pattern;
-
+import net.snowflake.client.core.EventHandler;
+import net.snowflake.client.core.EventUtil;
 import net.snowflake.client.log.*;
+import net.snowflake.common.core.ResourceBundleManager;
+import net.snowflake.common.core.SqlState;
 
 /**
- * JDBC Driver implementation of Snowflake for production.
- * To use this driver, specify the following URL:
- * jdbc:snowflake://host:port
+ * JDBC Driver implementation of Snowflake for production. To use this driver, specify the following
+ * URL: jdbc:snowflake://host:port
  *
  * @author jhuang
  */
-public class SnowflakeDriver implements Driver
-{
+public class SnowflakeDriver implements Driver {
   public static Handler fileHandler = null;
 
-  static final
-  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeDriver.class);
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeDriver.class);
 
   private static final String JDBC_PROTOCOL = "jdbc:snowflake://";
 
   // pattern for jdbc:snowflake://[host[:port]]/?q1=v1&q2=v2...
   private static final String JDBC_PROTOCOL_REGEX =
-  "jdbc:snowflake://([a-zA-Z_\\-0-9\\.]+(:\\d+)?)?"
-  + "(/?(\\?\\w+=\\w+)?(\\&\\w+=\\w+)*)?";
+      "jdbc:snowflake://([a-zA-Z_\\-0-9\\.]+(:\\d+)?)?" + "(/?(\\?\\w+=\\w+)?(\\&\\w+=\\w+)*)?";
 
   public static SnowflakeDriver INSTANCE = null;
 
-  private static final
-  DriverPropertyInfo[] EMPTY_INFO = new DriverPropertyInfo[0];
+  private static final DriverPropertyInfo[] EMPTY_INFO = new DriverPropertyInfo[0];
 
   public static String implementVersion = null;
 
@@ -65,29 +58,22 @@ public class SnowflakeDriver implements Driver
 
   protected static boolean disableIncidents = false;
 
-  private static final ResourceBundleManager versionResourceBundleManager
-      = ResourceBundleManager.getSingleton("net.snowflake.client.jdbc.version");
+  private static final ResourceBundleManager versionResourceBundleManager =
+      ResourceBundleManager.getSingleton("net.snowflake.client.jdbc.version");
 
-  static
-  {
-    try
-    {
+  static {
+    try {
       DriverManager.registerDriver(INSTANCE = new SnowflakeDriver());
-    }
-    catch (SQLException ex)
-    {
-      throw new IllegalStateException("Unable to register "
-              + SnowflakeDriver.class.getName(), ex);
+    } catch (SQLException ex) {
+      throw new IllegalStateException("Unable to register " + SnowflakeDriver.class.getName(), ex);
     }
 
-    try
-    {
+    try {
       String loggerImpl = System.getProperty("net.snowflake.jdbc.loggerImpl");
       EventUtil.initEventHandlerInstance(1000, 10000);
       EventHandler eventHandler = EventUtil.getEventHandlerInstance();
 
-      if (logger instanceof JDK14Logger)
-      {
+      if (logger instanceof JDK14Logger) {
         eventHandler.setLevel(Level.ALL);
         eventHandler.setFormatter(new SimpleFormatter());
 
@@ -96,8 +82,7 @@ public class SnowflakeDriver implements Driver
 
       // if this system property is not set and logger is still jdk logger, then we are
       // assuming the customer is using the old logging config
-      if (loggerImpl == null && (logger instanceof JDK14Logger))
-      {
+      if (loggerImpl == null && (logger instanceof JDK14Logger)) {
         String defaultLogSizeVal = System.getProperty("snowflake.jdbc.log.size");
         String defaultLogCountVal = System.getProperty("snowflake.jdbc.log.count");
 
@@ -110,21 +95,18 @@ public class SnowflakeDriver implements Driver
         if (defaultLogSizeVal != null) {
           try {
             logSize = Integer.parseInt(defaultLogSizeVal);
-          } catch (Exception ex) {
-            ;
+          } catch (Exception ex) {;
           }
         }
 
         if (defaultLogCountVal != null) {
           try {
             logCount = Integer.parseInt(defaultLogCountVal);
-          } catch (Exception ex) {
-            ;
+          } catch (Exception ex) {;
           }
         }
 
-        fileHandler = new FileHandler("%t/snowflake_jdbc%u.log",
-            logSize, logCount, true);
+        fileHandler = new FileHandler("%t/snowflake_jdbc%u.log", logSize, logCount, true);
 
         String defaultLevelVal = System.getProperty("snowflake.jdbc.log.level");
 
@@ -133,8 +115,7 @@ public class SnowflakeDriver implements Driver
         if (defaultLevelVal != null) {
           defaultLevel = Level.parse(defaultLevelVal.toUpperCase());
 
-          if (defaultLevel == null)
-            defaultLevel = Level.WARNING;
+          if (defaultLevel == null) defaultLevel = Level.WARNING;
         }
 
         fileHandler.setLevel(Level.ALL);
@@ -144,17 +125,15 @@ public class SnowflakeDriver implements Driver
         JDK14Logger.setLevel(defaultLevel);
         JDK14Logger.addHandler(SnowflakeDriver.fileHandler);
 
-        Logger snowflakeLoggerInformaticaV1 = Logger.getLogger(
-            SFFormatter.INFORMATICA_V1_CLASS_NAME_PREFIX);
+        Logger snowflakeLoggerInformaticaV1 =
+            Logger.getLogger(SFFormatter.INFORMATICA_V1_CLASS_NAME_PREFIX);
         snowflakeLoggerInformaticaV1.setLevel(defaultLevel);
         snowflakeLoggerInformaticaV1.addHandler(SnowflakeDriver.fileHandler);
         snowflakeLoggerInformaticaV1.addHandler(eventHandler);
       }
 
       logger.debug("registered driver");
-    }
-    catch (Exception ex)
-    {
+    } catch (Exception ex) {
       System.err.println("Unable to set up logging");
       ex.printStackTrace();
     }
@@ -166,224 +145,179 @@ public class SnowflakeDriver implements Driver
     initializeClientVersionFromManifest();
   }
 
-  static private void initializeClientVersionFromManifest()
-  {
+  private static void initializeClientVersionFromManifest() {
     /*
      * Get JDBC version numbers from version.properties in snowflake-jdbc
      */
-    try
-    {
+    try {
       implementVersion = versionResourceBundleManager.getLocalizedMessage("version");
 
       logger.debug("Snowflake JDBC Version: {}", implementVersion);
 
       // parse implementation version major.minor.change
-      if (implementVersion != null)
-      {
+      if (implementVersion != null) {
         String[] versionBreakdown = implementVersion.split("\\.");
 
-        if (versionBreakdown.length == 3)
-        {
+        if (versionBreakdown.length == 3) {
           majorVersion = Integer.parseInt(versionBreakdown[0]);
           minorVersion = Integer.parseInt(versionBreakdown[1]);
           changeVersion = Long.parseLong(versionBreakdown[2]);
-        }
-        else
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+        } else
+          throw new SnowflakeSQLException(
+              SqlState.INTERNAL_ERROR,
               ErrorCode.INTERNAL_ERROR.getMessageCode(),
               "Invalid Snowflake JDBC Version: " + implementVersion);
-      }
-      else
-      {
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+      } else {
+        throw new SnowflakeSQLException(
+            SqlState.INTERNAL_ERROR,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            "Snowflake JDBC Version is not set. " +
-                "Ensure version.properties is included.");
+            "Snowflake JDBC Version is not set. " + "Ensure version.properties is included.");
       }
-    }
-    catch (Exception ex)
-    {
-      logger.error("Exception encountered when retrieving client "
-          + "version attributes: {}", ex.getMessage());
+    } catch (Exception ex) {
+      logger.error(
+          "Exception encountered when retrieving client " + "version attributes: {}",
+          ex.getMessage());
     }
 
     /*
      * Get the svn revision here.
      */
-    try
-    {
-      if (SnowflakeConnectionV1.class.getProtectionDomain() == null ||
-          SnowflakeConnectionV1.class.getProtectionDomain().getCodeSource()
-          == null ||
-          SnowflakeConnectionV1.class.getProtectionDomain().getCodeSource().
-                  getLocation() == null)
-      {
+    try {
+      if (SnowflakeConnectionV1.class.getProtectionDomain() == null
+          || SnowflakeConnectionV1.class.getProtectionDomain().getCodeSource() == null
+          || SnowflakeConnectionV1.class.getProtectionDomain().getCodeSource().getLocation()
+              == null) {
         logger.debug("Couldn't get code source location");
         return;
       }
 
       URI jarURI =
-              SnowflakeConnectionV1.class.getProtectionDomain().getCodeSource().
-                      getLocation().toURI();
+          SnowflakeConnectionV1.class.getProtectionDomain().getCodeSource().getLocation().toURI();
 
-      logger.debug("jar uri: {}, to_url: {}", jarURI.getPath(),
-                             jarURI.toURL());
+      logger.debug("jar uri: {}, to_url: {}", jarURI.getPath(), jarURI.toURL());
 
       // if code source is not from a jar, there will be no manifest, so skip
       // the svn revision setup
-      if (jarURI == null || jarURI.getPath() == null ||
-          !jarURI.getPath().endsWith(".jar"))
-      {
+      if (jarURI == null || jarURI.getPath() == null || !jarURI.getPath().endsWith(".jar")) {
         logger.debug("couldn't determine code source");
         return;
       }
 
       URL jarURL = jarURI.toURL();
 
-      if (jarURL == null)
-      {
+      if (jarURL == null) {
         logger.debug("null jar URL");
         return;
       }
 
       InputStream is = jarURL.openStream();
 
-      if (is == null)
-      {
-        logger.debug("Can not open snowflake-jdbc.jar: " +
-                               jarURI.getPath());
+      if (is == null) {
+        logger.debug("Can not open snowflake-jdbc.jar: " + jarURI.getPath());
         return;
       }
 
       JarInputStream jarStream = new JarInputStream(is);
       Manifest mf = jarStream.getManifest();
 
-      if (mf == null)
-      {
+      if (mf == null) {
         logger.debug("Manifest not found from snowflake-jdbc.jar");
         return;
       }
 
       Attributes mainAttribs = mf.getMainAttributes();
 
-      if (mainAttribs == null)
-      {
-        logger.debug(
-                  "mainAttribs null from the manifest in snowflake-jdbc.jar");
+      if (mainAttribs == null) {
+        logger.debug("mainAttribs null from the manifest in snowflake-jdbc.jar");
         return;
       }
 
-    }
-    catch (Throwable ex)
-    {
-      logger.debug("Exception encountered when retrieving client "
-                               + "svn revision attribute from manifest: "
-                               + ex.getMessage());
+    } catch (Throwable ex) {
+      logger.debug(
+          "Exception encountered when retrieving client "
+              + "svn revision attribute from manifest: "
+              + ex.getMessage());
     }
   }
 
   /**
    * Checks whether a given url is in a valid format.
    *
-   * The current uri format is: jdbc:snowflake://[host[:port]]
+   * <p>The current uri format is: jdbc:snowflake://[host[:port]]
    *
-   * jdbc:snowflake:// - run in embedded mode jdbc:snowflake://localhost -
-   * connect to localhost default port (8080)
+   * <p>jdbc:snowflake:// - run in embedded mode jdbc:snowflake://localhost - connect to localhost
+   * default port (8080)
    *
-   * jdbc:snowflake://localhost:8080- connect to localhost port 8080
+   * <p>jdbc:snowflake://localhost:8080- connect to localhost port 8080
    *
-   * @param url
-   *   url of the database including host and port
-   * @return
-   *   true if the url is valid
+   * @param url url of the database including host and port
+   * @return true if the url is valid
    * @throws SQLException if failed to accept url
    */
   @Override
-  public boolean acceptsURL(String url) throws SQLException
-  {
-    if (url == null)
-      return false;
+  public boolean acceptsURL(String url) throws SQLException {
+    if (url == null) return false;
 
-    return url.indexOf("/?") > 0?
-           Pattern.matches(JDBC_PROTOCOL_REGEX,
-                           url.substring(0, url.indexOf("/?"))):
-           Pattern.matches(JDBC_PROTOCOL_REGEX, url);
+    return url.indexOf("/?") > 0
+        ? Pattern.matches(JDBC_PROTOCOL_REGEX, url.substring(0, url.indexOf("/?")))
+        : Pattern.matches(JDBC_PROTOCOL_REGEX, url);
   }
 
   /**
    * Connect method
    *
-   * @param url
-   *   jdbc url
-   * @param info
-   *   addition info for passing database/schema names
-   * @return
-   *   connection
+   * @param url jdbc url
+   * @param info addition info for passing database/schema names
+   * @return connection
    * @throws SQLException if failed to create a snowflake connection
    */
   @Override
-  public Connection connect(String url, Properties info) throws SQLException
-  {
-    if (acceptsURL(url))
-    {
+  public Connection connect(String url, Properties info) throws SQLException {
+    if (acceptsURL(url)) {
       return new SnowflakeConnectionV1(url, info);
     }
     return null;
   }
 
   @Override
-  public int getMajorVersion()
-  {
+  public int getMajorVersion() {
     return majorVersion;
   }
 
   @Override
-  public int getMinorVersion()
-  {
+  public int getMinorVersion() {
     return minorVersion;
   }
 
   @Override
-  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info)
-          throws SQLException
-  {
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
     return EMPTY_INFO;
   }
 
   @Override
-  public boolean jdbcCompliant()
-  {
+  public boolean jdbcCompliant() {
     return false;
   }
 
   @Override
-  public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException
-  {
+  public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
     return null;
   }
 
-  public static boolean isDisableIncidents()
-  {
+  public static boolean isDisableIncidents() {
     return disableIncidents;
   }
 
-  public static void setDisableIncidents(
-      boolean throttleIncidents)
-  {
-    if (throttleIncidents)
-      logger.trace("setting throttle incidents");
+  public static void setDisableIncidents(boolean throttleIncidents) {
+    if (throttleIncidents) logger.trace("setting throttle incidents");
 
-    SnowflakeDriver.disableIncidents =
-        throttleIncidents;
+    SnowflakeDriver.disableIncidents = throttleIncidents;
   }
 
-  public final static void main(String[] args)
-  {
-    if (args.length > 0 && "--version".equals(args[0]))
-    {
+  public static final void main(String[] args) {
+    if (args.length > 0 && "--version".equals(args[0])) {
       Package pkg = Package.getPackage("net.snowflake.client.jdbc");
-      if (pkg != null)
-      {
+      if (pkg != null) {
         System.out.println(pkg.getImplementationVersion());
       }
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFixedView.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFixedView.java
@@ -11,8 +11,7 @@ import java.util.List;
  *
  * @author jhuang
  */
-public interface SnowflakeFixedView
-{
+public interface SnowflakeFixedView {
   List<SnowflakeColumnMetadata> describeColumns() throws Exception;
 
   List<Object> getNextRow() throws Exception;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -10,13 +10,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.ParameterBindingDTO;
-import net.snowflake.client.core.ResultUtil;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFStatementMetaData;
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SqlState;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -46,18 +39,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import net.snowflake.client.core.ParameterBindingDTO;
+import net.snowflake.client.core.ResultUtil;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFStatementMetaData;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SqlState;
 
-/**
- *
- * @author jhuang
- */
-final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
-                                         implements PreparedStatement
-{
-  static final SFLogger logger = SFLoggerFactory.getLogger(
-      SnowflakePreparedStatementV1.class);
+/** @author jhuang */
+final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1 implements PreparedStatement {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakePreparedStatementV1.class);
 
   private final String sql;
 
@@ -67,24 +60,17 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   /**
    * map of bind name to bind values for single query execution
    *
-   * Currently, bind name is just value index
+   * <p>Currently, bind name is just value index
    */
   private Map<String, ParameterBindingDTO> parameterBindings = new HashMap<>();
 
-  /**
-   * map of bind values for batch query executions
-   *
-   */
-  private Map<String, ParameterBindingDTO> batchParameterBindings =
-      new HashMap<>();
+  /** map of bind values for batch query executions */
+  private Map<String, ParameterBindingDTO> batchParameterBindings = new HashMap<>();
 
-  /**
-   * Counter for batch size if we are executing a statement with array bind
-   * supported
-   */
+  /** Counter for batch size if we are executing a statement with array bind supported */
   private int batchSize = 0;
 
-  /** Error code returned when describing a statement that is binding table name*/
+  /** Error code returned when describing a statement that is binding table name */
   private static final Integer ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET = 2128;
 
   /** Error code when preparing statement with binding object names */
@@ -93,236 +79,197 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   /** Error code returned when describing a ddl command */
   private static final Integer ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED = 7;
 
-  /** snow-44393 Workaround for compiler cannot prepare to_timestamp(?, 3)*/
+  /** snow-44393 Workaround for compiler cannot prepare to_timestamp(?, 3) */
   private static final Integer ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING = 1026;
 
-  /**
-   * A hash set that contains the error code that will not lead to exception
-   * in describe mode
-   */
-  private static final Set<Integer> errorCodesIgnoredInDescribeMode
-      = new HashSet<>(Arrays.asList(
-       ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET,
-       ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED,
-       ERROR_CODE_OBJECT_BIND_NOT_SET,
-       ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING));
+  /** A hash set that contains the error code that will not lead to exception in describe mode */
+  private static final Set<Integer> errorCodesIgnoredInDescribeMode =
+      new HashSet<>(
+          Arrays.asList(
+              ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET,
+              ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED,
+              ERROR_CODE_OBJECT_BIND_NOT_SET,
+              ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING));
 
   /**
    * Construct SnowflakePreparedStatementV1
+   *
    * @param connection connection object
    * @param sql sql
-   * @param skipParsing true if the applications want to skip parsing
-   *                   to get metadata. false by default.
+   * @param skipParsing true if the applications want to skip parsing to get metadata. false by
+   *     default.
    * @throws SQLException
    */
-  SnowflakePreparedStatementV1(SnowflakeConnectionV1 connection,
-                               String sql, boolean skipParsing) throws SQLException
-  {
+  SnowflakePreparedStatementV1(SnowflakeConnectionV1 connection, String sql, boolean skipParsing)
+      throws SQLException {
     super(connection);
     this.sql = sql;
 
-    if (!skipParsing)
-    {
-      try
-      {
+    if (!skipParsing) {
+      try {
         this.statementMetaData = sfStatement.describe(sql);
-      }
-      catch(SFException e)
-      {
+      } catch (SFException e) {
         throw new SnowflakeSQLException(e);
-      }
-      catch(SnowflakeSQLException e)
-      {
-        if (!errorCodesIgnoredInDescribeMode.contains(e.getErrorCode()))
-        {
+      } catch (SnowflakeSQLException e) {
+        if (!errorCodesIgnoredInDescribeMode.contains(e.getErrorCode())) {
           throw e;
-        }
-        else
-        {
+        } else {
           statementMetaData = SFStatementMetaData.emptyMetaData();
         }
       }
-    }
-    else
-    {
+    } else {
       statementMetaData = SFStatementMetaData.emptyMetaData();
     }
   }
 
   @Override
-  public ResultSet executeQuery() throws SQLException
-  {
+  public ResultSet executeQuery() throws SQLException {
     logger.debug("executeQuery() throws SQLException");
 
     return executeQueryInternal(sql, parameterBindings);
   }
 
   @Override
-  public int executeUpdate() throws SQLException
-  {
-    logger.debug( "executeUpdate() throws SQLException");
+  public int executeUpdate() throws SQLException {
+    logger.debug("executeUpdate() throws SQLException");
 
     return executeUpdateInternal(sql, parameterBindings);
   }
 
   @Override
-  public void setNull(int parameterIndex, int sqlType) throws SQLException
-  {
-    logger.debug(
-        "setNull(int parameterIndex, int sqlType) throws SQLException");
+  public void setNull(int parameterIndex, int sqlType) throws SQLException {
+    logger.debug("setNull(int parameterIndex, int sqlType) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-                        SnowflakeUtil.javaTypeToSFTypeString(sqlType), null);
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(sqlType), null);
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBoolean(int parameterIndex, boolean x) throws SQLException
-  {
-    logger.debug(
-               "setBoolean(int parameterIndex, boolean x) throws SQLException");
+  public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+    logger.debug("setBoolean(int parameterIndex, boolean x) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setByte(int parameterIndex, byte x) throws SQLException
-  {
+  public void setByte(int parameterIndex, byte x) throws SQLException {
     throw new UnsupportedOperationException(
         "setByte(int parameterIndex, byte x) Not supported yet.");
   }
 
   @Override
-  public void setShort(int parameterIndex, short x) throws SQLException
-  {
-    logger.debug(
-        "setShort(int parameterIndex, short x) throws SQLException");
+  public void setShort(int parameterIndex, short x) throws SQLException {
+    logger.debug("setShort(int parameterIndex, short x) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
-        .javaTypeToSFTypeString(Types.SMALLINT), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.SMALLINT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setInt(int parameterIndex, int x) throws SQLException
-  {
-    logger.debug(
-        "setInt(int parameterIndex, int x) throws SQLException");
+  public void setInt(int parameterIndex, int x) throws SQLException {
+    logger.debug("setInt(int parameterIndex, int x) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
-                  .javaTypeToSFTypeString(Types.INTEGER), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.INTEGER), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setLong(int parameterIndex, long x) throws SQLException
-  {
-    logger.debug(
-        "setLong(int parameterIndex, long x) throws SQLException");
+  public void setLong(int parameterIndex, long x) throws SQLException {
+    logger.debug("setLong(int parameterIndex, long x) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-         SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setFloat(int parameterIndex, float x) throws SQLException
-  {
-    logger.debug(
-        "setFloat(int parameterIndex, float x) throws SQLException");
+  public void setFloat(int parameterIndex, float x) throws SQLException {
+    logger.debug("setFloat(int parameterIndex, float x) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setDouble(int parameterIndex, double x) throws SQLException
-  {
-    logger.debug(
-        "setDouble(int parameterIndex, double x) throws SQLException");
+  public void setDouble(int parameterIndex, double x) throws SQLException {
+    logger.debug("setDouble(int parameterIndex, double x) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException
-  {
-    logger.debug(
-        "setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException");
+  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+    logger.debug("setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException");
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, Types.DECIMAL);
-    }
-    else
-    {
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL), String.valueOf(x));
+    } else {
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL), String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setString(int parameterIndex, String x) throws SQLException
-  {
-    logger.debug(
-        "setString(int parameterIndex, String x) throws SQLException");
+  public void setString(int parameterIndex, String x) throws SQLException {
+    logger.debug("setString(int parameterIndex, String x) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR), x);
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR), x);
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBytes(int parameterIndex, byte[] x) throws SQLException
-  {
-    logger.debug(
-        "setBytes(int parameterIndex, byte[] x) throws SQLException");
+  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+    logger.debug("setBytes(int parameterIndex, byte[] x) throws SQLException");
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
-        .javaTypeToSFTypeString(Types.BINARY), new SFBinary(x).toHex());
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BINARY), new SFBinary(x).toHex());
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x) throws SQLException
-  {
-    logger.debug(
-        "setDate(int parameterIndex, Date x) throws SQLException");
+  public void setDate(int parameterIndex, Date x) throws SQLException {
+    logger.debug("setDate(int parameterIndex, Date x) throws SQLException");
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, Types.DATE);
-    }
-    else
-    {
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-          SnowflakeUtil.javaTypeToSFTypeString(Types.DATE),
-          String.valueOf(x.getTime() +
-          TimeZone.getDefault().getOffset(x.getTime())-
-          ResultUtil.msDiffJulianToGregorian(x)));
+    } else {
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(Types.DATE),
+              String.valueOf(
+                  x.getTime()
+                      + TimeZone.getDefault().getOffset(x.getTime())
+                      - ResultUtil.msDiffJulianToGregorian(x)));
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x) throws SQLException
-  {
-    logger.debug(
-        "setTime(int parameterIndex, Time x) throws SQLException");
+  public void setTime(int parameterIndex, Time x) throws SQLException {
+    logger.debug("setTime(int parameterIndex, Time x) throws SQLException");
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, Types.TIME);
-    }
-    else
-    {
+    } else {
       // Convert to nanoseconds since midnight using the input time mod 24 hours.
       final long MS_IN_DAY = 86400 * 1000;
       long msSinceEpoch = x.getTime();
@@ -331,9 +278,9 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       long msSinceMidnight = (msSinceEpoch % MS_IN_DAY + MS_IN_DAY) % MS_IN_DAY;
       long nanosSinceMidnight = msSinceMidnight * 1000 * 1000;
 
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-                      SnowflakeUtil.javaTypeToSFTypeString(Types.TIME),
-                      String.valueOf(nanosSinceMidnight));
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(Types.TIME), String.valueOf(nanosSinceMidnight));
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
       sfStatement.setHasUnsupportedStageBind(true);
@@ -341,21 +288,21 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException
-  {
-    logger.debug(
-        "setTimestamp(int parameterIndex, Timestamp x) throws SQLException");
+  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+    logger.debug("setTimestamp(int parameterIndex, Timestamp x) throws SQLException");
 
     // convert the timestamp from being in local time zone to be in UTC timezone
-    String value =  x == null ? null :
-        String.valueOf(
-        BigDecimal.valueOf((x.getTime() - ResultUtil.msDiffJulianToGregorian(x))/1000).
-        scaleByPowerOfTen(9).add(BigDecimal.valueOf(x.getNanos())));
+    String value =
+        x == null
+            ? null
+            : String.valueOf(
+                BigDecimal.valueOf((x.getTime() - ResultUtil.msDiffJulianToGregorian(x)) / 1000)
+                    .scaleByPowerOfTen(9)
+                    .add(BigDecimal.valueOf(x.getNanos())));
 
     SnowflakeType sfType = SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP);
 
-    if (sfType == SnowflakeType.TIMESTAMP)
-    {
+    if (sfType == SnowflakeType.TIMESTAMP) {
       sfType = connection.getSfSession().getTimestampMappedType();
     }
 
@@ -364,188 +311,129 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, int length)
-          throws SQLException
-  {
+  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
     throw new UnsupportedOperationException(
         "setAsciiStream(int parameterIndex, InputStream x, int length) Not supported yet.");
   }
 
   @Override
   @Deprecated
-  public void setUnicodeStream(int parameterIndex, InputStream x, int length)
-          throws SQLException
-  {
+  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
     throw new UnsupportedOperationException(
         "setUnicodeStream(int parameterIndex, InputStream x, int length) Not supported yet.");
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, int length)
-          throws SQLException
-  {
+  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
     throw new UnsupportedOperationException(
         "setBinaryStream(int parameterIndex, InputStream x, int length) Not supported yet.");
   }
 
   @Override
-  public void clearParameters() throws SQLException
-  {
+  public void clearParameters() throws SQLException {
     parameterBindings.clear();
-    if (batchParameterBindings.isEmpty())
-    {
+    if (batchParameterBindings.isEmpty()) {
       sfStatement.setHasUnsupportedStageBind(false);
     }
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException
-  {
-    logger.debug(
-        "setObject(int parameterIndex, Object x, int targetSqlType)");
+  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    logger.debug("setObject(int parameterIndex, Object x, int targetSqlType)");
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, targetSqlType);
-    }
-    else if (targetSqlType == Types.DATE)
-    {
+    } else if (targetSqlType == Types.DATE) {
       setDate(parameterIndex, (Date) x);
-    }
-    else if (targetSqlType == Types.TIME)
-    {
+    } else if (targetSqlType == Types.TIME) {
       setTime(parameterIndex, (Time) x);
-    }
-    else if (targetSqlType == Types.TIMESTAMP)
-    {
+    } else if (targetSqlType == Types.TIMESTAMP) {
       setTimestamp(parameterIndex, (Timestamp) x);
-    }
-    else
-    {
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-                        SnowflakeUtil.javaTypeToSFTypeString(targetSqlType),
-                        String.valueOf(x));
+    } else {
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(targetSqlType), String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x) throws SQLException
-  {
-    if (x == null)
-    {
+  public void setObject(int parameterIndex, Object x) throws SQLException {
+    if (x == null) {
       setNull(parameterIndex, Types.NULL);
-    }
-    else if (x instanceof String)
-    {
+    } else if (x instanceof String) {
       setString(parameterIndex, (String) x);
-    }
-    else if (x instanceof BigDecimal)
-    {
+    } else if (x instanceof BigDecimal) {
       setBigDecimal(parameterIndex, (BigDecimal) x);
-    }
-    else if (x instanceof Short)
-    {
-      setShort(parameterIndex, (Short)x);
-    }
-    else if (x instanceof Integer)
-    {
+    } else if (x instanceof Short) {
+      setShort(parameterIndex, (Short) x);
+    } else if (x instanceof Integer) {
       setInt(parameterIndex, (Integer) x);
-    }
-    else if (x instanceof Long)
-    {
+    } else if (x instanceof Long) {
       setLong(parameterIndex, (Long) x);
-    }
-    else if (x instanceof Float)
-    {
+    } else if (x instanceof Float) {
       setFloat(parameterIndex, (Float) x);
-    }
-    else if (x instanceof Double)
-    {
+    } else if (x instanceof Double) {
       setDouble(parameterIndex, (Double) x);
-    }
-    else if (x instanceof Date)
-    {
+    } else if (x instanceof Date) {
       setDate(parameterIndex, (Date) x);
-    }
-    else if (x instanceof Time)
-    {
+    } else if (x instanceof Time) {
       setTime(parameterIndex, (Time) x);
-    }
-    else if (x instanceof Timestamp)
-    {
+    } else if (x instanceof Timestamp) {
       setTimestamp(parameterIndex, (Timestamp) x);
-    }
-    else if (x instanceof Boolean)
-    {
-      setBoolean(parameterIndex, (Boolean)x);
-    }
-    else
-    {
-      throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+    } else if (x instanceof Boolean) {
+      setBoolean(parameterIndex, (Boolean) x);
+    } else {
+      throw new SnowflakeSQLException(
+          SqlState.FEATURE_NOT_SUPPORTED,
           ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
           "Object type: " + x.getClass());
     }
   }
 
   @Override
-  public boolean execute() throws SQLException
-  {
-    logger.debug( "execute: {}", sql);
+  public boolean execute() throws SQLException {
+    logger.debug("execute: {}", sql);
 
     return executeInternal(sql, parameterBindings);
   }
 
   @Override
-  public void addBatch() throws SQLException
-  {
-    logger.debug( "addBatch() throws SQLException");
+  public void addBatch() throws SQLException {
+    logger.debug("addBatch() throws SQLException");
 
-    if (isClosed())
-    {
+    if (isClosed()) {
       throw new SnowflakeSQLException(ErrorCode.STATEMENT_CLOSED);
     }
 
-    if (statementMetaData.isArrayBindSupported())
-    {
-      for(Map.Entry<String, ParameterBindingDTO> binding :
-          parameterBindings.entrySet())
-      {
+    if (statementMetaData.isArrayBindSupported()) {
+      for (Map.Entry<String, ParameterBindingDTO> binding : parameterBindings.entrySet()) {
         // get the entry for the bind variable in the batch binding map
-        ParameterBindingDTO bindingValueAndType =
-            batchParameterBindings.get(binding.getKey());
+        ParameterBindingDTO bindingValueAndType = batchParameterBindings.get(binding.getKey());
 
         List<String> values;
 
         // create binding value and type for the first time
-        if (bindingValueAndType == null)
-        {
+        if (bindingValueAndType == null) {
           // create the value list
           values = new ArrayList<String>();
 
-          bindingValueAndType = new ParameterBindingDTO(
-              binding.getValue().getType(), values);
+          bindingValueAndType = new ParameterBindingDTO(binding.getValue().getType(), values);
 
           // put the new map into the batch
-          batchParameterBindings.put(binding.getKey(),
-              bindingValueAndType);
-        }
-        else
-        {
+          batchParameterBindings.put(binding.getKey(), bindingValueAndType);
+        } else {
           // make sure type matches except for null values
           String prevType = bindingValueAndType.getType();
           String newType = binding.getValue().getType();
 
           // if previous type is null, replace it with new type
-          if (SnowflakeType.ANY.name().equalsIgnoreCase(prevType) &&
-              !SnowflakeType.ANY.name().equalsIgnoreCase(newType))
-          {
+          if (SnowflakeType.ANY.name().equalsIgnoreCase(prevType)
+              && !SnowflakeType.ANY.name().equalsIgnoreCase(newType)) {
             bindingValueAndType.setType(newType);
-          }
-          else if (binding.getValue().getValue() != null &&
-              !prevType.equalsIgnoreCase(newType))
-          {
-            throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+          } else if (binding.getValue().getValue() != null && !prevType.equalsIgnoreCase(newType)) {
+            throw new SnowflakeSQLException(
+                SqlState.FEATURE_NOT_SUPPORTED,
                 ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
                 SnowflakeType.getJavaType(SnowflakeType.fromString(prevType)).name(),
                 SnowflakeType.getJavaType(SnowflakeType.fromString(newType)).name());
@@ -556,12 +444,10 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
         }
 
         // add the value to the list of values in batch binding map
-        values.add((String)binding.getValue().getValue());
+        values.add((String) binding.getValue().getValue());
       }
       batchSize++;
-    }
-    else
-    {
+    } else {
       batch.add(new BatchEntry(this.sql, parameterBindings));
       parameterBindings = new HashMap<>();
     }
@@ -569,101 +455,82 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, int length)
-          throws SQLException
-  {
+      throws SQLException {
     throw new UnsupportedOperationException(
         "setCharacterStream(int parameterIndex, Reader reader, int length) Not supported yet.");
   }
 
   @Override
-  public void setRef(int parameterIndex, Ref x) throws SQLException
-  {
-    throw new UnsupportedOperationException(
-        "setRef(int parameterIndex, Ref x) Not supported yet.");
+  public void setRef(int parameterIndex, Ref x) throws SQLException {
+    throw new UnsupportedOperationException("setRef(int parameterIndex, Ref x) Not supported yet.");
   }
 
   @Override
-  public void setBlob(int parameterIndex, Blob x) throws SQLException
-  {
+  public void setBlob(int parameterIndex, Blob x) throws SQLException {
     throw new UnsupportedOperationException(
         "setBlob(int parameterIndex, Blob x) Not supported yet.");
   }
 
   @Override
-  public void setClob(int parameterIndex, Clob x) throws SQLException
-  {
+  public void setClob(int parameterIndex, Clob x) throws SQLException {
     setString(parameterIndex, x.toString());
   }
 
   @Override
-  public void setArray(int parameterIndex, Array x) throws SQLException
-  {
+  public void setArray(int parameterIndex, Array x) throws SQLException {
     throw new UnsupportedOperationException(
         "setArray(int parameterIndex, Array x) Not supported yet.");
   }
 
   @Override
-  public ResultSetMetaData getMetaData() throws SQLException
-  {
-    logger.debug( "getMetaData() throws SQLException");
+  public ResultSetMetaData getMetaData() throws SQLException {
+    logger.debug("getMetaData() throws SQLException");
 
-    return new SnowflakeResultSetMetaDataV1(
-        this.statementMetaData.getResultSetMetaData());
+    return new SnowflakeResultSetMetaDataV1(this.statementMetaData.getResultSetMetaData());
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x, Calendar cal)
-      throws SQLException
-  {
-    logger.debug( "setDate(int parameterIndex, Date x, Calendar cal)");
+  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+    logger.debug("setDate(int parameterIndex, Date x, Calendar cal)");
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, Types.DATE);
-    }
-    else
-    {
+    } else {
       // convert the date from to be in local time zone to be in UTC
-      String value = String.valueOf(x.getTime() +
-                             cal.getTimeZone().getOffset(x.getTime()));
+      String value = String.valueOf(x.getTime() + cal.getTimeZone().getOffset(x.getTime()));
 
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-          SnowflakeUtil.javaTypeToSFTypeString(Types.DATE), value);
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(Types.DATE), value);
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x, Calendar cal)
-      throws SQLException
-  {
-    logger.debug( "setTime(int parameterIndex, Time x, Calendar cal)");
+  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+    logger.debug("setTime(int parameterIndex, Time x, Calendar cal)");
     setTime(parameterIndex, x);
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal)
-      throws SQLException
-  {
-    logger.debug( "setTimestamp(int parameterIndex, Timestamp x, Calendar cal)");
+  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+    logger.debug("setTimestamp(int parameterIndex, Timestamp x, Calendar cal)");
 
     // convert the time from being in UTC to be in local time zone
     String value = null;
-    if (x != null)
-    {
+    if (x != null) {
       long milliSecSinceEpoch = x.getTime();
-      milliSecSinceEpoch = milliSecSinceEpoch +
-          cal.getTimeZone().getOffset(milliSecSinceEpoch);
+      milliSecSinceEpoch = milliSecSinceEpoch + cal.getTimeZone().getOffset(milliSecSinceEpoch);
 
-      value = String.valueOf(
-          BigDecimal.valueOf(milliSecSinceEpoch / 1000).
-              scaleByPowerOfTen(9).add(BigDecimal.valueOf(x.getNanos())));
+      value =
+          String.valueOf(
+              BigDecimal.valueOf(milliSecSinceEpoch / 1000)
+                  .scaleByPowerOfTen(9)
+                  .add(BigDecimal.valueOf(x.getNanos())));
     }
 
     SnowflakeType sfType = SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP);
 
-    if (sfType == SnowflakeType.TIMESTAMP)
-    {
+    if (sfType == SnowflakeType.TIMESTAMP) {
       sfType = connection.getSfSession().getTimestampMappedType();
     }
 
@@ -672,232 +539,185 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setNull(int parameterIndex, int sqlType, String typeName)
-      throws SQLException
-  {
-    logger.debug( "setNull(int parameterIndex, int sqlType, String typeName)");
+  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+    logger.debug("setNull(int parameterIndex, int sqlType, String typeName)");
 
     setNull(parameterIndex, sqlType);
   }
 
   @Override
-  public void setURL(int parameterIndex, URL x) throws SQLException
-  {
-    throw new UnsupportedOperationException(
-        "setURL(int parameterIndex, URL x) Not supported yet.");
+  public void setURL(int parameterIndex, URL x) throws SQLException {
+    throw new UnsupportedOperationException("setURL(int parameterIndex, URL x) Not supported yet.");
   }
 
   @Override
-  public ParameterMetaData getParameterMetaData() throws SQLException
-  {
-    throw new UnsupportedOperationException(
-        "getParameterMetaData() Not supported yet.");
+  public ParameterMetaData getParameterMetaData() throws SQLException {
+    throw new UnsupportedOperationException("getParameterMetaData() Not supported yet.");
   }
 
   @Override
-  public void setRowId(int parameterIndex, RowId x) throws SQLException
-  {
+  public void setRowId(int parameterIndex, RowId x) throws SQLException {
     throw new UnsupportedOperationException(
         "setRowId(int parameterIndex, RowId x) Not supported yet.");
   }
 
   @Override
-  public void setNString(int parameterIndex, String value) throws SQLException
-  {
+  public void setNString(int parameterIndex, String value) throws SQLException {
     throw new UnsupportedOperationException(
         "setNString(int parameterIndex, String value) Not supported yet.");
   }
 
   @Override
   public void setNCharacterStream(int parameterIndex, Reader value, long length)
-          throws SQLException
-  {
+      throws SQLException {
     throw new UnsupportedOperationException(
         "setNCharacterStream(int parameterIndex, Reader value, long length) Not supported yet.");
   }
 
   @Override
-  public void setNClob(int parameterIndex, NClob value) throws SQLException
-  {
+  public void setNClob(int parameterIndex, NClob value) throws SQLException {
     throw new UnsupportedOperationException(
         "setNClob(int parameterIndex, NClob value) Not supported yet.");
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader, long length)
-      throws SQLException
-  {
+  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
     throw new UnsupportedOperationException(
         "setClob(int parameterIndex, Reader reader, long length) Not supported yet.");
   }
 
   @Override
   public void setBlob(int parameterIndex, InputStream inputStream, long length)
-          throws SQLException
-  {
+      throws SQLException {
     throw new UnsupportedOperationException(
         "setBlob(int parameterIndex, InputStream inputStream, long length) Not supported yet.");
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader, long length)
-      throws SQLException
-  {
+  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
     throw new UnsupportedOperationException(
         "setNClob(int parameterIndex, Reader reader, long length) Not supported yet.");
   }
 
   @Override
-  public void setSQLXML(int parameterIndex, SQLXML xmlObject)
-      throws SQLException
-  {
+  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
     throw new UnsupportedOperationException(
         "setSQLXML(int parameterIndex, SQLXML xmlObject) Not supported yet.");
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType,
-                        int scaleOrLength) throws SQLException
-  {
-    logger.debug(
-        "setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)");
+  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+      throws SQLException {
+    logger.debug("setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)");
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, targetSqlType);
-    }
-    else if (targetSqlType == Types.DECIMAL ||
-        targetSqlType == Types.NUMERIC)
-    {
+    } else if (targetSqlType == Types.DECIMAL || targetSqlType == Types.NUMERIC) {
       BigDecimal decimalObj = new BigDecimal(String.valueOf(x));
       decimalObj.setScale(scaleOrLength);
       setBigDecimal(parameterIndex, decimalObj);
-    }
-    else
-    {
+    } else {
       setObject(parameterIndex, x, targetSqlType);
     }
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, long length)
-          throws SQLException
-  {
+  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
     throw new UnsupportedOperationException(
         "setAsciiStream(int parameterIndex, InputStream x, long length) Not supported yet.");
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, long length)
-          throws SQLException
-  {
+  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
     throw new UnsupportedOperationException(
         "setBinaryStream(int parameterIndex, InputStream x, long length) Not supported yet.");
   }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, long length)
-          throws SQLException
-  {
+      throws SQLException {
     throw new UnsupportedOperationException(
         "setCharacterStream(int parameterIndex, Reader reader, long length) Not supported yet.");
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x)
-      throws SQLException
-  {
+  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
     throw new UnsupportedOperationException(
         "setAsciiStream(int parameterIndex, InputStream x) Not supported yet.");
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x)
-      throws SQLException
-  {
+  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
     throw new UnsupportedOperationException(
         "setBinaryStream(int parameterIndex, InputStream x) Not supported yet.");
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader)
-      throws SQLException
-  {
+  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
     throw new UnsupportedOperationException(
         "setCharacterStream(int parameterIndex, Reader reader) Not supported yet.");
   }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value)
-      throws SQLException
-  {
+  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
     throw new UnsupportedOperationException(
         "setNCharacterStream(int parameterIndex, Reader value) Not supported yet.");
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader) throws SQLException
-  {
+  public void setClob(int parameterIndex, Reader reader) throws SQLException {
     throw new UnsupportedOperationException(
         "setClob(int parameterIndex, Reader reader) Not supported yet.");
   }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream)
-      throws SQLException
-  {
+  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
     throw new UnsupportedOperationException(
         "setBlob(int parameterIndex, InputStream inputStream) Not supported yet.");
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader) throws SQLException
-  {
+  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
     throw new UnsupportedOperationException(
         "setNClob(int parameterIndex, Reader reader) Not supported yet.");
   }
 
   @Override
-  public ResultSet executeQuery(String sql) throws SQLException
-  {
-    logger.debug( "executeQuery(String sql) throws SQLException");
+  public ResultSet executeQuery(String sql) throws SQLException {
+    logger.debug("executeQuery(String sql) throws SQLException");
 
-    throw new SnowflakeSQLException(ErrorCode.
-        UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+    throw new SnowflakeSQLException(
+        ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
         sql.length() > 20 ? sql.substring(0, 20) + "..." : sql);
   }
 
   @Override
-  public int executeUpdate(String sql) throws SQLException
-  {
-    logger.debug( "executeUpdate(String sql) throws SQLException");
+  public int executeUpdate(String sql) throws SQLException {
+    logger.debug("executeUpdate(String sql) throws SQLException");
 
-    throw new SnowflakeSQLException(ErrorCode.
-        UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+    throw new SnowflakeSQLException(
+        ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
         sql.length() > 20 ? sql.substring(0, 20) + "..." : sql);
   }
 
   @Override
-  public boolean execute(String sql) throws SQLException
-  {
-    logger.debug( "execute(String sql) throws SQLException");
+  public boolean execute(String sql) throws SQLException {
+    logger.debug("execute(String sql) throws SQLException");
 
-    throw new SnowflakeSQLException(ErrorCode.
-        UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+    throw new SnowflakeSQLException(
+        ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
         sql.length() > 20 ? sql.substring(0, 20) + "..." : sql);
   }
 
   @Override
-  public void addBatch(String sql) throws SQLException
-  {
-    throw new SnowflakeSQLException(ErrorCode.
-        UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+  public void addBatch(String sql) throws SQLException {
+    throw new SnowflakeSQLException(
+        ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
         sql.length() > 20 ? sql.substring(0, 20) + "..." : sql);
   }
 
   @Override
-  public void clearBatch() throws SQLException
-  {
+  public void clearBatch() throws SQLException {
     super.clearBatch();
     batchParameterBindings.clear();
     batchSize = 0;
@@ -905,45 +725,32 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public int[] executeBatch() throws SQLException
-  {
-    logger.debug( "executeBatch() throws SQLException");
+  public int[] executeBatch() throws SQLException {
+    logger.debug("executeBatch() throws SQLException");
 
-    if (this.statementMetaData.getStatementType().isGenerateResultSet())
-    {
-      throw new SnowflakeSQLException(ErrorCode.
-          UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+    if (this.statementMetaData.getStatementType().isGenerateResultSet()) {
+      throw new SnowflakeSQLException(
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
           sql.length() > 20 ? sql.substring(0, 20) + "..." : sql);
     }
 
     int[] updateCounts = null;
-    try
-    {
-      if (this.statementMetaData.isArrayBindSupported())
-      {
-        int updateCount = executeUpdateInternal(
-                              this.sql, batchParameterBindings);
+    try {
+      if (this.statementMetaData.isArrayBindSupported()) {
+        int updateCount = executeUpdateInternal(this.sql, batchParameterBindings);
 
         // when update count is the same as the number of bindings in the batch,
         // expand the update count into an array (SNOW-14034)
-        if (updateCount == batchSize)
-        {
+        if (updateCount == batchSize) {
           updateCounts = new int[updateCount];
-          for (int idx = 0; idx < updateCount; idx++)
-            updateCounts[idx] = 1;
+          for (int idx = 0; idx < updateCount; idx++) updateCounts[idx] = 1;
+        } else {
+          updateCounts = new int[] {updateCount};
         }
-        else
-        {
-          updateCounts = new int[]{updateCount};
-        }
-      }
-      else
-      {
+      } else {
         updateCounts = executeBatchInternal();
       }
-    }
-    finally
-    {
+    } finally {
       this.clearBatch();
     }
 
@@ -951,51 +758,43 @@ final class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public int executeUpdate(String sql, int autoGeneratedKeys)
-      throws SQLException
-  {
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
     throw new UnsupportedOperationException(
         "executeUpdate(String sql, int autoGeneratedKeys) Not supported yet.");
   }
 
   @Override
-  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException
-  {
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
     throw new UnsupportedOperationException(
         "executeUpdate(String sql, int[] columnIndexes) Not supported yet.");
   }
 
   @Override
-  public int executeUpdate(String sql, String[] columnNames) throws SQLException
-  {
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
     throw new UnsupportedOperationException(
         "executeUpdate(String sql, String[] columnNames) Not supported yet.");
   }
 
   @Override
-  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException
-  {
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
     throw new UnsupportedOperationException(
         "execute(String sql, int autoGeneratedKeys) Not supported yet.");
   }
 
   @Override
-  public boolean execute(String sql, int[] columnIndexes) throws SQLException
-  {
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
     throw new UnsupportedOperationException(
         "execute(String sql, int[] columnIndexes) Not supported yet.");
   }
 
   @Override
-  public boolean execute(String sql, String[] columnNames) throws SQLException
-  {
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
     throw new UnsupportedOperationException(
         "execute(String sql, String[] columnNames) Not supported yet.");
   }
 
   // For testing use only
-  Map<String, ParameterBindingDTO> getBatchParameterBindings()
-  {
+  Map<String, ParameterBindingDTO> getBatchParameterBindings() {
     return batchParameterBindings;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeReauthenticationRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeReauthenticationRequest.java
@@ -3,16 +3,10 @@
  */
 package net.snowflake.client.jdbc;
 
-/**
- * SnowflakeReauthenticationRequest signals the reauthentication used for SSO
- */
-public class SnowflakeReauthenticationRequest extends SnowflakeSQLException
-{
-  public SnowflakeReauthenticationRequest(String queryId,
-                                          String reason,
-                                          String sqlState,
-                                          int vendorCode)
-  {
+/** SnowflakeReauthenticationRequest signals the reauthentication used for SSO */
+public class SnowflakeReauthenticationRequest extends SnowflakeSQLException {
+  public SnowflakeReauthenticationRequest(
+      String queryId, String reason, String sqlState, int vendorCode) {
     super(queryId, reason, sqlState, vendorCode);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultChunk.java
@@ -5,26 +5,23 @@
 package net.snowflake.client.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.common.core.SqlState;
-
 import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import net.snowflake.common.core.SqlState;
 
 /**
  * Class for result chunk
  *
- * Created by jhuang on 11/12/14.
+ * <p>Created by jhuang on 11/12/14.
  */
-public class SnowflakeResultChunk
-{
+public class SnowflakeResultChunk {
   private static final int NULL_VALUE = Integer.MIN_VALUE;
 
-  public enum DownloadState
-  {
+  public enum DownloadState {
     NOT_STARTED,
     IN_PROGRESS,
     SUCCESS,
@@ -67,27 +64,20 @@ public class SnowflakeResultChunk
 
   private int currentRow;
 
-  public SnowflakeResultChunk(String url, int rowCount, int colCount,
-                              int uncompressedSize, boolean efficientStorage)
-  {
+  public SnowflakeResultChunk(
+      String url, int rowCount, int colCount, int uncompressedSize, boolean efficientStorage) {
     this.url = url;
     this.rowCount = rowCount;
     this.colCount = colCount;
     this.uncompressedSize = uncompressedSize;
-    if (efficientStorage)
-    {
-      data = new BlockResultChunkData(computeCharactersNeeded(),
-                                      rowCount * colCount);
-    }
-    else
-    {
-      data = new LegacyResultChunkData(computeCharactersNeeded(),
-                                       rowCount * colCount);
+    if (efficientStorage) {
+      data = new BlockResultChunkData(computeCharactersNeeded(), rowCount * colCount);
+    } else {
+      data = new LegacyResultChunkData(computeCharactersNeeded(), rowCount * colCount);
     }
   }
 
-  public void tryReuse(ResultChunkDataCache cache)
-  {
+  public void tryReuse(ResultChunkDataCache cache) {
     // Allocate chunk data, double necessary amount for later reuse
     cache.reuseOrCreateResultData(data);
   }
@@ -98,27 +88,20 @@ public class SnowflakeResultChunk
    * @param resultData result data in JSON form
    */
   @Deprecated
-  public void setResultData(JsonNode resultData)
-  {
+  public void setResultData(JsonNode resultData) {
     this.resultData = resultData;
   }
 
-  public static Object extractCell(JsonNode resultData, int rowIdx, int colIdx)
-  {
+  public static Object extractCell(JsonNode resultData, int rowIdx, int colIdx) {
     JsonNode currentRow = resultData.get(rowIdx);
 
     JsonNode colNode = currentRow.get(colIdx);
 
-    if (colNode.isTextual())
-    {
+    if (colNode.isTextual()) {
       return colNode.asText();
-    }
-    else if (colNode.isNumber())
-    {
+    } else if (colNode.isNumber()) {
       return colNode.numberValue();
-    }
-    else if (colNode.isNull())
-    {
+    } else if (colNode.isNull()) {
       return null;
     }
     throw new RuntimeException("Unknow json type");
@@ -131,62 +114,42 @@ public class SnowflakeResultChunk
    * @param colIdx zero based column
    * @return String
    */
-  public final Object getCell(int rowIdx, int colIdx)
-  {
-    if (resultData != null)
-    {
+  public final Object getCell(int rowIdx, int colIdx) {
+    if (resultData != null) {
       return extractCell(resultData, rowIdx, colIdx);
     }
     return data.get(colCount * rowIdx + colIdx);
   }
 
-  public final String getUrl()
-  {
+  public final String getUrl() {
     return url;
   }
 
-  public final int getRowCount()
-  {
+  public final int getRowCount() {
     return rowCount;
   }
 
-  public final int getUncompressedSize()
-  {
+  public final int getUncompressedSize() {
     return uncompressedSize;
   }
 
-  public final void addRow(Object[] row) throws SnowflakeSQLException
-  {
-    if (row.length != colCount)
-    {
+  public final void addRow(Object[] row) throws SnowflakeSQLException {
+    if (row.length != colCount) {
       throw new SnowflakeSQLException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR
-              .getMessageCode(),
-          "Exception: expected " +
-              colCount +
-              " columns and received " +
-              row.length);
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Exception: expected " + colCount + " columns and received " + row.length);
     }
 
-    for (Object cell : row)
-    {
-      if (cell == null)
-      {
+    for (Object cell : row) {
+      if (cell == null) {
         data.add(null);
-      }
-      else
-      {
-        if (cell instanceof String)
-        {
+      } else {
+        if (cell instanceof String) {
           data.add((String) cell);
-        }
-        else if (cell instanceof Boolean)
-        {
-          data.add((boolean)cell ? "1" : "0");
-        }
-        else
-        {
+        } else if (cell instanceof Boolean) {
+          data.add((boolean) cell ? "1" : "0");
+        } else {
           throw new SnowflakeSQLException(
               SqlState.INTERNAL_ERROR,
               ErrorCode.INTERNAL_ERROR.getMessageCode(),
@@ -202,20 +165,13 @@ public class SnowflakeResultChunk
    *
    * @throws SnowflakeSQLException when rows are not all downloaded
    */
-  public final void ensureRowsComplete() throws SnowflakeSQLException
-  {
+  public final void ensureRowsComplete() throws SnowflakeSQLException {
     // Check that all the rows have been decoded, raise an error if not
-    if (rowCount != currentRow)
-    {
-      throw
-          new SnowflakeSQLException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR
-                  .getMessageCode(),
-              "Exception: expected " +
-                  rowCount +
-                  " rows and received " +
-                  currentRow);
+    if (rowCount != currentRow) {
+      throw new SnowflakeSQLException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Exception: expected " + rowCount + " rows and received " + currentRow);
     }
   }
 
@@ -224,77 +180,62 @@ public class SnowflakeResultChunk
    *
    * @return necessary memory in bytes
    */
-  public final long computeNeededChunkMemory()
-  {
+  public final long computeNeededChunkMemory() {
     return data.computeNeededChunkMemory();
   }
 
-  public final void freeData()
-  {
-    if (data != null)
-    {
-     data.freeData();
+  public final void freeData() {
+    if (data != null) {
+      data.freeData();
     }
     resultData = null;
   }
 
-  public final int getColCount()
-  {
+  public final int getColCount() {
     return this.colCount;
   }
 
-  public long getDownloadTime()
-  {
+  public long getDownloadTime() {
     return downloadTime;
   }
 
-  public void setDownloadTime(long downloadTime)
-  {
+  public void setDownloadTime(long downloadTime) {
     this.downloadTime = downloadTime;
   }
 
-  public long getParseTime()
-  {
+  public long getParseTime() {
     return parseTime;
   }
 
-  public void setParseTime(long parseTime)
-  {
+  public void setParseTime(long parseTime) {
     this.parseTime = parseTime;
   }
 
-  public ReentrantLock getLock()
-  {
+  public ReentrantLock getLock() {
     return lock;
   }
 
-  public Condition getDownloadCondition()
-  {
+  public Condition getDownloadCondition() {
     return downloadCondition;
   }
 
-  public String getDownloadError()
-  {
+  public String getDownloadError() {
     return downloadError;
   }
 
-  public void setDownloadError(String downloadError)
-  {
+  public void setDownloadError(String downloadError) {
     this.downloadError = downloadError;
   }
 
-  public DownloadState getDownloadState()
-  {
+  public DownloadState getDownloadState() {
     return downloadState;
   }
 
-  public void setDownloadState(DownloadState downloadState)
-  {
+  public void setDownloadState(DownloadState downloadState) {
     this.downloadState = downloadState;
   }
 
-  private int computeCharactersNeeded()
-  {
+  private int computeCharactersNeeded() {
     // remove [ , ] characters, they won't be stored
     return uncompressedSize
         - (rowCount * 2) // opening [ and komma separating rows
@@ -302,11 +243,10 @@ public class SnowflakeResultChunk
   }
 
   /**
-   * This class abstracts the storage of the strings in one chunk.
-   * To the user the class behaves similar to an ArrayList.
+   * This class abstracts the storage of the strings in one chunk. To the user the class behaves
+   * similar to an ArrayList.
    */
-  private static interface ResultChunkData
-  {
+  private static interface ResultChunkData {
     /**
      * Add the string to the data list
      *
@@ -329,72 +269,54 @@ public class SnowflakeResultChunk
      */
     long computeNeededChunkMemory();
 
-    /**
-     * Let GC collect the memory
-     */
+    /** Let GC collect the memory */
     void freeData();
   }
 
   /**
-   * This implementation copies the strings to char arrays and stores the
-   * offsets and lengths.
-   * Multiple smaller arrays are necessary because java is not good at
-   * handling big arrays. They can cause OOM even if there is enough heap space
-   * left in theory.
+   * This implementation copies the strings to char arrays and stores the offsets and lengths.
+   * Multiple smaller arrays are necessary because java is not good at handling big arrays. They can
+   * cause OOM even if there is enough heap space left in theory.
    */
-  private static class BlockResultChunkData implements ResultChunkData
-  {
-    BlockResultChunkData(int totalLength, int count)
-    {
+  private static class BlockResultChunkData implements ResultChunkData {
+    BlockResultChunkData(int totalLength, int count) {
       this.blockCount = getBlock(totalLength - 1) + 1;
       this.metaBlockCount = getMetaBlock(count - 1) + 1;
     }
 
     @Override
-    public void add(String string)
-    {
-      if (data.size() < blockCount || offsets.size() < metaBlockCount)
-      {
+    public void add(String string) {
+      if (data.size() < blockCount || offsets.size() < metaBlockCount) {
         allocateArrays();
       }
 
-      if (string == null)
-      {
-        lengths.get(getMetaBlock(nextIndex))
-            [getMetaBlockIndex(nextIndex)] = NULL_VALUE;
-      }
-      else
-      {
+      if (string == null) {
+        lengths.get(getMetaBlock(nextIndex))[getMetaBlockIndex(nextIndex)] = NULL_VALUE;
+      } else {
         final int offset = currentDatOffset;
         final int length = string.length();
 
         // store offset and length
-        offsets.get(getMetaBlock(nextIndex))
-            [getMetaBlockIndex(nextIndex)] = offset;
-        lengths.get(getMetaBlock(nextIndex))
-            [getMetaBlockIndex(nextIndex)] = length;
+        offsets.get(getMetaBlock(nextIndex))[getMetaBlockIndex(nextIndex)] = offset;
+        lengths.get(getMetaBlock(nextIndex))[getMetaBlockIndex(nextIndex)] = length;
 
         // copy string to the char array
         int copied = 0;
         char[] source = string.toCharArray();
-        if (spaceLeftOnBlock(offset) < length)
-        {
-          while (copied < length)
-          {
-            final int copySize
-                = Math.min(length - copied, spaceLeftOnBlock(offset + copied));
-            System.arraycopy(source, copied,
-                             data.get(getBlock(offset + copied)),
-                             getBlockOffset(offset + copied),
-                             copySize);
+        if (spaceLeftOnBlock(offset) < length) {
+          while (copied < length) {
+            final int copySize = Math.min(length - copied, spaceLeftOnBlock(offset + copied));
+            System.arraycopy(
+                source,
+                copied,
+                data.get(getBlock(offset + copied)),
+                getBlockOffset(offset + copied),
+                copySize);
             copied += copySize;
           }
-        }
-        else
-        {
-          System.arraycopy(source, 0,
-                           data.get(getBlock(offset)),
-                           getBlockOffset(offset), string.length());
+        } else {
+          System.arraycopy(
+              source, 0, data.get(getBlock(offset)), getBlockOffset(offset), string.length());
         }
         currentDatOffset += string.length();
       }
@@ -402,49 +324,37 @@ public class SnowflakeResultChunk
     }
 
     @Override
-    public String get(int index)
-    {
-      final int length = lengths.get(getMetaBlock(index))
-          [getMetaBlockIndex(index)];
-      if (length == NULL_VALUE)
-      {
+    public String get(int index) {
+      final int length = lengths.get(getMetaBlock(index))[getMetaBlockIndex(index)];
+      if (length == NULL_VALUE) {
         return null;
-      }
-      else
-      {
-        final int offset = offsets.get(getMetaBlock(index))
-            [getMetaBlockIndex(index)];
+      } else {
+        final int offset = offsets.get(getMetaBlock(index))[getMetaBlockIndex(index)];
 
         // Create string from the char arrays
-        if (spaceLeftOnBlock(offset) < length)
-        {
+        if (spaceLeftOnBlock(offset) < length) {
           int copied = 0;
           char[] cell = new char[length];
-          while (copied < length)
-          {
-            final int copySize
-                = Math.min(length - copied, spaceLeftOnBlock(offset + copied));
-            System.arraycopy(data.get(getBlock(offset + copied)),
-                             getBlockOffset(offset + copied),
-                             cell, copied,
-                             copySize);
+          while (copied < length) {
+            final int copySize = Math.min(length - copied, spaceLeftOnBlock(offset + copied));
+            System.arraycopy(
+                data.get(getBlock(offset + copied)),
+                getBlockOffset(offset + copied),
+                cell,
+                copied,
+                copySize);
 
             copied += copySize;
           }
           return new String(cell);
-        }
-        else
-        {
-          return new String(data.get(getBlock(offset)),
-                            getBlockOffset(offset),
-                            length);
+        } else {
+          return new String(data.get(getBlock(offset)), getBlockOffset(offset), length);
         }
       }
     }
 
     @Override
-    public long computeNeededChunkMemory()
-    {
+    public long computeNeededChunkMemory() {
       long dataRequirement = blockCount * blockLength * 2L;
       long metadataRequirement = metaBlockCount * metaBlockLength * (4L + 4L);
 
@@ -452,46 +362,37 @@ public class SnowflakeResultChunk
     }
 
     @Override
-    public void freeData()
-    {
+    public void freeData() {
       data.clear();
       offsets.clear();
       lengths.clear();
     }
 
-    private static int getBlock(int offset)
-    {
+    private static int getBlock(int offset) {
       return offset >> blockLengthBits;
     }
 
-    private static int getBlockOffset(int offset)
-    {
+    private static int getBlockOffset(int offset) {
       return offset & (blockLength - 1);
     }
 
-    private static int spaceLeftOnBlock(int offset)
-    {
+    private static int spaceLeftOnBlock(int offset) {
       return blockLength - getBlockOffset(offset);
     }
 
-    private static int getMetaBlock(int index)
-    {
+    private static int getMetaBlock(int index) {
       return index >> metaBlockLengthBits;
     }
 
-    private static int getMetaBlockIndex(int index)
-    {
+    private static int getMetaBlockIndex(int index) {
       return index & (metaBlockLength - 1);
     }
 
-    private void allocateArrays()
-    {
-      while (data.size() < blockCount)
-      {
+    private void allocateArrays() {
+      while (data.size() < blockCount) {
         data.add(new char[1 << blockLengthBits]);
       }
-      while (offsets.size() < metaBlockCount)
-      {
+      while (offsets.size() < metaBlockCount) {
         offsets.add(new int[1 << metaBlockLengthBits]);
         lengths.add(new int[1 << metaBlockLengthBits]);
       }
@@ -513,63 +414,50 @@ public class SnowflakeResultChunk
     private int nextIndex = 0;
   }
 
-  private static class LegacyResultChunkData implements ResultChunkData
-  {
+  private static class LegacyResultChunkData implements ResultChunkData {
     private final int totalLength, count;
     ArrayList<String> list;
 
-    LegacyResultChunkData(int totalLength, int count)
-    {
+    LegacyResultChunkData(int totalLength, int count) {
       this.totalLength = totalLength;
       this.count = count;
     }
 
     @Override
-    public void add(String string)
-    {
-      if (list == null)
-      {
+    public void add(String string) {
+      if (list == null) {
         list = new ArrayList<>(count);
       }
       list.add(string);
     }
 
     @Override
-    public String get(int index)
-    {
+    public String get(int index) {
       return list.get(index);
     }
 
     @Override
-    public long computeNeededChunkMemory()
-    {
+    public long computeNeededChunkMemory() {
       return totalLength + 8 * count + 45 * count;
     }
 
     @Override
-    public void freeData()
-    {
-      if (list != null)
-      {
+    public void freeData() {
+      if (list != null) {
         list.clear();
         list.trimToSize();
       }
     }
   }
 
-  /**
-   * Cache the data, offset and length blocks
-   */
-  static class ResultChunkDataCache
-  {
+  /** Cache the data, offset and length blocks */
+  static class ResultChunkDataCache {
     /**
-     * Add the data to the cache.
-     * CAUTION: The result chunk is not usable afterward
+     * Add the data to the cache. CAUTION: The result chunk is not usable afterward
      *
      * @param chunk add this to the cache
      */
-    void add(SnowflakeResultChunk chunk)
-    {
+    void add(SnowflakeResultChunk chunk) {
       cache.add(new SoftReference<>(chunk.data));
       chunk.data = null;
     }
@@ -579,85 +467,64 @@ public class SnowflakeResultChunk
      *
      * @param data fill this with reused blocks
      */
-    void reuseOrCreateResultData(ResultChunkData data)
-    {
+    void reuseOrCreateResultData(ResultChunkData data) {
       List<SoftReference<ResultChunkData>> remove = new ArrayList<>();
-      try
-      {
-        for (SoftReference<ResultChunkData> ref : cache)
-        {
+      try {
+        for (SoftReference<ResultChunkData> ref : cache) {
           ResultChunkData dat = ref.get();
-          if (dat == null)
-          {
+          if (dat == null) {
             remove.add(ref);
             continue;
           }
-          if (dat instanceof BlockResultChunkData)
-          {
+          if (dat instanceof BlockResultChunkData) {
             BlockResultChunkData bTargetData = (BlockResultChunkData) data;
             BlockResultChunkData bCachedDat = (BlockResultChunkData) dat;
-            if (bCachedDat.data.size() == 0 && bCachedDat.offsets.size() == 0)
-            {
+            if (bCachedDat.data.size() == 0 && bCachedDat.offsets.size() == 0) {
               remove.add(ref);
               continue;
             }
 
-            while (bTargetData.data.size() < bTargetData.blockCount && bCachedDat.data.size() > 0)
-            {
+            while (bTargetData.data.size() < bTargetData.blockCount && bCachedDat.data.size() > 0) {
               bTargetData.data.add(bCachedDat.data.remove(bCachedDat.data.size() - 1));
             }
-            while (bTargetData.offsets.size() < bTargetData.metaBlockCount && bCachedDat.offsets.size() > 0)
-            {
+            while (bTargetData.offsets.size() < bTargetData.metaBlockCount
+                && bCachedDat.offsets.size() > 0) {
               bTargetData.offsets.add(bCachedDat.offsets.remove(bCachedDat.offsets.size() - 1));
               bTargetData.lengths.add(bCachedDat.lengths.remove(bCachedDat.lengths.size() - 1));
             }
-            if (bTargetData.data.size() == bTargetData.blockCount &&
-                bTargetData.offsets.size() == bTargetData.metaBlockCount)
-            {
+            if (bTargetData.data.size() == bTargetData.blockCount
+                && bTargetData.offsets.size() == bTargetData.metaBlockCount) {
               return;
             }
-          }
-          else if (dat instanceof LegacyResultChunkData)
-          {
+          } else if (dat instanceof LegacyResultChunkData) {
             LegacyResultChunkData lTargetData = (LegacyResultChunkData) data;
             LegacyResultChunkData lCachedDat = (LegacyResultChunkData) dat;
 
-            if (lCachedDat.list == null)
-            {
+            if (lCachedDat.list == null) {
               remove.add(ref);
               continue;
             }
-            if (lTargetData.list == null)
-            {
+            if (lTargetData.list == null) {
               lTargetData.list = lCachedDat.list;
               lTargetData.list.clear();
               lCachedDat.list = null;
               remove.add(ref);
               return;
             }
-          }
-          else
-          {
+          } else {
             remove.add(ref);
           }
         }
-      }
-      finally
-      {
+      } finally {
         cache.removeAll(remove);
       }
     }
 
-    /**
-     * Let GC collect all data hold by the cache
-     */
-    void clear()
-    {
-      for (SoftReference<ResultChunkData> ref : cache)
-      {
+    /** Let GC collect all data hold by the cache */
+    void clear() {
+      for (SoftReference<ResultChunkData> ref : cache) {
         ResultChunkData dat = ref.get();
-        if (dat != null)
-        {
+        if (dat != null) {
           dat.freeData();
         }
       }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaData.java
@@ -4,10 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.common.core.SqlState;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.core.ResultUtil;
-
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.ResultSetMetaData;
@@ -16,22 +12,23 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.util.List;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import net.snowflake.client.core.ResultUtil;
+import net.snowflake.client.core.SFSession;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SqlState;
 
 /**
  * Snowflake ResultSetMetaData
  *
  * @author jhuang
  */
-public class SnowflakeResultSetMetaData implements ResultSetMetaData
-{
+public class SnowflakeResultSetMetaData implements ResultSetMetaData {
 
-  static final
-  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetMetaData.class);
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetMetaData.class);
 
   private int columnCount = 0;
 
@@ -47,23 +44,21 @@ public class SnowflakeResultSetMetaData implements ResultSetMetaData
 
   private String queryId;
 
-  private Map<String, Integer> columnNamePositionMap =
-  new HashMap<>();
+  private Map<String, Integer> columnNamePositionMap = new HashMap<>();
 
-  private Map<String, Integer> columnNameUpperCasePositionMap =
-      new HashMap<>();
+  private Map<String, Integer> columnNameUpperCasePositionMap = new HashMap<>();
 
   private SFSession session;
 
   public SnowflakeResultSetMetaData() {}
 
-  public SnowflakeResultSetMetaData(int columnCount,
-                                    List<String> columnNames,
-                                    List<String> columnTypeNames,
-                                    List<Integer> columnTypes,
-                                    SFSession session)
-          throws SnowflakeSQLException
-  {
+  public SnowflakeResultSetMetaData(
+      int columnCount,
+      List<String> columnNames,
+      List<String> columnTypeNames,
+      List<Integer> columnTypes,
+      SFSession session)
+      throws SnowflakeSQLException {
     this.columnCount = columnCount;
     this.columnNames = columnNames;
     this.columnTypeNames = columnTypeNames;
@@ -71,19 +66,13 @@ public class SnowflakeResultSetMetaData implements ResultSetMetaData
     this.session = session;
   }
 
-  /**
-   * @return query id
-   */
-  public String getQueryId()
-  {
+  /** @return query id */
+  public String getQueryId() {
     return queryId;
   }
 
-  /**
-   * @return list of column names
-   */
-  public List<String> getColumnNames()
-  {
+  /** @return list of column names */
+  public List<String> getColumnNames() {
     return columnNames;
   }
 
@@ -91,22 +80,19 @@ public class SnowflakeResultSetMetaData implements ResultSetMetaData
    * @param columnName column name
    * @return index of the column
    */
-  public int getColumnIndex(String columnName)
-  {
+  public int getColumnIndex(String columnName) {
     boolean caseInsensitive = session != null && session.isResultColumnCaseInsensitive();
     columnName = caseInsensitive ? columnName.toUpperCase() : columnName;
-    Map<String, Integer> nameToIndexMap = caseInsensitive ?
-        columnNameUpperCasePositionMap : columnNamePositionMap;
+    Map<String, Integer> nameToIndexMap =
+        caseInsensitive ? columnNameUpperCasePositionMap : columnNamePositionMap;
 
-    if (nameToIndexMap.get(columnName) != null)
-    {
+    if (nameToIndexMap.get(columnName) != null) {
       return nameToIndexMap.get(columnName);
-    }
-    else
-    {
-      int columnIndex = caseInsensitive ?
-          ResultUtil.listSearchCaseInsensitive(columnNames, columnName) :
-          columnNames.indexOf(columnName);
+    } else {
+      int columnIndex =
+          caseInsensitive
+              ? ResultUtil.listSearchCaseInsensitive(columnNames, columnName)
+              : columnNames.indexOf(columnName);
       nameToIndexMap.put(columnName, columnIndex);
       return columnIndex;
     }
@@ -117,251 +103,208 @@ public class SnowflakeResultSetMetaData implements ResultSetMetaData
    * @throws SQLException if failed to get column count
    */
   @Override
-  public int getColumnCount() throws SQLException
-  {
-    logger.debug(
-	       "public int getColumnCount(), columnCount= {}",
-	       columnCount);
+  public int getColumnCount() throws SQLException {
+    logger.debug("public int getColumnCount(), columnCount= {}", columnCount);
 
     return columnCount;
   }
 
   @Override
-  public boolean isAutoIncrement(int column) throws SQLException
-  {
+  public boolean isAutoIncrement(int column) throws SQLException {
     logger.debug("public boolean isAutoIncrement(int column)");
 
     return false;
   }
 
   @Override
-  public boolean isCaseSensitive(int column) throws SQLException
-  {
+  public boolean isCaseSensitive(int column) throws SQLException {
     logger.debug("public boolean isCaseSensitive(int column)");
 
     return false;
   }
 
   @Override
-  public boolean isSearchable(int column) throws SQLException
-  {
+  public boolean isSearchable(int column) throws SQLException {
     logger.debug("public boolean isSearchable(int column)");
 
     return true;
   }
 
   @Override
-  public boolean isCurrency(int column) throws SQLException
-  {
+  public boolean isCurrency(int column) throws SQLException {
     logger.debug("public boolean isCurrency(int column)");
 
     return false;
   }
 
   @Override
-  public int isNullable(int column) throws SQLException
-  {
+  public int isNullable(int column) throws SQLException {
     logger.debug("public int isNullable(int column)");
 
     return columnNullableUnknown;
   }
 
   @Override
-  public boolean isSigned(int column) throws SQLException
-  {
+  public boolean isSigned(int column) throws SQLException {
     logger.debug("public boolean isSigned(int column)");
 
-    if (columnTypes.get(column-1) == Types.INTEGER ||
-        columnTypes.get(column-1) == Types.DECIMAL ||
-        columnTypes.get(column-1) == Types.DOUBLE)
-      return true;
-    else
-      return false;
+    if (columnTypes.get(column - 1) == Types.INTEGER
+        || columnTypes.get(column - 1) == Types.DECIMAL
+        || columnTypes.get(column - 1) == Types.DOUBLE) return true;
+    else return false;
   }
 
   @Override
-  public int getColumnDisplaySize(int column) throws SQLException
-  {
+  public int getColumnDisplaySize(int column) throws SQLException {
     logger.debug("public int getColumnDisplaySize(int column)");
 
     return 25;
   }
 
   @Override
-  public String getColumnLabel(int column) throws SQLException
-  {
+  public String getColumnLabel(int column) throws SQLException {
     logger.debug("public String getColumnLabel(int column)");
 
-    if(columnNames != null)
-      return columnNames.get(column-1);
-    else
-      return "C" + Integer.toString(column-1);
+    if (columnNames != null) return columnNames.get(column - 1);
+    else return "C" + Integer.toString(column - 1);
   }
 
   @Override
-  public String getColumnName(int column) throws SQLException
-  {
+  public String getColumnName(int column) throws SQLException {
     logger.debug("public String getColumnName(int column)");
 
-    if(columnNames != null)
-      return columnNames.get(column-1);
-    else
-      return "C" + Integer.toString(column-1);
+    if (columnNames != null) return columnNames.get(column - 1);
+    else return "C" + Integer.toString(column - 1);
   }
 
   @Override
-  public String getSchemaName(int column) throws SQLException
-  {
+  public String getSchemaName(int column) throws SQLException {
     logger.debug("public String getSchemaName(int column)");
 
     return "";
   }
 
   @Override
-  public int getPrecision(int column) throws SQLException
-  {
+  public int getPrecision(int column) throws SQLException {
     logger.debug("public int getPrecision(int column)");
 
-    if (precisions != null && precisions.size() >= column)
-    {
-      return precisions.get(column-1);
-    }
-    else
-    {
+    if (precisions != null && precisions.size() >= column) {
+      return precisions.get(column - 1);
+    } else {
       // TODO: fix this later to use different defaults for number or timestamp
       return 9;
     }
   }
 
   @Override
-  public int getScale(int column) throws SQLException
-  {
+  public int getScale(int column) throws SQLException {
     logger.debug("public int getScale(int column)");
 
-    if (scales != null && scales.size() >= column)
-    {
-      return scales.get(column-1);
-    }
-    else
-    {
+    if (scales != null && scales.size() >= column) {
+      return scales.get(column - 1);
+    } else {
       // TODO: fix this later to use different defaults for number or timestamp
       return 9;
     }
   }
 
   @Override
-  public String getTableName(int column) throws SQLException
-  {
+  public String getTableName(int column) throws SQLException {
     logger.debug("public String getTableName(int column)");
 
     return "T";
   }
 
   @Override
-  public String getCatalogName(int column) throws SQLException
-  {
+  public String getCatalogName(int column) throws SQLException {
     logger.debug("public String getCatalogName(int column)");
 
     return "";
   }
 
   @Override
-  public int getColumnType(int column) throws SQLException
-  {
+  public int getColumnType(int column) throws SQLException {
     logger.debug("public int getColumnType(int column)");
 
     int internalColumnType = getInternalColumnType(column);
 
     int externalColumnType = internalColumnType;
 
-    if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ ||
-        internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ)
+    if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ
+        || internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ)
       externalColumnType = Types.TIMESTAMP;
 
-    logger.debug(
-	       "column type = {}", 
-	       externalColumnType);
+    logger.debug("column type = {}", externalColumnType);
 
     return externalColumnType;
   }
 
-  public int getInternalColumnType(int column) throws SQLException
-  {
+  public int getInternalColumnType(int column) throws SQLException {
     logger.debug("public int getInternalColumnType(int column)");
 
-    int columnIdx = column-1;
-    if (column > columnTypes.size())
-    {
+    int columnIdx = column - 1;
+    if (column > columnTypes.size()) {
       throw new SQLException("Invalid column index: " + column);
     }
 
-    if(columnTypes.get(columnIdx) == null)
-    {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Missing column type for column " + column);
+    if (columnTypes.get(columnIdx) == null) {
+      throw new SnowflakeSQLException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Missing column type for column " + column);
     }
 
-    logger.debug(
-	       "column type = {}",
-	       columnTypes.get(column-1));
+    logger.debug("column type = {}", columnTypes.get(column - 1));
 
     return columnTypes.get(columnIdx);
   }
 
   @Override
-  public String getColumnTypeName(int column) throws SQLException
-  {
+  public String getColumnTypeName(int column) throws SQLException {
     logger.debug("public String getColumnTypeName(int column)");
 
-    if (column > columnTypeNames.size())
-    {
+    if (column > columnTypeNames.size()) {
       throw new SQLException("Invalid column index: " + column);
     }
 
-    if(columnTypeNames == null || columnTypeNames.get(column-1) == null)
-    {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Missing column type for column " + column);
+    if (columnTypeNames == null || columnTypeNames.get(column - 1) == null) {
+      throw new SnowflakeSQLException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Missing column type for column " + column);
     }
 
-    return columnTypeNames.get(column-1);
+    return columnTypeNames.get(column - 1);
   }
 
   @Override
-  public boolean isReadOnly(int column) throws SQLException
-  {
+  public boolean isReadOnly(int column) throws SQLException {
     logger.debug("public boolean isReadOnly(int column)");
 
     return true;
   }
 
   @Override
-  public boolean isWritable(int column) throws SQLException
-  {
+  public boolean isWritable(int column) throws SQLException {
     logger.debug("public boolean isWritable(int column)");
 
     return false;
   }
 
   @Override
-  public boolean isDefinitelyWritable(int column) throws SQLException
-  {
+  public boolean isDefinitelyWritable(int column) throws SQLException {
     logger.debug("public boolean isDefinitelyWritable(int column)");
 
     return false;
   }
 
   @Override
-  public String getColumnClassName(int column) throws SQLException
-  {
+  public String getColumnClassName(int column) throws SQLException {
     logger.debug("public String getColumnClassName(int column)");
 
     int type = this.getColumnType(column);
 
-    switch(type)
-    {
+    switch (type) {
       case Types.VARCHAR:
       case Types.CHAR:
       case Types.BINARY:
@@ -397,16 +340,14 @@ public class SnowflakeResultSetMetaData implements ResultSetMetaData
   }
 
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException
-  {
+  public <T> T unwrap(Class<T> iface) throws SQLException {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException
-  {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
     logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     throw new SQLFeatureNotSupportedException();

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaDataV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaDataV1.java
@@ -4,11 +4,10 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFResultSetMetaData;
-
 import java.sql.SQLException;
 import java.util.List;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFResultSetMetaData;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
@@ -17,40 +16,27 @@ import net.snowflake.client.log.SFLoggerFactory;
  *
  * @author jhuang
  */
-class SnowflakeResultSetMetaDataV1 extends SnowflakeResultSetMetaData
-{
-  static final
-  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetMetaDataV1.class);
+class SnowflakeResultSetMetaDataV1 extends SnowflakeResultSetMetaData {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetMetaDataV1.class);
 
   private SFResultSetMetaData resultSetMetaData;
 
-  SnowflakeResultSetMetaDataV1(SFResultSetMetaData resultSetMetaData)
-          throws SnowflakeSQLException
-  {
+  SnowflakeResultSetMetaDataV1(SFResultSetMetaData resultSetMetaData) throws SnowflakeSQLException {
     this.resultSetMetaData = resultSetMetaData;
   }
 
-  /**
-   * @return query id
-   */
-  public String getQueryId()
-  {
+  /** @return query id */
+  public String getQueryId() {
     return resultSetMetaData.getQueryId();
   }
 
-  /**
-   * @return list of column names
-   */
-  public List<String> getColumnNames()
-  {
+  /** @return list of column names */
+  public List<String> getColumnNames() {
     return resultSetMetaData.getColumnNames();
   }
 
-  /**
-   * @return index of the column by name, index starts from zero
-   */
-  public int getColumnIndex(String columnName)
-  {
+  /** @return index of the column by name, index starts from zero */
+  public int getColumnIndex(String columnName) {
     return resultSetMetaData.getColumnIndex(columnName);
   }
 
@@ -59,110 +45,87 @@ class SnowflakeResultSetMetaDataV1 extends SnowflakeResultSetMetaData
    * @throws java.sql.SQLException if failed to get column count
    */
   @Override
-  public int getColumnCount() throws SQLException
-  {
+  public int getColumnCount() throws SQLException {
     return resultSetMetaData.getColumnCount();
   }
 
   @Override
-  public boolean isSigned(int column) throws SQLException
-  {
+  public boolean isSigned(int column) throws SQLException {
     return resultSetMetaData.isSigned(column);
   }
 
   @Override
-  public String getColumnLabel(int column) throws SQLException
-  {
+  public String getColumnLabel(int column) throws SQLException {
     return resultSetMetaData.getColumnLabel(column);
   }
 
   @Override
-  public String getColumnName(int column) throws SQLException
-  {
+  public String getColumnName(int column) throws SQLException {
     return resultSetMetaData.getColumnName(column);
   }
 
   @Override
-  public int getPrecision(int column) throws SQLException
-  {
+  public int getPrecision(int column) throws SQLException {
     return resultSetMetaData.getPrecision(column);
   }
 
   @Override
-  public int getScale(int column) throws SQLException
-  {
+  public int getScale(int column) throws SQLException {
     return resultSetMetaData.getScale(column);
   }
 
   @Override
-  public int getInternalColumnType(int column) throws SQLException
-  {
-    try
-    {
+  public int getInternalColumnType(int column) throws SQLException {
+    try {
       return resultSetMetaData.getInternalColumnType(column);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public int getColumnType(int column) throws SQLException
-  {
-    try
-    {
+  public int getColumnType(int column) throws SQLException {
+    try {
       return resultSetMetaData.getColumnType(column);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public String getColumnTypeName(int column) throws SQLException
-  {
-    try
-    {
+  public String getColumnTypeName(int column) throws SQLException {
+    try {
       return resultSetMetaData.getColumnTypeName(column);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public int isNullable(int column) throws SQLException
-  {
+  public int isNullable(int column) throws SQLException {
     return resultSetMetaData.isNullable(column);
   }
 
   @Override
-  public String getCatalogName(int column) throws SQLException
-  {
+  public String getCatalogName(int column) throws SQLException {
     return resultSetMetaData.getCatalogName(column);
   }
 
   @Override
-  public String getSchemaName(int column) throws SQLException
-  {
+  public String getSchemaName(int column) throws SQLException {
     return resultSetMetaData.getSchemaName(column);
   }
 
   @Override
-  public String getTableName(int column) throws SQLException
-  {
+  public String getTableName(int column) throws SQLException {
     return resultSetMetaData.getTableName(column);
   }
 
   @Override
-  public int getColumnDisplaySize(int column) throws SQLException
-  {
+  public int getColumnDisplaySize(int column) throws SQLException {
     return resultSetMetaData.getColumnDisplaySize(column);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -4,11 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFResultSet;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFStatementType;
-
 import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigDecimal;
@@ -20,47 +15,41 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.TimeZone;
-import java.util.logging.Level;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
 
 /**
  * Snowflake ResultSet implementation
+ *
  * <p>
+ *
  * @author jhuang
  */
-class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
-{
+class SnowflakeResultSetV1 extends SnowflakeBaseResultSet {
   private SFBaseResultSet sfBaseResultSet;
   private Statement statement;
 
   /**
-   * Constructor takes an inputstream from the API response that we get from
-   * executing a SQL statement.
-   * <p>
-   * The constructor will fetch the first row (if any) so that it can initialize
-   * the ResultSetMetaData.
-   * </p>
+   * Constructor takes an inputstream from the API response that we get from executing a SQL
+   * statement.
+   *
+   * <p>The constructor will fetch the first row (if any) so that it can initialize the
+   * ResultSetMetaData.
    *
    * @param sfBaseResultSet snowflake core base result rest object
    * @param statement query statement that generates this result set
    * @throws SQLException if failed to construct snowflake result set metadata
    */
-  SnowflakeResultSetV1(SFBaseResultSet sfBaseResultSet, Statement statement)
-          throws SQLException
-  {
+  SnowflakeResultSetV1(SFBaseResultSet sfBaseResultSet, Statement statement) throws SQLException {
     this.sfBaseResultSet = sfBaseResultSet;
     this.statement = statement;
-    try
-    {
-      this.resultSetMetaData =
-          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    try {
+      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
-
 
   /**
    * Advance to next row
@@ -69,290 +58,209 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
    * @throws java.sql.SQLException if failed to move to the next row
    */
   @Override
-  public boolean next() throws SQLException
-  {
-    try
-    {
+  public boolean next() throws SQLException {
+    try {
       return sfBaseResultSet.next();
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void close() throws SQLException
-  {
+  public void close() throws SQLException {
     sfBaseResultSet.close();
   }
 
-
-  public boolean wasNull()
-  {
+  public boolean wasNull() {
     return sfBaseResultSet.wasNull();
   }
 
-  public String getString(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public String getString(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getString(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Clob getClob(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public Clob getClob(int columnIndex) throws SQLException {
+    try {
       String content = sfBaseResultSet.getString(columnIndex);
       Clob clob = new SnowflakeClob(content);
       return clob;
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public boolean getBoolean(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public boolean getBoolean(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getBoolean(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public short getShort(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public short getShort(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getShort(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public int getInt(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public int getInt(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getInt(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public long getLong(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public long getLong(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getLong(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public float getFloat(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public float getFloat(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getFloat(columnIndex);
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
-    }
-
   }
 
-  public double getDouble(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public double getDouble(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getDouble(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Date getDate(int columnIndex, TimeZone tz) throws SQLException
-  {
-    try
-    {
+  public Date getDate(int columnIndex, TimeZone tz) throws SQLException {
+    try {
       return sfBaseResultSet.getDate(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Time getTime(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public Time getTime(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getTime(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz)
-      throws SQLException
-  {
-    try
-    {
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SQLException {
+    try {
       return sfBaseResultSet.getTimestamp(columnIndex, tz);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public ResultSetMetaData getMetaData() throws SQLException
-  {
+  public ResultSetMetaData getMetaData() throws SQLException {
     logger.debug("public ResultSetMetaData getMetaData()");
 
     return resultSetMetaData;
   }
 
-  public Object getObject(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public Object getObject(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getObject(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public BigDecimal getBigDecimal(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getBigDecimal(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
-  {
-    try
-    {
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+    try {
       return sfBaseResultSet.getBigDecimal(columnIndex, scale);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public byte[] getBytes(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public byte[] getBytes(int columnIndex) throws SQLException {
+    try {
       return sfBaseResultSet.getBytes(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public int getRow() throws SQLException
-  {
+  public int getRow() throws SQLException {
     logger.debug("public int getRow()");
 
     return sfBaseResultSet.getRow();
   }
 
-  public boolean isFirst() throws SQLException
-  {
+  public boolean isFirst() throws SQLException {
     logger.debug("public boolean isFirst()");
-    
+
     return sfBaseResultSet.isFirst();
   }
 
-  public Statement getStatement() throws SQLException
-  {
+  public Statement getStatement() throws SQLException {
     return this.statement;
   }
 
-  public boolean isClosed() throws SQLException
-  {
+  public boolean isClosed() throws SQLException {
     return sfBaseResultSet.isClosed();
   }
 
   @Override
-  public boolean isLast() throws SQLException
-  {
+  public boolean isLast() throws SQLException {
     return sfBaseResultSet.isLast();
   }
 
   @Override
-  public boolean isAfterLast() throws SQLException
-  {
+  public boolean isAfterLast() throws SQLException {
     return sfBaseResultSet.isAfterLast();
   }
 
   @Override
-  public boolean isBeforeFirst() throws SQLException
-  {
+  public boolean isBeforeFirst() throws SQLException {
     return sfBaseResultSet.isBeforeFirst();
   }
 
   @Override
-  public Reader getCharacterStream(int columnIndex) throws SQLException
-  {
-    try
-    {
+  public Reader getCharacterStream(int columnIndex) throws SQLException {
+    try {
       return new StringReader(sfBaseResultSet.getString(columnIndex));
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -4,111 +4,110 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.SFException;
-import net.snowflake.common.core.ResourceBundleManager;
 import java.sql.SQLException;
+import net.snowflake.client.core.SFException;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.ResourceBundleManager;
 
-/**
- * @author jhuang
- */
-public class SnowflakeSQLException extends SQLException
-{
-  static final SFLogger logger =
-                       SFLoggerFactory.getLogger(SnowflakeSQLException.class);
+/** @author jhuang */
+public class SnowflakeSQLException extends SQLException {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeSQLException.class);
 
   static final ResourceBundleManager errorResourceBundleManager =
-  ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
+      ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
 
   private String queryId = "unknown";
 
   /**
-   * This constructor should only be used for error from
-   * Global service. Since Global service has already built the error message,
-   * we use it as is. For any errors local to JDBC driver, we should use one
-   * of the constructors below to build the error message.
+   * This constructor should only be used for error from Global service. Since Global service has
+   * already built the error message, we use it as is. For any errors local to JDBC driver, we
+   * should use one of the constructors below to build the error message.
+   *
    * @param queryId query id
    * @param reason reason for which exception is created
    * @param sqlState sql state
    * @param vendorCode vendor code
    */
-  public SnowflakeSQLException(String queryId,
-                               String reason,
-                               String sqlState,
-                               int vendorCode)
-  {
+  public SnowflakeSQLException(String queryId, String reason, String sqlState, int vendorCode) {
     super(reason, sqlState, vendorCode);
 
     this.queryId = queryId;
 
     // log user error from GS at fine level
-    logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}, queryId:{}",
-                reason, sqlState, vendorCode, queryId);
-
+    logger.debug(
+        "Snowflake exception: {}, sqlState:{}, vendorCode:{}, queryId:{}",
+        reason,
+        sqlState,
+        vendorCode,
+        queryId);
   }
 
-  public SnowflakeSQLException(String sqlState, int vendorCode)
-  {
-    super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode)), sqlState, vendorCode);
+  public SnowflakeSQLException(String sqlState, int vendorCode) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
+        sqlState,
+        vendorCode);
 
-    logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}",
-                errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
-                sqlState,
-                vendorCode);
+    logger.debug(
+        "Snowflake exception: {}, sqlState:{}, vendorCode:{}",
+        errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
+        sqlState,
+        vendorCode);
   }
 
-  public SnowflakeSQLException(String sqlState, int vendorCode, Object... params)
-  {
-    super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode), params), sqlState, vendorCode);
+  public SnowflakeSQLException(String sqlState, int vendorCode, Object... params) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params),
+        sqlState,
+        vendorCode);
 
-    logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}",
-                errorResourceBundleManager.getLocalizedMessage(
-                  String.valueOf(vendorCode), params),
-                sqlState,
-                vendorCode);
+    logger.debug(
+        "Snowflake exception: {}, sqlState:{}, vendorCode:{}",
+        errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params),
+        sqlState,
+        vendorCode);
   }
 
-  public SnowflakeSQLException(Throwable ex, String sqlState, int vendorCode)
-  {
-    super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode)), sqlState, vendorCode, ex);
+  public SnowflakeSQLException(Throwable ex, String sqlState, int vendorCode) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
+        sqlState,
+        vendorCode,
+        ex);
 
-    logger.debug("Snowflake exception: {}" +
-                              errorResourceBundleManager.getLocalizedMessage(
-                              String.valueOf(vendorCode)), ex);
+    logger.debug(
+        "Snowflake exception: {}"
+            + errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
+        ex);
   }
 
-  public SnowflakeSQLException(Throwable ex,
-                               String sqlState,
-                               int vendorCode,
-                               Object... params)
-  {
-    super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode), params), sqlState, vendorCode, ex);
+  public SnowflakeSQLException(Throwable ex, String sqlState, int vendorCode, Object... params) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params),
+        sqlState,
+        vendorCode,
+        ex);
 
-    logger.debug("Snowflake exception: " +
-                           errorResourceBundleManager.getLocalizedMessage(
-                                   String.valueOf(vendorCode), params), ex);
+    logger.debug(
+        "Snowflake exception: "
+            + errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params),
+        ex);
   }
 
-  public SnowflakeSQLException(ErrorCode errorCode, Object... params)
-  {
-    super(errorResourceBundleManager.getLocalizedMessage(
-        String.valueOf(errorCode.getMessageCode()), params),
+  public SnowflakeSQLException(ErrorCode errorCode, Object... params) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(
+            String.valueOf(errorCode.getMessageCode()), params),
         errorCode.getSqlState(),
         errorCode.getMessageCode());
   }
 
-  public SnowflakeSQLException(SFException e)
-  {
+  public SnowflakeSQLException(SFException e) {
     this(e.getQueryId(), e.getMessage(), e.getSqlState(), e.getVendorCode());
   }
 
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return queryId;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSimulatedUploadFailure.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSimulatedUploadFailure.java
@@ -7,26 +7,19 @@ package net.snowflake.client.jdbc;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
-/**
- * Snowflake Loader exception for Test. This should only be valid in tests.
- */
-public class SnowflakeSimulatedUploadFailure extends RuntimeException
-{
+/** Snowflake Loader exception for Test. This should only be valid in tests. */
+public class SnowflakeSimulatedUploadFailure extends RuntimeException {
 
-  static final SFLogger logger = SFLoggerFactory.getLogger(
-          SnowflakeSimulatedUploadFailure.class);
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeSimulatedUploadFailure.class);
 
-  public SnowflakeSimulatedUploadFailure()
-  {
+  public SnowflakeSimulatedUploadFailure() {
     super();
     logger.error("This constructor should not be used.");
   }
 
-  public SnowflakeSimulatedUploadFailure(String filename)
-  {
+  public SnowflakeSimulatedUploadFailure(String filename) {
     super("Simulated upload failure for " + filename);
 
     logger.info("{}. This should show up only in tests.", this.getMessage());
   }
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -4,24 +4,21 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.ParameterBindingDTO;
-import net.snowflake.client.core.ResultUtil;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFStatement;
-
 import java.sql.BatchUpdateException;
-import java.util.ArrayList;
-import java.util.List;
-
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-
+import net.snowflake.client.core.ParameterBindingDTO;
+import net.snowflake.client.core.ResultUtil;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.core.StmtUtil;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
@@ -31,8 +28,7 @@ import net.snowflake.client.log.SFLoggerFactory;
  *
  * @author jhuang
  */
-class SnowflakeStatementV1 implements Statement
-{
+class SnowflakeStatementV1 implements Statement {
 
   static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementV1.class);
 
@@ -70,10 +66,8 @@ class SnowflakeStatementV1 implements Statement
 
   protected SQLWarning sqlWarnings;
 
-  SnowflakeStatementV1(SnowflakeConnectionV1 conn)
-  {
-    logger.debug(
-               " public SnowflakeStatement(SnowflakeConnectionV1 conn)");
+  SnowflakeStatementV1(SnowflakeConnectionV1 conn) {
+    logger.debug(" public SnowflakeStatement(SnowflakeConnectionV1 conn)");
 
     connection = conn;
     sfStatement = new SFStatement(conn.getSfSession());
@@ -87,8 +81,7 @@ class SnowflakeStatementV1 implements Statement
    * @throws java.sql.SQLException if @link{#executeQueryInternal(String, Map)} throws an exception
    */
   @Override
-  public ResultSet executeQuery(String sql) throws SQLException
-  {
+  public ResultSet executeQuery(String sql) throws SQLException {
     return executeQueryInternal(sql, null);
   }
 
@@ -100,43 +93,34 @@ class SnowflakeStatementV1 implements Statement
    * @throws java.sql.SQLException if @link{#executeUpdateInternal(String, Map)} throws exception
    */
   @Override
-  public int executeUpdate(String sql) throws SQLException
-  {
+  public int executeUpdate(String sql) throws SQLException {
     return executeUpdateInternal(sql, null);
   }
 
-  int executeUpdateInternal(String sql,
-                            Map<String, ParameterBindingDTO> parameterBindings)
-          throws SQLException
-  {
-    if (StmtUtil.checkStageManageCommand(sql) != null)
-    {
-      throw new SnowflakeSQLException(ErrorCode.
-          UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+  int executeUpdateInternal(String sql, Map<String, ParameterBindingDTO> parameterBindings)
+      throws SQLException {
+    if (StmtUtil.checkStageManageCommand(sql) != null) {
+      throw new SnowflakeSQLException(
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
           sql.length() > 20 ? sql.substring(0, 20) + "..." : sql);
     }
 
     SFBaseResultSet sfResultSet = null;
-    try
-    {
-      sfResultSet = sfStatement.execute(sql, parameterBindings,
-          SFStatement.CallingMethod.EXECUTE_UPDATE);
+    try {
+      sfResultSet =
+          sfStatement.execute(sql, parameterBindings, SFStatement.CallingMethod.EXECUTE_UPDATE);
       sfResultSet.setSession(this.connection.getSfSession());
       updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       resultSet = null;
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
 
-    if (getUpdateCount() == NO_UPDATES)
-    {
-      throw new SnowflakeSQLException(ErrorCode.
-          UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+    if (getUpdateCount() == NO_UPDATES) {
+      throw new SnowflakeSQLException(
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
           sql.length() > 20 ? sql.substring(0, 20) + "..." : sql);
-
     }
 
     return getUpdateCount();
@@ -150,22 +134,16 @@ class SnowflakeStatementV1 implements Statement
    * @return query result set
    * @throws SQLException if @link{SFStatement.execute(String)} throws exception
    */
-   ResultSet executeQueryInternal(
-      String sql,
-      Map<String, ParameterBindingDTO> parameterBindings)
-      throws SQLException
-  {
+  ResultSet executeQueryInternal(String sql, Map<String, ParameterBindingDTO> parameterBindings)
+      throws SQLException {
     SFBaseResultSet sfResultSet = null;
-    try
-    {
-      sfResultSet = sfStatement.execute(sql, parameterBindings,
-          SFStatement.CallingMethod.EXECUTE_QUERY);
+    try {
+      sfResultSet =
+          sfStatement.execute(sql, parameterBindings, SFStatement.CallingMethod.EXECUTE_QUERY);
       sfResultSet.setSession(this.connection.getSfSession());
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
 
     resultSet = new SnowflakeResultSetV1(sfResultSet, this);
@@ -181,29 +159,23 @@ class SnowflakeStatementV1 implements Statement
    * @return whether there is result set or not
    * @throws java.sql.SQLException if @link{#executeQuery(String)} throws exception
    */
-  boolean executeInternal(String sql,
-                          Map<String, ParameterBindingDTO> parameterBindings)
-                          throws SQLException
-  {
+  boolean executeInternal(String sql, Map<String, ParameterBindingDTO> parameterBindings)
+      throws SQLException {
     connection.injectedDelay();
 
     logger.debug("execute: {}", sql);
 
     String trimmedSql = sql.trim();
 
-    if (trimmedSql.length() >= 20
-        && trimmedSql.toLowerCase().startsWith("set-sf-property"))
-    {
+    if (trimmedSql.length() >= 20 && trimmedSql.toLowerCase().startsWith("set-sf-property")) {
       // deprecated: sfsql
       executeSetProperty(sql);
       return false;
     }
 
     SFBaseResultSet sfResultSet = null;
-    try
-    {
-      sfResultSet = sfStatement.execute(sql, parameterBindings,
-          SFStatement.CallingMethod.EXECUTE);
+    try {
+      sfResultSet = sfStatement.execute(sql, parameterBindings, SFStatement.CallingMethod.EXECUTE);
       sfResultSet.setSession(this.connection.getSfSession());
       resultSet = new SnowflakeResultSetV1(sfResultSet, this);
 
@@ -211,10 +183,9 @@ class SnowflakeStatementV1 implements Statement
       // statement execute, so we only treat update counts as update counts
       // if JDBC_EXECUTE_RETURN_COUNT_FOR_DML is set, or if a statement
       // is multi-statement
-      if (!sfResultSet.getStatementType().isGenerateResultSet() &&
-          (connection.getSfSession().isExecuteReturnCountForDML() ||
-           sfStatement.hasChildren()))
-      {
+      if (!sfResultSet.getStatementType().isGenerateResultSet()
+          && (connection.getSfSession().isExecuteReturnCountForDML()
+              || sfStatement.hasChildren())) {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
         resultSet = null;
         return false;
@@ -222,11 +193,9 @@ class SnowflakeStatementV1 implements Statement
 
       updateCount = NO_UPDATES;
       return true;
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
@@ -238,99 +207,80 @@ class SnowflakeStatementV1 implements Statement
    * @throws java.sql.SQLException if @link{#executeQuery(String)} throws exception
    */
   @Override
-  public boolean execute(String sql) throws SQLException
-  {
+  public boolean execute(String sql) throws SQLException {
     return executeInternal(sql, null);
   }
 
-
   @Override
-  public boolean execute(String sql, int autoGeneratedKeys)
-          throws SQLException
-  {
-    logger.debug(
-               "public int execute(String sql, int autoGeneratedKeys)");
-    
-    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS)
-    {
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+    logger.debug("public int execute(String sql, int autoGeneratedKeys)");
+
+    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
       return execute(sql);
-    }
-    else
-    {
+    } else {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public boolean execute(String sql, int[] columnIndexes) throws SQLException
-  {
-    logger.debug(
-               "public boolean execute(String sql, int[] columnIndexes)");
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+    logger.debug("public boolean execute(String sql, int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, String[] columnNames) throws SQLException
-  {
-    logger.debug(
-               "public boolean execute(String sql, String[] columnNames)");
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
+    logger.debug("public boolean execute(String sql, String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   /**
-   * Batch Execute. If one of the commands in the batch failed, JDBC will
-   * continuing processing and throw BatchUpdateException after all commands
-   * are processed.
+   * Batch Execute. If one of the commands in the batch failed, JDBC will continuing processing and
+   * throw BatchUpdateException after all commands are processed.
+   *
    * @return
    * @throws SQLException
    */
   @Override
-  public int[] executeBatch() throws SQLException
-  {
+  public int[] executeBatch() throws SQLException {
     logger.debug("public int[] executeBatch()");
 
     return executeBatchInternal();
   }
 
   /**
-   * This method will iterate through batch and provide sql and bindings to
-   * underlying SFStatement to get result set.
+   * This method will iterate through batch and provide sql and bindings to underlying SFStatement
+   * to get result set.
    *
-   * Note, array binds use a different code path since only one network
-   * roundtrip in the array bind execution case.
+   * <p>Note, array binds use a different code path since only one network roundtrip in the array
+   * bind execution case.
    *
    * @return
    * @throws SQLException
    */
-  int[] executeBatchInternal() throws SQLException
-  {
-    if (isClosed)
-    {
+  int[] executeBatchInternal() throws SQLException {
+    if (isClosed) {
       throw new SnowflakeSQLException(ErrorCode.STATEMENT_CLOSED);
     }
 
     SQLException exceptionReturned = null;
     int updateCounts[] = new int[batch.size()];
 
-    for (int i=0; i<batch.size(); i++)
-    {
-      try
-      {
-        updateCounts[i] = this.executeUpdateInternal(
-            batch.get(i).getSql(), batch.get(i).getParameterBindings());
-      }
-      catch(SQLException e)
-      {
+    for (int i = 0; i < batch.size(); i++) {
+      try {
+        updateCounts[i] =
+            this.executeUpdateInternal(batch.get(i).getSql(), batch.get(i).getParameterBindings());
+      } catch (SQLException e) {
         exceptionReturned = exceptionReturned == null ? e : exceptionReturned;
         updateCounts[i] = EXECUTE_FAILED;
       }
     }
 
-    if (exceptionReturned != null)
-    {
-      throw new BatchUpdateException(exceptionReturned.getLocalizedMessage(),
+    if (exceptionReturned != null) {
+      throw new BatchUpdateException(
+          exceptionReturned.getLocalizedMessage(),
           exceptionReturned.getSQLState(),
           exceptionReturned.getErrorCode(),
           updateCounts,
@@ -341,111 +291,88 @@ class SnowflakeStatementV1 implements Statement
   }
 
   @Override
-  public int executeUpdate(String sql, int autoGeneratedKeys)
-          throws SQLException
-  {
-    logger.debug(
-               "public int executeUpdate(String sql, int autoGeneratedKeys)");
-    
-    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS)
-    {
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+    logger.debug("public int executeUpdate(String sql, int autoGeneratedKeys)");
+
+    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
       return executeUpdate(sql);
-    }
-    else
-    {
+    } else {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public int executeUpdate(String sql, int[] columnIndexes)
-          throws SQLException
-  {
-    logger.debug(
-               "public int executeUpdate(String sql, int[] columnIndexes)");
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    logger.debug("public int executeUpdate(String sql, int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql, String[] columnNames)
-          throws SQLException
-  {
-    logger.debug(
-               "public int executeUpdate(String sql, String[] columnNames)");
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+    logger.debug("public int executeUpdate(String sql, String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Connection getConnection() throws SQLException
-  {
+  public Connection getConnection() throws SQLException {
     logger.debug("public Connection getConnection()");
 
     return connection;
   }
 
   @Override
-  public int getFetchDirection() throws SQLException
-  {
+  public int getFetchDirection() throws SQLException {
     logger.debug("public int getFetchDirection()");
 
     return ResultSet.FETCH_FORWARD;
   }
 
   @Override
-  public int getFetchSize() throws SQLException
-  {
+  public int getFetchSize() throws SQLException {
     logger.debug("public int getFetchSize()");
 
     return fetchSize;
   }
 
   @Override
-  public ResultSet getGeneratedKeys() throws SQLException
-  {
+  public ResultSet getGeneratedKeys() throws SQLException {
     logger.debug("public ResultSet getGeneratedKeys()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getMaxFieldSize() throws SQLException
-  {
+  public int getMaxFieldSize() throws SQLException {
     logger.debug("public int getMaxFieldSize()");
 
     return maxFieldSize;
   }
 
   @Override
-  public int getMaxRows() throws SQLException
-  {
+  public int getMaxRows() throws SQLException {
     logger.debug("public int getMaxRows()");
 
     return maxRows;
   }
 
   @Override
-  public boolean getMoreResults() throws SQLException
-  {
+  public boolean getMoreResults() throws SQLException {
     logger.debug("public boolean getMoreResults()");
 
     return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
   }
 
   @Override
-  public boolean getMoreResults(int current) throws SQLException
-  {
+  public boolean getMoreResults(int current) throws SQLException {
     logger.debug("public boolean getMoreResults(int current)");
 
     // clean up the current result set, if it exists
-    if (resultSet != null &&
-        (current == Statement.CLOSE_CURRENT_RESULT ||
-        current == Statement.CLOSE_ALL_RESULTS))
-    {
+    if (resultSet != null
+        && (current == Statement.CLOSE_CURRENT_RESULT || current == Statement.CLOSE_ALL_RESULTS)) {
       resultSet.close();
     }
-
 
     boolean hasResultSet = sfStatement.getMoreResults(current);
     SFBaseResultSet sfResultSet = sfStatement.getResultSet();
@@ -456,21 +383,16 @@ class SnowflakeStatementV1 implements Statement
       resultSet = new SnowflakeResultSetV1(sfResultSet, this);
       updateCount = NO_UPDATES;
       return true;
-    }
-    else if (sfResultSet != null) // update count returned
+    } else if (sfResultSet != null) // update count returned
     {
       resultSet = null;
-      try
-      {
+      try {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
-      }
-      catch (SFException ex)
-      {
+      } catch (SFException ex) {
         throw new SnowflakeSQLException(ex);
       }
       return false;
-    }
-    else // no more results
+    } else // no more results
     {
       updateCount = NO_UPDATES;
       return false;
@@ -478,191 +400,159 @@ class SnowflakeStatementV1 implements Statement
   }
 
   @Override
-  public int getQueryTimeout() throws SQLException
-  {
+  public int getQueryTimeout() throws SQLException {
     logger.debug("public int getQueryTimeout()");
 
     return this.queryTimeout;
   }
 
   @Override
-  public ResultSet getResultSet() throws SQLException
-  {
+  public ResultSet getResultSet() throws SQLException {
     logger.debug("public ResultSet getResultSet()");
 
     return resultSet;
   }
 
   @Override
-  public int getResultSetConcurrency() throws SQLException
-  {
+  public int getResultSetConcurrency() throws SQLException {
     logger.debug("public int getResultSetConcurrency()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getResultSetHoldability() throws SQLException
-  {
+  public int getResultSetHoldability() throws SQLException {
     logger.debug("public int getResultSetHoldability()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getResultSetType() throws SQLException
-  {
+  public int getResultSetType() throws SQLException {
     logger.debug("public int getResultSetType()");
 
     return ResultSet.TYPE_FORWARD_ONLY;
   }
 
   @Override
-  public int getUpdateCount() throws SQLException
-  {
+  public int getUpdateCount() throws SQLException {
     logger.debug("public int getUpdateCount()");
 
     return updateCount;
   }
 
   @Override
-  public SQLWarning getWarnings() throws SQLException
-  {
+  public SQLWarning getWarnings() throws SQLException {
     logger.debug("public SQLWarning getWarnings()");
 
     return sqlWarnings;
   }
 
   @Override
-  public boolean isClosed() throws SQLException
-  {
+  public boolean isClosed() throws SQLException {
     logger.debug("public boolean isClosed()");
 
     return isClosed;
   }
 
   @Override
-  public boolean isPoolable() throws SQLException
-  {
+  public boolean isPoolable() throws SQLException {
     logger.debug("public boolean isPoolable()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setCursorName(String name) throws SQLException
-  {
+  public void setCursorName(String name) throws SQLException {
     logger.debug("public void setCursorName(String name)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setEscapeProcessing(boolean enable) throws SQLException
-  {
+  public void setEscapeProcessing(boolean enable) throws SQLException {
     logger.debug("public void setEscapeProcessing(boolean enable)");
 
     escapeProcessing = true;
   }
 
   @Override
-  public void setFetchDirection(int direction) throws SQLException
-  {
+  public void setFetchDirection(int direction) throws SQLException {
     logger.debug("public void setFetchDirection(int direction)");
 
-    if (direction != ResultSet.FETCH_FORWARD)
-    {
+    if (direction != ResultSet.FETCH_FORWARD) {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public void setFetchSize(int rows) throws SQLException
-  {
+  public void setFetchSize(int rows) throws SQLException {
     logger.debug("public void setFetchSize(int rows), rows={}", rows);
 
     fetchSize = rows;
   }
 
   @Override
-  public void setMaxFieldSize(int max) throws SQLException
-  {
+  public void setMaxFieldSize(int max) throws SQLException {
     logger.debug("public void setMaxFieldSize(int max)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setMaxRows(int max) throws SQLException
-  {
+  public void setMaxRows(int max) throws SQLException {
     logger.debug("public void setMaxRows(int max)");
 
     this.maxRows = max;
-    try
-    {
-      if (this.sfStatement != null)
-        this.sfStatement.addProperty("rows_per_resultset", max);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    try {
+      if (this.sfStatement != null) this.sfStatement.addProperty("rows_per_resultset", max);
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void setPoolable(boolean poolable) throws SQLException
-  {
+  public void setPoolable(boolean poolable) throws SQLException {
     logger.debug("public void setPoolable(boolean poolable)");
 
-    if (poolable)
-    {
+    if (poolable) {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   /**
    * Sets a parameter at the statement level. Used for internal testing.
+   *
    * @throws Exception
    */
-  public void setParameter(String name, Object value) throws Exception
-  {
+  public void setParameter(String name, Object value) throws Exception {
     logger.debug("public void setParameter");
 
-    try
-    {
-      if (this.sfStatement != null)
-      {
+    try {
+      if (this.sfStatement != null) {
         this.sfStatement.addProperty(name, value);
       }
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLException(ex);
     }
   }
 
   @Override
-  public void setQueryTimeout(int seconds) throws SQLException
-  {
+  public void setQueryTimeout(int seconds) throws SQLException {
     logger.debug("public void setQueryTimeout(int seconds)");
 
     this.queryTimeout = seconds;
-    try
-    {
-      if (this.sfStatement != null)
-        this.sfStatement.addProperty("query_timeout", seconds);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-          ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    try {
+      if (this.sfStatement != null) this.sfStatement.addProperty("query_timeout", seconds);
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException
-  {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
     logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -670,38 +560,32 @@ class SnowflakeStatementV1 implements Statement
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException
-  {
+  public <T> T unwrap(Class<T> iface) throws SQLException {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this))
-    {
+    if (!iface.isInstance(this)) {
       throw new SQLException(
-              this.getClass().getName() + " not unwrappable from " + iface
-              .getName());
+          this.getClass().getName() + " not unwrappable from " + iface.getName());
     }
     return (T) this;
   }
 
   @Override
-  public void closeOnCompletion() throws SQLException
-  {
+  public void closeOnCompletion() throws SQLException {
     logger.debug("public void closeOnCompletion()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isCloseOnCompletion() throws SQLException
-  {
+  public boolean isCloseOnCompletion() throws SQLException {
     logger.debug("public boolean isCloseOnCompletion()");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void close() throws SQLException
-  {
+  public void close() throws SQLException {
     logger.debug("public void close()");
 
     resultSet = null;
@@ -712,36 +596,28 @@ class SnowflakeStatementV1 implements Statement
   }
 
   @Override
-  public void cancel() throws SQLException
-  {
+  public void cancel() throws SQLException {
     logger.debug("public void cancel()");
 
-    try
-    {
+    try {
       sfStatement.cancel();
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex, ex.getSqlState(),
-          ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(ex, ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void clearWarnings() throws SQLException
-  {
+  public void clearWarnings() throws SQLException {
     logger.debug("public void clearWarnings()");
 
     sqlWarnings = null;
   }
 
   @Override
-  public void addBatch(String sql) throws SQLException
-  {
+  public void addBatch(String sql) throws SQLException {
     logger.debug("public void addBatch(String sql)");
 
-    if (isClosed)
-    {
+    if (isClosed) {
       throw new SnowflakeSQLException(ErrorCode.STATEMENT_CLOSED);
     }
 
@@ -749,34 +625,28 @@ class SnowflakeStatementV1 implements Statement
   }
 
   @Override
-  public void clearBatch() throws SQLException
-  {
+  public void clearBatch() throws SQLException {
     logger.debug("public void clearBatch()");
 
-    if (isClosed)
-    {
+    if (isClosed) {
       throw new SnowflakeSQLException(ErrorCode.STATEMENT_CLOSED);
     }
 
     batch.clear();
   }
 
-  private void executeSetProperty(final String sql)
-  {
+  private void executeSetProperty(final String sql) {
     logger.debug("setting property");
 
     // tokenize the sql
     String[] tokens = sql.split("\\s+");
 
-    if (tokens == null || tokens.length < 2)
-    {
+    if (tokens == null || tokens.length < 2) {
       return;
     }
 
-    if ("tracing".equalsIgnoreCase(tokens[1]))
-    {
-      if (tokens.length >= 3)
-      {
+    if ("tracing".equalsIgnoreCase(tokens[1])) {
+      if (tokens.length >= 3) {
         /*connection.tracingLevel = Level.parse(tokens[2].toUpperCase());
         if (connection.tracingLevel != null)
         {
@@ -784,50 +654,38 @@ class SnowflakeStatementV1 implements Statement
           snowflakeLogger.setLevel(connection.tracingLevel);
         }*/
       }
-    }
-    else
-    {
+    } else {
       this.sfStatement.executeSetProperty(sql);
     }
   }
 
-  public SFStatement getSfStatement()
-  {
+  public SFStatement getSfStatement() {
     return sfStatement;
   }
 
-  protected void appendWarning(SQLWarning w)
-  {
-    if (sqlWarnings == null)
-    {
+  protected void appendWarning(SQLWarning w) {
+    if (sqlWarnings == null) {
       sqlWarnings = w;
-    }
-    else
-    {
+    } else {
       sqlWarnings.setNextWarning(w);
     }
   }
 
-  final class BatchEntry
-  {
+  final class BatchEntry {
     private final String sql;
 
     private final Map<String, ParameterBindingDTO> parameterBindings;
 
-    BatchEntry(String sql,
-               Map<String, ParameterBindingDTO> parameterBindings)
-    {
+    BatchEntry(String sql, Map<String, ParameterBindingDTO> parameterBindings) {
       this.sql = sql;
       this.parameterBindings = parameterBindings;
     }
 
-    public String getSql()
-    {
+    public String getSql() {
       return sql;
     }
 
-    public Map<String, ParameterBindingDTO> getParameterBindings()
-    {
+    public Map<String, ParameterBindingDTO> getParameterBindings() {
       return parameterBindings;
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -4,38 +4,45 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SqlState;
-
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.text.DateFormat;
 import java.util.Date;
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SqlState;
 
-/**
- * Type converters
- */
-public enum SnowflakeType
-{
-
-  TEXT, CHAR, INTEGER, FIXED, REAL, TIMESTAMP, TIMESTAMP_LTZ, TIMESTAMP_NTZ, TIMESTAMP_TZ,
-  DATE, TIME, BOOLEAN, ARRAY, OBJECT, VARIANT, BINARY, ANY;
+/** Type converters */
+public enum SnowflakeType {
+  TEXT,
+  CHAR,
+  INTEGER,
+  FIXED,
+  REAL,
+  TIMESTAMP,
+  TIMESTAMP_LTZ,
+  TIMESTAMP_NTZ,
+  TIMESTAMP_TZ,
+  DATE,
+  TIME,
+  BOOLEAN,
+  ARRAY,
+  OBJECT,
+  VARIANT,
+  BINARY,
+  ANY;
 
   public static final String DATE_OR_TIME_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
   public static final String TIMESTAMP_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.";
   public static final String TIMESTAMP_FORMAT_TZ_PATTERN = "XXX";
   public static final String TIME_FORMAT_PATTERN = "HH:mm:ss.SSS";
 
-  public static SnowflakeType fromString(String name)
-  {
+  public static SnowflakeType fromString(String name) {
     return SnowflakeType.valueOf(name.toUpperCase());
   }
 
-  public static JavaDataType getJavaType(SnowflakeType type)
-  {
-    switch (type)
-    {
+  public static JavaDataType getJavaType(SnowflakeType type) {
+    switch (type) {
       case TEXT:
         return JavaDataType.JAVA_STRING;
       case CHAR:
@@ -70,9 +77,7 @@ public enum SnowflakeType
     }
   }
 
-  public enum JavaDataType
-  {
-
+  public enum JavaDataType {
     JAVA_STRING(String.class),
     JAVA_LONG(Long.class),
     JAVA_DOUBLE(Double.class),
@@ -82,8 +87,7 @@ public enum SnowflakeType
     JAVA_BOOLEAN(Boolean.class),
     JAVA_OBJECT(Object.class);
 
-    JavaDataType(Class c)
-    {
+    JavaDataType(Class c) {
       this._class = c;
     }
 
@@ -91,13 +95,12 @@ public enum SnowflakeType
   }
 
   /**
-   * Returns a lexical value of an object that is suitable for Snowflake import
-   * serialization
+   * Returns a lexical value of an object that is suitable for Snowflake import serialization
    *
-   * @param o                 Java object representing value in Snowflake.
-   * @param dateFormat        java.sql.Date or java.sqlTime format
-   * @param timeFormat        java.sql.Time format
-   * @param timestampFormat   first part of java.sql.Timestamp format
+   * @param o Java object representing value in Snowflake.
+   * @param dateFormat java.sql.Date or java.sqlTime format
+   * @param timeFormat java.sql.Time format
+   * @param timestampFormat first part of java.sql.Timestamp format
    * @param timestampTzFormat last part of java.sql.Timestamp format
    * @return String representation of it that can be used for creating a load file
    */
@@ -106,94 +109,76 @@ public enum SnowflakeType
       DateFormat dateFormat,
       DateFormat timeFormat,
       DateFormat timestampFormat,
-      DateFormat timestampTzFormat)
-  {
-    if (o == null)
-    {
+      DateFormat timestampTzFormat) {
+    if (o == null) {
       return null;
     }
 
     Class c = o.getClass();
 
-    if (c == Date.class || c == java.sql.Date.class)
-    {
+    if (c == Date.class || c == java.sql.Date.class) {
       return synchronizeFormat(o, dateFormat);
     }
 
-    if (c == java.sql.Time.class)
-    {
+    if (c == java.sql.Time.class) {
       return synchronizeFormat(o, timeFormat);
     }
 
-    if (c == java.sql.Timestamp.class)
-    {
+    if (c == java.sql.Timestamp.class) {
       String stdFmt = o.toString();
       String nanos = stdFmt.substring(stdFmt.indexOf('.') + 1);
       String ret1 = synchronizeFormat(o, timestampFormat);
       String ret2 = synchronizeFormat(o, timestampTzFormat);
       return ret1 + nanos + ret2;
     }
-    if (c == Double.class)
-    {
+    if (c == Double.class) {
       return Double.toHexString((Double) o);
     }
 
-    if (c == Float.class)
-    {
+    if (c == Float.class) {
       return Float.toHexString((Float) o);
     }
 
-    if (c == Integer.class)
-    {
+    if (c == Integer.class) {
       return o.toString();
     }
 
-    if (c == BigDecimal.class)
-    {
+    if (c == BigDecimal.class) {
       return o.toString();
     }
 
-    if (c == byte[].class)
-    {
+    if (c == byte[].class) {
       return new SFBinary((byte[]) o).toHex();
     }
 
     return String.valueOf(o);
   }
 
-  private static synchronized String synchronizeFormat(
-      Object o, DateFormat sdf)
-  {
+  private static synchronized String synchronizeFormat(Object o, DateFormat sdf) {
     return sdf.format(o);
   }
 
-  public static String escapeForCSV(String value)
-  {
-    if (value == null)
-    {
+  public static String escapeForCSV(String value) {
+    if (value == null) {
       return ""; // null => an empty string without quotes
     }
-    if (value.isEmpty())
-    {
+    if (value.isEmpty()) {
       return "\"\""; // an empty string => an empty string with quotes
     }
-    if (value.indexOf('"') >= 0 || value.indexOf('\n') >= 0
-        || value.indexOf(',') >= 0 || value.indexOf('\\') >= 0)
-    {
+    if (value.indexOf('"') >= 0
+        || value.indexOf('\n') >= 0
+        || value.indexOf(',') >= 0
+        || value.indexOf('\\') >= 0) {
       // anything else including double quotes or commas will have quotes
       return '"' + value.replaceAll("\"", "\"\"") + '"';
-    }
-    else
-    {
+    } else {
       return value;
     }
   }
 
-  public static SnowflakeType javaTypeToSFType(int javaType) throws SnowflakeSQLException
-  {
+  public static SnowflakeType javaTypeToSFType(int javaType) throws SnowflakeSQLException {
 
-    switch (javaType)
-    {
+    switch (javaType) {
       case Types.INTEGER:
       case Types.BIGINT:
       case Types.DECIMAL:
@@ -229,9 +214,9 @@ public enum SnowflakeType
         return ANY;
 
       default:
-        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-            ErrorCode.DATA_TYPE_NOT_SUPPORTED
-                .getMessageCode(),
+        throw new SnowflakeSQLException(
+            SqlState.FEATURE_NOT_SUPPORTED,
+            ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
             javaType);
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -5,9 +5,6 @@
 package net.snowflake.client.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.common.core.SqlState;
-import net.snowflake.common.util.ClassUtil;
-import net.snowflake.common.util.FixedViewColumn;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -23,22 +20,20 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import net.snowflake.client.log.SFLogger;
+import net.snowflake.common.core.SqlState;
+import net.snowflake.common.util.ClassUtil;
+import net.snowflake.common.util.FixedViewColumn;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
-/**
- *
- * @author jhuang
- */
-public class SnowflakeUtil
-{
 
-  /**
-   * Additional data types not covered by standard JDBC
-   */
-  public final static int EXTRA_TYPES_TIMESTAMP_LTZ = 50000;
+/** @author jhuang */
+public class SnowflakeUtil {
 
-  public final static int EXTRA_TYPES_TIMESTAMP_TZ = 50001;
+  /** Additional data types not covered by standard JDBC */
+  public static final int EXTRA_TYPES_TIMESTAMP_LTZ = 50000;
+
+  public static final int EXTRA_TYPES_TIMESTAMP_TZ = 50001;
 
   // reauthenticate
   private static final int ID_TOKEN_EXPIRED_GS_CODE = 390110;
@@ -47,35 +42,27 @@ public class SnowflakeUtil
   private static final int MASTER_EXPIRED_GS_CODE = 390114;
   private static final int MASTER_TOKEN_INVALID_GS_CODE = 390115;
 
-
-  static public void checkErrorAndThrowExceptionIncludingReauth(JsonNode rootNode)
-      throws SnowflakeSQLException
-  {
+  public static void checkErrorAndThrowExceptionIncludingReauth(JsonNode rootNode)
+      throws SnowflakeSQLException {
     checkErrorAndThrowExceptionSub(rootNode, true);
   }
 
-  static public void checkErrorAndThrowException(JsonNode rootNode)
-      throws SnowflakeSQLException
-  {
+  public static void checkErrorAndThrowException(JsonNode rootNode) throws SnowflakeSQLException {
     checkErrorAndThrowExceptionSub(rootNode, false);
   }
 
   /**
-   * Check the error in the JSON node and generate an exception based on
-   * information extracted from the node.
+   * Check the error in the JSON node and generate an exception based on information extracted from
+   * the node.
    *
    * @param rootNode json object contains error information
-   * @param raiseReauthenticateError raises SnowflakeReauthenticationRequest
-   *                                if true
+   * @param raiseReauthenticateError raises SnowflakeReauthenticationRequest if true
    * @throws SnowflakeSQLException the exception get from the error in the json
    */
-  static private void checkErrorAndThrowExceptionSub(
-      JsonNode rootNode, boolean raiseReauthenticateError)
-      throws SnowflakeSQLException
-  {
+  private static void checkErrorAndThrowExceptionSub(
+      JsonNode rootNode, boolean raiseReauthenticateError) throws SnowflakeSQLException {
     // no need to throw exception if success
-    if (rootNode.path("success").asBoolean())
-    {
+    if (rootNode.path("success").asBoolean()) {
       return;
     }
 
@@ -85,62 +72,46 @@ public class SnowflakeUtil
     String queryId = "unknown";
 
     // if we have sqlstate in data, it's a sql error
-    if (!rootNode.path("data").path("sqlState").isMissingNode())
-    {
+    if (!rootNode.path("data").path("sqlState").isMissingNode()) {
       sqlState = rootNode.path("data").path("sqlState").asText();
       errorCode = rootNode.path("data").path("errorCode").asInt();
       queryId = rootNode.path("data").path("queryId").asText();
       errorMessage = rootNode.path("message").asText();
-    }
-    else
-    {
+    } else {
       sqlState = SqlState.INTERNAL_ERROR; // use internal error sql state
 
       // check if there is an error code in the envelope
-      if (!rootNode.path("code").isMissingNode())
-      {
+      if (!rootNode.path("code").isMissingNode()) {
         errorCode = rootNode.path("code").asInt();
         errorMessage = rootNode.path("message").asText();
-      }
-      else
-      {
+      } else {
         errorCode = ErrorCode.INTERNAL_ERROR.getMessageCode();
         errorMessage = "no_error_code_from_server";
 
-        try
-        {
+        try {
           PrintWriter writer = new PrintWriter("output.json", "UTF-8");
           writer.print(rootNode.toString());
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
           String s = ex.toString();
         }
       }
     }
 
-    if (raiseReauthenticateError)
-    {
-      switch(errorCode)
-      {
+    if (raiseReauthenticateError) {
+      switch (errorCode) {
         case ID_TOKEN_EXPIRED_GS_CODE:
         case SESSION_NOT_EXIST_GS_CODE:
         case MASTER_TOKEN_NOTFOUND:
         case MASTER_EXPIRED_GS_CODE:
         case MASTER_TOKEN_INVALID_GS_CODE:
-          throw new SnowflakeReauthenticationRequest(
-              queryId, errorMessage, sqlState, errorCode);
+          throw new SnowflakeReauthenticationRequest(queryId, errorMessage, sqlState, errorCode);
       }
     }
-    throw new SnowflakeSQLException(queryId, errorMessage, sqlState,
-                                    errorCode);
+    throw new SnowflakeSQLException(queryId, errorMessage, sqlState, errorCode);
   }
 
-  static public SnowflakeColumnMetadata extractColumnMetadata(
-                                                  JsonNode colNode,
-                                                  boolean jdbcTreatDecimalAsInt)
-          throws SnowflakeSQLException
-  {
+  public static SnowflakeColumnMetadata extractColumnMetadata(
+      JsonNode colNode, boolean jdbcTreatDecimalAsInt) throws SnowflakeSQLException {
     String colName = colNode.path("name").asText();
     String internalColTypeName = colNode.path("type").asText();
     boolean nullable = colNode.path("nullable").asBoolean();
@@ -154,9 +125,7 @@ public class SnowflakeUtil
 
     SnowflakeType baseType = SnowflakeType.fromString(internalColTypeName);
 
-    switch (baseType)
-    {
-
+    switch (baseType) {
       case TEXT:
         colType = Types.VARCHAR;
         extColTypeName = "VARCHAR";
@@ -173,8 +142,7 @@ public class SnowflakeUtil
         break;
 
       case FIXED:
-        colType = jdbcTreatDecimalAsInt && scale == 0
-            ? Types.BIGINT : Types.DECIMAL;
+        colType = jdbcTreatDecimalAsInt && scale == 0 ? Types.BIGINT : Types.DECIMAL;
         extColTypeName = "NUMBER";
         break;
 
@@ -195,7 +163,6 @@ public class SnowflakeUtil
         break;
 
       case TIMESTAMP_TZ:
-
         colType = EXTRA_TYPES_TIMESTAMP_TZ;
         extColTypeName = "TIMESTAMPTZ";
         break;
@@ -236,81 +203,72 @@ public class SnowflakeUtil
         break;
 
       default:
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR
-                                        .getMessageCode(),
-                                        "Unknown column type: " + internalColTypeName);
+        throw new SnowflakeSQLException(
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            "Unknown column type: " + internalColTypeName);
     }
 
     String colSrcDatabase = colNode.path("database").asText();
     String colSrcSchema = colNode.path("schema").asText();
     String colSrcTable = colNode.path("table").asText();
 
-    return new SnowflakeColumnMetadata(colName, colType, nullable, length,
-                                       precision, scale, extColTypeName,
-                                       fixed, baseType, colSrcDatabase,
-                                       colSrcSchema, colSrcTable);
+    return new SnowflakeColumnMetadata(
+        colName,
+        colType,
+        nullable,
+        length,
+        precision,
+        scale,
+        extColTypeName,
+        fixed,
+        baseType,
+        colSrcDatabase,
+        colSrcSchema,
+        colSrcTable);
   }
 
-  public static String javaTypeToSFTypeString(int javaType)
-          throws SnowflakeSQLException
-  {
+  public static String javaTypeToSFTypeString(int javaType) throws SnowflakeSQLException {
     return SnowflakeType.javaTypeToSFType(javaType).name();
   }
 
-  public static SnowflakeType javaTypeToSFType(int javaType)
-          throws SnowflakeSQLException
-  {
+  public static SnowflakeType javaTypeToSFType(int javaType) throws SnowflakeSQLException {
     return SnowflakeType.javaTypeToSFType(javaType);
   }
 
   /**
-   * A small function for concatenating two file paths by making sure one and
-   * only one path separator is placed between the two paths.
-   * <p>
-   * This is necessary since for S3 file name, having different number of file
-   * separators in a path will mean different files.
-   * </p>
-   * <p>
-   * Typical use case is to concatenate a file name to a directory.
-   * </p>
+   * A small function for concatenating two file paths by making sure one and only one path
+   * separator is placed between the two paths.
+   *
+   * <p>This is necessary since for S3 file name, having different number of file separators in a
+   * path will mean different files.
+   *
+   * <p>Typical use case is to concatenate a file name to a directory.
+   *
    * @param leftPath left path
    * @param rightPath right path
    * @param fileSep file separator
    * @return concatenated file path
    */
-  static public String concatFilePathNames(String leftPath,
-                                           String rightPath,
-                                           String fileSep)
-  {
+  public static String concatFilePathNames(String leftPath, String rightPath, String fileSep) {
     String leftPathTrimmed = leftPath.trim();
     String rightPathTrimmed = rightPath.trim();
 
-    if (leftPathTrimmed.isEmpty())
-    {
+    if (leftPathTrimmed.isEmpty()) {
       return rightPath;
     }
 
-    if (leftPathTrimmed.endsWith(fileSep)
-        && rightPathTrimmed.startsWith(fileSep))
-    {
+    if (leftPathTrimmed.endsWith(fileSep) && rightPathTrimmed.startsWith(fileSep)) {
       return leftPathTrimmed + rightPathTrimmed.substring(1);
-    }
-    else if (!leftPathTrimmed.endsWith(fileSep)
-             && !rightPathTrimmed.startsWith(fileSep))
-    {
+    } else if (!leftPathTrimmed.endsWith(fileSep) && !rightPathTrimmed.startsWith(fileSep)) {
       return leftPathTrimmed + fileSep + rightPathTrimmed;
-    }
-    else
-    {
+    } else {
       return leftPathTrimmed + rightPathTrimmed;
     }
   }
 
-  static public String greatestCommonPrefix(String val1, String val2)
-  {
-    if (val1 == null || val2 == null)
-    {
+  public static String greatestCommonPrefix(String val1, String val2) {
+    if (val1 == null || val2 == null) {
       return null;
     }
 
@@ -318,14 +276,10 @@ public class SnowflakeUtil
 
     int len = Math.min(val1.length(), val2.length());
 
-    for (int idx = 0; idx < len; idx++)
-    {
-      if (val1.charAt(idx) == val2.charAt(idx))
-      {
+    for (int idx = 0; idx < len; idx++) {
+      if (val1.charAt(idx) == val2.charAt(idx)) {
         greatestCommonPrefix.append(val1.charAt(idx));
-      }
-      else
-      {
+      } else {
         break;
       }
     }
@@ -333,21 +287,16 @@ public class SnowflakeUtil
     return greatestCommonPrefix.toString();
   }
 
-  public static List<SnowflakeColumnMetadata> describeFixedViewColumns(
-          Class clazz) throws SnowflakeSQLException
-  {
-    Field[] columns
-            = ClassUtil.getAnnotatedDeclaredFields(clazz, FixedViewColumn.class,
-                                                   true);
+  public static List<SnowflakeColumnMetadata> describeFixedViewColumns(Class clazz)
+      throws SnowflakeSQLException {
+    Field[] columns = ClassUtil.getAnnotatedDeclaredFields(clazz, FixedViewColumn.class, true);
 
     Arrays.sort(columns, new FixedViewColumn.OrdinalComparatorForFields());
 
     List<SnowflakeColumnMetadata> rowType = new ArrayList<SnowflakeColumnMetadata>();
 
-    for (Field column : columns)
-    {
-      FixedViewColumn columnAnnotation
-                      = column.getAnnotation(FixedViewColumn.class);
+    for (Field column : columns) {
+      FixedViewColumn columnAnnotation = column.getAnnotation(FixedViewColumn.class);
 
       String typeName;
       int colType;
@@ -355,37 +304,30 @@ public class SnowflakeUtil
       Class<?> type = column.getType();
       SnowflakeType stype = SnowflakeType.TEXT;
 
-
-      if (type == Integer.TYPE)
-      {
+      if (type == Integer.TYPE) {
         colType = Types.INTEGER;
         typeName = "INTEGER";
         stype = SnowflakeType.INTEGER;
       }
-      if (type == Long.TYPE)
-      {
+      if (type == Long.TYPE) {
         colType = Types.DECIMAL;
         typeName = "DECIMAL";
         stype = SnowflakeType.INTEGER;
-      }
-      else if (type == String.class)
-      {
+      } else if (type == String.class) {
         colType = Types.VARCHAR;
         typeName = "VARCHAR";
         stype = SnowflakeType.TEXT;
-      }
-      else
-      {
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR
-                                        .getMessageCode(),
-                                        "Unsupported column type: " + type
-                                        .getName());
+      } else {
+        throw new SnowflakeSQLException(
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            "Unsupported column type: " + type.getName());
       }
 
       // TODO: we hard code some of the values below but can change them
       // later to derive from annotation as well.
-      rowType.add(new SnowflakeColumnMetadata(
+      rowType.add(
+          new SnowflakeColumnMetadata(
               columnAnnotation.name(), // column name
               colType, // column type
               false, // nullable
@@ -394,10 +336,10 @@ public class SnowflakeUtil
               0, // scale
               typeName, // type name
               true,
-              stype,  // fixed
-              "",     // database
-              "",     // schema
-              ""));   // table
+              stype, // fixed
+              "", // database
+              "", // schema
+              "")); // table
     }
 
     return rowType;
@@ -405,53 +347,41 @@ public class SnowflakeUtil
 
   /**
    * A utility to log response details.
-   * <p>
-   * Used when there is an error in http response
-   * </p>
+   *
+   * <p>Used when there is an error in http response
+   *
    * @param response http response get from server
    * @param logger logger object
    */
-  static public void logResponseDetails(HttpResponse response, SFLogger logger)
-  {
-    if (response == null)
-    {
+  public static void logResponseDetails(HttpResponse response, SFLogger logger) {
+    if (response == null) {
       logger.error("null response");
       return;
     }
 
     // log the response
-    if (response.getStatusLine() != null)
-    {
-      logger.error("Response status line reason: {}",
-                 response.getStatusLine().getReasonPhrase());
+    if (response.getStatusLine() != null) {
+      logger.error("Response status line reason: {}", response.getStatusLine().getReasonPhrase());
     }
 
     // log each header from response
     Header[] headers = response.getAllHeaders();
-    if (headers != null)
-    {
-      for (Header header : headers)
-      {
-        logger.error("Header name: {}, value: {}",
-                     header.getName(), header.getValue());
+    if (headers != null) {
+      for (Header header : headers) {
+        logger.error("Header name: {}, value: {}", header.getName(), header.getValue());
       }
     }
 
     // log response
-    if (response.getEntity() != null)
-    {
-      try
-      {
+    if (response.getEntity() != null) {
+      try {
         StringWriter writer = new StringWriter();
-        BufferedReader bufferedReader = new BufferedReader(
-                new InputStreamReader((response.getEntity().getContent())));
+        BufferedReader bufferedReader =
+            new BufferedReader(new InputStreamReader((response.getEntity().getContent())));
         IOUtils.copy(bufferedReader, writer);
         logger.error("Response content: {}", writer.toString());
-      }
-      catch (IOException ex)
-      {
-        logger.error("Failed to read content due to exception: "
-                               + "{}", ex.getMessage());
+      } catch (IOException ex) {
+        logger.error("Failed to read content due to exception: " + "{}", ex.getMessage());
       }
     }
   }
@@ -463,44 +393,37 @@ public class SnowflakeUtil
    * @param parallel the number of concurrency
    * @return A new thread pool configured with the default settings.
    */
-  static public ThreadPoolExecutor createDefaultExecutorService(
-      final String threadNamePrefix, final int parallel)
-  {
-    ThreadFactory threadFactory = new ThreadFactory() {
-      private int threadCount = 1;
+  public static ThreadPoolExecutor createDefaultExecutorService(
+      final String threadNamePrefix, final int parallel) {
+    ThreadFactory threadFactory =
+        new ThreadFactory() {
+          private int threadCount = 1;
 
-      public Thread newThread(Runnable r) {
-        Thread thread = new Thread(r);
-        thread.setName(threadNamePrefix + threadCount++);
-        return thread;
-      }
-    };
-    return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallel,
-        threadFactory);
+          public Thread newThread(Runnable r) {
+            Thread thread = new Thread(r);
+            thread.setName(threadNamePrefix + threadCount++);
+            return thread;
+          }
+        };
+    return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallel, threadFactory);
   }
 
-  static public Throwable getRootCause(Exception ex)
-  {
+  public static Throwable getRootCause(Exception ex) {
     Throwable cause = ex;
-    while(cause.getCause() != null)
-    {
+    while (cause.getCause() != null) {
       cause = cause.getCause();
     }
 
     return cause;
   }
 
-  static public boolean isBlank(String input)
-  {
-    if ("".equals(input) || input == null)
-    {
+  public static boolean isBlank(String input) {
+    if ("".equals(input) || input == null) {
       return true;
     }
 
-    for(char c : input.toCharArray())
-    {
-      if (!Character.isWhitespace(c))
-      {
+    for (char c : input.toCharArray()) {
+      if (!Character.isWhitespace(c)) {
         return false;
       }
     }
@@ -508,15 +431,12 @@ public class SnowflakeUtil
     return true;
   }
 
-  private static final String ALPHA_NUMERIC_STRING =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  private static final String ALPHA_NUMERIC_STRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
-  public static String randomAlphaNumeric(int count)
-  {
+  public static String randomAlphaNumeric(int count) {
     StringBuilder builder = new StringBuilder();
     Random random = new Random();
-    while (count-- != 0)
-    {
+    while (count-- != 0) {
       int character = random.nextInt(ALPHA_NUMERIC_STRING.length());
       builder.append(ALPHA_NUMERIC_STRING.charAt(character));
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/AzureObjectMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/AzureObjectMetadata.java
@@ -7,22 +7,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Implements  platform-independent interface Azure BLOB object metadata
+ * Implements platform-independent interface Azure BLOB object metadata
  *
- * Only the metadata accessors and mutators used by the JDBC client currently are supported,
+ * <p>Only the metadata accessors and mutators used by the JDBC client currently are supported,
  * additional methods should be added as needed
  *
  * @author lgiakoumakis
- *
- **/
-public class AzureObjectMetadata implements StorageObjectMetadata
-{
+ */
+public class AzureObjectMetadata implements StorageObjectMetadata {
   private long contentLength;
   private Map<String, String> userDefinedMetadata;
   private String contentEncoding;
 
-  AzureObjectMetadata()
-  {
+  AzureObjectMetadata() {
     userDefinedMetadata = new HashMap<>();
   }
 
@@ -30,66 +27,52 @@ public class AzureObjectMetadata implements StorageObjectMetadata
    * Constructs a Azure metadata object
    * from the set of parameters that the JDBC client is using
    */
-  AzureObjectMetadata(long contentLength, String contentEncoding, Map<String, String> userDefinedMetadata)
-  {
+  AzureObjectMetadata(
+      long contentLength, String contentEncoding, Map<String, String> userDefinedMetadata) {
     this.contentEncoding = contentEncoding;
     this.contentLength = contentLength;
     this.userDefinedMetadata = userDefinedMetadata;
   }
 
-  /**
-   * @return returns a Map/key-value pairs of metadata properties
-   */
+  /** @return returns a Map/key-value pairs of metadata properties */
   @Override
-  public Map<String, String> getUserMetadata()
-  {
+  public Map<String, String> getUserMetadata() {
     return userDefinedMetadata;
   };
 
-  /**
-   * @return returns the size of object in bytes
-   */
+  /** @return returns the size of object in bytes */
   @Override
-  public long getContentLength()
-  {
+  public long getContentLength() {
     return contentLength;
   }
 
-  /**
-   * Sets size of the associated object in bytes
-   */
+  /** Sets size of the associated object in bytes */
   @Override
-  public void setContentLength(long contentLength)
-  {
+  public void setContentLength(long contentLength) {
     this.contentLength = contentLength;
   }
 
-  /**
-   * Adds the key value pair of custom user-metadata for the associated object.
-   */
+  /** Adds the key value pair of custom user-metadata for the associated object. */
   @Override
-  public void addUserMetadata(String key, String value)
-  {
+  public void addUserMetadata(String key, String value) {
     userDefinedMetadata.put(key, value);
   }
 
   /**
-   * Sets the optional Content-Encoding HTTP header specifying what content encodings,
-   * have been applied to the object and what decoding mechanisms must be applied,
-   * in order to obtain the media-type referenced by the Content-Type field.
+   * Sets the optional Content-Encoding HTTP header specifying what content encodings, have been
+   * applied to the object and what decoding mechanisms must be applied, in order to obtain the
+   * media-type referenced by the Content-Type field.
    */
   @Override
-  public void setContentEncoding(String encoding)
-  {
+  public void setContentEncoding(String encoding) {
     contentEncoding = encoding;
   }
 
   /*
- * @return returns the content encoding type
- */
+   * @return returns the content encoding type
+   */
   @Override
-  public String getContentEncoding()
-  {
+  public String getContentEncoding() {
     return contentEncoding;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/AzureObjectSummariesIterator.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/AzureObjectSummariesIterator.java
@@ -7,17 +7,15 @@ package net.snowflake.client.jdbc.cloud.storage;
 import com.amazonaws.services.kms.model.UnsupportedOperationException;
 import com.microsoft.azure.storage.blob.CloudBlob;
 import com.microsoft.azure.storage.blob.ListBlobItem;
-
 import java.util.Iterator;
 
 /**
- * Iterator class for ObjectSummary objects on Azure
- * Returns platform-independent instances (StorageObjectSummary)
+ * Iterator class for ObjectSummary objects on Azure Returns platform-independent instances
+ * (StorageObjectSummary)
  *
  * @author lgiakoumakis
  */
-public class AzureObjectSummariesIterator implements Iterator<StorageObjectSummary>
-{
+public class AzureObjectSummariesIterator implements Iterator<StorageObjectSummary> {
   Iterator<ListBlobItem> itemIterator;
 
   /*
@@ -25,22 +23,18 @@ public class AzureObjectSummariesIterator implements Iterator<StorageObjectSumma
    * lostBlobs method
    * @param azCloudBlobIterable an iterable set of ListBlobItems
    */
-  public AzureObjectSummariesIterator(Iterable<ListBlobItem>  azCloudBlobIterable)
-  {
+  public AzureObjectSummariesIterator(Iterable<ListBlobItem> azCloudBlobIterable) {
     itemIterator = azCloudBlobIterable.iterator();
   }
 
-  public boolean hasNext()
-  {
-    return  itemIterator.hasNext();
+  public boolean hasNext() {
+    return itemIterator.hasNext();
   }
 
-  public StorageObjectSummary next()
-  {
+  public StorageObjectSummary next() {
     ListBlobItem listBlobItem = itemIterator.next();
 
-    if(!(listBlobItem instanceof CloudBlob))
-    {
+    if (!(listBlobItem instanceof CloudBlob)) {
       // The only other possible type would a CloudDirectory
       // This should never happen since we are listing items as a flat list
       throw new IllegalArgumentException("Unexpected listBlobItem instace type");
@@ -52,5 +46,4 @@ public class AzureObjectSummariesIterator implements Iterator<StorageObjectSumma
   public void remove() {
     throw new UnsupportedOperationException("remove() method not supported");
   }
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/EncryptionProvider.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/EncryptionProvider.java
@@ -3,6 +3,9 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+
 import com.amazonaws.util.Base64;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -28,38 +31,27 @@ import javax.crypto.spec.SecretKeySpec;
 import net.snowflake.client.jdbc.MatDesc;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.READ;
-
 /**
  * Handles encryption and decryption using AES.
  *
  * @author ppaulus
  */
-public class EncryptionProvider
-{
-  private final static String AES = "AES";
-  private final static String FILE_CIPHER = "AES/CBC/PKCS5Padding";
-  private final static String KEY_CIPHER = "AES/ECB/PKCS5Padding";
-  private final static int BUFFER_SIZE = 2*1024*1024; // 2 MB
+public class EncryptionProvider {
+  private static final String AES = "AES";
+  private static final String FILE_CIPHER = "AES/CBC/PKCS5Padding";
+  private static final String KEY_CIPHER = "AES/ECB/PKCS5Padding";
+  private static final int BUFFER_SIZE = 2 * 1024 * 1024; // 2 MB
   private static SecureRandom secRnd;
 
   /*
    * decrypt
    * Decrypts a file given the key and iv. Uses AES decryption.
    */
-  public static void decrypt(File file,
-                             String keyBase64,
-                             String ivBase64,
-                             RemoteStoreFileEncryptionMaterial encMat)
-          throws NoSuchAlgorithmException,
-                 NoSuchPaddingException,
-                 InvalidKeyException,
-                 IllegalBlockSizeException,
-                 BadPaddingException,
-                 InvalidAlgorithmParameterException,
-                 IOException
-  {
+  public static void decrypt(
+      File file, String keyBase64, String ivBase64, RemoteStoreFileEncryptionMaterial encMat)
+      throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException,
+          IllegalBlockSizeException, BadPaddingException, InvalidAlgorithmParameterException,
+          IOException {
     byte[] keyBytes = Base64.decode(keyBase64);
     byte[] ivBytes = Base64.decode(ivBase64);
     byte[] qsmkBytes = Base64.decode(encMat.getQueryStageMasterKey());
@@ -68,8 +60,7 @@ public class EncryptionProvider
     // Decrypt file key
     {
       final Cipher keyCipher = Cipher.getInstance(KEY_CIPHER);
-      SecretKey queryStageMasterKey =
-          new SecretKeySpec(qsmkBytes, 0, qsmkBytes.length, AES);
+      SecretKey queryStageMasterKey = new SecretKeySpec(qsmkBytes, 0, qsmkBytes.length, AES);
       keyCipher.init(Cipher.DECRYPT_MODE, queryStageMasterKey);
       byte[] fileKeyBytes = keyCipher.doFinal(keyBytes);
 
@@ -88,20 +79,17 @@ public class EncryptionProvider
       long totalBytesRead = 0;
       // Overwrite file contents buffer-wise with decrypted data
       try (InputStream is = Files.newInputStream(file.toPath(), READ);
-           InputStream cis = new CipherInputStream(is, fileCipher);
-           OutputStream os = Files.newOutputStream(file.toPath(), CREATE);)
-      {
+          InputStream cis = new CipherInputStream(is, fileCipher);
+          OutputStream os = Files.newOutputStream(file.toPath(), CREATE); ) {
         int bytesRead;
-        while ((bytesRead = cis.read(buffer)) > -1)
-        {
+        while ((bytesRead = cis.read(buffer)) > -1) {
           os.write(buffer, 0, bytesRead);
           totalBytesRead += bytesRead;
         }
       }
 
       // Discard any padding that the encrypted file had
-      try (FileChannel fc = new FileOutputStream(file, true).getChannel())
-      {
+      try (FileChannel fc = new FileOutputStream(file, true).getChannel()) {
         fc.truncate(totalBytesRead);
       }
     }
@@ -114,20 +102,15 @@ public class EncryptionProvider
    * The key and iv are added to the JSON block in the encryptionData
    * metadata object.
    */
-  public static CipherInputStream encrypt(StorageObjectMetadata meta,
-                                    long originalContentLength,
-                                    InputStream src,
-                                    RemoteStoreFileEncryptionMaterial encMat,
-                                    SnowflakeStorageClient client)
-          throws InvalidKeyException,
-                 InvalidAlgorithmParameterException,
-                 NoSuchAlgorithmException,
-                 NoSuchProviderException,
-                 NoSuchPaddingException,
-                 FileNotFoundException,
-                 IllegalBlockSizeException,
-                 BadPaddingException
-  {
+  public static CipherInputStream encrypt(
+      StorageObjectMetadata meta,
+      long originalContentLength,
+      InputStream src,
+      RemoteStoreFileEncryptionMaterial encMat,
+      SnowflakeStorageClient client)
+      throws InvalidKeyException, InvalidAlgorithmParameterException, NoSuchAlgorithmException,
+          NoSuchProviderException, NoSuchPaddingException, FileNotFoundException,
+          IllegalBlockSizeException, BadPaddingException {
     final byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
     final int keySize = decodedKey.length;
     final byte[] fileKeyBytes = new byte[keySize];
@@ -156,17 +139,15 @@ public class EncryptionProvider
 
     // Encrypt the file key with the QRMK
     {
-      final Cipher keyCipher =  Cipher.getInstance(KEY_CIPHER);
-      SecretKey queryStageMasterKey =
-          new SecretKeySpec(decodedKey, 0, keySize, AES);
+      final Cipher keyCipher = Cipher.getInstance(KEY_CIPHER);
+      SecretKey queryStageMasterKey = new SecretKeySpec(decodedKey, 0, keySize, AES);
 
       // Init cipher
       keyCipher.init(Cipher.ENCRYPT_MODE, queryStageMasterKey);
       byte[] encKeK = keyCipher.doFinal(fileKeyBytes);
 
       // Store metadata
-      MatDesc matDesc =
-          new MatDesc(encMat.getSmkId(), encMat.getQueryId(), keySize * 8);
+      MatDesc matDesc = new MatDesc(encMat.getSmkId(), encMat.getQueryId(), keySize * 8);
       // Round up length to next multiple of the block size
       // Sizes that are multiples of the block size need to be padded to next
       // multiple
@@ -182,16 +163,12 @@ public class EncryptionProvider
    * Gets a random number for encryption purposes.
    */
   private static synchronized SecureRandom getSecRnd()
-          throws NoSuchAlgorithmException,
-                 NoSuchProviderException
-  {
-    if (secRnd == null)
-    {
+      throws NoSuchAlgorithmException, NoSuchProviderException {
+    if (secRnd == null) {
       secRnd = SecureRandom.getInstance("SHA1PRNG");
       byte[] bytes = new byte[10];
       secRnd.nextBytes(bytes);
     }
     return secRnd;
   }
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/S3ObjectMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/S3ObjectMetadata.java
@@ -7,72 +7,57 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import java.util.Map;
 
 /**
- * s3 implementation of platform independent StorageObjectMetadata interface,
- * wraps an S3 ObjectMetadata class
+ * s3 implementation of platform independent StorageObjectMetadata interface, wraps an S3
+ * ObjectMetadata class
  *
- * It only supports a limited set of metadata properties
- * currrently used by the JDBC client
+ * <p>It only supports a limited set of metadata properties currrently used by the JDBC client
  *
  * @author lgiakoumakis
- *
- **/
-public class S3ObjectMetadata implements StorageObjectMetadata
-{
+ */
+public class S3ObjectMetadata implements StorageObjectMetadata {
   private ObjectMetadata objectMetadata;
 
-  S3ObjectMetadata()
-  {
+  S3ObjectMetadata() {
     objectMetadata = new ObjectMetadata();
   }
 
-  //Construct from an AWS S3 ObjectMetadata object
-  S3ObjectMetadata(ObjectMetadata meta)
-  {
+  // Construct from an AWS S3 ObjectMetadata object
+  S3ObjectMetadata(ObjectMetadata meta) {
     objectMetadata = meta;
   }
 
   @Override
-  public Map<String, String> getUserMetadata()
-  {
+  public Map<String, String> getUserMetadata() {
     return objectMetadata.getUserMetadata();
   }
 
   @Override
-  public long getContentLength()
-  {
+  public long getContentLength() {
     return objectMetadata.getContentLength();
   }
 
   @Override
-  public void setContentLength(long contentLength)
-  {
+  public void setContentLength(long contentLength) {
     objectMetadata.setContentLength(contentLength);
   }
 
   @Override
-  public void addUserMetadata(String key, String value)
-  {
+  public void addUserMetadata(String key, String value) {
     objectMetadata.addUserMetadata(key, value);
   }
 
   @Override
-  public void setContentEncoding(String encoding)
-  {
+  public void setContentEncoding(String encoding) {
     objectMetadata.setContentEncoding(encoding);
   }
 
   @Override
-  public String getContentEncoding()
-  {
+  public String getContentEncoding() {
     return objectMetadata.getContentEncoding();
   }
 
-  /**
-   * @return Returns the encapsulated AWS S3 metadata object
-   */
-  ObjectMetadata getS3ObjectMetadata()
-  {
+  /** @return Returns the encapsulated AWS S3 metadata object */
+  ObjectMetadata getS3ObjectMetadata() {
     return objectMetadata;
   }
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/S3ObjectSummariesIterator.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/S3ObjectSummariesIterator.java
@@ -6,18 +6,16 @@ package net.snowflake.client.jdbc.cloud.storage;
 
 import com.amazonaws.services.kms.model.UnsupportedOperationException;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-
 import java.util.Iterator;
 import java.util.List;
 
 /**
- * Iterator class for ObjectSummary objects on S3
- * Wraps an iterator of S3 object summaries and returns platform independent instances (StorageObjectSummary)
+ * Iterator class for ObjectSummary objects on S3 Wraps an iterator of S3 object summaries and
+ * returns platform independent instances (StorageObjectSummary)
  *
  * @author lgiakoumakis
  */
-public class  S3ObjectSummariesIterator implements Iterator<StorageObjectSummary>
-{
+public class S3ObjectSummariesIterator implements Iterator<StorageObjectSummary> {
 
   // Encapsulated S3 iterator
   private Iterator<S3ObjectSummary> s3ObjSummariesIterator;
@@ -27,26 +25,23 @@ public class  S3ObjectSummariesIterator implements Iterator<StorageObjectSummary
    * derived from the AWS client
    * @param s3ObjectSummaries a list of S3ObjectSummaries to construct from
    */
-  public S3ObjectSummariesIterator(List<S3ObjectSummary> s3ObjectSummaries)
-  {
+  public S3ObjectSummariesIterator(List<S3ObjectSummary> s3ObjectSummaries) {
     s3ObjSummariesIterator = s3ObjectSummaries.iterator();
   }
 
-  public boolean hasNext()
-  {
-      return s3ObjSummariesIterator.hasNext();
+  public boolean hasNext() {
+    return s3ObjSummariesIterator.hasNext();
   }
 
-  public StorageObjectSummary next()
-  {
-      // Get the next S3 summary object and return it as a platform-agnostic object (StorageObjectSummary)
-      S3ObjectSummary s3Obj = s3ObjSummariesIterator.next();
+  public StorageObjectSummary next() {
+    // Get the next S3 summary object and return it as a platform-agnostic object
+    // (StorageObjectSummary)
+    S3ObjectSummary s3Obj = s3ObjSummariesIterator.next();
 
-      return  StorageObjectSummary.createFromS3ObjectSummary(s3Obj);
+    return StorageObjectSummary.createFromS3ObjectSummary(s3Obj);
   }
 
   public void remove() {
     throw new UnsupportedOperationException("remove() method not supported");
   }
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/S3StorageObjectMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/S3StorageObjectMetadata.java
@@ -9,79 +9,68 @@ import java.util.Map;
 /**
  * Implementation of StorageObjectMetadata for S3 for remote storage object metadata.
  *
- *
  * @author ppaulus
  */
-public class S3StorageObjectMetadata implements StorageObjectMetadata
-{
+public class S3StorageObjectMetadata implements StorageObjectMetadata {
   private ObjectMetadata s3Metadata;
 
-  public S3StorageObjectMetadata(ObjectMetadata s3Metadata)
-  {
-    if (s3Metadata == null)
-    {
+  public S3StorageObjectMetadata(ObjectMetadata s3Metadata) {
+    if (s3Metadata == null) {
       throw new IllegalArgumentException("s3Metadata must not be null");
     }
     this.s3Metadata = s3Metadata;
   }
 
-  /**
-   * @return returns a Map/key-value pairs of metadata properties
-   */
+  /** @return returns a Map/key-value pairs of metadata properties */
   @Override
-  public Map<String, String> getUserMetadata()
-  {
+  public Map<String, String> getUserMetadata() {
     return this.s3Metadata.getUserMetadata();
   }
 
-  /**
-   * @return returns the size of object in bytes
-   */
+  /** @return returns the size of object in bytes */
   @Override
-  public long getContentLength()
-  {
+  public long getContentLength() {
     return this.s3Metadata.getContentLength();
   }
 
   /**
    * Sets size of the associated object in bytes
+   *
    * @param contentLength the length of content
    */
   @Override
-  public void setContentLength(long contentLength)
-  {
+  public void setContentLength(long contentLength) {
     this.s3Metadata.setContentLength(contentLength);
   }
 
   /**
    * Adds the key value pair of custom user-metadata for the associated object.
+   *
    * @param key the key of user metadata
    * @param value the value of user metadata
    */
   @Override
-  public void addUserMetadata(String key, String value)
-  {
+  public void addUserMetadata(String key, String value) {
     this.s3Metadata.addUserMetadata(key, value);
   }
 
   /**
-   * Sets the optional Content-Encoding HTTP header specifying what content encodings,
-   * have been applied to the object and what decoding mechanisms must be applied,
-   * in order to obtain the media-type referenced by the Content-Type field.
+   * Sets the optional Content-Encoding HTTP header specifying what content encodings, have been
+   * applied to the object and what decoding mechanisms must be applied, in order to obtain the
+   * media-type referenced by the Content-Type field.
+   *
    * @param encoding the encoding name using in HTTP header Content-Encoding
    */
   @Override
-  public void setContentEncoding(String encoding)
-  {
+  public void setContentEncoding(String encoding) {
     this.s3Metadata.setContentEncoding(encoding);
   }
 
   /*
    * @return returns the content encoding type
    */
-   @Override
-   public String getContentEncoding()
-   {
-     return this.s3Metadata.getContentEncoding();
-   }
+  @Override
+  public String getContentEncoding() {
+    return this.s3Metadata.getContentEncoding();
+  }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -8,29 +8,16 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.microsoft.azure.storage.blob.BlobProperties;
-import com.microsoft.azure.storage.blob.CloudBlob;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.FileBackedOutputStream;
-import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
 import com.microsoft.azure.storage.StorageCredentials;
 import com.microsoft.azure.storage.StorageCredentialsAnonymous;
 import com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature;
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.BlobProperties;
+import com.microsoft.azure.storage.blob.CloudBlob;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.blob.ListBlobItem;
-import net.snowflake.client.jdbc.SnowflakeUtil;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.util.SFPair;
-import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
-import net.snowflake.common.core.SqlState;
-import org.apache.commons.io.IOUtils;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -46,27 +33,35 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.FileBackedOutputStream;
 import net.snowflake.client.jdbc.MatDesc;
+import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.util.SFPair;
+import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
+import net.snowflake.common.core.SqlState;
+import org.apache.commons.io.IOUtils;
 
 /**
- * Encapsulates the Azure Storage client
- * and all Azure Storage operations and logic
+ * Encapsulates the Azure Storage client and all Azure Storage operations and logic
  *
  * @author lgiakoumakis
  */
+public class SnowflakeAzureClient implements SnowflakeStorageClient {
 
-public class SnowflakeAzureClient implements SnowflakeStorageClient
-{
-
-  private final static String localFileSep = System.getProperty("file.separator");
-  private final static String AZ_ENCRYPTIONDATAPROP = "encryptiondata";
+  private static final String localFileSep = System.getProperty("file.separator");
+  private static final String AZ_ENCRYPTIONDATAPROP = "encryptiondata";
 
   private int encryptionKeySize = 0; // used for PUTs
   private StageInfo stageInfo;
   private RemoteStoreFileEncryptionMaterial encMat;
   private CloudBlobClient azStorageClient;
-  private final static SFLogger logger =
-          SFLoggerFactory.getLogger(SnowflakeS3Client.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeS3Client.class);
 
   private SnowflakeAzureClient() {};
 
@@ -76,10 +71,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * @param encMat  The encryption material
    *                required to decrypt/encrypt content in stage
    */
-  public static SnowflakeAzureClient createSnowflakeAzureClient(StageInfo stage,
-                                                               RemoteStoreFileEncryptionMaterial encMat)
-          throws SnowflakeSQLException
-  {
+  public static SnowflakeAzureClient createSnowflakeAzureClient(
+      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat) throws SnowflakeSQLException {
     SnowflakeAzureClient azureClient = new SnowflakeAzureClient();
     azureClient.setupAzureClient(stage, encMat);
 
@@ -97,8 +90,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * @throws IllegalArgumentException when invalid credentials are used
    */
   private void setupAzureClient(StageInfo stage, RemoteStoreFileEncryptionMaterial encMat)
-          throws IllegalArgumentException, SnowflakeSQLException
-  {
+      throws IllegalArgumentException, SnowflakeSQLException {
     // Save the client creation parameters so that we can reuse them,
     // to reset the Azure client.
     this.stageInfo = stage;
@@ -106,81 +98,65 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
 
     logger.debug("Setting up the Azure client ");
 
-    try
-    {
-      URI storageEndpoint = buildAzureStorageEndpointURI(stage.getEndPoint(), stage.getStorageAccount());
+    try {
+      URI storageEndpoint =
+          buildAzureStorageEndpointURI(stage.getEndPoint(), stage.getStorageAccount());
 
       StorageCredentials azCreds;
       String sasToken = (String) stage.getCredentials().get("AZURE_SAS_TOKEN");
-      if (sasToken != null)
-      {
+      if (sasToken != null) {
         // We are authenticated with a shared access token.
         azCreds = new StorageCredentialsSharedAccessSignature(sasToken);
-      }
-      else
-      {
+      } else {
         // Use anonymous authentication.
         azCreds = StorageCredentialsAnonymous.ANONYMOUS;
       }
 
-      if (encMat != null)
-      {
+      if (encMat != null) {
         byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
-        encryptionKeySize = decodedKey.length*8;
+        encryptionKeySize = decodedKey.length * 8;
 
-        if (encryptionKeySize != 128 &&
-            encryptionKeySize != 192 &&
-            encryptionKeySize != 256)
-        {
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                "unsupported key size", encryptionKeySize);
+        if (encryptionKeySize != 128 && encryptionKeySize != 192 && encryptionKeySize != 256) {
+          throw new SnowflakeSQLException(
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              "unsupported key size",
+              encryptionKeySize);
         }
       }
       this.azStorageClient = new CloudBlobClient(storageEndpoint, azCreds);
-    }
-    catch (URISyntaxException ex)
-    {
+    } catch (URISyntaxException ex) {
       throw new IllegalArgumentException("invalid_azure_credentials");
     }
   }
 
   // Reurns the Max number of retry attempts
   @Override
-  public int getMaxRetries()
-  {
+  public int getMaxRetries() {
     return 25;
   }
 
   // Returns the max exponent for multiplying backoff with the power of 2, the value
   // of 4 will give us 16secs as the max number of time to sleep before retry
   @Override
-  public int getRetryBackoffMaxExponent()
-  {
+  public int getRetryBackoffMaxExponent() {
     return 4;
   }
 
   // Returns the min number of milliseconds to sleep before retry
   @Override
-  public int getRetryBackoffMin()
-  {
+  public int getRetryBackoffMin() {
     return 1000;
   }
 
-  /**
-   * @return Returns true if encryption is enabled
-   */
-  public boolean isEncrypting()
-  {
+  /** @return Returns true if encryption is enabled */
+  public boolean isEncrypting() {
     return encryptionKeySize > 0;
   }
 
-  /**
-   * @return Returns the size of the encryption key
-   */
+  /** @return Returns the size of the encryption key */
   @Override
-  public int getEncryptionKeySize()
-  {
+  public int getEncryptionKeySize() {
     return encryptionKeySize;
   }
 
@@ -189,46 +165,42 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    *
    * @param stageCredentials a Map (as returned by GS) which contains the new credential properties
    * @throws SnowflakeSQLException failure to renew the client
-   **/
+   */
   @Override
-  public void renew(Map stageCredentials) throws SnowflakeSQLException
-  {
+  public void renew(Map stageCredentials) throws SnowflakeSQLException {
     stageInfo.setCredentials(stageCredentials);
     setupAzureClient(stageInfo, encMat);
   }
 
-  /**
-   * shuts down the client
-   */
+  /** shuts down the client */
   @Override
-  public void shutdown() { /* Not available */ }
+  public void shutdown() {
+    /* Not available */
+  }
 
   /**
-   * For a set of remote storage objects under a remote location and a given prefix/path
-   * returns their properties wrapped in ObjectSummary objects
+   * For a set of remote storage objects under a remote location and a given prefix/path returns
+   * their properties wrapped in ObjectSummary objects
    *
    * @param remoteStorageLocation location, i.e. container for Azure
-   * @param prefix                the prefix/path to list under
+   * @param prefix the prefix/path to list under
    * @return a collection of storage summary objects
    * @throws StorageProviderException Azure storage exception
    */
   @Override
   public StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
-          throws StorageProviderException
-  {
+      throws StorageProviderException {
     StorageObjectSummaryCollection storageObjectSummaries;
 
-    try
-    {
+    try {
       CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
-      Iterable<ListBlobItem> listBlobItemIterable = container.listBlobs(
-              prefix,       // List the BLOBs under this prefix
-              true          // List the BLOBs as a flat list, i.e. do not list directories
+      Iterable<ListBlobItem> listBlobItemIterable =
+          container.listBlobs(
+              prefix, // List the BLOBs under this prefix
+              true // List the BLOBs as a flat list, i.e. do not list directories
               );
       storageObjectSummaries = new StorageObjectSummaryCollection(listBlobItemIterable);
-    }
-    catch (URISyntaxException | StorageException ex)
-    {
+    } catch (URISyntaxException | StorageException ex) {
       logger.debug("Failed to list objects: {}", ex);
       throw new StorageProviderException(ex);
     }
@@ -239,17 +211,15 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * Returns the metadata properties for a remote storage object
    *
    * @param remoteStorageLocation location, i.e. bucket for S3
-   * @param prefix                the prefix/path of the object to retrieve
+   * @param prefix the prefix/path of the object to retrieve
    * @return storage metadata object
    * @throws StorageProviderException azure storage exception
    */
   @Override
   public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
-          throws StorageProviderException
-  {
+      throws StorageProviderException {
     AzureObjectMetadata azureObjectMetadata = null;
-    try
-    {
+    try {
       // Get a reference to the BLOB, to retrieve its metadata
       CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
       CloudBlob blob = container.getBlockBlobReference(prefix);
@@ -264,16 +234,15 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
       String contentEncoding = properties.getContentEncoding();
 
       // Construct an Azure metadata object
-      azureObjectMetadata = new AzureObjectMetadata(contentLength, contentEncoding, userDefinedMetadata);
-    }
-    catch(StorageException ex)
-    {
-      logger.debug("Failed to retrieve BLOB metadata: {} - {}", ex.getErrorCode(),
-                    ex.getExtendedErrorInformation());
+      azureObjectMetadata =
+          new AzureObjectMetadata(contentLength, contentEncoding, userDefinedMetadata);
+    } catch (StorageException ex) {
+      logger.debug(
+          "Failed to retrieve BLOB metadata: {} - {}",
+          ex.getErrorCode(),
+          ex.getExtendedErrorInformation());
       throw new StorageProviderException(ex);
-    }
-    catch (URISyntaxException ex)
-    {
+    } catch (URISyntaxException ex) {
       logger.debug("Cannot retrieve BLOB properties, invalid URI: {}", ex);
       throw new StorageProviderException(ex);
     }
@@ -284,26 +253,30 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
   /**
    * Download a file from remote storage.
    *
-   * @param connection            connection object
-   * @param command               command to download file
-   * @param localLocation         local file path
-   * @param destFileName          destination file name
-   * @param parallelism           [ not used by the Azure implementation ]
+   * @param connection connection object
+   * @param command command to download file
+   * @param localLocation local file path
+   * @param destFileName destination file name
+   * @param parallelism [ not used by the Azure implementation ]
    * @param remoteStorageLocation remote storage location, i.e. bucket for S3
-   * @param stageFilePath         stage file path
-   * @param stageRegion           region name where the stage persists
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
    * @throws SnowflakeSQLException download failure
-   **/
+   */
   @Override
-  public void download(SFSession connection, String command, String localLocation, String destFileName,
-                       int parallelism, String remoteStorageLocation, String stageFilePath, String stageRegion)
-          throws SnowflakeSQLException
-  {
+  public void download(
+      SFSession connection,
+      String command,
+      String localLocation,
+      String destFileName,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion)
+      throws SnowflakeSQLException {
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
         String localFilePath = localLocation + localFileSep + destFileName;
         File localFile = new File(localFilePath);
         CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
@@ -321,356 +294,356 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
         // Get the user-defined BLOB metadata
         Map<String, String> userDefinedMetadata = blob.getMetadata();
         AbstractMap.SimpleEntry<String, String> encryptionData =
-          parseEncryptionData(userDefinedMetadata.get(AZ_ENCRYPTIONDATAPROP));
+            parseEncryptionData(userDefinedMetadata.get(AZ_ENCRYPTIONDATAPROP));
 
         String key = encryptionData.getKey();
         String iv = encryptionData.getValue();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() < 256)
-        {
-          if (key == null || iv == null)
-          {
-            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() < 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                "File metadata incomplete");
           }
 
           // Decrypt file
-          try
-          {
+          try {
             EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          }
-          catch (Exception ex)
-          {
-            logger.error("Error decrypting file",ex);
+          } catch (Exception ex) {
+            logger.error("Error decrypting file", ex);
             throw ex;
           }
         }
         return;
 
-      } catch (Exception ex)
-      {
+      } catch (Exception ex) {
         logger.debug("Download unsuccessful {}", ex);
         handleAzureException(ex, ++retryCount, "download", connection, command, this);
       }
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file/stream to remote storage
    *
-   * @param connection             connection object
-   * @param command                upload command
-   * @param parallelism            [ not used by the Azure implementation ]
-   * @param uploadFromStream       true if upload source is stream
-   * @param remoteStorageLocation  storage container name
-   * @param srcFile                source file if not uploading from a stream
-   * @param destFileName           file name on remote storage after upload
-   * @param inputStream            stream used for uploading if fileBackedOutputStream is null
+   * @param connection connection object
+   * @param command upload command
+   * @param parallelism [ not used by the Azure implementation ]
+   * @param uploadFromStream true if upload source is stream
+   * @param remoteStorageLocation storage container name
+   * @param srcFile source file if not uploading from a stream
+   * @param destFileName file name on remote storage after upload
+   * @param inputStream stream used for uploading if fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta                   object meta data
-   * @param stageRegion            region name where the stage persists
+   * @param meta object meta data
+   * @param stageRegion region name where the stage persists
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   @Override
-  public void upload(SFSession connection, String command, int parallelism, boolean uploadFromStream,
-                     String remoteStorageLocation, File srcFile, String destFileName, InputStream inputStream,
-                     FileBackedOutputStream fileBackedOutputStream, StorageObjectMetadata meta, String stageRegion)
-          throws SnowflakeSQLException
-  {
+  public void upload(
+      SFSession connection,
+      String command,
+      int parallelism,
+      boolean uploadFromStream,
+      String remoteStorageLocation,
+      File srcFile,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      StorageObjectMetadata meta,
+      String stageRegion)
+      throws SnowflakeSQLException {
     final List<FileInputStream> toClose = new ArrayList<>();
     long originalContentLength = meta.getContentLength();
 
-    SFPair<InputStream, Boolean> uploadStreamInfo = createUploadStream(
-            srcFile, uploadFromStream, inputStream, meta, originalContentLength,
-            fileBackedOutputStream, toClose);
+    SFPair<InputStream, Boolean> uploadStreamInfo =
+        createUploadStream(
+            srcFile,
+            uploadFromStream,
+            inputStream,
+            meta,
+            originalContentLength,
+            fileBackedOutputStream,
+            toClose);
 
     if (!(meta instanceof AzureObjectMetadata))
       throw new IllegalArgumentException("Unexpected metadata object type");
 
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
         logger.debug("Starting upload");
         InputStream fileInputStream = uploadStreamInfo.left;
         CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
         CloudBlockBlob blob = container.getBlockBlobReference(destFileName);
 
         // Set the user-defined/Snowflake metadata and upload the BLOB
-        blob.setMetadata((HashMap<String, String>)meta.getUserMetadata());
+        blob.setMetadata((HashMap<String, String>) meta.getUserMetadata());
 
         // Note that Azure doesn't offer a multi-part parallel upload library,
         // where the user has control of block size and parallelism
         // we rely on Azure to handle the upload, hence the "parallelism" parameter is ignored
         // in the Azure implementation of the method
-        blob.upload(fileInputStream,  // input stream to upload from
-                    -1                // -1 indicates an unknown stream length
-                   );
+        blob.upload(
+            fileInputStream, // input stream to upload from
+            -1 // -1 indicates an unknown stream length
+            );
         logger.debug("Upload successful");
 
         blob.uploadMetadata();
 
         // close any open streams in the "toClose" list and return
-        for (FileInputStream is : toClose)
-          IOUtils.closeQuietly(is);
+        for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
         return;
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
         handleAzureException(ex, ++retryCount, "upload", connection, command, this);
 
-        if (uploadFromStream && fileBackedOutputStream == null)
-        {
-          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-                  ErrorCode.IO_ERROR.getMessageCode(),
-                  "Encountered exception during upload: " +
-                          ex.getMessage() + "\nCannot retry upload from stream.");
+        if (uploadFromStream && fileBackedOutputStream == null) {
+          throw new SnowflakeSQLException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              "Encountered exception during upload: "
+                  + ex.getMessage()
+                  + "\nCannot retry upload from stream.");
         }
-        uploadStreamInfo = createUploadStream(srcFile, uploadFromStream,
-                inputStream, meta, originalContentLength,
-                fileBackedOutputStream, toClose);
+        uploadStreamInfo =
+            createUploadStream(
+                srcFile,
+                uploadFromStream,
+                inputStream,
+                meta,
+                originalContentLength,
+                fileBackedOutputStream,
+                toClose);
       }
 
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    for (FileInputStream is : toClose)
-      IOUtils.closeQuietly(is);
+    for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            "Unexpected: upload unsuccessful without exception!");
+    throw new SnowflakeSQLException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        "Unexpected: upload unsuccessful without exception!");
   }
 
   /**
    * Handles exceptions thrown by Azure Storage
    *
-   * @param ex         the exception to handle
+   * @param ex the exception to handle
    * @param retryCount current number of retries, incremented by the caller before each call
-   * @param operation  string that indicates the function/operation that was taking place,
-   *                   when the exception was raised, for example "upload"
+   * @param operation string that indicates the function/operation that was taking place, when the
+   *     exception was raised, for example "upload"
    * @param connection the current SFSession object used by the client
-   * @param command    the command attempted at the time of the exception
+   * @param command the command attempted at the time of the exception
    * @throws SnowflakeSQLException exceptions not handled
    */
   @Override
-  public void handleStorageException(Exception ex, int retryCount, String operation, SFSession connection, String command)
-          throws SnowflakeSQLException
-  {
+  public void handleStorageException(
+      Exception ex, int retryCount, String operation, SFSession connection, String command)
+      throws SnowflakeSQLException {
     handleAzureException(ex, retryCount, operation, connection, command, this);
   }
 
   private SFPair<InputStream, Boolean> createUploadStream(
-          File srcFile,
-          boolean uploadFromStream,
-          InputStream inputStream,
-          StorageObjectMetadata meta,
-          long originalContentLength,
-          FileBackedOutputStream fileBackedOutputStream,
-          List<FileInputStream> toClose)
-          throws SnowflakeSQLException
-  {
+      File srcFile,
+      boolean uploadFromStream,
+      InputStream inputStream,
+      StorageObjectMetadata meta,
+      long originalContentLength,
+      FileBackedOutputStream fileBackedOutputStream,
+      List<FileInputStream> toClose)
+      throws SnowflakeSQLException {
     logger.debug(
-            "createUploadStream({}, {}, {}, {}, {}, {})",
-            this,srcFile,uploadFromStream,inputStream, fileBackedOutputStream,toClose);
+        "createUploadStream({}, {}, {}, {}, {}, {})",
+        this,
+        srcFile,
+        uploadFromStream,
+        inputStream,
+        fileBackedOutputStream,
+        toClose);
 
     final InputStream stream;
     FileInputStream srcFileStream = null;
-    try
-    {
-      if (isEncrypting() && getEncryptionKeySize() < 256)
-      {
-        try
-        {
-          final InputStream uploadStream = uploadFromStream ?
-              (fileBackedOutputStream != null ?
-                    fileBackedOutputStream.asByteSource().openStream() :
-                    inputStream) :
-              (srcFileStream = new FileInputStream(srcFile));
+    try {
+      if (isEncrypting() && getEncryptionKeySize() < 256) {
+        try {
+          final InputStream uploadStream =
+              uploadFromStream
+                  ? (fileBackedOutputStream != null
+                      ? fileBackedOutputStream.asByteSource().openStream()
+                      : inputStream)
+                  : (srcFileStream = new FileInputStream(srcFile));
           toClose.add(srcFileStream);
 
           // Encrypt
-          stream = EncryptionProvider.encrypt(meta, originalContentLength,
-                                              uploadStream, this.encMat, this);
+          stream =
+              EncryptionProvider.encrypt(
+                  meta, originalContentLength, uploadStream, this.encMat, this);
           uploadFromStream = true;
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
           logger.error("Failed to encrypt input", ex);
-          throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  "Failed to encrypt input",ex.getMessage());
+          throw new SnowflakeSQLException(
+              ex,
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              "Failed to encrypt input",
+              ex.getMessage());
         }
-      }
-      else
-      {
-        if(uploadFromStream)
-        {
-          if(fileBackedOutputStream!=null)
-          {
+      } else {
+        if (uploadFromStream) {
+          if (fileBackedOutputStream != null) {
             stream = fileBackedOutputStream.asByteSource().openStream();
-          }
-          else
-          {
+          } else {
             stream = inputStream;
           }
-        }
-        else
-        {
+        } else {
           srcFileStream = new FileInputStream(srcFile);
           toClose.add(srcFileStream);
           stream = srcFileStream;
         }
       }
-    }
-    catch (FileNotFoundException ex)
-    {
+    } catch (FileNotFoundException ex) {
       logger.error("Failed to open input file", ex);
-      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Failed to open input file",ex.getMessage());
-    }
-    catch (IOException ex)
-    {
+      throw new SnowflakeSQLException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Failed to open input file",
+          ex.getMessage());
+    } catch (IOException ex) {
       logger.error("Failed to open input stream", ex);
-      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Failed to open input stream",ex.getMessage());
+      throw new SnowflakeSQLException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Failed to open input stream",
+          ex.getMessage());
     }
 
     return SFPair.of(stream, uploadFromStream);
   }
 
   /**
-   * Handles exceptions thrown by Azure Storage
-   * It will retry transient errors as defined by the Azure Client retry policy
-   * It will re-create the client if the SAS token has expired, and re-try
+   * Handles exceptions thrown by Azure Storage It will retry transient errors as defined by the
+   * Azure Client retry policy It will re-create the client if the SAS token has expired, and re-try
    *
-   * @param ex         the exception to handle
+   * @param ex the exception to handle
    * @param retryCount current number of retries, incremented by the caller before each call
-   * @param operation  string that indicates the function/operation that was taking place,
-   *                   when the exception was raised, for example "upload"
+   * @param operation string that indicates the function/operation that was taking place, when the
+   *     exception was raised, for example "upload"
    * @param connection the current SFSession object used by the client
-   * @param command    the command attempted at the time of the exception
-   * @param azClient   the current Snowflake Azure client object
+   * @param command the command attempted at the time of the exception
+   * @param azClient the current Snowflake Azure client object
    * @throws SnowflakeSQLException exceptions not handled
    */
   private static void handleAzureException(
-          Exception ex,
-          int retryCount,
-          String operation,
-          SFSession connection,
-          String command,
-          SnowflakeAzureClient azClient)
-          throws SnowflakeSQLException
-  {
+      Exception ex,
+      int retryCount,
+      String operation,
+      SFSession connection,
+      String command,
+      SnowflakeAzureClient azClient)
+      throws SnowflakeSQLException {
 
     // no need to retry if it is invalid key exception
-    if (ex.getCause() instanceof InvalidKeyException)
-    {
+    if (ex.getCause() instanceof InvalidKeyException) {
       // Most likely cause is that the unlimited strength policy files are not installed
       // Log the error and throw a message that explains the cause
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
-    if (((StorageException) ex).getHttpStatusCode() == 403)
-    {
+    if (((StorageException) ex).getHttpStatusCode() == 403) {
       // A 403 indicates that the SAS token has expired,
       // we need to refresh the Azure client with the new token
       SnowflakeFileTransferAgent.renewExpiredToken(connection, command, azClient);
     }
 
-    if (ex instanceof StorageException)
-    {
+    if (ex instanceof StorageException) {
       StorageException se = (StorageException) ex;
 
       // If we have exceeded the max number of retries, propagate the error
-      if (retryCount > azClient.getMaxRetries())
-      {
-        throw new SnowflakeSQLException(se, SqlState.SYSTEM_ERROR,
-                ErrorCode.AZURE_SERVICE_ERROR.getMessageCode(),
-                operation,
-                se.getErrorCode(),
-                se.getExtendedErrorInformation(),
-                se.getHttpStatusCode(),
-                se.getMessage());
-      }
-      else
-      {
-        logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                ex.getMessage(), operation, retryCount);
+      if (retryCount > azClient.getMaxRetries()) {
+        throw new SnowflakeSQLException(
+            se,
+            SqlState.SYSTEM_ERROR,
+            ErrorCode.AZURE_SERVICE_ERROR.getMessageCode(),
+            operation,
+            se.getErrorCode(),
+            se.getExtendedErrorInformation(),
+            se.getHttpStatusCode(),
+            se.getMessage());
+      } else {
+        logger.debug(
+            "Encountered exception ({}) during {}, retry count: {}",
+            ex.getMessage(),
+            operation,
+            retryCount);
         logger.debug("Stack trace: ", ex);
 
         // exponential backoff up to a limit
         int backoffInMillis = azClient.getRetryBackoffMin();
 
         if (retryCount > 1)
-          backoffInMillis <<= (Math.min(retryCount - 1,
-                  azClient.getRetryBackoffMaxExponent()));
+          backoffInMillis <<= (Math.min(retryCount - 1, azClient.getRetryBackoffMaxExponent()));
 
-        try
-        {
+        try {
           logger.debug("Sleep for {} milliseconds before retry", backoffInMillis);
 
           Thread.sleep(backoffInMillis);
-        } catch (InterruptedException ex1)
-        {
+        } catch (InterruptedException ex1) {
           // ignore
         }
 
-        if (se.getHttpStatusCode() == 403)
-        {
+        if (se.getHttpStatusCode() == 403) {
           // A 403 indicates that the SAS token has expired,
           // we need to refresh the Azure client with the new token
           SnowflakeFileTransferAgent.renewExpiredToken(connection, command, azClient);
         }
       }
-    }
-    else
-    {
-      if (ex instanceof InterruptedException ||
-              SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException)
-      {
+    } else {
+      if (ex instanceof InterruptedException
+          || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
         if (retryCount > azClient.getMaxRetries())
-          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-                  ErrorCode.IO_ERROR.getMessageCode(),
-                  "Encountered exception during " + operation +  ": " +
-                          ex.getMessage());
-        else
-        {
-          logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                  ex.getMessage(), operation, retryCount);
+          throw new SnowflakeSQLException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              "Encountered exception during " + operation + ": " + ex.getMessage());
+        else {
+          logger.debug(
+              "Encountered exception ({}) during {}, retry count: {}",
+              ex.getMessage(),
+              operation,
+              retryCount);
         }
-      }
-      else
-        throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-                ErrorCode.IO_ERROR.getMessageCode(),
-                "Encountered exception during " + operation + ": " +
-                        ex.getMessage());
+      } else
+        throw new SnowflakeSQLException(
+            ex,
+            SqlState.SYSTEM_ERROR,
+            ErrorCode.IO_ERROR.getMessageCode(),
+            "Encountered exception during " + operation + ": " + ex.getMessage());
     }
   }
 
-
   /*
-  * Builds a URI to a Azure Storage account endpoint
-  *
-  *  @param storageEndPoint   the storage endpoint name
-  *  @param storageAccount    the storage account name
-  */
-  private static URI buildAzureStorageEndpointURI(String storageEndPoint, String storageAccount )
-                  throws URISyntaxException
-  {
-    URI storageEndpoint = new URI(
-            "https", storageAccount  + "." + storageEndPoint + "/",
-            null, null);
+   * Builds a URI to a Azure Storage account endpoint
+   *
+   *  @param storageEndPoint   the storage endpoint name
+   *  @param storageAccount    the storage account name
+   */
+  private static URI buildAzureStorageEndpointURI(String storageEndPoint, String storageAccount)
+      throws URISyntaxException {
+    URI storageEndpoint =
+        new URI("https", storageAccount + "." + storageEndPoint + "/", null, null);
 
     return storageEndpoint;
   }
@@ -680,15 +653,16 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * Takes the base64-encoded iv and key and creates the JSON block to be
    * used as the encryptiondata metadata field on the blob.
    */
-  private String buildEncryptionMetadataJSON(String iv64, String key64)
-  {
-    return String.format("{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
-                         + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
-                         + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
-                         + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
-                         + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
-                         + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
-                         + "\"Java 5.3.0\"}}", key64, iv64);
+  private String buildEncryptionMetadataJSON(String iv64, String key64) {
+    return String.format(
+        "{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
+            + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
+            + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
+            + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
+            + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
+            + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
+            + "\"Java 5.3.0\"}}",
+        key64, iv64);
   }
 
   /*
@@ -697,12 +671,10 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * blob and parses out the key and iv. Returns the pair as key = key, iv = value.
    */
   private SimpleEntry<String, String> parseEncryptionData(String jsonEncryptionData)
-          throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     ObjectMapper mapper = new ObjectMapper();
     JsonFactory factory = mapper.getJsonFactory();
-    try
-    {
+    try {
       JsonParser parser = factory.createJsonParser(jsonEncryptionData);
       JsonNode encryptionDataNode = mapper.readTree(parser);
 
@@ -710,63 +682,48 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
       String key = encryptionDataNode.get("WrappedContentKey").get("EncryptedKey").asText();
 
       return new SimpleEntry<String, String>(key, iv);
-    }
-    catch (Exception ex)
-    {
-      throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-            ErrorCode.IO_ERROR.getMessageCode(),
-            "Error parsing encryption data as json" + ": " +
-                    ex.getMessage());
+    } catch (Exception ex) {
+      throw new SnowflakeSQLException(
+          ex,
+          SqlState.SYSTEM_ERROR,
+          ErrorCode.IO_ERROR.getMessageCode(),
+          "Error parsing encryption data as json" + ": " + ex.getMessage());
     }
   }
 
-  /**
-   * Returns the material descriptor key
-   */
+  /** Returns the material descriptor key */
   @Override
-  public String getMatdescKey()
-  {
+  public String getMatdescKey() {
     return "matdesc";
   }
 
-  /**
-   * Adds encryption metadata to the StorageObjectMetadata object
-   */
-   @Override
-   public void addEncryptionMetadata(StorageObjectMetadata meta,
-                              MatDesc matDesc,
-                              byte[] ivData,
-                              byte[] encKeK,
-                              long contentLength)
-   {
-      meta.addUserMetadata(getMatdescKey(),
-                           matDesc.toString());
-      meta.addUserMetadata(AZ_ENCRYPTIONDATAPROP, buildEncryptionMetadataJSON(
-                            Base64.encodeAsString(ivData),
-                            Base64.encodeAsString(encKeK))
-                          );
-      meta.setContentLength(contentLength);
-   }
+  /** Adds encryption metadata to the StorageObjectMetadata object */
+  @Override
+  public void addEncryptionMetadata(
+      StorageObjectMetadata meta,
+      MatDesc matDesc,
+      byte[] ivData,
+      byte[] encKeK,
+      long contentLength) {
+    meta.addUserMetadata(getMatdescKey(), matDesc.toString());
+    meta.addUserMetadata(
+        AZ_ENCRYPTIONDATAPROP,
+        buildEncryptionMetadataJSON(Base64.encodeAsString(ivData), Base64.encodeAsString(encKeK)));
+    meta.setContentLength(contentLength);
+  }
 
-  /**
-   * Adds digest metadata to the StorageObjectMetadata object
-   */
-   @Override
-   public void addDigestMetadata(StorageObjectMetadata meta, String digest)
-   {
-     if (!SnowflakeUtil.isBlank(digest))
-     {
-       // Azure doesn't allow hyphens in the name of a metadata field.
-       meta.addUserMetadata("sfcdigest", digest);
-     }
-   }
+  /** Adds digest metadata to the StorageObjectMetadata object */
+  @Override
+  public void addDigestMetadata(StorageObjectMetadata meta, String digest) {
+    if (!SnowflakeUtil.isBlank(digest)) {
+      // Azure doesn't allow hyphens in the name of a metadata field.
+      meta.addUserMetadata("sfcdigest", digest);
+    }
+  }
 
-  /**
-   * Gets digest metadata to the StorageObjectMetadata object
-   */
-   @Override
-   public String getDigestMetadata(StorageObjectMetadata meta)
-   {
-     return meta.getUserMetadata().get("sfcdigest");
-   }
+  /** Gets digest metadata to the StorageObjectMetadata object */
+  @Override
+  public String getDigestMetadata(StorageObjectMetadata meta) {
+    return meta.getUserMetadata().get("sfcdigest");
+  }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -27,6 +27,20 @@ import com.amazonaws.services.s3.transfer.Download;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.util.Base64;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketTimeoutException;
+import java.security.InvalidKeyException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.SFSSLConnectionSocketFactory;
 import net.snowflake.client.core.SFSession;
@@ -45,37 +59,20 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLInitializationException;
 
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.SocketTimeoutException;
-import java.security.InvalidKeyException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 /**
  * Wrapper around AmazonS3Client.
+ *
  * @author ffunke
  */
-public class SnowflakeS3Client implements SnowflakeStorageClient
-{
-  private final static SFLogger logger =
-    SFLoggerFactory.getLogger(SnowflakeS3Client.class);
-  private final  static String localFileSep =
-      System.getProperty("file.separator");
-  private final  static String AES = "AES";
-  private final  static String AMZ_KEY = "x-amz-key";
-  private final  static String AMZ_IV = "x-amz-iv";
+public class SnowflakeS3Client implements SnowflakeStorageClient {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeS3Client.class);
+  private static final String localFileSep = System.getProperty("file.separator");
+  private static final String AES = "AES";
+  private static final String AMZ_KEY = "x-amz-key";
+  private static final String AMZ_IV = "x-amz-iv";
 
   // expired AWS token error code
-  private final static String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
+  private static final String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
 
   private int encryptionKeySize = 0; // used for PUTs
   private AmazonS3Client amazonClient = null;
@@ -86,22 +83,21 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
   // socket factory used by s3 client's http client.
   private static SSLConnectionSocketFactory s3ConnectionSocketFactory = null;
 
-  public SnowflakeS3Client(Map stageCredentials,
-                           ClientConfiguration clientConfig,
-                           RemoteStoreFileEncryptionMaterial encMat,
-                           String stageRegion)
-          throws SnowflakeSQLException
-  {
-      setupSnowflakeS3Client(stageCredentials, clientConfig,
-                            encMat, stageRegion);
+  public SnowflakeS3Client(
+      Map stageCredentials,
+      ClientConfiguration clientConfig,
+      RemoteStoreFileEncryptionMaterial encMat,
+      String stageRegion)
+      throws SnowflakeSQLException {
+    setupSnowflakeS3Client(stageCredentials, clientConfig, encMat, stageRegion);
   }
 
-    private void setupSnowflakeS3Client(Map stageCredentials,
-                                        ClientConfiguration clientConfig,
-                                        RemoteStoreFileEncryptionMaterial encMat,
-                                        String stageRegion)
-          throws SnowflakeSQLException
-  {
+  private void setupSnowflakeS3Client(
+      Map stageCredentials,
+      ClientConfiguration clientConfig,
+      RemoteStoreFileEncryptionMaterial encMat,
+      String stageRegion)
+      throws SnowflakeSQLException {
     // Save the client creation parameters so that we can reuse them,
     // to reset the AWS client. We won't save the awsCredentials since
     // we will be refreshing that, every time we reset the AWS client
@@ -112,62 +108,51 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
     logger.debug("Setting up AWS client ");
 
     // Retrieve S3 stage credentials
-    String awsID = (String)stageCredentials.get("AWS_KEY_ID");
-    String awsKey = (String)stageCredentials.get("AWS_SECRET_KEY");
-    String awsToken = (String)stageCredentials.get("AWS_TOKEN");
-    
+    String awsID = (String) stageCredentials.get("AWS_KEY_ID");
+    String awsKey = (String) stageCredentials.get("AWS_SECRET_KEY");
+    String awsToken = (String) stageCredentials.get("AWS_TOKEN");
+
     // initialize aws credentials
-    AWSCredentials awsCredentials = (awsToken != null) ?
-            new BasicSessionCredentials(awsID, awsKey, awsToken)
+    AWSCredentials awsCredentials =
+        (awsToken != null)
+            ? new BasicSessionCredentials(awsID, awsKey, awsToken)
             : new BasicAWSCredentials(awsID, awsKey);
 
-
     clientConfig.withSignerOverride("AWSS3V4SignerType");
-    clientConfig.getApacheHttpClientConfig().setSslSocketFactory(
-        getSSLConnectionSocketFactory());
-    if (encMat != null)
-    {
+    clientConfig.getApacheHttpClientConfig().setSslSocketFactory(getSSLConnectionSocketFactory());
+    if (encMat != null) {
       byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
-      encryptionKeySize = decodedKey.length*8;
+      encryptionKeySize = decodedKey.length * 8;
 
-      if (encryptionKeySize == 256)
-      {
-        SecretKey queryStageMasterKey =
-            new SecretKeySpec(decodedKey, 0, decodedKey.length, AES);
-        EncryptionMaterials encryptionMaterials =
-            new EncryptionMaterials(queryStageMasterKey);
-        encryptionMaterials.addDescription("queryId",
-                                           encMat.getQueryId());
-        encryptionMaterials.addDescription("smkId",
-                                           Long.toString(encMat.getSmkId()));
-        CryptoConfiguration cryptoConfig =
-            new CryptoConfiguration(CryptoMode.EncryptionOnly);
+      if (encryptionKeySize == 256) {
+        SecretKey queryStageMasterKey = new SecretKeySpec(decodedKey, 0, decodedKey.length, AES);
+        EncryptionMaterials encryptionMaterials = new EncryptionMaterials(queryStageMasterKey);
+        encryptionMaterials.addDescription("queryId", encMat.getQueryId());
+        encryptionMaterials.addDescription("smkId", Long.toString(encMat.getSmkId()));
+        CryptoConfiguration cryptoConfig = new CryptoConfiguration(CryptoMode.EncryptionOnly);
 
-        amazonClient = new AmazonS3EncryptionClient(awsCredentials,
-              new StaticEncryptionMaterialsProvider(encryptionMaterials),
-              clientConfig, cryptoConfig);
-      }
-      else if (encryptionKeySize == 128)
-      {
+        amazonClient =
+            new AmazonS3EncryptionClient(
+                awsCredentials,
+                new StaticEncryptionMaterialsProvider(encryptionMaterials),
+                clientConfig,
+                cryptoConfig);
+      } else if (encryptionKeySize == 128) {
         amazonClient = new AmazonS3Client(awsCredentials, clientConfig);
+      } else {
+        throw new SnowflakeSQLException(
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            "unsupported key size",
+            encryptionKeySize);
       }
-      else
-      {
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "unsupported key size", encryptionKeySize);
-      }
-    }
-    else
-    {
+    } else {
       amazonClient = new AmazonS3Client(awsCredentials, clientConfig);
     }
 
-    if (stageRegion != null)
-    {
+    if (stageRegion != null) {
       Region region = RegionUtils.getRegion(stageRegion);
-      if (region != null)
-      {
+      if (region != null) {
         amazonClient.setRegion(region);
       }
     }
@@ -177,75 +162,68 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
 
   // Returns the Max number of retry attempts
   @Override
-  public int getMaxRetries()
-  {
+  public int getMaxRetries() {
     return 25;
   }
 
   // Returns the max exponent for multiplying backoff with the power of 2, the value
   // of 4 will give us 16secs as the max number of time to sleep before retry
   @Override
-  public int getRetryBackoffMaxExponent()
-  {
+  public int getRetryBackoffMaxExponent() {
     return 4;
   }
 
   // Returns the min number of milliseconds to sleep before retry
   @Override
-  public int getRetryBackoffMin()
-  {
+  public int getRetryBackoffMin() {
     return 1000;
   }
-  
+
   @Override
-  public boolean isEncrypting()
-  {
+  public boolean isEncrypting() {
     return encryptionKeySize > 0;
   }
 
   @Override
-  public int getEncryptionKeySize()
-  {
+  public int getEncryptionKeySize() {
     return encryptionKeySize;
   }
 
   /**
    * Renew the S3 client with fresh AWS credentials/access token
-   * @param stageCredentials a Map of new AWS credential properties, to refresh the client with (as returned by GS)
+   *
+   * @param stageCredentials a Map of new AWS credential properties, to refresh the client with (as
+   *     returned by GS)
    * @throws SnowflakeSQLException if any error occurs
    */
   @Override
-  public void renew(Map stageCredentials)
-          throws SnowflakeSQLException
-  {
-      // We renew the client with fresh credentials and with its original parameters
-      setupSnowflakeS3Client(stageCredentials,this.clientConfig, this.encMat, this.stageRegion);
+  public void renew(Map stageCredentials) throws SnowflakeSQLException {
+    // We renew the client with fresh credentials and with its original parameters
+    setupSnowflakeS3Client(stageCredentials, this.clientConfig, this.encMat, this.stageRegion);
   }
 
   @Override
-  public void shutdown()
-  {
+  public void shutdown() {
     amazonClient.shutdown();
   }
 
   @Override
   public StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
-                          throws StorageProviderException
-  {
+      throws StorageProviderException {
     ObjectListing objListing = amazonClient.listObjects(remoteStorageLocation, prefix);
 
-    return  new StorageObjectSummaryCollection(objListing.getObjectSummaries());
+    return new StorageObjectSummaryCollection(objListing.getObjectSummaries());
   }
 
   @Override
   public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
-                          throws StorageProviderException
-  {
+      throws StorageProviderException {
     return new S3ObjectMetadata(amazonClient.getObjectMetadata(remoteStorageLocation, prefix));
   }
 
   /**
    * Download a file from S3.
+   *
    * @param connection connection object
    * @param command command to download file
    * @param localLocation local file path
@@ -259,88 +237,79 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
    * @throws SnowflakeSQLException if file metadata is incomplete
    */
   @Override
-  public void download(       SFSession connection,
-                              String command,
-                              String localLocation,
-                              String destFileName,
-                              int parallelism,
-                              String remoteStorageLocation,
-                              String stageFilePath,
-                              String stageRegion) throws SnowflakeSQLException
-  {
+  public void download(
+      SFSession connection,
+      String command,
+      String localLocation,
+      String destFileName,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion)
+      throws SnowflakeSQLException {
     TransferManager tx = null;
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
         File localFile = new File(localLocation + localFileSep + destFileName);
 
-        logger.debug("Creating executor service for transfer" +
-            "manager with {} threads", parallelism);
+        logger.debug(
+            "Creating executor service for transfer" + "manager with {} threads", parallelism);
 
         // download file from s3
-        tx = new TransferManager(amazonClient,
-            SnowflakeUtil.createDefaultExecutorService(
-                "s3-transfer-manager-downloader-", parallelism));
+        tx =
+            new TransferManager(
+                amazonClient,
+                SnowflakeUtil.createDefaultExecutorService(
+                    "s3-transfer-manager-downloader-", parallelism));
 
-        Download myDownload = tx.download(remoteStorageLocation,
-            stageFilePath, localFile);
+        Download myDownload = tx.download(remoteStorageLocation, stageFilePath, localFile);
 
         // Pull object metadata from S3
-        ObjectMetadata meta =
-            amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
+        ObjectMetadata meta = amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
 
-        Map<String,String> metaMap = meta.getUserMetadata();
+        Map<String, String> metaMap = meta.getUserMetadata();
         String key = metaMap.get(AMZ_KEY);
         String iv = metaMap.get(AMZ_IV);
 
         myDownload.waitForCompletion();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() < 256)
-        {
-          if (key == null || iv == null)
-          {
-            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() < 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                "File metadata incomplete");
           }
 
           // Decrypt file
-          try
-          {
+          try {
             EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          }
-          catch (Exception ex)
-          {
-            logger.error("Error decrypting file",ex);
+          } catch (Exception ex) {
+            logger.error("Error decrypting file", ex);
             throw ex;
           }
         }
 
         return;
 
-      } catch (Exception ex)
-      {
-        handleS3Exception(ex, ++retryCount, "download",
-                connection, command, this);
+      } catch (Exception ex) {
+        handleS3Exception(ex, ++retryCount, "download", connection, command, this);
 
+      } finally {
+        if (tx != null) tx.shutdownNow(false);
       }
-      finally
-      {
-        if (tx != null)
-          tx.shutdownNow(false);
-      }
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+    throw new SnowflakeSQLException(
+        SqlState.INTERNAL_ERROR,
         ErrorCode.INTERNAL_ERROR.getMessageCode(),
         "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file (-stream) to S3.
+   *
    * @param connection connection object
    * @param command upload command
    * @param parallelism number of threads do parallel uploading
@@ -356,59 +325,57 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
    */
   @Override
   public void upload(
-          SFSession connection,
-          String command,
-          int parallelism,
-          boolean uploadFromStream,
-          String remoteStorageLocation,
-          File srcFile,
-          String destFileName,
-          InputStream inputStream,
-          FileBackedOutputStream fileBackedOutputStream,
-          StorageObjectMetadata meta,
-          String stageRegion) throws SnowflakeSQLException
-  {
+      SFSession connection,
+      String command,
+      int parallelism,
+      boolean uploadFromStream,
+      String remoteStorageLocation,
+      File srcFile,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      StorageObjectMetadata meta,
+      String stageRegion)
+      throws SnowflakeSQLException {
     final long originalContentLength = meta.getContentLength();
     final List<FileInputStream> toClose = new ArrayList<>();
     SFPair<InputStream, Boolean> uploadStreamInfo =
-            createUploadStream( srcFile, uploadFromStream,
-                    inputStream, fileBackedOutputStream,
-                    ((S3ObjectMetadata)meta).getS3ObjectMetadata(),
-                    originalContentLength, toClose);
+        createUploadStream(
+            srcFile,
+            uploadFromStream,
+            inputStream,
+            fileBackedOutputStream,
+            ((S3ObjectMetadata) meta).getS3ObjectMetadata(),
+            originalContentLength,
+            toClose);
 
     ObjectMetadata s3Meta;
-    if(meta instanceof S3ObjectMetadata) {
+    if (meta instanceof S3ObjectMetadata) {
       s3Meta = ((S3ObjectMetadata) meta).getS3ObjectMetadata();
-    }
-    else throw new IllegalArgumentException("Unexpected metadata object type");
+    } else throw new IllegalArgumentException("Unexpected metadata object type");
 
     TransferManager tx = null;
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
 
-        logger.debug("Creating executor service for transfer" +
-                "manager with {} threads", parallelism);
+        logger.debug(
+            "Creating executor service for transfer" + "manager with {} threads", parallelism);
 
         // upload files to s3
-        tx = new TransferManager(this.amazonClient,
+        tx =
+            new TransferManager(
+                this.amazonClient,
                 SnowflakeUtil.createDefaultExecutorService(
-                        "s3-transfer-manager-uploader-",
-                        parallelism));
+                    "s3-transfer-manager-uploader-", parallelism));
 
         final Upload myUpload;
 
-        if (uploadStreamInfo.right)
-        {
-          myUpload = tx.upload(remoteStorageLocation, destFileName,
-                  uploadStreamInfo.left, s3Meta);
-        }
-        else
-        {
+        if (uploadStreamInfo.right) {
+          myUpload = tx.upload(remoteStorageLocation, destFileName, uploadStreamInfo.left, s3Meta);
+        } else {
           PutObjectRequest putRequest =
-                  new PutObjectRequest(remoteStorageLocation, destFileName, srcFile);
+              new PutObjectRequest(remoteStorageLocation, destFileName, srcFile);
           putRequest.setMetadata(s3Meta);
 
           myUpload = tx.upload(putRequest);
@@ -417,182 +384,185 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
         myUpload.waitForCompletion();
 
         // get out
-        for (FileInputStream is : toClose)
-          IOUtils.closeQuietly(is);
+        for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
         return;
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
 
-        handleS3Exception(ex, ++retryCount, "upload",
-                connection, command, this);
-        if (uploadFromStream && fileBackedOutputStream == null)
-        {
-          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-                  ErrorCode.IO_ERROR.getMessageCode(),
-                  "Encountered exception during upload: " +
-                          ex.getMessage() + "\nCannot retry upload from stream.");
+        handleS3Exception(ex, ++retryCount, "upload", connection, command, this);
+        if (uploadFromStream && fileBackedOutputStream == null) {
+          throw new SnowflakeSQLException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              "Encountered exception during upload: "
+                  + ex.getMessage()
+                  + "\nCannot retry upload from stream.");
         }
-        uploadStreamInfo = createUploadStream(srcFile, uploadFromStream,
-                inputStream, fileBackedOutputStream,
-                s3Meta, originalContentLength, toClose);
-      } finally
-      {
-        if (tx != null)
-          tx.shutdownNow(false);
+        uploadStreamInfo =
+            createUploadStream(
+                srcFile,
+                uploadFromStream,
+                inputStream,
+                fileBackedOutputStream,
+                s3Meta,
+                originalContentLength,
+                toClose);
+      } finally {
+        if (tx != null) tx.shutdownNow(false);
+      }
+    } while (retryCount <= getMaxRetries());
+
+    for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
+
+    throw new SnowflakeSQLException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        "Unexpected: upload unsuccessful without exception!");
+  }
+
+  private SFPair<InputStream, Boolean> createUploadStream(
+      File srcFile,
+      boolean uploadFromStream,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      ObjectMetadata meta,
+      long originalContentLength,
+      List<FileInputStream> toClose)
+      throws SnowflakeSQLException {
+    logger.debug(
+        "createUploadStream({}, {}, {}, {}, {}, {}, {}) " + "keySize={}",
+        this,
+        srcFile,
+        uploadFromStream,
+        inputStream,
+        fileBackedOutputStream,
+        meta,
+        toClose,
+        this.getEncryptionKeySize());
+    final InputStream result;
+    FileInputStream srcFileStream = null;
+    if (isEncrypting() && getEncryptionKeySize() < 256) {
+      try {
+        final InputStream uploadStream =
+            uploadFromStream
+                ? (fileBackedOutputStream != null
+                    ? fileBackedOutputStream.asByteSource().openStream()
+                    : inputStream)
+                : (srcFileStream = new FileInputStream(srcFile));
+        toClose.add(srcFileStream);
+
+        // Encrypt
+        S3StorageObjectMetadata s3Metadata = new S3StorageObjectMetadata(meta);
+        result =
+            EncryptionProvider.encrypt(
+                s3Metadata, originalContentLength, uploadStream, this.encMat, this);
+        uploadFromStream = true;
+      } catch (Exception ex) {
+        logger.error("Failed to encrypt input", ex);
+        throw new SnowflakeSQLException(
+            ex,
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            "Failed to encrypt input",
+            ex.getMessage());
+      }
+    } else {
+      try {
+        result =
+            uploadFromStream
+                ? (fileBackedOutputStream != null
+                    ? fileBackedOutputStream.asByteSource().openStream()
+                    : inputStream)
+                : (srcFileStream = new FileInputStream(srcFile));
+        toClose.add(srcFileStream);
+
+      } catch (FileNotFoundException ex) {
+        logger.error("Failed to open input file", ex);
+        throw new SnowflakeSQLException(
+            ex,
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            "Failed to open input file",
+            ex.getMessage());
+      } catch (IOException ex) {
+        logger.error("Failed to open input stream", ex);
+        throw new SnowflakeSQLException(
+            ex,
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            "Failed to open input stream",
+            ex.getMessage());
       }
     }
-    while(retryCount <= getMaxRetries());
-
-    for (FileInputStream is : toClose)
-      IOUtils.closeQuietly(is);
-
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            "Unexpected: upload unsuccessful without exception!");
+    return SFPair.of(result, uploadFromStream);
   }
-
-  private SFPair<InputStream, Boolean>
-        createUploadStream( File srcFile,
-                            boolean uploadFromStream,
-                            InputStream inputStream,
-                            FileBackedOutputStream fileBackedOutputStream,
-                            ObjectMetadata meta,
-                            long originalContentLength,
-                            List<FileInputStream> toClose)
-          throws SnowflakeSQLException
-  {
-      logger.debug(
-                 "createUploadStream({}, {}, {}, {}, {}, {}, {}) "+
-                 "keySize={}",
-                 this,srcFile,uploadFromStream,inputStream,
-                              fileBackedOutputStream, meta, toClose,
-                              this.getEncryptionKeySize());
-      final InputStream result;
-      FileInputStream srcFileStream = null;
-      if (isEncrypting() && getEncryptionKeySize() < 256)
-      {
-        try
-        {
-          final InputStream uploadStream = uploadFromStream ?
-              (fileBackedOutputStream != null ?
-                    fileBackedOutputStream.asByteSource().openStream() :
-                    inputStream) :
-              (srcFileStream = new FileInputStream(srcFile));
-          toClose.add(srcFileStream);
-
-          // Encrypt
-          S3StorageObjectMetadata s3Metadata = new S3StorageObjectMetadata(meta);
-          result = EncryptionProvider.encrypt(s3Metadata, originalContentLength,
-                                              uploadStream, this.encMat, this);
-          uploadFromStream = true;
-        }
-        catch (Exception ex)
-        {
-          logger.error("Failed to encrypt input", ex);
-          throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  "Failed to encrypt input",ex.getMessage());
-        }
-      }
-      else
-      {
-        try
-        {
-          result = uploadFromStream ?
-                   (fileBackedOutputStream != null ?
-               fileBackedOutputStream.asByteSource().openStream() :
-               inputStream) :
-                   (srcFileStream = new FileInputStream(srcFile));
-          toClose.add(srcFileStream);
-
-        }
-        catch (FileNotFoundException ex)
-        {
-          logger.error("Failed to open input file", ex);
-          throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  "Failed to open input file",ex.getMessage());
-        }
-        catch (IOException ex)
-        {
-          logger.error("Failed to open input stream", ex);
-          throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  "Failed to open input stream",ex.getMessage());
-        }
-      }
-      return SFPair.of(result, uploadFromStream);
-  }
-
 
   @Override
-  public void handleStorageException(Exception ex, int retryCount, String operation,SFSession connection, String command)
-          throws SnowflakeSQLException
-  {
-      handleS3Exception(ex, retryCount, operation, connection, command, this);
+  public void handleStorageException(
+      Exception ex, int retryCount, String operation, SFSession connection, String command)
+      throws SnowflakeSQLException {
+    handleS3Exception(ex, retryCount, operation, connection, command, this);
   }
 
   private static void handleS3Exception(
-                          Exception ex,
-                          int retryCount,
-                          String operation,
-                          SFSession connection,
-                          String command,
-                          SnowflakeS3Client s3Client)
-      throws SnowflakeSQLException
-  {
+      Exception ex,
+      int retryCount,
+      String operation,
+      SFSession connection,
+      String command,
+      SnowflakeS3Client s3Client)
+      throws SnowflakeSQLException {
     // no need to retry if it is invalid key exception
-    if (ex.getCause() instanceof InvalidKeyException)
-    {
+    if (ex.getCause() instanceof InvalidKeyException) {
       // Most likely cause is that the unlimited strength policy files are not installed
       // Log the error and throw a message that explains the cause
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
-    if (ex instanceof AmazonClientException)
-    {
-      if (retryCount > s3Client.getMaxRetries())
-      {
+    if (ex instanceof AmazonClientException) {
+      if (retryCount > s3Client.getMaxRetries()) {
         String extendedRequestId = "none";
 
-        if (ex instanceof AmazonS3Exception)
-        {
+        if (ex instanceof AmazonS3Exception) {
           AmazonS3Exception ex1 = (AmazonS3Exception) ex;
           extendedRequestId = ex1.getExtendedRequestId();
         }
 
-        if (ex instanceof AmazonServiceException)
-        {
+        if (ex instanceof AmazonServiceException) {
           AmazonServiceException ex1 = (AmazonServiceException) ex;
-          throw new SnowflakeSQLException(ex1, SqlState.SYSTEM_ERROR,
+          throw new SnowflakeSQLException(
+              ex1,
+              SqlState.SYSTEM_ERROR,
               ErrorCode.S3_OPERATION_ERROR.getMessageCode(),
               operation,
               ex1.getErrorType().toString(),
               ex1.getErrorCode(),
-              ex1.getMessage(), ex1.getRequestId(),
+              ex1.getMessage(),
+              ex1.getRequestId(),
               extendedRequestId);
-        }
-        else
-          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
+        } else
+          throw new SnowflakeSQLException(
+              ex,
+              SqlState.SYSTEM_ERROR,
               ErrorCode.AWS_CLIENT_ERROR.getMessageCode(),
-              operation, ex.getMessage());
-      }
-      else {
-        logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                ex.getMessage(), operation, retryCount);
+              operation,
+              ex.getMessage());
+      } else {
+        logger.debug(
+            "Encountered exception ({}) during {}, retry count: {}",
+            ex.getMessage(),
+            operation,
+            retryCount);
         logger.debug("Stack trace: ", ex);
 
         // exponential backoff up to a limit
         int backoffInMillis = s3Client.getRetryBackoffMin();
 
         if (retryCount > 1)
-          backoffInMillis <<= (Math.min(retryCount - 1,
-                  s3Client.getRetryBackoffMaxExponent()));
+          backoffInMillis <<= (Math.min(retryCount - 1, s3Client.getRetryBackoffMaxExponent()));
 
         try {
-          logger.debug("Sleep for {} milliseconds before retry",
-                  backoffInMillis);
+          logger.debug("Sleep for {} milliseconds before retry", backoffInMillis);
 
           Thread.sleep(backoffInMillis);
         } catch (InterruptedException ex1) {
@@ -601,103 +571,80 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
 
         // If the exception indicates that the AWS token has expired,
         // we need to refresh our S3 client with the new token
-        if (ex instanceof AmazonS3Exception)
-        {
+        if (ex instanceof AmazonS3Exception) {
           AmazonS3Exception s3ex = (AmazonS3Exception) ex;
-          if (s3ex.getErrorCode().equalsIgnoreCase(EXPIRED_AWS_TOKEN_ERROR_CODE))
-          {
+          if (s3ex.getErrorCode().equalsIgnoreCase(EXPIRED_AWS_TOKEN_ERROR_CODE)) {
             SnowflakeFileTransferAgent.renewExpiredToken(connection, command, s3Client);
           }
         }
       }
-    }
-    else
-    {
-      if (ex instanceof InterruptedException ||
-          SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException)
-      {
+    } else {
+      if (ex instanceof InterruptedException
+          || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
         if (retryCount > s3Client.getMaxRetries())
-          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
+          throw new SnowflakeSQLException(
+              ex,
+              SqlState.SYSTEM_ERROR,
               ErrorCode.IO_ERROR.getMessageCode(),
-              "Encountered exception during " + operation +  ": " +
-                  ex.getMessage());
-        else
-        {
-          logger.debug("Encountered exception ({}) during {}, retry count: {}",
-              ex.getMessage(), operation, retryCount);
+              "Encountered exception during " + operation + ": " + ex.getMessage());
+        else {
+          logger.debug(
+              "Encountered exception ({}) during {}, retry count: {}",
+              ex.getMessage(),
+              operation,
+              retryCount);
         }
-      }
-      else
-        throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
+      } else
+        throw new SnowflakeSQLException(
+            ex,
+            SqlState.SYSTEM_ERROR,
             ErrorCode.IO_ERROR.getMessageCode(),
-            "Encountered exception during " + operation + ": " +
-                ex.getMessage());
+            "Encountered exception during " + operation + ": " + ex.getMessage());
     }
   }
 
-  /**
-   * Returns the material descriptor key
-   */
+  /** Returns the material descriptor key */
   @Override
-  public String getMatdescKey()
-  {
+  public String getMatdescKey() {
     return "x-amz-matdesc";
   }
 
-  /**
-   * Adds encryption metadata to the StorageObjectMetadata object
-   */
-   @Override
-   public void addEncryptionMetadata(StorageObjectMetadata meta,
-                              MatDesc matDesc,
-                              byte[] ivData,
-                              byte[] encKeK,
-                              long contentLength)
-   {
-      meta.addUserMetadata(getMatdescKey(),
-                           matDesc.toString());
-      meta.addUserMetadata(AMZ_KEY,
-                           Base64.encodeAsString(encKeK));
-      meta.addUserMetadata(AMZ_IV,
-                           Base64.encodeAsString(ivData));
-      meta.setContentLength(contentLength);
-   }
+  /** Adds encryption metadata to the StorageObjectMetadata object */
+  @Override
+  public void addEncryptionMetadata(
+      StorageObjectMetadata meta,
+      MatDesc matDesc,
+      byte[] ivData,
+      byte[] encKeK,
+      long contentLength) {
+    meta.addUserMetadata(getMatdescKey(), matDesc.toString());
+    meta.addUserMetadata(AMZ_KEY, Base64.encodeAsString(encKeK));
+    meta.addUserMetadata(AMZ_IV, Base64.encodeAsString(ivData));
+    meta.setContentLength(contentLength);
+  }
 
-  /**
-   * Adds digest metadata to the StorageObjectMetadata object
-   */
-   @Override
-   public void addDigestMetadata(StorageObjectMetadata meta, String digest)
-   {
-     meta.addUserMetadata("sfc-digest", digest);
-   }
+  /** Adds digest metadata to the StorageObjectMetadata object */
+  @Override
+  public void addDigestMetadata(StorageObjectMetadata meta, String digest) {
+    meta.addUserMetadata("sfc-digest", digest);
+  }
 
-  /**
-   * Gets digest metadata to the StorageObjectMetadata object
-   */
-   @Override
-   public String getDigestMetadata(StorageObjectMetadata meta)
-   {
-     return meta.getUserMetadata().get("sfc-digest");
-   }
+  /** Gets digest metadata to the StorageObjectMetadata object */
+  @Override
+  public String getDigestMetadata(StorageObjectMetadata meta) {
+    return meta.getUserMetadata().get("sfc-digest");
+  }
 
-  private static SSLConnectionSocketFactory getSSLConnectionSocketFactory()
-  {
-    if (s3ConnectionSocketFactory == null)
-    {
-      synchronized (SnowflakeS3Client.class)
-      {
-        if (s3ConnectionSocketFactory == null)
-        {
-          try
-          {
+  private static SSLConnectionSocketFactory getSSLConnectionSocketFactory() {
+    if (s3ConnectionSocketFactory == null) {
+      synchronized (SnowflakeS3Client.class) {
+        if (s3ConnectionSocketFactory == null) {
+          try {
             // trust manager is set to null, which will use default ones
             // instead of SFTrustManager (which enables ocsp checking)
-            s3ConnectionSocketFactory = new SFSSLConnectionSocketFactory(null,
-                HttpUtil.isSocksProxyDisabled());
-          }
-          catch (KeyManagementException | NoSuchAlgorithmException e)
-          {
+            s3ConnectionSocketFactory =
+                new SFSSLConnectionSocketFactory(null, HttpUtil.isSocksProxyDisabled());
+          } catch (KeyManagementException | NoSuchAlgorithmException e) {
             throw new SSLInitializationException(e.getMessage(), e);
           }
         }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
@@ -3,84 +3,77 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.jdbc.FileBackedOutputStream;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.jdbc.FileBackedOutputStream;
 import net.snowflake.client.jdbc.MatDesc;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
 
 /**
  * Interface for storage client provider implementations
  *
  * @author lgiakoumakis
  */
-public interface SnowflakeStorageClient
-{
-  /**
-   * @return Returns the Max number of retry attempts
-   */
+public interface SnowflakeStorageClient {
+  /** @return Returns the Max number of retry attempts */
   int getMaxRetries();
 
   /**
-   * Returns the max exponent for multiplying backoff with the power of 2, the value
-   * of 4 will give us 16secs as the max number of time to sleep before retry
+   * Returns the max exponent for multiplying backoff with the power of 2, the value of 4 will give
+   * us 16secs as the max number of time to sleep before retry
    *
    * @return Returns the exponent
    */
   int getRetryBackoffMaxExponent();
 
-  /**
-   * @return  Returns the min number of milliseconds to sleep before retry
-   */
-   int getRetryBackoffMin();
+  /** @return Returns the min number of milliseconds to sleep before retry */
+  int getRetryBackoffMin();
 
-  /**
-   * @return Returns true if encryption is enabled
-   */
+  /** @return Returns true if encryption is enabled */
   boolean isEncrypting();
 
-  /**
-   * @return Returns the size of the encryption key
-   */
+  /** @return Returns the size of the encryption key */
   int getEncryptionKeySize();
 
-  /** Re-creates the encapsulated storage client with a fresh access token
+  /**
+   * Re-creates the encapsulated storage client with a fresh access token
+   *
    * @param stageCredentials a Map (as returned by GS) which contains the new credential properties
    * @throws SnowflakeSQLException failure to renew the storage client
-   **/
+   */
   void renew(Map stageCredentials) throws SnowflakeSQLException;
 
-  /**
-   *   shuts down the client
-   */
+  /** shuts down the client */
   void shutdown();
 
   /**
-   * For a set of remote storage objects under a remote location and a given prefix/path
-   * returns their properties wrapped in ObjectSummary objects
+   * For a set of remote storage objects under a remote location and a given prefix/path returns
+   * their properties wrapped in ObjectSummary objects
+   *
    * @param remoteStorageLocation location, i.e. bucket for S3
    * @param prefix the prefix to list
    * @return a collection of storage summary objects
    * @throws StorageProviderException cloud storage provider error
    */
   StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
-                                            throws StorageProviderException;
+      throws StorageProviderException;
 
   /**
    * Returns the metadata properties for a remote storage object
+   *
    * @param remoteStorageLocation location, i.e. bucket for S3
    * @param prefix the prefix/path of the object to retrieve
    * @return storage metadata object
    * @throws StorageProviderException cloud storage provider error
    */
   StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
-                                         throws StorageProviderException;
+      throws StorageProviderException;
 
   /**
    * Download a file from remote storage.
+   *
    * @param connection connection object
    * @param command command to download file
    * @param localLocation local file path
@@ -90,13 +83,21 @@ public interface SnowflakeStorageClient
    * @param stageFilePath stage file path
    * @param stageRegion region name where the stage persists
    * @throws SnowflakeSQLException download failure
-   **/
-void download(SFSession connection, String command, String localLocation, String destFileName,
-                int parallelism, String remoteStorageLocation, String stageFilePath, String stageRegion)
-                throws SnowflakeSQLException;
+   */
+  void download(
+      SFSession connection,
+      String command,
+      String localLocation,
+      String destFileName,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion)
+      throws SnowflakeSQLException;
 
   /**
    * Upload a file (-stream) to remote storage
+   *
    * @param connection connection object
    * @param command upload command
    * @param parallelism number of threads do parallel uploading
@@ -110,51 +111,71 @@ void download(SFSession connection, String command, String localLocation, String
    * @param stageRegion region name where the stage persists
    * @throws SnowflakeSQLException if upload failed even after retry
    */
-  void upload(SFSession connection, String command, int parallelism, boolean uploadFromStream,
-              String remoteStorageLocation, File srcFile, String destFileName, InputStream inputStream,
-              FileBackedOutputStream fileBackedOutputStream, StorageObjectMetadata meta, String stageRegion)
-                throws SnowflakeSQLException;
+  void upload(
+      SFSession connection,
+      String command,
+      int parallelism,
+      boolean uploadFromStream,
+      String remoteStorageLocation,
+      File srcFile,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      StorageObjectMetadata meta,
+      String stageRegion)
+      throws SnowflakeSQLException;
   /**
    * Handles exceptions thrown by the remote storage provider
+   *
    * @param ex the exception to handle
    * @param retryCount current number of retries, incremented by the caller before each call
-   * @param operation string that indicates the function/operation that was taking place,
-   *                  when the exception was raised, for example "upload"
+   * @param operation string that indicates the function/operation that was taking place, when the
+   *     exception was raised, for example "upload"
    * @param connection the current SFSession object used by the client
    * @param command the command attempted at the time of the exception
-   * @throws SnowflakeSQLException exceptions that were not handled, or retried past
-   *                               what the retry policy allows, are propagated
+   * @throws SnowflakeSQLException exceptions that were not handled, or retried past what the retry
+   *     policy allows, are propagated
    */
-  void handleStorageException(Exception ex, int retryCount, String operation, SFSession connection, String command)
-          throws SnowflakeSQLException;
+  void handleStorageException(
+      Exception ex, int retryCount, String operation, SFSession connection, String command)
+      throws SnowflakeSQLException;
 
   /**
    * Returns the material descriptor key
+   *
    * @return the material descriptor key
    */
-   String getMatdescKey();
+  String getMatdescKey();
 
   /**
    * Adds encryption metadata to the StorageObjectMetadata object
+   *
    * @param meta the storage metadata object to add the encyption info to
    * @param matDesc the material decriptor
    * @param ivData the initialization vector
    * @param encKeK the key encryption key
    * @param contentLength the length of the encrypted content
    */
-   void addEncryptionMetadata(StorageObjectMetadata meta, MatDesc matDesc, byte[] ivData, byte[] encKeK, long contentLength);
+  void addEncryptionMetadata(
+      StorageObjectMetadata meta,
+      MatDesc matDesc,
+      byte[] ivData,
+      byte[] encKeK,
+      long contentLength);
 
   /**
    * Adds digest metadata to the StorageObjectMetadata object
+   *
    * @param meta the storage metadata object to add the digest to
    * @param digest the digest metadata to add
    */
-   void addDigestMetadata(StorageObjectMetadata meta, String digest);
+  void addDigestMetadata(StorageObjectMetadata meta, String digest);
 
   /**
    * Gets digest metadata to the StorageObjectMetadata object
+   *
    * @param meta the metadata object to extract the digest metadata from
    * @return the digest metadata value
    */
-   String getDigestMetadata(StorageObjectMetadata meta);
+  String getDigestMetadata(StorageObjectMetadata meta);
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
@@ -2,19 +2,20 @@ package net.snowflake.client.jdbc.cloud.storage;
 
 import java.util.Map;
 
-/**
- * Encapsulates all the required stage properties used by GET/PUT
- * for Azure and S3 stages
- */
-public class StageInfo
-{
-  public enum StageType {S3, AZURE, LOCAL_FS};
-  private StageType stageType;        // The stage type
-  private String location;            // The container or bucket
-  private Map credentials;            // the credentials required for the stage
-  private String region;              // AWS/S3 region (S3 only)
-  private String endPoint;            // The Azure Storage endpoint (Azure only)
-  private String storageAccount;      // The Azure Storage account (Azure only)
+/** Encapsulates all the required stage properties used by GET/PUT for Azure and S3 stages */
+public class StageInfo {
+  public enum StageType {
+    S3,
+    AZURE,
+    LOCAL_FS
+  };
+
+  private StageType stageType; // The stage type
+  private String location; // The container or bucket
+  private Map credentials; // the credentials required for the stage
+  private String region; // AWS/S3 region (S3 only)
+  private String endPoint; // The Azure Storage endpoint (Azure only)
+  private String storageAccount; // The Azure Storage account (Azure only)
 
   /*
    * Creates a StageInfo object
@@ -28,18 +29,23 @@ public class StageInfo
    * @param storageAccount The Azure Storage account (azure only)
    * @throws IllegalArgumentException one or more parameters required were missing
    */
-  public static StageInfo createStageInfo(String locationType, String location, Map credentials,
-                                          String region, String endPoint, String storageAccount)
-    throws IllegalArgumentException
-  {
+  public static StageInfo createStageInfo(
+      String locationType,
+      String location,
+      Map credentials,
+      String region,
+      String endPoint,
+      String storageAccount)
+      throws IllegalArgumentException {
     StageType stageType;
     // Ensure that all the required parameters are specified
-    switch(locationType)
-    {
+    switch (locationType) {
       case "AZURE":
         stageType = StageType.AZURE;
-        if(!isSpecified(location) || !isSpecified(endPoint) || !isSpecified(storageAccount)
-                || credentials == null)
+        if (!isSpecified(location)
+            || !isSpecified(endPoint)
+            || !isSpecified(storageAccount)
+            || credentials == null)
           throw new IllegalArgumentException("Incomplete parameters specified for Azure stage");
         break;
 
@@ -51,7 +57,7 @@ public class StageInfo
 
       case "LOCAL_FS":
         stageType = StageType.LOCAL_FS;
-        if(!isSpecified(location))
+        if (!isSpecified(location))
           throw new IllegalArgumentException("Incomplete parameters specific for local stage");
         break;
 
@@ -73,9 +79,13 @@ public class StageInfo
    * @param endPoint The Azure Storage end point (Azure only)
    * @param storageAccount The Azure Storage account (azure only)
    */
-  private StageInfo(StageType stageType, String location, Map credentials,
-                    String region, String endPoint, String storageAccount)
-  {
+  private StageInfo(
+      StageType stageType,
+      String location,
+      Map credentials,
+      String region,
+      String endPoint,
+      String storageAccount) {
     this.stageType = stageType;
     this.location = location;
     this.credentials = credentials;
@@ -84,43 +94,35 @@ public class StageInfo
     this.storageAccount = storageAccount;
   }
 
-  public  StageType getStageType()
-  {
+  public StageType getStageType() {
     return stageType;
   }
 
-  public String getLocation()
-  {
+  public String getLocation() {
     return location;
   }
 
-  public Map getCredentials()
-  {
+  public Map getCredentials() {
     return credentials;
   }
 
-  public void setCredentials(Map credentials)
-  {
+  public void setCredentials(Map credentials) {
     this.credentials = credentials;
   }
 
-  public String getRegion()
-  {
+  public String getRegion() {
     return region;
   }
 
-  public String getEndPoint()
-  {
+  public String getEndPoint() {
     return endPoint;
   }
 
-  public String getStorageAccount()
-  {
+  public String getStorageAccount() {
     return storageAccount;
   }
 
-  private static boolean isSpecified(String arg)
-  {
-    return !(arg == null || arg.equalsIgnoreCase("") );
+  private static boolean isSpecified(String arg) {
+    return !(arg == null || arg.equalsIgnoreCase(""));
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -2,26 +2,24 @@
  * Copyright (c) 2012-2018 Snowflake Computing Inc. All rights reserved.
  */
 package net.snowflake.client.jdbc.cloud.storage;
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.log.SFLogger;
+
 import com.amazonaws.ClientConfiguration;
+import java.util.Map;
+import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 
-import java.util.Map;
-
 /**
- * Factory object for abstracting the creation of storage client objects:
- * SnowflakeStorageClient and StorageObjectMetadata
+ * Factory object for abstracting the creation of storage client objects: SnowflakeStorageClient and
+ * StorageObjectMetadata
  *
  * @author lgiakoumakis
  */
-public class StorageClientFactory
-{
+public class StorageClientFactory {
 
-  private final static SFLogger logger =
-          SFLoggerFactory.getLogger(SnowflakeS3Client.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeS3Client.class);
 
   private static StorageClientFactory factory;
 
@@ -29,11 +27,11 @@ public class StorageClientFactory
 
   /**
    * Creates or returns the single instance of the factory object
+   *
    * @return the storage client instance
    */
-  public static StorageClientFactory getFactory()
-  {
-    if(factory == null) factory = new StorageClientFactory();
+  public static StorageClientFactory getFactory() {
+    if (factory == null) factory = new StorageClientFactory();
 
     return factory;
   }
@@ -47,15 +45,12 @@ public class StorageClientFactory
    * @return a SnowflakeStorageClient interface to the instance created
    * @throws SnowflakeSQLException if any error occurs
    */
-  public SnowflakeStorageClient createClient(StageInfo stage,
-                                             int parallel,
-                                             RemoteStoreFileEncryptionMaterial encMat)
-                                             throws SnowflakeSQLException
-  {
+  public SnowflakeStorageClient createClient(
+      StageInfo stage, int parallel, RemoteStoreFileEncryptionMaterial encMat)
+      throws SnowflakeSQLException {
     logger.debug("createClient client type={}", stage.getStageType().name());
 
-    switch (stage.getStageType())
-    {
+    switch (stage.getStageType()) {
       case S3:
         return createS3Client(stage.getCredentials(), parallel, encMat, stage.getRegion());
 
@@ -66,28 +61,27 @@ public class StorageClientFactory
         // We don't create a storage client for FS_LOCAL,
         // so we should only find ourselves here if an unsupported
         // remote storage client type is specified
-        throw new IllegalArgumentException("Unsupported storage client specified: "
-                + stage.getStageType().name());
+        throw new IllegalArgumentException(
+            "Unsupported storage client specified: " + stage.getStageType().name());
     }
   }
 
   /**
-   * Creates a SnowflakeS3ClientObject which encapsulates
-   * the Amazon S3 client
+   * Creates a SnowflakeS3ClientObject which encapsulates the Amazon S3 client
    *
    * @param stageCredentials Map of stage credential properties
    * @param parallel degree of parallelism
    * @param encMat encryption material for the client
    * @param stageRegion the region where the stage is located
-   * @return the SnowflakeS3Client  instance created
+   * @return the SnowflakeS3Client instance created
    * @throws SnowflakeSQLException failure to create the S3 client
    */
-  private SnowflakeS3Client createS3Client(Map stageCredentials,
-                                           int parallel,
-                                           RemoteStoreFileEncryptionMaterial encMat,
-                                           String stageRegion)
-          throws SnowflakeSQLException
-  {
+  private SnowflakeS3Client createS3Client(
+      Map stageCredentials,
+      int parallel,
+      RemoteStoreFileEncryptionMaterial encMat,
+      String stageRegion)
+      throws SnowflakeSQLException {
     final int S3_TRANSFER_MAX_RETRIES = 3;
 
     logger.debug("createS3Client encryption={}", (encMat == null ? "no" : "yes"));
@@ -95,23 +89,21 @@ public class StorageClientFactory
     SnowflakeS3Client s3Client;
 
     ClientConfiguration clientConfig = new ClientConfiguration();
-    clientConfig.setMaxConnections(parallel+1);
+    clientConfig.setMaxConnections(parallel + 1);
     clientConfig.setMaxErrorRetry(S3_TRANSFER_MAX_RETRIES);
     clientConfig.setDisableSocketProxy(HttpUtil.isSocksProxyDisabled());
 
-    logger.debug("s3 client configuration: maxConnection={}, connectionTimeout={}, " +
-                    "socketTimeout={}, maxErrorRetry={}",
-            clientConfig.getMaxConnections(),
-            clientConfig.getConnectionTimeout(),
-            clientConfig.getSocketTimeout(),
-            clientConfig.getMaxErrorRetry());
+    logger.debug(
+        "s3 client configuration: maxConnection={}, connectionTimeout={}, "
+            + "socketTimeout={}, maxErrorRetry={}",
+        clientConfig.getMaxConnections(),
+        clientConfig.getConnectionTimeout(),
+        clientConfig.getSocketTimeout(),
+        clientConfig.getMaxErrorRetry());
 
-    try
-    {
+    try {
       s3Client = new SnowflakeS3Client(stageCredentials, clientConfig, encMat, stageRegion);
-    }
-    catch(Exception ex)
-    {
+    } catch (Exception ex) {
       logger.debug("Exception creating s3 client", ex);
       throw ex;
     }
@@ -121,16 +113,14 @@ public class StorageClientFactory
   }
 
   /**
-   * Creates a storage provider specific metadata object,
-   * accessible via the platform independent interface
+   * Creates a storage provider specific metadata object, accessible via the platform independent
+   * interface
    *
    * @param stageType determines the implementation to be created
    * @return the implementation of StorageObjectMetadata
    */
-  public StorageObjectMetadata createStorageMetadataObj(StageInfo.StageType stageType)
-  {
-    switch (stageType)
-    {
+  public StorageObjectMetadata createStorageMetadataObj(StageInfo.StageType stageType) {
+    switch (stageType) {
       case S3:
         return new S3ObjectMetadata();
 
@@ -141,35 +131,28 @@ public class StorageClientFactory
         // An unsupported remote storage client type was specified
         // We don't create/implement a storage client for FS_LOCAL,
         // so we should never end up here while running on local file system
-        throw new IllegalArgumentException("Unsupported stage type specified: "
-                + stageType.name());
-      }
+        throw new IllegalArgumentException("Unsupported stage type specified: " + stageType.name());
+    }
   }
 
   /**
-   * Creates a SnowflakeAzureClientObject which encapsulates
-   * the Azure Storage client
+   * Creates a SnowflakeAzureClientObject which encapsulates the Azure Storage client
    *
    * @param stage Stage information
    * @param encMat encryption material for the client
-   * @return the SnowflakeS3Client  instance created
+   * @return the SnowflakeS3Client instance created
    */
-  private SnowflakeAzureClient createAzureClient(StageInfo stage,
-                                           RemoteStoreFileEncryptionMaterial encMat)
-                              throws SnowflakeSQLException
-  {
+  private SnowflakeAzureClient createAzureClient(
+      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat) throws SnowflakeSQLException {
     logger.debug("createAzureClient encryption={}", (encMat == null ? "no" : "yes"));
 
-    //TODO: implement support for encryption SNOW-33042
+    // TODO: implement support for encryption SNOW-33042
 
     SnowflakeAzureClient azureClient;
 
-    try
-    {
+    try {
       azureClient = SnowflakeAzureClient.createSnowflakeAzureClient(stage, encMat);
-    }
-    catch(Exception ex)
-    {
+    } catch (Exception ex) {
       logger.debug("Exception creating Azure Storage client", ex);
       throw ex;
     }
@@ -177,7 +160,4 @@ public class StorageClientFactory
 
     return azureClient;
   }
-
-
 }
-

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageObjectMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageObjectMetadata.java
@@ -6,44 +6,41 @@ package net.snowflake.client.jdbc.cloud.storage;
 import java.util.Map;
 
 /**
- * Interface for platform-independent remote storage object metadata,
- * modeled after the S3 ObjectMetadata class
+ * Interface for platform-independent remote storage object metadata, modeled after the S3
+ * ObjectMetadata class
  *
- * Only the metadata accessors and mutators used by the Client currently are supported,
+ * <p>Only the metadata accessors and mutators used by the Client currently are supported,
  * additional methods should be added as needed
  *
  * @author lgiakoumakis
- *
- **/
-public interface StorageObjectMetadata
-{
-  /**
-   * @return returns a Map/key-value pairs of metadata properties
-   */
+ */
+public interface StorageObjectMetadata {
+  /** @return returns a Map/key-value pairs of metadata properties */
   Map<String, String> getUserMetadata();
 
-  /**
-   * @return returns the size of object in bytes
-   */
+  /** @return returns the size of object in bytes */
   long getContentLength();
 
   /**
    * Sets size of the associated object in bytes
+   *
    * @param contentLength the length of content
    */
   void setContentLength(long contentLength);
 
   /**
    * Adds the key value pair of custom user-metadata for the associated object.
+   *
    * @param key the key of user metadata
    * @param value the value of user metadata
    */
   void addUserMetadata(String key, String value);
 
   /**
-   * Sets the optional Content-Encoding HTTP header specifying what content encodings,
-   * have been applied to the object and what decoding mechanisms must be applied,
-   * in order to obtain the media-type referenced by the Content-Type field.
+   * Sets the optional Content-Encoding HTTP header specifying what content encodings, have been
+   * applied to the object and what decoding mechanisms must be applied, in order to obtain the
+   * media-type referenced by the Content-Type field.
+   *
    * @param encoding the encoding name using in HTTP header Content-Encoding
    */
   void setContentEncoding(String encoding);
@@ -51,5 +48,5 @@ public interface StorageObjectMetadata
   /*
    * @return returns the content encoding type
    */
-   String getContentEncoding();
+  String getContentEncoding();
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageObjectSummary.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageObjectSummary.java
@@ -9,7 +9,6 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobProperties;
 import com.microsoft.azure.storage.blob.CloudBlob;
 import com.microsoft.azure.storage.blob.ListBlobItem;
-
 import java.net.URISyntaxException;
 
 /**
@@ -17,20 +16,18 @@ import java.net.URISyntaxException;
  *
  * @author lgiakoumakis
  */
-public class StorageObjectSummary
-{
-  private String location;      // location translates to "bucket" for S3
+public class StorageObjectSummary {
+  private String location; // location translates to "bucket" for S3
   private String key;
   private String md5;
   private long size;
 
-
   /**
    * Contructs a StorageObjectSummary object from the S3 equivalent S3ObjectSummary
+   *
    * @param
    */
-  private StorageObjectSummary(String location, String key, String md5, long size)
-  {
+  private StorageObjectSummary(String location, String key, String md5, long size) {
     this.location = location;
     this.key = key;
     this.md5 = md5;
@@ -39,33 +36,31 @@ public class StorageObjectSummary
 
   /**
    * Contructs a StorageObjectSummary object from the S3 equivalent S3ObjectSummary
+   *
    * @param objSummary the AWS S3 ObjectSummary object to copy from
    * @return the ObjectSummary object created
    */
- public static StorageObjectSummary createFromS3ObjectSummary(S3ObjectSummary objSummary)
-  {
+  public static StorageObjectSummary createFromS3ObjectSummary(S3ObjectSummary objSummary) {
 
     return new StorageObjectSummary(
-                  objSummary.getBucketName(),
-                  objSummary.getKey(),
-                  // S3 ETag is not always MD5, but since this code path is only
-                  // used in skip duplicate files in PUT command, It's not
-                  // critical to guarantee that it's MD5
-                  objSummary.getETag(),
-                  objSummary.getSize()
-                  );
+        objSummary.getBucketName(),
+        objSummary.getKey(),
+        // S3 ETag is not always MD5, but since this code path is only
+        // used in skip duplicate files in PUT command, It's not
+        // critical to guarantee that it's MD5
+        objSummary.getETag(),
+        objSummary.getSize());
   }
 
   /**
-   * Contructs a StorageObjectSummary object from Azure BLOB properties
-   * Using factory methods to create these objects since Azure can throw,
-   * while retrieving the BLOB properties
+   * Contructs a StorageObjectSummary object from Azure BLOB properties Using factory methods to
+   * create these objects since Azure can throw, while retrieving the BLOB properties
+   *
    * @param listBlobItem an Azure ListBlobItem object
    * @return the ObjectSummary object created
    */
   public static StorageObjectSummary createFromAzureListBlobItem(ListBlobItem listBlobItem)
-    throws StorageProviderException
-  {
+      throws StorageProviderException {
     String location, key, md5;
     long size;
 
@@ -74,8 +69,7 @@ public class StorageObjectSummary
     // will point us to the underlying BLOB and will get the properties from it
     // During the process the Storage Client could fail, hence we need to wrap the
     // get calls in try/catch and handle possible exceptions
-    try
-    {
+    try {
       location = listBlobItem.getContainer().getName();
 
       CloudBlob cloudBlob = (CloudBlob) listBlobItem;
@@ -86,61 +80,49 @@ public class StorageObjectSummary
       // used for skipping file on PUT command, hense is ok.
       md5 = convertBase64ToHex(blobProperties.getContentMD5());
       size = blobProperties.getLength();
-    }
-    catch (URISyntaxException | StorageException ex)
-    {
-      // This should only happen if somehow we got here with and invalid URI (it should never happen)
-      // ...or there is a Storage service error. Unlike S3, Azure fetches metadata from the BLOB itself,
+    } catch (URISyntaxException | StorageException ex) {
+      // This should only happen if somehow we got here with and invalid URI (it should never
+      // happen)
+      // ...or there is a Storage service error. Unlike S3, Azure fetches metadata from the BLOB
+      // itself,
       // and its a lazy operation
       throw new StorageProviderException(ex);
     }
     return new StorageObjectSummary(location, key, md5, size);
-
   }
 
-  private static String convertBase64ToHex(String base64String){
-    try{
+  private static String convertBase64ToHex(String base64String) {
+    try {
       byte[] bytes = Base64.decode(base64String);
-    
+
       final StringBuilder builder = new StringBuilder();
-      for(byte b : bytes) {
+      for (byte b : bytes) {
         builder.append(String.format("%02x", b));
       }
       return builder.toString();
-    // return empty string if input is not a valid Base64 string
-    }catch(Exception e){
+      // return empty string if input is not a valid Base64 string
+    } catch (Exception e) {
       return "";
     }
   }
-  
-  /**
-   * @return returns the location of the object
-   */
-  public String getLocation()
-  {
+
+  /** @return returns the location of the object */
+  public String getLocation() {
     return location;
   }
 
-  /**
-   * @return returns the key property of the object
-   */
+  /** @return returns the key property of the object */
   public String getKey() {
     return key;
   }
 
-  /**
-   * @return returns the MD5 hash of the object
-   */
-  public String getMD5()
-  {
+  /** @return returns the MD5 hash of the object */
+  public String getMD5() {
     return md5;
   }
 
-  /**
-   * @return returns the size property of the object
-   */
-  public long getSize()
-  {
+  /** @return returns the size property of the object */
+  public long getSize() {
     return size;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageObjectSummaryCollection.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageObjectSummaryCollection.java
@@ -4,54 +4,44 @@
 package net.snowflake.client.jdbc.cloud.storage;
 
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.microsoft.azure.storage.blob.CloudBlobDirectory;
 import com.microsoft.azure.storage.blob.ListBlobItem;
-
 import java.util.Iterator;
 import java.util.List;
 
-
 /**
- * Provides and iterator over storage object summaries
- * from all supported cloud storage providers
+ * Provides and iterator over storage object summaries from all supported cloud storage providers
  *
  * @author lgiakoumakis
- *
  */
 public class StorageObjectSummaryCollection implements Iterable<StorageObjectSummary> {
 
-  private enum storageType {S3, AZURE};
+  private enum storageType {
+    S3,
+    AZURE
+  };
+
   private final storageType sType;
   private List<S3ObjectSummary> s3ObjSummariesList = null;
   private Iterable<ListBlobItem> azCLoudBlobIterable = null;
 
   // Constructs platform-agnostic collection of object summaries from S3 object summaries
-  public StorageObjectSummaryCollection (List<S3ObjectSummary> s3ObjectSummaries)
-  {
+  public StorageObjectSummaryCollection(List<S3ObjectSummary> s3ObjectSummaries) {
     this.s3ObjSummariesList = s3ObjectSummaries;
     sType = storageType.S3;
   }
 
-  // Constructs platform-agnostic collection of object summaries from an Azure CloudBlobDirectory object
-  public StorageObjectSummaryCollection (Iterable<ListBlobItem> azCLoudBlobIterable)
-  {
+  // Constructs platform-agnostic collection of object summaries from an Azure CloudBlobDirectory
+  // object
+  public StorageObjectSummaryCollection(Iterable<ListBlobItem> azCLoudBlobIterable) {
     this.azCLoudBlobIterable = azCLoudBlobIterable;
     sType = storageType.AZURE;
   }
 
-
-  public Iterator<StorageObjectSummary> iterator()
-  {
-    if(sType==storageType.S3)
-    {
+  public Iterator<StorageObjectSummary> iterator() {
+    if (sType == storageType.S3) {
       return new S3ObjectSummariesIterator(s3ObjSummariesList);
-    }
-    else if(sType==storageType.AZURE)
-    {
+    } else if (sType == storageType.AZURE) {
       return new AzureObjectSummariesIterator(azCLoudBlobIterable);
-    }
-    else throw new IllegalArgumentException("Unspecified storage provider");
-
+    } else throw new IllegalArgumentException("Unspecified storage provider");
   }
 }
-

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageProviderException.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageProviderException.java
@@ -7,8 +7,7 @@ import com.amazonaws.AmazonServiceException;
 import org.apache.http.HttpStatus;
 
 /**
- * Custom exception class to signal a remote provider exception in 
- * a platform-independent manner.
+ * Custom exception class to signal a remote provider exception in a platform-independent manner.
  *
  * @author lgiakoumakis
  */
@@ -23,27 +22,23 @@ public class StorageProviderException extends RuntimeException {
   }
 
   /**
-   * Method to obtain the original provider exception that led to this
-   * exception being thrown.
+   * Method to obtain the original provider exception that led to this exception being thrown.
    *
    * @return The original provider exception that led to this exception.
    */
-  public Exception getOriginalProviderException()
-  {
+  public Exception getOriginalProviderException() {
     return (Exception) (super.getCause());
   }
 
   /**
-   * Returns true if this is an exception corresponding to a HTTP 404 error
-   * returned by the storage provider
+   * Returns true if this is an exception corresponding to a HTTP 404 error returned by the storage
+   * provider
    *
-   * @return true if the specified exception is an AmazonServiceException
-   * instance and if it was thrown because of a 404, false otherwise.
- */
-  public boolean isServiceException404()
-  {
-    if ((Exception) this instanceof AmazonServiceException)
-    {
+   * @return true if the specified exception is an AmazonServiceException instance and if it was
+   *     thrown because of a 404, false otherwise.
+   */
+  public boolean isServiceException404() {
+    if ((Exception) this instanceof AmazonServiceException) {
       AmazonServiceException asEx = (AmazonServiceException) ((java.lang.Exception) this);
       return (asEx.getStatusCode() == HttpStatus.SC_NOT_FOUND);
     }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/Telemetry.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/Telemetry.java
@@ -3,6 +3,10 @@ package net.snowflake.client.jdbc.telemetry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.rmi.UnexpectedException;
+import java.sql.Connection;
+import java.util.LinkedList;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
@@ -12,21 +16,13 @@ import net.snowflake.client.log.SFLoggerFactory;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 
-import java.io.IOException;
-import java.rmi.UnexpectedException;
-import java.sql.Connection;
-import java.util.LinkedList;
-
-
 /**
  * Copyright (c) 2018 Snowflake Computing Inc. All rights reserved.
- * <p>
- * Telemetry Service Interface
+ *
+ * <p>Telemetry Service Interface
  */
-public class Telemetry
-{
-  private static final SFLogger logger =
-      SFLoggerFactory.getLogger(SFSession.class);
+public class Telemetry {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SFSession.class);
 
   private static final String SF_PATH_TELEMETRY = "/telemetry/send";
 
@@ -39,7 +35,6 @@ public class Telemetry
   private final String serverUrl;
   private final String telemetryUrl;
 
-
   private final SFSession session;
   private LinkedList<TelemetryData> logBatch;
   private static final ObjectMapper mapper = new ObjectMapper();
@@ -48,42 +43,36 @@ public class Telemetry
 
   private Object locker = new Object();
 
-  //false if meet any error when sending metrics
+  // false if meet any error when sending metrics
   private boolean isTelemetryServiceAvailable = true;
 
-  private Telemetry(SFSession session, int flushSize)
-  {
+  private Telemetry(SFSession session, int flushSize) {
     this.session = session;
     this.serverUrl = session.getUrl();
 
-    if(this.serverUrl.endsWith("/"))
+    if (this.serverUrl.endsWith("/"))
       this.telemetryUrl =
-          this.serverUrl.substring(0, this.serverUrl.length()-1)
-              + SF_PATH_TELEMETRY;
+          this.serverUrl.substring(0, this.serverUrl.length() - 1) + SF_PATH_TELEMETRY;
     else this.telemetryUrl = this.serverUrl + SF_PATH_TELEMETRY;
 
     this.logBatch = new LinkedList<>();
     this.isClosed = false;
     this.forceFlushSize = flushSize;
-
   }
 
   /**
    * Return whether the client can be used to add/send metrics
+   *
    * @return whether client is enabled
    */
-  public boolean isTelemetryEnabled()
-  {
+  public boolean isTelemetryEnabled() {
     return this.session.isClientTelemetryEnabled() && this.isTelemetryServiceAvailable;
   }
 
-  /**
-   * Disable any use of the client to add/send metrics
-   */
-  public void disableTelemetry(){
+  /** Disable any use of the client to add/send metrics */
+  public void disableTelemetry() {
     this.isTelemetryServiceAvailable = false;
   }
-
 
   /**
    * Initialize the telemetry connector
@@ -92,10 +81,8 @@ public class Telemetry
    * @param flushSize maximum size of telemetry batch before flush
    * @return a telemetry connector
    */
-  public static Telemetry createTelemetry(Connection conn, int flushSize)
-  {
-    if (conn instanceof SnowflakeConnectionV1)
-    {
+  public static Telemetry createTelemetry(Connection conn, int flushSize) {
+    if (conn instanceof SnowflakeConnectionV1) {
       return createTelemetry(((SnowflakeConnectionV1) conn).getSfSession(), flushSize);
     }
     logger.debug("input connection is not a SnowflakeConnection");
@@ -108,194 +95,170 @@ public class Telemetry
    * @param conn connection with the session to use for the connector
    * @return a telemetry connector
    */
-  public static Telemetry createTelemetry(Connection conn)
-  {
+  public static Telemetry createTelemetry(Connection conn) {
     return createTelemetry(conn, DEFAULT_FORCE_FLUSH_SIZE);
   }
 
-
   /**
    * Initialize the telemetry connector
+   *
    * @param session session to use for telemetry dumps
    * @return a telemetry connector
    */
-  public static Telemetry createTelemetry(SFSession session)
-  {
+  public static Telemetry createTelemetry(SFSession session) {
     return createTelemetry(session, DEFAULT_FORCE_FLUSH_SIZE);
   }
 
   /**
    * Initialize the telemetry connector
+   *
    * @param session session to use for telemetry dumps
    * @param flushSize maximum size of telemetry batch before flush
    * @return a telemetry connector
    */
-  public static Telemetry createTelemetry(SFSession session, int flushSize)
-  {
+  public static Telemetry createTelemetry(SFSession session, int flushSize) {
     return new Telemetry(session, flushSize);
   }
 
   /**
-   * Add log to batch to be submitted to telemetry. Send batch if forceFlushSize
-   * reached
+   * Add log to batch to be submitted to telemetry. Send batch if forceFlushSize reached
+   *
    * @param log entry to add
    * @throws IOException if closed or uploading batch fails
    */
-  public void addLogToBatch(TelemetryData log) throws IOException
-  {
-    if (isClosed)
-    {
+  public void addLogToBatch(TelemetryData log) throws IOException {
+    if (isClosed) {
       throw new IOException("Telemetry connector is closed");
     }
     if (!isTelemetryEnabled()) return; // if disable, do nothing
 
-    synchronized (locker)
-    {
+    synchronized (locker) {
       this.logBatch.add(log);
     }
 
-    if (this.logBatch.size() >= this.forceFlushSize)
-    {
+    if (this.logBatch.size() >= this.forceFlushSize) {
       this.sendBatch();
     }
   }
 
   /**
-   * Add log to batch to be submitted to telemetry. Send batch if forceFlushSize
-   * reached
+   * Add log to batch to be submitted to telemetry. Send batch if forceFlushSize reached
+   *
    * @param message json node of log
    * @param timeStamp timestamp to use for log
    * @throws IOException if closed or uploading batch fails
    */
-  public void addLogToBatch(ObjectNode message, long timeStamp) throws
-      IOException
-  {
+  public void addLogToBatch(ObjectNode message, long timeStamp) throws IOException {
     this.addLogToBatch(new TelemetryData(message, timeStamp));
   }
 
   /**
-   * Attempt to add log to batch, and suppress exceptions thrown in case of
-   * failure
+   * Attempt to add log to batch, and suppress exceptions thrown in case of failure
+   *
    * @param log entry to add
    */
-  public void tryAddLogToBatch(TelemetryData log)
-  {
-    try
-    {
+  public void tryAddLogToBatch(TelemetryData log) {
+    try {
       addLogToBatch(log);
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       logger.warn("Exception encountered while sending metrics to telemetry endpoint.", ex);
     }
   }
 
   /**
    * Close telemetry connector and send any unsubmitted logs
+   *
    * @throws IOException if closed or uploading batch fails
    */
-  public void close() throws IOException
-  {
-    if (isClosed)
-    {
+  public void close() throws IOException {
+    if (isClosed) {
       throw new IOException("Telemetry connector is closed");
     }
-    try
-    {
+    try {
       this.sendBatch();
-    } catch (IOException e)
-    {
+    } catch (IOException e) {
       logger.error("Send logs failed on closing", e);
-    } finally
-    {
+    } finally {
       this.isClosed = true;
     }
   }
 
   /**
    * Return whether the client has been closed
+   *
    * @return whether client is closed
    */
-  public boolean isClosed()
-  {
+  public boolean isClosed() {
     return this.isClosed;
   }
 
   /**
    * Send all cached logs to server
+   *
    * @return whether the logs were sent successfully
    * @throws IOException if closed or uploading batch fails
    */
-  public boolean sendBatch() throws IOException
-  {
-    if (isClosed)
-    {
+  public boolean sendBatch() throws IOException {
+    if (isClosed) {
       throw new IOException("Telemetry connector is closed");
     }
     if (!isTelemetryEnabled()) return false;
 
     LinkedList<TelemetryData> tmpList;
-    synchronized (locker)
-    {
+    synchronized (locker) {
       tmpList = this.logBatch;
       this.logBatch = new LinkedList<>();
     }
 
-    if (session.isClosed())
-    {
+    if (session.isClosed()) {
       throw new UnexpectedException("Session is closed when sending log");
     }
 
-    if (!tmpList.isEmpty())
-    {
-      //session shared with JDBC
+    if (!tmpList.isEmpty()) {
+      // session shared with JDBC
       String sessionToken = this.session.getSessionToken();
 
       HttpPost post = new HttpPost(this.telemetryUrl);
       post.setEntity(new StringEntity(logsToString(tmpList)));
       post.setHeader("Content-type", "application/json");
-      post.setHeader("Authorization", "Snowflake Token=\"" + sessionToken +
-          "\"");
+      post.setHeader("Authorization", "Snowflake Token=\"" + sessionToken + "\"");
 
       String response = null;
 
-      try
-      {
+      try {
         response = HttpUtil.executeRequest(post, 1000, 0, null);
-      } catch (SnowflakeSQLException e)
-      {
-        disableTelemetry(); // when got error like 404 or bad request, disable telemetry in this telemetry instance
+      } catch (SnowflakeSQLException e) {
+        disableTelemetry(); // when got error like 404 or bad request, disable telemetry in this
+                            // telemetry instance
         logger.error(
-            "Telemetry request failed, " +
-                "response: {}, exception: {}", response, e.getMessage());
+            "Telemetry request failed, " + "response: {}, exception: {}", response, e.getMessage());
         return false;
       }
     }
     return true;
   }
 
-
   /**
    * Send a log to the server, along with any existing logs waiting to be sent
+   *
    * @param log entry to send
    * @return whether the logs were sent successfully
    * @throws IOException if closed or uploading batch fails
    */
-  public boolean sendLog(TelemetryData log) throws IOException
-  {
+  public boolean sendLog(TelemetryData log) throws IOException {
     addLogToBatch(log);
     return sendBatch();
   }
 
   /**
    * Send a log to the server, along with any existing logs waiting to be sent
+   *
    * @param message json node of log
    * @param timeStamp timestamp to use for log
    * @return whether the logs were sent successfully
    * @throws IOException if closed or uploading batch fails
    */
-  public boolean sendLog(ObjectNode message, long timeStamp) throws IOException
-  {
+  public boolean sendLog(ObjectNode message, long timeStamp) throws IOException {
     return this.sendLog(new TelemetryData(message, timeStamp));
   }
 
@@ -305,12 +268,10 @@ public class Telemetry
    * @param telemetryData a list of log
    * @return the result json string
    */
-  static ObjectNode logsToJson(LinkedList<TelemetryData> telemetryData)
-  {
+  static ObjectNode logsToJson(LinkedList<TelemetryData> telemetryData) {
     ObjectNode node = mapper.createObjectNode();
     ArrayNode logs = mapper.createArrayNode();
-    for (TelemetryData data : telemetryData)
-    {
+    for (TelemetryData data : telemetryData) {
       logs.add(data.toJson());
     }
     node.set("logs", logs);
@@ -324,26 +285,25 @@ public class Telemetry
    * @param telemetryData a list of log
    * @return the result json string
    */
-  static String logsToString(LinkedList<TelemetryData> telemetryData)
-  {
+  static String logsToString(LinkedList<TelemetryData> telemetryData) {
     return logsToJson(telemetryData).toString();
   }
 
   /**
    * For test use only
+   *
    * @return the number of cached logs
    */
-  public int bufferSize()
-  {
+  public int bufferSize() {
     return this.logBatch.size();
   }
 
   /**
    * For test use only
+   *
    * @return a copy of the logs currently in the buffer
    */
-  public LinkedList<TelemetryData> logBuffer()
-  {
+  public LinkedList<TelemetryData> logBuffer() {
     return new LinkedList<>(this.logBatch);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryData.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryData.java
@@ -3,45 +3,36 @@ package net.snowflake.client.jdbc.telemetry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-/**
- * Copyright (c) 2018 Snowflake Computing Inc. All rights reserved.
- */
-public class TelemetryData
-{
-  //message is a json node
+/** Copyright (c) 2018 Snowflake Computing Inc. All rights reserved. */
+public class TelemetryData {
+  // message is a json node
   private final ObjectNode message;
   private final long timeStamp;
-  private final static ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper mapper = new ObjectMapper();
 
-  public TelemetryData(ObjectNode message, long timeStamp)
-  {
+  public TelemetryData(ObjectNode message, long timeStamp) {
     this.message = message;
     this.timeStamp = timeStamp;
   }
 
-  public long getTimeStamp()
-  {
+  public long getTimeStamp() {
     return timeStamp;
   }
 
-  public ObjectNode getMessage()
-  {
+  public ObjectNode getMessage() {
     return message;
   }
 
-  public ObjectNode toJson()
-  {
+  public ObjectNode toJson() {
     ObjectNode node = mapper.createObjectNode();
-    node.put("timestamp",this.timeStamp+"");
-    node.set("message",this.message);
+    node.put("timestamp", this.timeStamp + "");
+    node.set("message", this.message);
     return node;
   }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
 
     return toJson().toString();
-
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryField.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryField.java
@@ -1,7 +1,6 @@
 package net.snowflake.client.jdbc.telemetry;
 
-public enum TelemetryField
-{
+public enum TelemetryField {
   // we use "client_" as a prefix for all metrics on the client side
   TIME_CONSUME_FIRST_RESULT("client_time_consume_first_result"),
   TIME_CONSUME_LAST_RESULT("client_time_consume_last_result"),
@@ -16,14 +15,12 @@ public enum TelemetryField
 
   public final String field;
 
-  TelemetryField(String field)
-  {
+  TelemetryField(String field) {
     this.field = field;
   }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
     return field;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryUtil.java
@@ -3,23 +3,22 @@ package net.snowflake.client.jdbc.telemetry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-public class TelemetryUtil
-{
-  private final static ObjectMapper mapper = new ObjectMapper();
+public class TelemetryUtil {
+  private static final ObjectMapper mapper = new ObjectMapper();
 
-  public final static String TYPE = "type";
-  public final static String QUERY_ID = "query_id";
-  public final static String VALUE = "value";
+  public static final String TYPE = "type";
+  public static final String QUERY_ID = "query_id";
+  public static final String VALUE = "value";
 
   /**
    * Create a simple TelemetryData instance for Job metrics using given parameters
+   *
    * @param queryId the id of the query
    * @param field the field to log (represents the "type" field in telemetry)
    * @param value the value to log for the field
    * @return TelemetryData instance constructed from parameters
    */
-  public static TelemetryData buildJobData(String queryId, TelemetryField field, long value)
-  {
+  public static TelemetryData buildJobData(String queryId, TelemetryField field, long value) {
     ObjectNode obj = mapper.createObjectNode();
     obj.put(TYPE, field.toString());
     obj.put(QUERY_ID, queryId);

--- a/src/main/java/net/snowflake/client/loader/BufferStage.java
+++ b/src/main/java/net/snowflake/client/loader/BufferStage.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.loader;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -14,32 +16,32 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPOutputStream;
-
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 /**
- * Class representing a unit of work for uploader. Corresponds to a collection
- * of data files for a single processing stage.
+ * Class representing a unit of work for uploader. Corresponds to a collection of data files for a
+ * single processing stage.
  */
-public class BufferStage
-{
-  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(
-          BufferStage.class);
+public class BufferStage {
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(BufferStage.class);
 
-  public enum State
-  {
-
-    CREATED, LOADING, LOADED, EMPTY, UPLOADED, VALIDATED, VALIDATED_CLEANED,
-    ERROR, PROCESSED, CLEANED, REMOVED
-
+  public enum State {
+    CREATED,
+    LOADING,
+    LOADED,
+    EMPTY,
+    UPLOADED,
+    VALIDATED,
+    VALIDATED_CLEANED,
+    ERROR,
+    PROCESSED,
+    CLEANED,
+    REMOVED
   };
 
-
-  public static final int  FILE_BUCKET_SIZE = 64;   // threshold to schedule processing
-  public static final long FILE_SIZE = 50L * 1024L * 1024L;   // individual file, 50Mb
+  public static final int FILE_BUCKET_SIZE = 64; // threshold to schedule processing
+  public static final long FILE_SIZE = 50L * 1024L * 1024L; // individual file, 50Mb
 
   private State _state;
 
@@ -84,41 +86,43 @@ public class BufferStage
   // List of all scheduled uploaders
   private ArrayList<FileUploader> _uploaders = new ArrayList<>();
 
-  BufferStage(StreamLoader loader, Operation op, long csvFileBucketSize, long csvFileSize)
-  {
+  BufferStage(StreamLoader loader, Operation op, long csvFileBucketSize, long csvFileSize) {
     LOGGER.debug("Operation: {}", op);
 
     _state = State.CREATED;
     _loader = loader;
 
-    _stamp = new SimpleDateFormat(
-        "yyyyMMdd'_'HHmmss'_'SSS").format(new Date());
+    _stamp = new SimpleDateFormat("yyyyMMdd'_'HHmmss'_'SSS").format(new Date());
     _csvFileBucketSize = csvFileBucketSize;
     _csvFileSize = csvFileSize;
 
     long mark = MARK.getAndIncrement() % 10000000;
 
     // Security Fix: A table name can include slashes and dots, so if a table
-    // name is used as part of a file name, the file can be created 
+    // name is used as part of a file name, the file can be created
     // outside of the given directory. This replaces slashes with underscores.
-    _location = BufferStage.escapeFileSeparatorChar(_loader.getTable())
-                + File.separatorChar
-                + op.name()
-                + File.separatorChar
-                + _stamp + "_" + _loader.getNoise() + '_' + mark;
+    _location =
+        BufferStage.escapeFileSeparatorChar(_loader.getTable())
+            + File.separatorChar
+            + op.name()
+            + File.separatorChar
+            + _stamp
+            + "_"
+            + _loader.getNoise()
+            + '_'
+            + mark;
 
-    _id = BufferStage.escapeFileSeparatorChar(_loader.getTable())
-          + "_" + _stamp + '_' + mark;
+    _id = BufferStage.escapeFileSeparatorChar(_loader.getTable()) + "_" + _stamp + '_' + mark;
 
-    String localStageDirectory = _loader.getBase()
-                                 + File.separatorChar + _location;
+    String localStageDirectory = _loader.getBase() + File.separatorChar + _location;
 
     _directory = new File(localStageDirectory);
     if (!_directory.mkdirs()) {
-      RuntimeException ex = new RuntimeException(
-              "Could not initialize the local staging area. " +
-                      "Make sure the directory is writable and readable: " +
-                      localStageDirectory);
+      RuntimeException ex =
+          new RuntimeException(
+              "Could not initialize the local staging area. "
+                  + "Make sure the directory is writable and readable: "
+                  + localStageDirectory);
 
       _loader.abort(ex);
       throw ex;
@@ -129,55 +133,47 @@ public class BufferStage
     openFile();
   }
 
-  /**
-   * Create local file for caching data before upload
-   */
-  private synchronized void openFile()
-  {
+  /** Create local file for caching data before upload */
+  private synchronized void openFile() {
     try {
-      String fName = _directory.getAbsolutePath()
-                     + File.separatorChar + StreamLoader.FILE_PREFIX
-                     + _stamp + _fileCount;
-      if (_loader._compressDataBeforePut)
-      {
+      String fName =
+          _directory.getAbsolutePath()
+              + File.separatorChar
+              + StreamLoader.FILE_PREFIX
+              + _stamp
+              + _fileCount;
+      if (_loader._compressDataBeforePut) {
         fName += StreamLoader.FILE_SUFFIX;
       }
       LOGGER.info("openFile: {}", fName);
 
       OutputStream fileStream = new FileOutputStream(fName);
-      if (_loader._compressDataBeforePut)
-      {
-        OutputStream gzipOutputStream = new GZIPOutputStream(
-            fileStream, 64 * 1024,  true) {
-          {
-            def.setLevel((int)_loader._compressLevel);
-          }
-        };
+      if (_loader._compressDataBeforePut) {
+        OutputStream gzipOutputStream =
+            new GZIPOutputStream(fileStream, 64 * 1024, true) {
+              {
+                def.setLevel((int) _loader._compressLevel);
+              }
+            };
         _outstream = new BufferedOutputStream(gzipOutputStream);
-      }
-      else
-      {
+      } else {
         _outstream = new BufferedOutputStream(fileStream);
       }
 
       _file = new File(fName);
 
       _fileCount++;
-    }
-    catch (IOException ex) {
+    } catch (IOException ex) {
       _loader.abort(new Loader.ConnectionError(Utils.getCause(ex)));
     }
   }
 
   private static byte[] newLineBytes = "\n".getBytes(UTF_8);
 
-
   // not thread safe
-  boolean stageData(final byte[] line) throws IOException
-  {
+  boolean stageData(final byte[] line) throws IOException {
     if (this._rowCount % 10000 == 0) {
-      LOGGER.debug(
-              "rowCount: {}, currentSize: {}", this._rowCount, _currentSize);
+      LOGGER.debug("rowCount: {}, currentSize: {}", this._rowCount, _currentSize);
     }
     _outstream.write(line);
     _currentSize += line.length;
@@ -189,16 +185,19 @@ public class BufferStage
       // inject garbage for a negative test case
       // The file will be uploaded to the stage, but COPY command will
       // fail and raise LoaderError
-      _outstream.write(new byte[] { (byte)0x01, (byte)0x02});
+      _outstream.write(new byte[] {(byte) 0x01, (byte) 0x02});
       _outstream.write(newLineBytes);
       this._rowCount++;
     }
 
-    if(_currentSize >= this._csvFileSize) {
-      LOGGER.info("name: {}, currentSize: {}, Threshold: {},"
-                      + " fileCount: {}, fileBucketSize: {}",
-              _file.getAbsolutePath(), _currentSize, this._csvFileSize, _fileCount,
-              this._csvFileBucketSize);
+    if (_currentSize >= this._csvFileSize) {
+      LOGGER.info(
+          "name: {}, currentSize: {}, Threshold: {}," + " fileCount: {}, fileBucketSize: {}",
+          _file.getAbsolutePath(),
+          _currentSize,
+          this._csvFileSize,
+          _fileCount,
+          this._csvFileBucketSize);
       _outstream.flush();
       _outstream.close();
       _outstream = null;
@@ -212,24 +211,24 @@ public class BufferStage
     return _fileCount > this._csvFileBucketSize;
   }
 
-
   /**
    * Wait for all files to finish uploading and schedule stage for processing
+   *
    * @throws IOException raises an exception if IO error occurs
    */
-  void completeUploading() throws IOException
-  {
-    LOGGER.debug("name: {}, currentSize: {}, Threshold: {},"
-            + " fileCount: {}, fileBucketSize: {}",
+  void completeUploading() throws IOException {
+    LOGGER.debug(
+        "name: {}, currentSize: {}, Threshold: {}," + " fileCount: {}, fileBucketSize: {}",
         _file.getAbsolutePath(),
-        _currentSize, this._csvFileSize, _fileCount,
+        _currentSize,
+        this._csvFileSize,
+        _fileCount,
         this._csvFileBucketSize);
 
     _outstream.flush();
     _outstream.close();
-    //last file
-    if(_currentSize > 0)
-    {
+    // last file
+    if (_currentSize > 0) {
       FileUploader fu = new FileUploader(_loader, _location, _file);
       fu.upload();
       _uploaders.add(fu);
@@ -238,8 +237,7 @@ public class BufferStage
       _file.delete();
     }
 
-    for(FileUploader fu: _uploaders)
-    {
+    for (FileUploader fu : _uploaders) {
       // Finish all files being uploaded
       fu.join();
     }
@@ -248,75 +246,62 @@ public class BufferStage
     // of what is going on)
     _directory.deleteOnExit();
 
-    if (this._rowCount == 0)
-    {
+    if (this._rowCount == 0) {
       setState(State.EMPTY);
     }
   }
 
-  String getRemoteLocation()
-  {
+  String getRemoteLocation() {
     return remoteSeparator(_location);
   }
 
-  Operation getOp()
-  {
+  Operation getOp() {
     return _op;
   }
 
-  public boolean isTerminate()
-  {
+  public boolean isTerminate() {
     return _terminate;
   }
 
-  public void setTerminate(boolean terminate)
-  {
+  public void setTerminate(boolean terminate) {
     this._terminate = terminate;
   }
 
-  public String getId()
-  {
+  public String getId() {
     return _id;
   }
 
-  public void setId(String _id)
-  {
+  public void setId(String _id) {
     this._id = _id;
   }
 
-  public State state()
-  {
+  public State state() {
     return _state;
   }
 
-  public void setState(State state)
-  {
-    if (_state != state)
-    {
+  public void setState(State state) {
+    if (_state != state) {
       // Logging goes here
       // Need to keep trace of states.
       _state = state;
     }
   }
 
-  int getRowCount()
-  {
+  int getRowCount() {
     return _rowCount;
   }
 
   // convert any back slashes to forward slashes if necessary when converting
   // a local filename to a one suitable for S3
-  private String remoteSeparator(String fname)
-  {
-    if (File.separatorChar == '\\')
-      return fname.replace("\\", "/");
-    else
-      return fname;
+  private String remoteSeparator(String fname) {
+    if (File.separatorChar == '\\') return fname.replace("\\", "/");
+    else return fname;
   }
 
   /**
-   * Escape file separator char to underscore. This prevents the file name
-   * from using file path separator.
+   * Escape file separator char to underscore. This prevents the file name from using file path
+   * separator.
+   *
    * @param fname
    * @return escaped file name
    */

--- a/src/main/java/net/snowflake/client/loader/FileUploader.java
+++ b/src/main/java/net/snowflake/client/loader/FileUploader.java
@@ -4,23 +4,19 @@
 
 package net.snowflake.client.loader;
 
-import net.snowflake.client.jdbc.SnowflakeConnectionV1;
-import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
 import java.io.File;
 import java.sql.ResultSet;
 import java.sql.Statement;
-
+import net.snowflake.client.jdbc.SnowflakeConnectionV1;
+import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
-/**
- * Class responsible for uploading a single data file.
- */
+/** Class responsible for uploading a single data file. */
 public class FileUploader implements Runnable {
-  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(
-          PutQueue.class);
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(PutQueue.class);
 
-  private final static int RETRY = 6;
+  private static final int RETRY = 6;
   private final Thread _thread;
   private final StreamLoader _loader;
   private final String _stage;
@@ -51,26 +47,27 @@ public class FileUploader implements Runnable {
 
         if (attempt == RETRY) {
           if (previousException != null) {
-            _loader.abort(new Loader.ConnectionError(
+            _loader.abort(
+                new Loader.ConnectionError(
                     String.format(
-                            "File could not be uploaded to remote stage " +
-                            "after retrying %d times: %s", RETRY,
-                            _file.getCanonicalPath()),
+                        "File could not be uploaded to remote stage "
+                            + "after retrying %d times: %s",
+                        RETRY, _file.getCanonicalPath()),
                     Utils.getCause(previousException)));
           } else {
-            _loader.abort(new Loader.ConnectionError(
+            _loader.abort(
+                new Loader.ConnectionError(
                     String.format(
-                            "File could not be uploaded to remote stage " +
-                            "after retrying %d times: %s", RETRY,
-                            _file.getCanonicalPath())));
+                        "File could not be uploaded to remote stage "
+                            + "after retrying %d times: %s",
+                        RETRY, _file.getCanonicalPath())));
           }
           break;
         }
 
         if (attempt > 0) {
-          LOGGER.info("Will retry PUT after {} seconds",
-                                 Math.pow(2, attempt));
-          Thread.sleep(1000 * ((int)Math.pow(2, attempt)));
+          LOGGER.info("Will retry PUT after {} seconds", Math.pow(2, attempt));
+          Thread.sleep(1000 * ((int) Math.pow(2, attempt)));
         }
 
         // In test mode force fail first file
@@ -79,11 +76,9 @@ public class FileUploader implements Runnable {
           if (attempt < 2) {
             ((SnowflakeConnectionV1) _loader.getPutConnection())
                 .setInjectFileUploadFailure(_file.getName());
-          }
-          else {
+          } else {
             // so that retry now succeeds.
-            ((SnowflakeConnectionV1) _loader.getPutConnection())
-                .setInjectFileUploadFailure(null);
+            ((SnowflakeConnectionV1) _loader.getPutConnection()).setInjectFileUploadFailure(null);
           }
         }
 
@@ -92,29 +87,22 @@ public class FileUploader implements Runnable {
         // No double quote is added _loader.getRemoteStage(), since
         // it is most likely "~". If not, we may need to double quote
         // them.
-        String remoteStage = "@" + _loader.getRemoteStage()
-                             + "/" + remoteSeparator(_stage);
+        String remoteStage = "@" + _loader.getRemoteStage() + "/" + remoteSeparator(_stage);
 
-
-        String putStatement = "PUT "
-                              + (attempt > 0 ? "/* retry:"+attempt+" */ " : "")
-                              + "'file://"
-                              + _file.getCanonicalPath().replaceAll("\\\\", "\\\\\\\\")
-                              + "' '"
-                              + remoteStage
-                              + "' parallel=10"        // upload chunks in parallel
-                              + " overwrite=true";     // skip file existence check
-        if (_loader._compressDataBeforePut)
-        {
-          putStatement += " auto_compress=false"
-                        + " SOURCE_COMPRESSION=gzip";
-        }
-        else if (_loader._compressFileByPut)
-        {
+        String putStatement =
+            "PUT "
+                + (attempt > 0 ? "/* retry:" + attempt + " */ " : "")
+                + "'file://"
+                + _file.getCanonicalPath().replaceAll("\\\\", "\\\\\\\\")
+                + "' '"
+                + remoteStage
+                + "' parallel=10" // upload chunks in parallel
+                + " overwrite=true"; // skip file existence check
+        if (_loader._compressDataBeforePut) {
+          putStatement += " auto_compress=false" + " SOURCE_COMPRESSION=gzip";
+        } else if (_loader._compressFileByPut) {
           putStatement += " auto_compress=true";
-        }
-        else
-        {
+        } else {
           // don't compress file at all
           putStatement += " auto_compress=false";
         }
@@ -128,43 +116,42 @@ public class FileUploader implements Runnable {
 
           putResult.next();
 
-          String file = localSeparator(
-                  putResult.getString(
-                          SnowflakeFileTransferAgent.UploadColumns.source.name()));
-          String status = putResult.getString(
-                  SnowflakeFileTransferAgent.UploadColumns.status.name());
-          String message = putResult.getString(
-                  SnowflakeFileTransferAgent.UploadColumns.message.name());
+          String file =
+              localSeparator(
+                  putResult.getString(SnowflakeFileTransferAgent.UploadColumns.source.name()));
+          String status =
+              putResult.getString(SnowflakeFileTransferAgent.UploadColumns.status.name());
+          String message =
+              putResult.getString(SnowflakeFileTransferAgent.UploadColumns.message.name());
 
-          if (status != null && status.equals(
-                  SnowflakeFileTransferAgent.ResultStatus.UPLOADED.name())) {
+          if (status != null
+              && status.equals(SnowflakeFileTransferAgent.ResultStatus.UPLOADED.name())) {
             // UPLOAD is success
             _file.delete();
             break;
           } else {
             // The log level should be WARNING for a single upload failure.
-            if (message.startsWith("Simulated upload failure"))
-            {
-              LOGGER.info("Failed to upload a file:"
-                      + " status={},"
-                      + " filename={},"
-                      + " message={}",
-                  status, file, message);
-            }
-            else
-            {
-              LOGGER.warn("Failed to upload a file:"
-                      + " status={},"
-                      + " filename={},"
-                      + " message={}",
-                  status, file, message);
+            if (message.startsWith("Simulated upload failure")) {
+              LOGGER.info(
+                  "Failed to upload a file:" + " status={}," + " filename={}," + " message={}",
+                  status,
+                  file,
+                  message);
+            } else {
+              LOGGER.warn(
+                  "Failed to upload a file:" + " status={}," + " filename={}," + " message={}",
+                  status,
+                  file,
+                  message);
             }
           }
         } catch (Throwable t) {
           // The log level for unknown error is set to SEVERE
-          LOGGER.error(String.format(
-                  "Failed to PUT on attempt: attempt=[%s], "
-                  +"Message=[%s]", attempt, t.getMessage()), t.getCause());
+          LOGGER.error(
+              String.format(
+                  "Failed to PUT on attempt: attempt=[%s], " + "Message=[%s]",
+                  attempt, t.getMessage()),
+              t.getCause());
           previousException = t;
         }
       }
@@ -185,32 +172,27 @@ public class FileUploader implements Runnable {
     }
   }
 
-
   /**
-   * convert any back slashes to forward slashes if necessary when converting
-   * a local filename to a one suitable for S3
-   * 
+   * convert any back slashes to forward slashes if necessary when converting a local filename to a
+   * one suitable for S3
+   *
    * @param fname a file name to PUT
    * @return A fname string for S3
    */
   private String remoteSeparator(String fname) {
-    if (File.separatorChar == '\\')
-      return fname.replace("\\", "/");
-    else
-      return fname;
+    if (File.separatorChar == '\\') return fname.replace("\\", "/");
+    else return fname;
   }
 
   /**
-   * convert any forward slashes to back slashes if necessary when converting
-   * a S3 file name to a local file name
+   * convert any forward slashes to back slashes if necessary when converting a S3 file name to a
+   * local file name
+   *
    * @param fname a file name to PUT
    * @return A fname string for the local FS (Windows/other Unix like OS)
    */
   private String localSeparator(String fname) {
-    if (File.separatorChar == '\\')
-      return fname.replace("/", "\\");
-    else
-      return fname;
+    if (File.separatorChar == '\\') return fname.replace("/", "\\");
+    else return fname;
   }
 }
-

--- a/src/main/java/net/snowflake/client/loader/LoadResultListener.java
+++ b/src/main/java/net/snowflake/client/loader/LoadResultListener.java
@@ -4,98 +4,86 @@
 
 package net.snowflake.client.loader;
 
-/**
- * Callback API for processing errors and statistics of upload operation
- */
-public interface LoadResultListener
-{
+/** Callback API for processing errors and statistics of upload operation */
+public interface LoadResultListener {
+
+  /** @return this result listener needs to listen to the provided records */
+  boolean needSuccessRecords();
 
   /**
-   * @return this result listener needs to listen to the provided records
-   */
-  boolean needSuccessRecords();
-  
-  /**
-   * @param op  Operation requested
+   * @param op Operation requested
    * @param record Data submitted for processing
    */
   void recordProvided(Operation op, Object[] record);
-  
+
   /**
    * @param op Operation requested
    * @param i number of rows that had been processed
    */
   void addProcessedRecordCount(Operation op, int i);
-  
+
   /**
    * @param op Operation requested
-   * @param i  number of rows that had been affected by a given operation
+   * @param i number of rows that had been affected by a given operation
    */
   void addOperationRecordCount(Operation op, int i);
 
-  /**
-   * @return whether this result listener needs to listen to error records 
-   */
+  /** @return whether this result listener needs to listen to error records */
   boolean needErrors();
-  
-  /**
-   * @param error information about error that was encountered
-   */
+
+  /** @param error information about error that was encountered */
   void addError(LoadingError error);
-  
-  /** 
-   * @return  Whether to throw an exception upon encountering error 
-   */
+
+  /** @return Whether to throw an exception upon encountering error */
   boolean throwOnError();
 
   /**
    * Method to add to the the error count for a listener
+   *
    * @param number the number of errors
    */
   void addErrorCount(int number);
 
-  /**
-   * Method to reset the error count back to zero
-   */
+  /** Method to reset the error count back to zero */
   void resetErrorCount();
 
   /**
    * method to get the total number of errors
+   *
    * @return the number of errors
    */
   int getErrorCount();
 
-
   /**
    * Method to add to the the error record count for a listener
+   *
    * @param number the number of error records
    */
   void addErrorRecordCount(int number);
 
-  /**
-   * Method to reset the errorRecordCount back to zero
-   */
+  /** Method to reset the errorRecordCount back to zero */
   void resetErrorRecordCount();
 
   /**
    * method to get the total number of error records
+   *
    * @return the number of rows in errors
    */
   int getErrorRecordCount();
 
-  /**
-   * Resets submitted row count
-   */
+  /** Resets submitted row count */
   void resetSubmittedRowCount();
-  
+
   /**
    * Adds the number of submitted rows
+   *
    * @param number the number of submitted row
    */
   void addSubmittedRowCount(int number);
-  
+
   /**
    * Gets the number of submitted row
+   *
    * @return the number of submitted row
    */
   int getSubmittedRowCount();

--- a/src/main/java/net/snowflake/client/loader/Loader.java
+++ b/src/main/java/net/snowflake/client/loader/Loader.java
@@ -6,17 +6,18 @@ package net.snowflake.client.loader;
 
 import java.io.File;
 
-/**
- *  Bulk loader for Snowflake
- */
-public interface Loader
-{
+/** Bulk loader for Snowflake */
+public interface Loader {
 
   // Temporary directory used for data cache
   String tmpdir = System.getProperty("java.io.tmpdir");
 
-  String BASE = tmpdir + (!(tmpdir.endsWith("/") || tmpdir.endsWith("\\")) ? File.separatorChar : "")
-                       + "snowflake" + File.separatorChar + "stage";
+  String BASE =
+      tmpdir
+          + (!(tmpdir.endsWith("/") || tmpdir.endsWith("\\")) ? File.separatorChar : "")
+          + "snowflake"
+          + File.separatorChar
+          + "stage";
 
   // Configuration, see LoaderProperty
   void setProperty(LoaderProperty property, Object value);
@@ -24,83 +25,71 @@ public interface Loader
   // Callback API
   void setListener(LoadResultListener listener);
 
-
-  /**
-   * Initiates loading threads.  Executes "before" statement
-   */
+  /** Initiates loading threads. Executes "before" statement */
   void start();
-
 
   /**
    * Pass row data
+   *
    * @param data, must match shape of the table (requested columns, in the order provided)
    */
   void submitRow(Object[] data);
 
-
   /**
    * If operation is changed, previous data is committed
+   *
    * @param op operation will be reset
    */
   void resetOperation(Operation op);
 
   /**
-   *  Rollback uncommitted changes.    If no transaction was initialized,
-   *  indeterminate fraction of rows could have been committed.
+   * Rollback uncommitted changes. If no transaction was initialized, indeterminate fraction of rows
+   * could have been committed.
    */
   void rollback();
 
   /**
-   * Finishes processing and commits or rolls back.
-   * Will throw the exception that was the cause of an abort
+   * Finishes processing and commits or rolls back. Will throw the exception that was the cause of
+   * an abort
    *
    * @throws Exception if that was the cause of an abort
    */
   void finish() throws Exception;
 
-
-  /**
-   * Close connections that have been provided upon initialization
-   */
+  /** Close connections that have been provided upon initialization */
   void close();
 
-
   // Raised for data conversion errors, if requested
-  class DataError extends RuntimeException
-  {
-    DataError(String msg)
-    {
+  class DataError extends RuntimeException {
+    DataError(String msg) {
       super(msg);
     }
-    DataError(String msg, Throwable ex)
-    {
+
+    DataError(String msg, Throwable ex) {
       super(msg, ex);
     }
+
     DataError(Throwable ex) {
-      super(ex); }
+      super(ex);
+    }
   }
 
   // Raised for connection and other system errors.
-  class ConnectionError extends RuntimeException
-  {
-    ConnectionError(String msg)
-    {
+  class ConnectionError extends RuntimeException {
+    ConnectionError(String msg) {
       super(msg);
     }
 
     // SNOW-22336: pass cause to connector
-    ConnectionError(String msg, Throwable ex)
-    {
+    ConnectionError(String msg, Throwable ex) {
       super(msg, ex);
     }
+
     ConnectionError(Throwable ex) {
       super(ex);
     }
-
   }
 
-  //get the listener instance used by this loader instance
+  // get the listener instance used by this loader instance
   LoadResultListener getListener();
-
-
 }

--- a/src/main/java/net/snowflake/client/loader/LoaderFactory.java
+++ b/src/main/java/net/snowflake/client/loader/LoaderFactory.java
@@ -4,24 +4,20 @@
 
 package net.snowflake.client.loader;
 
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.log.SFLogger;
-
 import java.sql.Connection;
 import java.util.Map;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 
-public class LoaderFactory
-{
-  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(
-          LoaderFactory.class);
-  public static Loader createLoader(Map<LoaderProperty, Object> properties,
-                                    Connection uploadConnection,
-                                    Connection processingConnection)
-  {
-      LOGGER.debug("");
-      StreamLoader loader = new StreamLoader(properties, uploadConnection,
-              processingConnection);
-      return loader;
+public class LoaderFactory {
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(LoaderFactory.class);
+
+  public static Loader createLoader(
+      Map<LoaderProperty, Object> properties,
+      Connection uploadConnection,
+      Connection processingConnection) {
+    LOGGER.debug("");
+    StreamLoader loader = new StreamLoader(properties, uploadConnection, processingConnection);
+    return loader;
   }
-
 }

--- a/src/main/java/net/snowflake/client/loader/LoaderProperty.java
+++ b/src/main/java/net/snowflake/client/loader/LoaderProperty.java
@@ -4,45 +4,41 @@
 
 package net.snowflake.client.loader;
 
-
-/**
- * Configuration parameters for Loader
- */
-public enum LoaderProperty
-{
-  tableName,         // Target table name                                          String
-  schemaName,        // Target table schema                                        String
-  databaseName,      // Target table database                                      String
-  remoteStage,       // Stage to use - "~" is default                              String
-  columns,           // List of columns that will be uploaded                      List<String>
-  keys,              // List of columns used as keys for updating                  List<String>
-  operation,         // UPDATE, DELETE, MODIFY, UPSERT                             Enum Operation
-  startTransaction,  // start transaction for the operation                        Boolean
-  oneBatch,          // process all data in one batch                              Boolean
-  truncateTable,     // delete all data from the table prior to run                Boolean
-  executeBefore,     // SQL statement to execute before run                        String
-  executeAfter,      // SQL statement to execute after run                         String
-  isFirstStartCall,  // skip deleting data. Used in multiple calls of loader.start Boolean
-  isLastFinishCall,  // skip commit. Used in multiple calls of loader.finish       Boolean
-  batchRowSize,      // Batch row size. Flush queues when it reaches this          Long
-  onError,           // on_error option                                            String
+/** Configuration parameters for Loader */
+public enum LoaderProperty {
+  tableName, // Target table name                                          String
+  schemaName, // Target table schema                                        String
+  databaseName, // Target table database                                      String
+  remoteStage, // Stage to use - "~" is default                              String
+  columns, // List of columns that will be uploaded                      List<String>
+  keys, // List of columns used as keys for updating                  List<String>
+  operation, // UPDATE, DELETE, MODIFY, UPSERT                             Enum Operation
+  startTransaction, // start transaction for the operation                        Boolean
+  oneBatch, // process all data in one batch                              Boolean
+  truncateTable, // delete all data from the table prior to run                Boolean
+  executeBefore, // SQL statement to execute before run                        String
+  executeAfter, // SQL statement to execute after run                         String
+  isFirstStartCall, // skip deleting data. Used in multiple calls of loader.start Boolean
+  isLastFinishCall, // skip commit. Used in multiple calls of loader.finish       Boolean
+  batchRowSize, // Batch row size. Flush queues when it reaches this          Long
+  onError, // on_error option                                            String
   csvFileBucketSize, // File bucket size. 64 by default.                           Long
-  csvFileSize,       // File size. 50MB by default.                                Long
+  csvFileSize, // File size. 50MB by default.                                Long
   preserveStageFile, // Preserve stage files if error occurs                       Boolean
-  useLocalTimezone,  // Use local timezone in converting TIMESTAMP                 Boolean
+  useLocalTimezone, // Use local timezone in converting TIMESTAMP                 Boolean
   compressFileByPut, // Compress file by PUT. false by default                     Boolean
   compressDataBeforePut, // Compress data before PUT. true by default              Boolean
-  compressLevel,     // Compress level: 1 (Speed) to 9 (Compression) for
-                     // compressDataBeforePut option. No impact to
-                     // compressFileByPut.  1 by default.                          Long
+  compressLevel, // Compress level: 1 (Speed) to 9 (Compression) for
+  // compressDataBeforePut option. No impact to
+  // compressFileByPut.  1 by default.                          Long
 
   // compatibility parameters
   mapTimeToTimestamp, // map TIME data type to TIMESTAMP. Informatica v1
-                      // connector behavior.                                       Boolean
+  // connector behavior.                                       Boolean
 
   // deprecated. to be removed.
   copyEmptyFieldAsEmpty, // EMPTY_FIELD_AS_NULL = true by default                  Boolean
 
   // test parameters
-  testRemoteBadCSV   // TEST: Inject bad CSV in the remote stage                   Boolean
+  testRemoteBadCSV // TEST: Inject bad CSV in the remote stage                   Boolean
 }

--- a/src/main/java/net/snowflake/client/loader/LoadingError.java
+++ b/src/main/java/net/snowflake/client/loader/LoadingError.java
@@ -4,30 +4,28 @@
 
 package net.snowflake.client.loader;
 
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 
-/**
- *   Wrapper for data format errors returned by the COPY/validate command
- */
-public class LoadingError
-{
-  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(
-          LoadingError.class);
+/** Wrapper for data format errors returned by the COPY/validate command */
+public class LoadingError {
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(LoadingError.class);
 
-  public enum ErrorProperty
-  {
-
-    ERROR, LINE, CHARACTER, BYTE_OFFSET, CATEGORY, CODE,
-    SQL_STATE, COLUMN_NAME, ROW_NUMBER,
+  public enum ErrorProperty {
+    ERROR,
+    LINE,
+    CHARACTER,
+    BYTE_OFFSET,
+    CATEGORY,
+    CODE,
+    SQL_STATE,
+    COLUMN_NAME,
+    ROW_NUMBER,
     ROW_START_LINE
-
   };
 
   private String _stage;
@@ -38,8 +36,7 @@ public class LoadingError
 
   private final String _target;
 
-  private final Map<ErrorProperty, String> _properties
-                                           = new HashMap<ErrorProperty, String>();
+  private final Map<ErrorProperty, String> _properties = new HashMap<ErrorProperty, String>();
 
   public static String UNKNOWN = "unknown";
 
@@ -50,79 +47,63 @@ public class LoadingError
    * @param bs buffer stage
    * @param loader stream loader
    */
-  public LoadingError(ResultSet rs, BufferStage bs, StreamLoader loader)
-  {
+  public LoadingError(ResultSet rs, BufferStage bs, StreamLoader loader) {
     _stage = bs.getRemoteLocation();
 
-    try
-    {
+    try {
       String ffile = rs.getString("FILE");
       _file = ffile.substring(ffile.lastIndexOf("/"));
       _prefix = ffile.substring(0, ffile.lastIndexOf("/"));
-    }
-    catch (SQLException ex)
-    {
+    } catch (SQLException ex) {
       _file = UNKNOWN;
     }
 
     _target = loader.getTable();
 
-    for (ErrorProperty p : ErrorProperty.values())
-    {
-      try
-      {
+    for (ErrorProperty p : ErrorProperty.values()) {
+      try {
         _properties.put(p, rs.getString(p.name()));
-      }
-      catch (SQLException ex)
-      {
+      } catch (SQLException ex) {
         LOGGER.error("Exception", ex);
       }
     }
   }
 
-  public String getStage()
-  {
+  public String getStage() {
     return _stage;
   }
 
-  public String getPrefix()
-  {
+  public String getPrefix() {
     return _prefix;
   }
 
-  public String getFile()
-  {
+  public String getFile() {
     return _file;
   }
 
-  public String getTarget()
-  {
+  public String getTarget() {
     return _target;
   }
 
-  public String getProperty(ErrorProperty p)
-  {
+  public String getProperty(ErrorProperty p) {
     return this._properties.get(p);
   }
 
-  public void setProperty(ErrorProperty p, String value)
-  {
+  public void setProperty(ErrorProperty p, String value) {
     this._properties.put(p, value);
   }
 
-  public String toString()
-  {
+  public String toString() {
     StringBuilder sb = new StringBuilder();
 
     sb.append("{");
     String prefix = "";
-    for (ErrorProperty p : ErrorProperty.values())
-    {
+    for (ErrorProperty p : ErrorProperty.values()) {
       sb.append(prefix);
       sb.append("\"").append(p.name()).append("\": ");
       sb.append("\"");
       String value = String.valueOf(_properties.get(p));
-      sb.append(value.replaceAll("[\\s]+"," ").replace("\"", "\\\""));
+      sb.append(value.replaceAll("[\\s]+", " ").replace("\"", "\\\""));
       sb.append("\"");
       prefix = ",";
     }
@@ -131,8 +112,7 @@ public class LoadingError
     return sb.toString();
   }
 
-  public Loader.DataError getException()
-  {
+  public Loader.DataError getException() {
     return new Loader.DataError(this.toString());
   }
 }

--- a/src/main/java/net/snowflake/client/loader/OnError.java
+++ b/src/main/java/net/snowflake/client/loader/OnError.java
@@ -6,23 +6,15 @@ package net.snowflake.client.loader;
 
 import java.util.regex.Pattern;
 
-/**
- * COPY ON_ERROR option
- */
-class OnError
-{
-  private final static Pattern validPattern = Pattern.compile(
-      "(?i)(?:ABORT_STATEMENT|CONTINUE|SKIP_FILE(?:_\\d+%?)?)"
-  );
+/** COPY ON_ERROR option */
+class OnError {
+  private static final Pattern validPattern =
+      Pattern.compile("(?i)(?:ABORT_STATEMENT|CONTINUE|SKIP_FILE(?:_\\d+%?)?)");
 
-  /**
-   * Default behavior for ON_ERROR for Loader API.
-   */
-  final static String DEFAULT = "CONTINUE";
+  /** Default behavior for ON_ERROR for Loader API. */
+  static final String DEFAULT = "CONTINUE";
 
-  private OnError()
-  {
-  }
+  private OnError() {}
 
   /**
    * Validates ON_ERROR value and return true if valid otherwise false.
@@ -30,8 +22,7 @@ class OnError
    * @param value ON_ERROR value
    * @return true if valid otherwise false.
    */
-  static boolean validate(String value)
-  {
+  static boolean validate(String value) {
     return value != null && validPattern.matcher(value).matches();
   }
 }

--- a/src/main/java/net/snowflake/client/loader/Operation.java
+++ b/src/main/java/net/snowflake/client/loader/Operation.java
@@ -4,11 +4,10 @@
 
 package net.snowflake.client.loader;
 
-/**
- * Operations supported by Loader
- */
-
-public enum Operation
-  {
-    INSERT, DELETE, MODIFY, UPSERT
-  };
+/** Operations supported by Loader */
+public enum Operation {
+  INSERT,
+  DELETE,
+  MODIFY,
+  UPSERT
+};

--- a/src/main/java/net/snowflake/client/loader/PutQueue.java
+++ b/src/main/java/net/snowflake/client/loader/PutQueue.java
@@ -5,25 +5,21 @@
 package net.snowflake.client.loader;
 
 import java.io.IOException;
-
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
 /**
- *  Queue that sequentially finalizes BufferStage uploads and schedules them for 
- *  processing in ProcessQueue.
+ * Queue that sequentially finalizes BufferStage uploads and schedules them for processing in
+ * ProcessQueue.
  */
-public class PutQueue implements Runnable
-{
-  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(
-          PutQueue.class);
+public class PutQueue implements Runnable {
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(PutQueue.class);
 
   private final Thread _thread;
 
   private final StreamLoader _loader;
 
-  public PutQueue(StreamLoader loader)
-  {
+  public PutQueue(StreamLoader loader) {
     LOGGER.debug("");
     _loader = loader;
     _thread = new Thread(this);
@@ -32,68 +28,51 @@ public class PutQueue implements Runnable
   }
 
   @Override
-  public void run()
-  {
+  public void run() {
 
-    while (true)
-    {
+    while (true) {
 
       BufferStage stage = null;
 
-      try
-      {
+      try {
 
         stage = _loader.takePut();
 
-        if (stage.getRowCount() == 0)
-        {
+        if (stage.getRowCount() == 0) {
           // Nothing was written to that stage
-          if (stage.isTerminate())
-          {
+          if (stage.isTerminate()) {
             _loader.queueProcess(stage);
             stage.completeUploading();
             break;
-          }
-          else
-          {
+          } else {
             continue;
           }
         }
 
         // Uploads the stage
         stage.completeUploading();
-        
+
         // Schedules it for processing
         _loader.queueProcess(stage);
 
-        if (stage.isTerminate())
-        {
+        if (stage.isTerminate()) {
           break;
         }
 
-      }
-      catch (InterruptedException | IOException ex)
-      {
+      } catch (InterruptedException | IOException ex) {
         LOGGER.error("Exception: ", ex);
         break;
-      }
-      finally
-      {
+      } finally {
 
       }
     }
   }
 
-  public void join()
-  {
-    try
-    {
+  public void join() {
+    try {
       _thread.join(0);
-    }
-    catch (InterruptedException ex)
-    {
+    } catch (InterruptedException ex) {
       LOGGER.error("Exception: ", ex);
     }
   }
-
 }

--- a/src/main/java/net/snowflake/client/loader/StreamLoader.java
+++ b/src/main/java/net/snowflake/client/loader/StreamLoader.java
@@ -4,10 +4,7 @@
 
 package net.snowflake.client.loader;
 
-import net.snowflake.client.jdbc.SnowflakeType;
-import net.snowflake.client.jdbc.SnowflakeUtil;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -25,27 +22,23 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.Deflater;
+import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.SnowflakeUtil;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+/** Stream Loader */
+public class StreamLoader implements Loader, Runnable {
+  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(StreamLoader.class);
 
-/**
- * Stream Loader
- */
-public class StreamLoader implements Loader, Runnable
-{
-  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(
-      StreamLoader.class);
+  private static final String SYSTEM_PARAMETER_PREFIX = "net.snowflake.client.loader.";
 
-  private final static String SYSTEM_PARAMETER_PREFIX = "net.snowflake.client.loader.";
+  static final String FILE_PREFIX = "stream_";
 
-  final static String FILE_PREFIX = "stream_";
+  static final String FILE_SUFFIX = ".gz";
 
-  final static String FILE_SUFFIX = ".gz";
-
-  /**
-   * Default batch row size
-   */
-  private final static long DEFAULT_BATCH_ROW_SIZE = -1L;
+  /** Default batch row size */
+  private static final long DEFAULT_BATCH_ROW_SIZE = -1L;
 
   public static DatabaseMetaData metadata;
 
@@ -55,7 +48,7 @@ public class StreamLoader implements Loader, Runnable
 
   private boolean _startTransaction = false;
 
-  // force not to truncate in case where loader.start is called in 
+  // force not to truncate in case where loader.start is called in
   // multiple times in a single job.
   private boolean _is_first_start_call = true;
 
@@ -107,7 +100,8 @@ public class StreamLoader implements Loader, Runnable
 
   private boolean _useLocalTimezone = false; // use local timezone instead of UTC
 
-  private boolean _mapTimeToTimestamp = false; // map TIME to TIMESTAMP. Informatica V1 connector behavior
+  private boolean _mapTimeToTimestamp =
+      false; // map TIME to TIMESTAMP. Informatica V1 connector behavior
 
   boolean _compressDataBeforePut = true; // compress data before PUT
 
@@ -124,29 +118,22 @@ public class StreamLoader implements Loader, Runnable
   private final Connection _putConn;
   private final Connection _processConn;
 
-
-  //a per-instance bit of random noise to make make filenames more unique
+  // a per-instance bit of random noise to make make filenames more unique
   private final String _noise;
-
 
   // Track fatal errors
   private AtomicBoolean _active = new AtomicBoolean(false);
   private AtomicBoolean _aborted = new AtomicBoolean(false);
-  private RuntimeException _abortCause = new ConnectionError(
-      "Unknown exception");
+  private RuntimeException _abortCause = new ConnectionError("Unknown exception");
 
   private AtomicInteger _throttleCounter = new AtomicInteger(0);
 
-  private final GregorianCalendar _calendarUTC = new GregorianCalendar(
-      TimeZone.getTimeZone("UTC"));
+  private final GregorianCalendar _calendarUTC = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
 
   private GregorianCalendar _calendarLocal;
 
-  /**
-   * Resets calendar when start the job.
-   */
-  private void resetCalendar()
-  {
+  /** Resets calendar when start the job. */
+  private void resetCalendar() {
     _calendarUTC.clear();
     _calendarLocal = new GregorianCalendar(TimeZone.getDefault());
     _calendarLocal.clear();
@@ -157,14 +144,13 @@ public class StreamLoader implements Loader, Runnable
   private DateFormat _timestampFormat;
   private DateFormat _timestampTzFormat;
 
-  public StreamLoader(Map<LoaderProperty, Object> properties,
-                      Connection putConnection,
-                      Connection processConnection)
-  {
+  public StreamLoader(
+      Map<LoaderProperty, Object> properties,
+      Connection putConnection,
+      Connection processConnection) {
     _putConn = putConnection;
     _processConn = processConnection;
-    for (Map.Entry e : properties.entrySet())
-    {
+    for (Map.Entry e : properties.entrySet()) {
       setProperty((LoaderProperty) e.getKey(), e.getValue());
     }
 
@@ -172,10 +158,8 @@ public class StreamLoader implements Loader, Runnable
   }
 
   @Override
-  public void setProperty(LoaderProperty property, Object value)
-  {
-    switch (property)
-    {
+  public void setProperty(LoaderProperty property, Object value) {
+    switch (property) {
       case tableName:
         _table = (String) value;
         break;
@@ -250,10 +234,8 @@ public class StreamLoader implements Loader, Runnable
         break;
       case compressLevel:
         _compressLevel = parseLongValue(LoaderProperty.compressLevel, value);
-        if ((_compressLevel < Deflater.BEST_SPEED ||
-            _compressLevel > Deflater.BEST_COMPRESSION) &&
-            _compressLevel != Deflater.DEFAULT_COMPRESSION)
-        {
+        if ((_compressLevel < Deflater.BEST_SPEED || _compressLevel > Deflater.BEST_COMPRESSION)
+            && _compressLevel != Deflater.DEFAULT_COMPRESSION) {
           throw new IllegalArgumentException("invalid compression level");
         }
       case onError:
@@ -268,31 +250,22 @@ public class StreamLoader implements Loader, Runnable
     }
   }
 
-  private long parseLongValue(LoaderProperty name, Object value)
-  {
+  private long parseLongValue(LoaderProperty name, Object value) {
     long ret;
-    if (value instanceof String)
-    {
+    if (value instanceof String) {
       ret = new Long((String) value);
-    }
-    else if (value instanceof Long)
-    {
+    } else if (value instanceof Long) {
       ret = (Long) value;
-    }
-    else if (value instanceof Integer)
-    {
+    } else if (value instanceof Integer) {
       ret = Long.valueOf((Integer) value);
-    }
-    else
-    {
+    } else {
       throw new IllegalArgumentException(
           String.format("'%s' Must be a LONG value", name.toString()));
     }
     return ret;
   }
 
-  private void setPropertyBySystemProperty()
-  {
+  private void setPropertyBySystemProperty() {
     final String BATCH_ROW_SIZE_KEY = SYSTEM_PARAMETER_PREFIX + "batchRowSize";
     final String CSV_FILE_BUCKET_SIZE = SYSTEM_PARAMETER_PREFIX + "csvFileBucketSize";
     final String CSV_FILE_SIZE = SYSTEM_PARAMETER_PREFIX + "csvFileSize";
@@ -301,48 +274,32 @@ public class StreamLoader implements Loader, Runnable
     final String COMPRESS_LEVEL = SYSTEM_PARAMETER_PREFIX + "compressLevel";
 
     Properties props = System.getProperties();
-    for (String propKey : props.stringPropertyNames())
-    {
+    for (String propKey : props.stringPropertyNames()) {
       String value = props.getProperty(propKey);
-      if (BATCH_ROW_SIZE_KEY.equals(propKey))
-      {
+      if (BATCH_ROW_SIZE_KEY.equals(propKey)) {
         _batchRowSize = parseLongValue(LoaderProperty.batchRowSize, value);
-      }
-      else if (CSV_FILE_BUCKET_SIZE.equals(propKey))
-      {
+      } else if (CSV_FILE_BUCKET_SIZE.equals(propKey)) {
         _csvFileBucketSize = parseLongValue(LoaderProperty.csvFileBucketSize, value);
-      }
-      else if (CSV_FILE_SIZE.equals(propKey))
-      {
+      } else if (CSV_FILE_SIZE.equals(propKey)) {
         _csvFileSize = parseLongValue(LoaderProperty.csvFileSize, value);
-      }
-      else if (COMPRESS_DATA_BEFORE_PUT_KEY.equals(propKey))
-      {
+      } else if (COMPRESS_DATA_BEFORE_PUT_KEY.equals(propKey)) {
         _compressDataBeforePut = Boolean.valueOf(value);
-      }
-      else if (COMPRESS_FILE_BY_PUT_KEY.equals(propKey))
-      {
+      } else if (COMPRESS_FILE_BY_PUT_KEY.equals(propKey)) {
         _compressFileByPut = Boolean.valueOf(value);
-      }
-      else if (COMPRESS_LEVEL.equals(propKey))
-      {
+      } else if (COMPRESS_LEVEL.equals(propKey)) {
         _compressLevel = Long.valueOf(value);
       }
     }
   }
 
-  private void initDateFormats()
-  {
+  private void initDateFormats() {
     resetCalendar();
 
     _dateFormat = new SimpleDateFormat(SnowflakeType.DATE_OR_TIME_FORMAT_PATTERN);
-    if (_mapTimeToTimestamp)
-    {
+    if (_mapTimeToTimestamp) {
       // same format for TIME to TIMESTAMP
       _timeFormat = _dateFormat;
-    }
-    else
-    {
+    } else {
       _timeFormat = new SimpleDateFormat(SnowflakeType.TIME_FORMAT_PATTERN);
     }
     _timestampFormat = new SimpleDateFormat(SnowflakeType.TIMESTAMP_FORMAT_PATTERN);
@@ -355,18 +312,14 @@ public class StreamLoader implements Loader, Runnable
     _timestampTzFormat.setCalendar(cal);
   }
 
-  /**
-   * Starts the loader
-   */
+  /** Starts the loader */
   @Override
-  public void start()
-  {
+  public void start() {
     LOGGER.debug("Start Loading");
     // validate parameters
     validateParameters();
 
-    if (_op == null)
-    {
+    if (_op == null) {
       this.abort(new ConnectionError("Loader started with no operation"));
       return;
     }
@@ -375,96 +328,94 @@ public class StreamLoader implements Loader, Runnable
 
     initQueues();
 
-    if (_is_first_start_call)
-    {
+    if (_is_first_start_call) {
       // is this the first start call?
 
-      try
-      {
-        if (_startTransaction)
-        {
+      try {
+        if (_startTransaction) {
           LOGGER.info("Begin Transaction");
           _processConn.createStatement().execute("begin transaction");
-        }
-        else
-        {
+        } else {
           LOGGER.info("No Transaction started");
         }
-      }
-      catch (SQLException ex)
-      {
-        abort(new Loader.ConnectionError("Failed to start Transaction",
-            Utils.getCause(ex)));
+      } catch (SQLException ex) {
+        abort(new Loader.ConnectionError("Failed to start Transaction", Utils.getCause(ex)));
       }
 
-      if (_truncate)
-      {
+      if (_truncate) {
         truncateTargetTable();
       }
 
-      try
-      {
-        if (_before != null)
-        {
+      try {
+        if (_before != null) {
           LOGGER.info("Running Execute Before SQL");
           _processConn.createStatement().execute(_before);
         }
-      }
-      catch (SQLException ex)
-      {
-        abort(new Loader.ConnectionError(
-            String.format("Execute Before SQL failed to run: %s", _before),
-            Utils.getCause(ex)));
+      } catch (SQLException ex) {
+        abort(
+            new Loader.ConnectionError(
+                String.format("Execute Before SQL failed to run: %s", _before),
+                Utils.getCause(ex)));
       }
     }
   }
 
-  private void validateParameters()
-  {
+  private void validateParameters() {
     LOGGER.debug("Validate Parameters");
-    if (Operation.INSERT != this._op)
-    {
-      if (this._keys == null || this._keys.isEmpty())
-      {
+    if (Operation.INSERT != this._op) {
+      if (this._keys == null || this._keys.isEmpty()) {
         throw new ConnectionError("Updating operations require keys");
       }
     }
     setPropertyBySystemProperty();
-    LOGGER.info("Database Name: {}, Schema Name: {}, Table Name: {}, " +
-            "Remote Stage: {}, Columns: {}, Keys: {}, Operation: {}, " +
-            "Start Transaction: {}, OneBatch: {}, Truncate Table: {}, " +
-            "Execute Before: {}, Execute After: {}, Batch Row Size: {}, " +
-            "CSV File Bucket Size: {}, CSV File Size: {}, Preserve Stage File: {}, " +
-            "Use Local TimeZone: {}, Copy Empty Field As Empty: {}, " +
-            "MapTimeToTimestamp: {}, Compress Data before PUT: {}, " +
-            "Compress File By Put: {}, Compress Level: {}, OnError: {}",
-        _database, _schema, _table, _remoteStage, _columns, _keys, _op,
-        _startTransaction, _oneBatch, _truncate, _before, _after,
-        _batchRowSize, _csvFileBucketSize, _csvFileSize, _preserveStageFile,
-        _useLocalTimezone, _copyEmptyFieldAsEmpty, _mapTimeToTimestamp,
-        _compressDataBeforePut, _compressFileByPut, _compressLevel, _onError
-    );
+    LOGGER.info(
+        "Database Name: {}, Schema Name: {}, Table Name: {}, "
+            + "Remote Stage: {}, Columns: {}, Keys: {}, Operation: {}, "
+            + "Start Transaction: {}, OneBatch: {}, Truncate Table: {}, "
+            + "Execute Before: {}, Execute After: {}, Batch Row Size: {}, "
+            + "CSV File Bucket Size: {}, CSV File Size: {}, Preserve Stage File: {}, "
+            + "Use Local TimeZone: {}, Copy Empty Field As Empty: {}, "
+            + "MapTimeToTimestamp: {}, Compress Data before PUT: {}, "
+            + "Compress File By Put: {}, Compress Level: {}, OnError: {}",
+        _database,
+        _schema,
+        _table,
+        _remoteStage,
+        _columns,
+        _keys,
+        _op,
+        _startTransaction,
+        _oneBatch,
+        _truncate,
+        _before,
+        _after,
+        _batchRowSize,
+        _csvFileBucketSize,
+        _csvFileSize,
+        _preserveStageFile,
+        _useLocalTimezone,
+        _copyEmptyFieldAsEmpty,
+        _mapTimeToTimestamp,
+        _compressDataBeforePut,
+        _compressFileByPut,
+        _compressLevel,
+        _onError);
   }
 
-  String getNoise()
-  {
+  String getNoise() {
     return _noise;
   }
 
-  public void abort(RuntimeException t)
-  {
-    synchronized (this)
-    {
+  public void abort(RuntimeException t) {
+    synchronized (this) {
       // Abort once, keep first error.
       LOGGER.warn("Exception received. Aborting...", t);
 
-      if (_aborted.getAndSet(true))
-      {
+      if (_aborted.getAndSet(true)) {
         return;
       }
 
-      if (t != null)
-      {
+      if (t != null) {
         _abortCause = t;
       }
 
@@ -473,121 +424,88 @@ public class StreamLoader implements Loader, Runnable
     }
   }
 
-  boolean isAborted()
-  {
-    synchronized (this)
-    {
+  boolean isAborted() {
+    synchronized (this) {
       // don't synchronize unless the caller does
       return _aborted.get();
     }
   }
 
   @Override
-  public void rollback()
-  {
+  public void rollback() {
     LOGGER.debug("Rollback");
-    try
-    {
+    try {
       terminate();
 
       LOGGER.warn("Rollback");
       this._processConn.createStatement().execute("rollback");
-    }
-    catch (SQLException ex)
-    {
+    } catch (SQLException ex) {
       LOGGER.error(ex.getMessage(), ex);
     }
   }
 
   @Override
-  public void submitRow(final Object[] row)
-  {
-    try
-    {
-      if (_aborted.get())
-      {
-        if (_listener.throwOnError())
-        {
+  public void submitRow(final Object[] row) {
+    try {
+      if (_aborted.get()) {
+        if (_listener.throwOnError()) {
           throw _abortCause;
         }
         return;
       }
-    }
-    catch (Exception ex)
-    {
-      abort(new Loader.ConnectionError(
-          "Throwing Error", Utils.getCause(ex)));
+    } catch (Exception ex) {
+      abort(new Loader.ConnectionError("Throwing Error", Utils.getCause(ex)));
     }
 
     byte[] data = null;
-    try
-    {
-      if (!_active.get())
-      {
+    try {
+      if (!_active.get()) {
         LOGGER.warn("Inactive loader. Row ignored");
         return;
       }
 
       data = createCSVRecord(row);
 
-    }
-    catch (Exception ex)
-    {
-      abort(new Loader.ConnectionError(
-          "Creating data set for CSV", Utils.getCause(ex)));
+    } catch (Exception ex) {
+      abort(new Loader.ConnectionError("Creating data set for CSV", Utils.getCause(ex)));
     }
 
-    try
-    {
+    try {
       writeBytes(data);
       _listener.addSubmittedRowCount(1);
 
-      if (_listener.needSuccessRecords())
-      {
+      if (_listener.needSuccessRecords()) {
         _listener.recordProvided(_op, row);
       }
-    }
-    catch (Exception ex)
-    {
-      abort(new Loader.ConnectionError(
-          "Writing Bytes to CSV files", Utils.getCause(ex)));
+    } catch (Exception ex) {
+      abort(new Loader.ConnectionError("Writing Bytes to CSV files", Utils.getCause(ex)));
     }
 
-    if (_batchRowSize > 0 && _listener.getSubmittedRowCount() > 0 &&
-        (_listener.getSubmittedRowCount() % _batchRowSize) == 0)
-    {
-      LOGGER.debug("Flushing Queue: Submitted Row Count: {}, Batch Row Size: {}",
-          _listener.getSubmittedRowCount(), _batchRowSize);
+    if (_batchRowSize > 0
+        && _listener.getSubmittedRowCount() > 0
+        && (_listener.getSubmittedRowCount() % _batchRowSize) == 0) {
+      LOGGER.debug(
+          "Flushing Queue: Submitted Row Count: {}, Batch Row Size: {}",
+          _listener.getSubmittedRowCount(),
+          _batchRowSize);
       // flush data loading
-      try
-      {
+      try {
         flushQueues();
+      } catch (Exception ex) {
+        abort(new Loader.ConnectionError("Flush Queues", Utils.getCause(ex)));
       }
-      catch (Exception ex)
-      {
-        abort(new Loader.ConnectionError(
-            "Flush Queues", Utils.getCause(ex)));
-      }
-      try
-      {
+      try {
         initQueues();
-      }
-      catch (Exception ex)
-      {
-        abort(new Loader.ConnectionError(
-            "Init Queues", Utils.getCause(ex)));
+      } catch (Exception ex) {
+        abort(new Loader.ConnectionError("Init Queues", Utils.getCause(ex)));
       }
     }
   }
 
-  /**
-   * Initializes queues
-   */
-  private void initQueues()
-  {
+  /** Initializes queues */
+  private void initQueues() {
     LOGGER.debug("Init Queues");
-    if (_active.getAndSet(true))
-    {
+    if (_active.getAndSet(true)) {
       // NOP if the loader is already active
       return;
     }
@@ -607,25 +525,18 @@ public class StreamLoader implements Loader, Runnable
     _stage = new BufferStage(this, _op, _csvFileBucketSize, _csvFileSize);
   }
 
-  /**
-   * Flushes data by joining PUT and PROCESS queues
-   */
-  private void flushQueues()
-  {
+  /** Flushes data by joining PUT and PROCESS queues */
+  private void flushQueues() {
     // Terminate data loading thread.
     LOGGER.debug("Flush Queues");
-    try
-    {
+    try {
       _queueData.put(new byte[0]);
       _thread.join(10000);
 
-      if (_thread.isAlive())
-      {
+      if (_thread.isAlive()) {
         _thread.interrupt();
       }
-    }
-    catch (Exception ex)
-    {
+    } catch (Exception ex) {
       String msg = "Failed to join StreamLoader queue: " + ex.getMessage();
       LOGGER.error(msg, ex);
       throw new DataError(msg, Utils.getCause(ex));
@@ -637,29 +548,25 @@ public class StreamLoader implements Loader, Runnable
     _put.join();
     _process.join();
 
-    if (_aborted.get())
-    {
-      // Loader was aborted due to an exception. 
+    if (_aborted.get()) {
+      // Loader was aborted due to an exception.
       // It was rolled back at that time.
 
-      //LOGGER.log(Level.WARNING,
+      // LOGGER.log(Level.WARNING,
       //            "Loader had been previously aborted by error", _abortCause);
       throw _abortCause;
     }
   }
 
-  private void writeBytes(final byte[] data) throws IOException, InterruptedException
-  {
+  private void writeBytes(final byte[] data) throws IOException, InterruptedException {
     // this loader was aborted
-    if (_aborted.get())
-    {
+    if (_aborted.get()) {
       return;
     }
 
     boolean full = _stage.stageData(data);
 
-    if (full && !_oneBatch)
-    {
+    if (full && !_oneBatch) {
       // if Buffer stage is full and NOT one batch mode,
       // queue PUT request.
       queuePut(_stage);
@@ -667,60 +574,43 @@ public class StreamLoader implements Loader, Runnable
     }
   }
 
-
-  private void truncateTargetTable()
-  {
-    try
-    {
+  private void truncateTargetTable() {
+    try {
       // TODO: could be replaced with TRUNCATE?
-      _processConn.createStatement().execute(
-          "DELETE FROM " + this.getFullTableName());
-    }
-    catch (SQLException ex)
-    {
+      _processConn.createStatement().execute("DELETE FROM " + this.getFullTableName());
+    } catch (SQLException ex) {
       LOGGER.error(ex.getMessage(), ex);
       abort(new Loader.ConnectionError(Utils.getCause(ex)));
     }
   }
 
   @Override
-  public void run()
-  {
-    try
-    {
-      while (true)
-      {
+  public void run() {
+    try {
+      while (true) {
         byte[] data = this._queueData.take();
 
-        if (data.length == 0)
-        {
+        if (data.length == 0) {
           break;
         }
 
         this.writeBytes(data);
       }
-    }
-    catch (Exception ex)
-    {
+    } catch (Exception ex) {
       LOGGER.error(ex.getMessage(), ex);
       abort(new Loader.ConnectionError(Utils.getCause(ex)));
     }
   }
 
-  private byte[] createCSVRecord(final Object[] data)
-  {
+  private byte[] createCSVRecord(final Object[] data) {
     StringBuilder sb = new StringBuilder();
 
-    for (int i = 0; i < data.length; ++i)
-    {
+    for (int i = 0; i < data.length; ++i) {
       if (i > 0) sb.append(',');
-      sb.append(SnowflakeType.escapeForCSV(
-          SnowflakeType.lexicalValue(
-              data[i],
-              _dateFormat,
-              _timeFormat,
-              _timestampFormat,
-              _timestampTzFormat)));
+      sb.append(
+          SnowflakeType.escapeForCSV(
+              SnowflakeType.lexicalValue(
+                  data[i], _dateFormat, _timeFormat, _timestampFormat, _timestampTzFormat)));
     }
     return sb.toString().getBytes(UTF_8);
   }
@@ -731,161 +621,122 @@ public class StreamLoader implements Loader, Runnable
    * @throws Exception an exception raised in finishing loader.
    */
   @Override
-  public void finish() throws Exception
-  {
+  public void finish() throws Exception {
     LOGGER.debug("Finish Loading");
     flushQueues();
 
-    if (_is_last_finish_call)
-    {
-      try
-      {
-        if (_after != null)
-        {
+    if (_is_last_finish_call) {
+      try {
+        if (_after != null) {
           LOGGER.info("Running Execute After SQL");
           _processConn.createStatement().execute(_after);
         }
         // Loader sucessfully completed. Commit and return.
         _processConn.createStatement().execute("commit");
         LOGGER.info("Committed");
-      }
-      catch (SQLException ex)
-      {
-        try
-        {
+      } catch (SQLException ex) {
+        try {
           _processConn.createStatement().execute("rollback");
-        }
-        catch (SQLException ex0)
-        {
+        } catch (SQLException ex0) {
           LOGGER.warn("Failed to rollback");
         }
-        LOGGER.warn(String.format("Execute After SQL failed to run: %s", _after),
-            ex);
+        LOGGER.warn(String.format("Execute After SQL failed to run: %s", _after), ex);
         throw new Loader.ConnectionError(Utils.getCause(ex));
       }
     }
   }
 
   @Override
-  public void close()
-  {
+  public void close() {
     LOGGER.info("Close Loader");
-    try
-    {
+    try {
       this._processConn.close();
       this._putConn.close();
-    }
-    catch (SQLException ex)
-    {
+    } catch (SQLException ex) {
       LOGGER.error(ex.getMessage(), ex);
       throw new ConnectionError(Utils.getCause(ex));
     }
   }
 
-  /**
-   * Set active to false (no-op if not active), add a stage with terminate flag
-   * onto the queue
-   */
-  private void terminate()
-  {
+  /** Set active to false (no-op if not active), add a stage with terminate flag onto the queue */
+  private void terminate() {
     LOGGER.debug("Terminate Loader");
 
     boolean active = _active.getAndSet(false);
 
-    if (!active) return;  // No-op
+    if (!active) return; // No-op
 
-    if (_stage == null)
-    {
+    if (_stage == null) {
       _stage = new BufferStage(this, Operation.INSERT, _csvFileBucketSize, _csvFileSize);
     }
 
     _stage.setTerminate(true);
 
-    try
-    {
+    try {
       queuePut(_stage);
-    }
-    catch (InterruptedException ex)
-    {
+    } catch (InterruptedException ex) {
       LOGGER.error("Unknown Error", ex);
     }
 
     LOGGER.debug("Snowflake loader terminating");
-
   }
 
   // If operation changes, existing stage needs to be scheduled for processing.
   @Override
-  public void resetOperation(Operation op)
-  {
+  public void resetOperation(Operation op) {
     LOGGER.debug("Reset Loader");
 
-    if (op.equals(_op))
-    {
-      //no-op
+    if (op.equals(_op)) {
+      // no-op
       return;
     }
 
     LOGGER.debug("Operation is changing from {} to {}", _op, op);
     _op = op;
 
-    if (_stage != null)
-    {
-      try
-      {
+    if (_stage != null) {
+      try {
         queuePut(_stage);
-      }
-      catch (InterruptedException ex)
-      {
+      } catch (InterruptedException ex) {
         LOGGER.error(_stage.getId(), ex);
       }
     }
 
     _stage = new BufferStage(this, _op, _csvFileBucketSize, _csvFileSize);
-
   }
 
-  String getTable()
-  {
+  String getTable() {
     return _table;
   }
 
-  String getBase()
-  {
+  String getBase() {
     return BASE;
   }
 
-  Connection getPutConnection()
-  {
+  Connection getPutConnection() {
     return _putConn;
   }
 
-  Connection getProcessConnection()
-  {
+  Connection getProcessConnection() {
     return _processConn;
   }
 
-  String getRemoteStage()
-  {
+  String getRemoteStage() {
     return _remoteStage;
   }
 
-  List<String> getKeys()
-  {
+  List<String> getKeys() {
     return this._keys;
   }
 
-  List<String> getColumns()
-  {
+  List<String> getColumns() {
     return this._columns;
   }
 
-  String getColumnsAsString()
-  {
+  String getColumnsAsString() {
     // comma separate list of column names
     StringBuilder sb = new StringBuilder("\"");
-    for (int i = 0; i < _columns.size(); i++)
-    {
+    for (int i = 0; i < _columns.size(); i++) {
       if (i > 0) sb.append("\",\"");
       sb.append(_columns.get(i));
     }
@@ -893,70 +744,57 @@ public class StreamLoader implements Loader, Runnable
     return sb.toString();
   }
 
-  String getFullTableName()
-  {
+  String getFullTableName() {
     return (_database == null ? "" : ("\"" + _database + "\"."))
         + (_schema == null ? "" : ("\"" + _schema + "\"."))
-        + "\"" + _table + "\"";
+        + "\""
+        + _table
+        + "\"";
   }
 
-  public LoadResultListener getListener()
-  {
+  public LoadResultListener getListener() {
     return _listener;
   }
 
   @Override
-  public void setListener(LoadResultListener _listener)
-  {
+  public void setListener(LoadResultListener _listener) {
     this._listener = _listener;
   }
 
-  private void queuePut(BufferStage stage) throws InterruptedException
-  {
+  private void queuePut(BufferStage stage) throws InterruptedException {
     _queuePut.put(stage);
   }
 
-  BufferStage takePut() throws InterruptedException
-  {
+  BufferStage takePut() throws InterruptedException {
     return _queuePut.take();
   }
 
-  void queueProcess(BufferStage stage) throws InterruptedException
-  {
+  void queueProcess(BufferStage stage) throws InterruptedException {
     _queueProcess.put(stage);
-
   }
 
-  BufferStage takeProcess() throws InterruptedException
-  {
+  BufferStage takeProcess() throws InterruptedException {
     return _queueProcess.take();
   }
 
-  void throttleUp()
-  {
+  void throttleUp() {
     int open = this._throttleCounter.incrementAndGet();
     LOGGER.info("PUT Throttle Up: {}", open);
-    if (open > 8)
-    {
-      LOGGER.info("Will retry scheduling file for upload after {} seconds",
-          (Math.pow(2, open - 7)));
-      try
-      {
+    if (open > 8) {
+      LOGGER.info(
+          "Will retry scheduling file for upload after {} seconds", (Math.pow(2, open - 7)));
+      try {
         Thread.sleep(1000 * ((int) Math.pow(2, open - 7)));
-      }
-      catch (InterruptedException ex)
-      {
+      } catch (InterruptedException ex) {
         LOGGER.error("Exception occurs while waiting", ex);
       }
     }
   }
 
-  void throttleDown()
-  {
+  void throttleDown() {
     int throttleLevel = this._throttleCounter.decrementAndGet();
     LOGGER.info("PUT Throttle Down: {}", throttleLevel);
-    if (throttleLevel < 0)
-    {
+    if (throttleLevel < 0) {
       LOGGER.warn("Unbalanced throttle");
       _throttleCounter.set(0);
     }
@@ -964,110 +802,87 @@ public class StreamLoader implements Loader, Runnable
     LOGGER.debug("Connector throttle {}", throttleLevel);
   }
 
-  private LoadResultListener _listener = new LoadResultListener()
-  {
+  private LoadResultListener _listener =
+      new LoadResultListener() {
 
-    final private AtomicInteger errorCount = new AtomicInteger(0);
-    final private AtomicInteger errorRecordCount = new AtomicInteger(0);
-    final private AtomicInteger submittedRowCount = new AtomicInteger(0);
+        private final AtomicInteger errorCount = new AtomicInteger(0);
+        private final AtomicInteger errorRecordCount = new AtomicInteger(0);
+        private final AtomicInteger submittedRowCount = new AtomicInteger(0);
 
-    @Override
-    public boolean needErrors()
-    {
-      return false;
-    }
+        @Override
+        public boolean needErrors() {
+          return false;
+        }
 
-    @Override
-    public boolean needSuccessRecords()
-    {
-      return false;
-    }
+        @Override
+        public boolean needSuccessRecords() {
+          return false;
+        }
 
-    @Override
-    public void addError(LoadingError error)
-    {
-    }
+        @Override
+        public void addError(LoadingError error) {}
 
-    @Override
-    public boolean throwOnError()
-    {
-      return false;
-    }
+        @Override
+        public boolean throwOnError() {
+          return false;
+        }
 
-    @Override
-    public void recordProvided(Operation op, Object[] record)
-    {
-    }
+        @Override
+        public void recordProvided(Operation op, Object[] record) {}
 
-    @Override
-    public void addProcessedRecordCount(Operation op, int i)
-    {
-    }
+        @Override
+        public void addProcessedRecordCount(Operation op, int i) {}
 
-    @Override
-    public void addOperationRecordCount(Operation op, int i)
-    {
-    }
+        @Override
+        public void addOperationRecordCount(Operation op, int i) {}
 
+        @Override
+        public int getErrorCount() {
+          return errorCount.get();
+        }
 
-    @Override
-    public int getErrorCount()
-    {
-      return errorCount.get();
-    }
+        @Override
+        public int getErrorRecordCount() {
+          return errorRecordCount.get();
+        }
 
-    @Override
-    public int getErrorRecordCount()
-    {
-      return errorRecordCount.get();
-    }
+        @Override
+        public void resetErrorCount() {
+          errorCount.set(0);
+        }
 
-    @Override
-    public void resetErrorCount()
-    {
-      errorCount.set(0);
-    }
+        @Override
+        public void resetErrorRecordCount() {
+          errorRecordCount.set(0);
+        }
 
-    @Override
-    public void resetErrorRecordCount()
-    {
-      errorRecordCount.set(0);
-    }
+        @Override
+        public void addErrorCount(int count) {
+          errorCount.addAndGet(count);
+        }
 
-    @Override
-    public void addErrorCount(int count)
-    {
-      errorCount.addAndGet(count);
-    }
+        @Override
+        public void addErrorRecordCount(int count) {
+          errorRecordCount.addAndGet(count);
+        }
 
-    @Override
-    public void addErrorRecordCount(int count)
-    {
-      errorRecordCount.addAndGet(count);
-    }
+        @Override
+        public void resetSubmittedRowCount() {
+          submittedRowCount.set(0);
+        }
 
-    @Override
-    public void resetSubmittedRowCount()
-    {
-      submittedRowCount.set(0);
-    }
+        @Override
+        public void addSubmittedRowCount(int count) {
+          submittedRowCount.addAndGet(count);
+        }
 
-    @Override
-    public void addSubmittedRowCount(int count)
-    {
-      submittedRowCount.addAndGet(count);
-    }
+        @Override
+        public int getSubmittedRowCount() {
+          return submittedRowCount.get();
+        }
+      };
 
-    @Override
-    public int getSubmittedRowCount()
-    {
-      return submittedRowCount.get();
-    }
-
-  };
-
-  void setTestMode(boolean mode)
-  {
+  void setTestMode(boolean mode) {
     this._testMode = mode;
   }
 }

--- a/src/main/java/net/snowflake/client/loader/Utils.java
+++ b/src/main/java/net/snowflake/client/loader/Utils.java
@@ -3,23 +3,22 @@
  */
 package net.snowflake.client.loader;
 
-/**
- * Utils class for Loader API
- */
+/** Utils class for Loader API */
 public class Utils {
 
-    /**
-     * Find the root cause of the exception
-     * @param e throwable object
-     * @return the thowable cause
-     */
-    public static Throwable getCause(Throwable e) {
-        Throwable cause = null;
-        Throwable result = e;
+  /**
+   * Find the root cause of the exception
+   *
+   * @param e throwable object
+   * @return the thowable cause
+   */
+  public static Throwable getCause(Throwable e) {
+    Throwable cause = null;
+    Throwable result = e;
 
-        while (null != (cause = result.getCause()) && (result != cause)) {
-            result = cause;
-        }
-        return result;
+    while (null != (cause = result.getCause()) && (result != cause)) {
+      result = cause;
     }
+    return result;
+  }
 }

--- a/src/main/java/net/snowflake/client/log/JDK14Logger.java
+++ b/src/main/java/net/snowflake/client/log/JDK14Logger.java
@@ -9,208 +9,167 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
-import java.util.logging.Level;
 import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.logging.StreamHandler;
 
 /**
  * Use java.util.logging to implements SFLogger.
  *
- * Log Level mapping from SFLogger to java.util.logging:
- * ERROR -- SEVERE
- * WARN  -- WARNING
- * INFO  -- INFO
- * DEBUG -- FINE
- * TRACE -- FINEST
+ * <p>Log Level mapping from SFLogger to java.util.logging: ERROR -- SEVERE WARN -- WARNING INFO --
+ * INFO DEBUG -- FINE TRACE -- FINEST
  *
- * Created by hyu on 11/17/16.
+ * <p>Created by hyu on 11/17/16.
  */
-public class JDK14Logger implements SFLogger
-{
+public class JDK14Logger implements SFLogger {
   private Logger jdkLogger;
 
-  private Set<String> logMethods = new HashSet<>(Arrays.asList(
-      "debug", "error", "info", "trace", "warn"));
+  private Set<String> logMethods =
+      new HashSet<>(Arrays.asList("debug", "error", "info", "trace", "warn"));
 
-  public JDK14Logger(String name)
-  {
+  public JDK14Logger(String name) {
     this.jdkLogger = Logger.getLogger(name);
   }
 
-  public boolean isDebugEnabled()
-  {
+  public boolean isDebugEnabled() {
     return this.jdkLogger.isLoggable(Level.FINE);
   }
 
-  public boolean isErrorEnabled()
-  {
+  public boolean isErrorEnabled() {
     return this.jdkLogger.isLoggable(Level.SEVERE);
   }
 
-  public boolean isInfoEnabled()
-  {
+  public boolean isInfoEnabled() {
     return this.jdkLogger.isLoggable(Level.INFO);
   }
 
-  public boolean isTraceEnabled()
-  {
+  public boolean isTraceEnabled() {
     return this.jdkLogger.isLoggable(Level.FINEST);
   }
 
-  public boolean isWarnEnabled()
-  {
+  public boolean isWarnEnabled() {
     return this.jdkLogger.isLoggable(Level.WARNING);
   }
 
-  public void debug(String msg)
-  {
+  public void debug(String msg) {
     logInternal(Level.FINE, msg);
   }
 
-  public void debug(String msg, Object... arguments)
-  {
+  public void debug(String msg, Object... arguments) {
     logInternal(Level.FINE, msg, arguments);
   }
 
-  public void debug(String msg, Throwable t)
-  {
+  public void debug(String msg, Throwable t) {
     logInternal(Level.FINE, msg, t);
   }
 
-  public void error(String msg)
-  {
+  public void error(String msg) {
     logInternal(Level.SEVERE, msg);
   }
 
-  public void error(String msg, Object... arguments)
-  {
+  public void error(String msg, Object... arguments) {
     logInternal(Level.SEVERE, msg, arguments);
   }
 
-  public void error(String msg, Throwable t)
-  {
+  public void error(String msg, Throwable t) {
     logInternal(Level.SEVERE, msg, t);
   }
 
-  public void info(String msg)
-  {
+  public void info(String msg) {
     logInternal(Level.INFO, msg);
   }
 
-  public void info(String msg, Object... arguments)
-  {
+  public void info(String msg, Object... arguments) {
     logInternal(Level.INFO, msg, arguments);
   }
 
-  public void info(String msg, Throwable t)
-  {
+  public void info(String msg, Throwable t) {
     logInternal(Level.INFO, msg, t);
   }
 
-  public void trace(String msg)
-  {
+  public void trace(String msg) {
     logInternal(Level.FINEST, msg);
   }
 
-  public void trace(String msg, Object... arguments)
-  {
+  public void trace(String msg, Object... arguments) {
     logInternal(Level.FINEST, msg, arguments);
   }
 
-  public void trace(String msg, Throwable t)
-  {
+  public void trace(String msg, Throwable t) {
     logInternal(Level.FINEST, msg, t);
   }
 
-  public void warn(String msg)
-  {
+  public void warn(String msg) {
     logInternal(Level.WARNING, msg);
   }
 
-  public void warn(String msg, Object... arguments)
-  {
+  public void warn(String msg, Object... arguments) {
     logInternal(Level.WARNING, msg, arguments);
   }
 
-  public void warn(String msg, Throwable t)
-  {
+  public void warn(String msg, Throwable t) {
     logInternal(Level.WARNING, msg, t);
   }
 
-  private void logInternal(Level level, String msg)
-  {
-    if (jdkLogger.isLoggable(level))
-    {
+  private void logInternal(Level level, String msg) {
+    if (jdkLogger.isLoggable(level)) {
       String[] source = findSourceInStack();
       jdkLogger.logp(level, source[0], source[1], msg);
     }
   }
 
-  private void logInternal(Level level, String msg, Object... arguments)
-  {
-    if (jdkLogger.isLoggable(level))
-    {
+  private void logInternal(Level level, String msg, Object... arguments) {
+    if (jdkLogger.isLoggable(level)) {
       String[] source = findSourceInStack();
       jdkLogger.logp(level, source[0], source[1], refactorString(msg), arguments);
     }
   }
 
-  private void logInternal(Level level, String msg, Throwable t)
-  {
-    if (jdkLogger.isLoggable(level))
-    {
+  private void logInternal(Level level, String msg, Throwable t) {
+    if (jdkLogger.isLoggable(level)) {
       String[] source = findSourceInStack();
       jdkLogger.logp(level, source[0], source[1], msg, t);
     }
   }
 
-  public static void addHandler(Handler handler)
-  {
+  public static void addHandler(Handler handler) {
     Logger snowflakeLogger = Logger.getLogger(SFFormatter.CLASS_NAME_PREFIX);
     snowflakeLogger.addHandler(handler);
   }
 
-  public static void setLevel(Level level)
-  {
+  public static void setLevel(Level level) {
     Logger snowflakeLogger = Logger.getLogger(SFFormatter.CLASS_NAME_PREFIX);
     snowflakeLogger.setLevel(level);
   }
 
   /**
-   * Since we use SLF4J ways of formatting string we need to refactor message string
-   * if we have arguments.
-   * For example, in sl4j, this string can be formatted with 2 arguments
+   * Since we use SLF4J ways of formatting string we need to refactor message string if we have
+   * arguments. For example, in sl4j, this string can be formatted with 2 arguments
    *
-   *   ex.1: Error happened in {} on {}
+   * <p>ex.1: Error happened in {} on {}
    *
-   * And if two arguments are provided, error message can be formatted.
+   * <p>And if two arguments are provided, error message can be formatted.
    *
-   * However, in java.util.logging, to achieve formatted error message,
-   * Same string should be converted to
+   * <p>However, in java.util.logging, to achieve formatted error message, Same string should be
+   * converted to
    *
-   *   ex.2: Error happened in {0} on {1}
+   * <p>ex.2: Error happened in {0} on {1}
    *
-   * Which represented first arguments and second arguments will be replaced in the
-   * corresponding places.
+   * <p>Which represented first arguments and second arguments will be replaced in the corresponding
+   * places.
    *
-   * This method will convert string in ex.1 to ex.2
-   *
+   * <p>This method will convert string in ex.1 to ex.2
    */
-  private String refactorString(String original)
-  {
+  private String refactorString(String original) {
     StringBuilder sb = new StringBuilder();
     int argCount = 0;
-    for (int i=0; i<original.length(); i++)
-    {
-      if (original.charAt(i) == '{' && i < original.length()-1 && original.charAt(i+1) == '}')
-      {
+    for (int i = 0; i < original.length(); i++) {
+      if (original.charAt(i) == '{' && i < original.length() - 1 && original.charAt(i + 1) == '}') {
         sb.append(String.format("{%d}", argCount));
-        argCount ++;
-        i ++;
-      }
-      else
-      {
+        argCount++;
+        i++;
+      } else {
         sb.append(original.charAt(i));
       }
     }
@@ -218,25 +177,20 @@ public class JDK14Logger implements SFLogger
   }
 
   /**
-   * Used to find the index of the source class/method in current stack
-   * This method will locate the source as the first method after logMethods
-   * @return an array of size two, first element is className and second is
-   *          methodName
+   * Used to find the index of the source class/method in current stack This method will locate the
+   * source as the first method after logMethods
+   *
+   * @return an array of size two, first element is className and second is methodName
    */
-  private String[] findSourceInStack()
-  {
+  private String[] findSourceInStack() {
     StackTraceElement[] stackTraces = Thread.currentThread().getStackTrace();
     String[] results = new String[2];
-    for (int i=0; i<stackTraces.length; i++)
-    {
-      if (logMethods.contains(stackTraces[i].getMethodName()))
-      {
+    for (int i = 0; i < stackTraces.length; i++) {
+      if (logMethods.contains(stackTraces[i].getMethodName())) {
         // since already find the highest logMethods, find the first method after this one
         // and is not a logMethods. This is done to avoid multiple wrapper over log methods
-        for (int j=i; j<stackTraces.length; j++)
-        {
-          if (!logMethods.contains(stackTraces[j].getMethodName()))
-          {
+        for (int j = i; j < stackTraces.length; j++) {
+          if (!logMethods.contains(stackTraces[j].getMethodName())) {
             results[0] = stackTraces[j].getClassName();
             results[1] = stackTraces[j].getMethodName();
             return results;
@@ -247,41 +201,30 @@ public class JDK14Logger implements SFLogger
     return results;
   }
 
-  static void defaultInit()
-  {
-    if (!hasLoggingConfig())
-    {
-      java.util.logging.Logger sfRootLogger = java.util.logging.Logger
-          .getLogger("net.snowflake");
+  static void defaultInit() {
+    if (!hasLoggingConfig()) {
+      java.util.logging.Logger sfRootLogger = java.util.logging.Logger.getLogger("net.snowflake");
       // disable parent's default console handler
       sfRootLogger.setUseParentHandlers(false);
       // change to use Stream handler print to stdout
-      sfRootLogger.addHandler(new StreamHandler(System.out,
-          new SFFormatter()));
+      sfRootLogger.addHandler(new StreamHandler(System.out, new SFFormatter()));
     }
   }
 
   /**
    * Check whether a logging.properties exists or not.
    *
-   * It will first check where $JRE/lib/logging.properties exist or not,
-   * Then check if two system property
-   *    - java.util.logging.config.class
-   *    - java.util.logging.config.file
-   * has been set or not.
+   * <p>It will first check where $JRE/lib/logging.properties exist or not, Then check if two system
+   * property - java.util.logging.config.class - java.util.logging.config.file has been set or not.
    *
-   * If yes, return true. If none of the above is set, return false
+   * <p>If yes, return true. If none of the above is set, return false
    */
-  private static boolean hasLoggingConfig()
-  {
+  private static boolean hasLoggingConfig() {
     String JRE = System.getProperty("java.home");
     Path configFilePath = Paths.get(JRE, "lib", "logging.properties");
-    if (Files.exists(configFilePath))
-    {
+    if (Files.exists(configFilePath)) {
       return true;
-    }
-    else
-    {
+    } else {
       String configClass = System.getProperty("java.util.logging.config.class");
       String configFile = System.getProperty("java.util.logging.config.file");
 

--- a/src/main/java/net/snowflake/client/log/SFFormatter.java
+++ b/src/main/java/net/snowflake/client/log/SFFormatter.java
@@ -3,7 +3,6 @@
  */
 package net.snowflake.client.log;
 
-import net.snowflake.client.jdbc.SnowflakeDriver;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -11,49 +10,40 @@ import java.util.TimeZone;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
+import net.snowflake.client.jdbc.SnowflakeDriver;
 
-/**
- * SFFormatter
- */
-public class SFFormatter extends Formatter
-{
-  private static final DateFormat df = new SimpleDateFormat(
-          "yyyy-MM-dd HH:mm:ss.SSS");
-  static
-  {
+/** SFFormatter */
+public class SFFormatter extends Formatter {
+  private static final DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+  static {
     df.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
   public static final String CLASS_NAME_PREFIX =
-    SnowflakeDriver.class.getPackage().getName().substring(0,
-    SnowflakeDriver.class.getPackage().getName().lastIndexOf('.'));
+      SnowflakeDriver.class
+          .getPackage()
+          .getName()
+          .substring(0, SnowflakeDriver.class.getPackage().getName().lastIndexOf('.'));
 
-  public static final String INFORMATICA_V1_CLASS_NAME_PREFIX =
-          "com.snowflake";
+  public static final String INFORMATICA_V1_CLASS_NAME_PREFIX = "com.snowflake";
 
   @Override
-  public String format(LogRecord record)
-  {
+  public String format(LogRecord record) {
     int lineNumber = -1;
     String className = record.getSourceClassName();
     final String methodName = record.getSourceMethodName();
     StackTraceElement[] stackTraces = Thread.currentThread().getStackTrace();
-    for (StackTraceElement ste : stackTraces)
-    {
-      if (className.equals(ste.getClassName())
-          && methodName.equals(ste.getMethodName()))
-      {
+    for (StackTraceElement ste : stackTraces) {
+      if (className.equals(ste.getClassName()) && methodName.equals(ste.getMethodName())) {
         lineNumber = ste.getLineNumber();
         break;
       }
     }
-    if (className.startsWith(CLASS_NAME_PREFIX))
-    {
+    if (className.startsWith(CLASS_NAME_PREFIX)) {
       className = "n.s.c" + className.substring(CLASS_NAME_PREFIX.length());
-    }
-    else if (className.startsWith(INFORMATICA_V1_CLASS_NAME_PREFIX)) {
-      className = "c.s" + className.substring(
-              INFORMATICA_V1_CLASS_NAME_PREFIX.length());
+    } else if (className.startsWith(INFORMATICA_V1_CLASS_NAME_PREFIX)) {
+      className = "c.s" + className.substring(INFORMATICA_V1_CLASS_NAME_PREFIX.length());
     }
 
     StringBuilder builder = new StringBuilder(1000);
@@ -68,14 +58,12 @@ public class SFFormatter extends Formatter
   }
 
   @Override
-  public String getHead(Handler h)
-  {
+  public String getHead(Handler h) {
     return super.getHead(h);
   }
 
   @Override
-  public String getTail(Handler h)
-  {
+  public String getTail(Handler h) {
     return super.getTail(h);
   }
 }

--- a/src/main/java/net/snowflake/client/log/SFLogger.java
+++ b/src/main/java/net/snowflake/client/log/SFLogger.java
@@ -6,43 +6,42 @@ package net.snowflake.client.log;
 /**
  * Interface used by JDBC driver to log information
  *
- * Five levels are included in this interface, from high to low:
- *   ERROR
- *   WARN
- *   INFO
- *   DEBUG
- *   TRACE
+ * <p>Five levels are included in this interface, from high to low: ERROR WARN INFO DEBUG TRACE
  *
- * Created by hyu on 11/17/16.
+ * <p>Created by hyu on 11/17/16.
  */
-public interface SFLogger
-{
+public interface SFLogger {
   /**
    * Is debug level enabled?
+   *
    * @return true if the trace level is DEBUG
    */
   boolean isDebugEnabled();
 
   /**
    * Is error level enabled?
+   *
    * @return true if the trace level is ERROR
    */
   boolean isErrorEnabled();
 
   /**
    * Is info level enabled?
+   *
    * @return true if the trace level is INFO
    */
   boolean isInfoEnabled();
 
   /**
    * Is trace level enabled?
+   *
    * @return true if the trace level is TRACE
    */
   boolean isTraceEnabled();
 
   /**
    * Is warn level enabled?
+   *
    * @return true if the trace level is WARN
    */
   boolean isWarnEnabled();

--- a/src/main/java/net/snowflake/client/log/SFLoggerFactory.java
+++ b/src/main/java/net/snowflake/client/log/SFLoggerFactory.java
@@ -10,38 +10,29 @@ import java.util.Enumeration;
 /**
  * Used to create SFLogger instance
  *
- * Created by hyu on 11/17/16.
+ * <p>Created by hyu on 11/17/16.
  */
-public class SFLoggerFactory
-{
+public class SFLoggerFactory {
   public static LoggerImpl loggerImplementation;
 
-  enum LoggerImpl
-  {
+  enum LoggerImpl {
     SLF4JLOGGER("net.snowflake.client.log.SLF4JLogger"),
     JDK14LOGGER("net.snowflake.client.log.JDK14Logger");
 
     private String loggerImplClassName;
 
-    LoggerImpl(String loggerClass)
-    {
+    LoggerImpl(String loggerClass) {
       this.loggerImplClassName = loggerClass;
     }
 
-    public String getLoggerImplClassName()
-    {
+    public String getLoggerImplClassName() {
       return this.loggerImplClassName;
     }
 
-    public static LoggerImpl fromString(String loggerImplClassName)
-    {
-      if (loggerImplClassName != null)
-      {
-        for (LoggerImpl imp : LoggerImpl.values())
-        {
-          if (loggerImplClassName.equalsIgnoreCase(
-              imp.getLoggerImplClassName()))
-          {
+    public static LoggerImpl fromString(String loggerImplClassName) {
+      if (loggerImplClassName != null) {
+        for (LoggerImpl imp : LoggerImpl.values()) {
+          if (loggerImplClassName.equalsIgnoreCase(imp.getLoggerImplClassName())) {
             return imp;
           }
         }
@@ -54,29 +45,24 @@ public class SFLoggerFactory
    * @param clazz Class type that the logger is instantiated
    * @return An SFLogger instance given the name of the class
    */
-  public static SFLogger getLogger(Class<?> clazz)
-  {
+  public static SFLogger getLogger(Class<?> clazz) {
     // only need to determine the logger implementation only once
-    if (loggerImplementation == null)
-    {
+    if (loggerImplementation == null) {
       String logger = System.getProperty("net.snowflake.jdbc.loggerImpl");
 
       loggerImplementation = LoggerImpl.fromString(logger);
 
       if (loggerImplementation == null) {
         // try to load slf4j implementation class first
-        loggerImplementation = slf4jImplExist() ? LoggerImpl.SLF4JLOGGER
-            : LoggerImpl.JDK14LOGGER;
+        loggerImplementation = slf4jImplExist() ? LoggerImpl.SLF4JLOGGER : LoggerImpl.JDK14LOGGER;
       }
 
-      if (loggerImplementation == LoggerImpl.JDK14LOGGER)
-      {
+      if (loggerImplementation == LoggerImpl.JDK14LOGGER) {
         JDK14Logger.defaultInit();
       }
     }
 
-    switch (loggerImplementation)
-    {
+    switch (loggerImplementation) {
       case SLF4JLOGGER:
         return new SLF4JLogger(clazz);
       case JDK14LOGGER:
@@ -85,34 +71,26 @@ public class SFLoggerFactory
     }
   }
 
-  private static final String STATIC_LOGGER_BINDER_PATH="org/slf4j/impl/StaticLoggerBinder.class";
+  private static final String STATIC_LOGGER_BINDER_PATH = "org/slf4j/impl/StaticLoggerBinder.class";
   /**
-   * Methods used to determine if the slf4j implementation exist
-   * or not.
+   * Methods used to determine if the slf4j implementation exist or not.
    *
-   * The way to determine is to figure out if org.slf4j.StaticLoggerBinder
-   * is in the classpath or not. If not, then there is no implementation,
-   * switch to JDKLogger by default;
+   * <p>The way to determine is to figure out if org.slf4j.StaticLoggerBinder is in the classpath or
+   * not. If not, then there is no implementation, switch to JDKLogger by default;
+   *
    * @return
    */
-  private static boolean slf4jImplExist()
-  {
-    try
-    {
+  private static boolean slf4jImplExist() {
+    try {
       ClassLoader loggerFactoryClassLoader = SFLoggerFactory.class.getClassLoader();
       Enumeration<URL> paths;
-      if (loggerFactoryClassLoader == null)
-      {
+      if (loggerFactoryClassLoader == null) {
         paths = ClassLoader.getSystemResources(STATIC_LOGGER_BINDER_PATH);
-      }
-      else
-      {
+      } else {
         paths = loggerFactoryClassLoader.getResources(STATIC_LOGGER_BINDER_PATH);
       }
       return paths.hasMoreElements();
-    }
-    catch (IOException e)
-    {
+    } catch (IOException e) {
       System.err.println(e);
     }
     return false;

--- a/src/main/java/net/snowflake/client/log/SLF4JLogger.java
+++ b/src/main/java/net/snowflake/client/log/SLF4JLogger.java
@@ -9,11 +9,8 @@ import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 import org.slf4j.spi.LocationAwareLogger;
 
-/**
- * Created by hyu on 11/17/16.
- */
-public class SLF4JLogger implements SFLogger
-{
+/** Created by hyu on 11/17/16. */
+public class SLF4JLogger implements SFLogger {
   private Logger slf4jLogger;
 
   private boolean isLocationAwareLogger;
@@ -45,167 +42,127 @@ public class SLF4JLogger implements SFLogger
     return this.slf4jLogger.isWarnEnabled();
   }
 
-  public void debug(String msg)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
-    }
-    else
-    {
+  public void debug(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
+    } else {
       slf4jLogger.debug(msg);
     }
   }
 
-  public void debug(String msg, Object... arguments)
-  {
-    if (isDebugEnabled())
-    {
+  public void debug(String msg, Object... arguments) {
+    if (isDebugEnabled()) {
       FormattingTuple ft = MessageFormatter.arrayFormat(msg, arguments);
       this.debug(ft.getMessage());
     }
   }
 
-  public void debug(String msg, Throwable t)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, t);
-    }
-    else
-    {
+  public void debug(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, t);
+    } else {
       slf4jLogger.debug(msg, t);
     }
   }
 
-  public void error(String msg)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, null);
-    }
-    else
-    {
+  public void error(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, null);
+    } else {
       slf4jLogger.error(msg);
     }
   }
 
-  public void error(String msg, Object... arguments)
-  {
-    if (isErrorEnabled())
-    {
+  public void error(String msg, Object... arguments) {
+    if (isErrorEnabled()) {
       FormattingTuple ft = MessageFormatter.arrayFormat(msg, arguments);
       this.error(ft.getMessage());
     }
   }
 
-  public void error(String msg, Throwable t)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, t);
-    }
-    else
-    {
+  public void error(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, t);
+    } else {
       slf4jLogger.error(msg, t);
     }
   }
 
-  public void info(String msg)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, null);
-    }
-    else
-    {
+  public void info(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, null);
+    } else {
       slf4jLogger.info(msg);
     }
   }
 
-  public void info(String msg, Object... arguments)
-  {
-    if (isInfoEnabled())
-    {
+  public void info(String msg, Object... arguments) {
+    if (isInfoEnabled()) {
       FormattingTuple ft = MessageFormatter.arrayFormat(msg, arguments);
       this.info(ft.getMessage());
     }
   }
 
-  public void info(String msg, Throwable t)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, t);
-    }
-    else
-    {
+  public void info(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, t);
+    } else {
       slf4jLogger.error(msg, t);
     }
   }
 
-  public void trace(String msg)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, null);
-    }
-    else
-    {
+  public void trace(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, null);
+    } else {
       slf4jLogger.trace(msg);
     }
   }
 
-  public void trace(String msg, Object... arguments)
-  {
-    if (isTraceEnabled())
-    {
+  public void trace(String msg, Object... arguments) {
+    if (isTraceEnabled()) {
       FormattingTuple ft = MessageFormatter.arrayFormat(msg, arguments);
       this.trace(ft.getMessage());
     }
   }
 
-  public void trace(String msg, Throwable t)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, t);
-    }
-    else
-    {
+  public void trace(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, t);
+    } else {
       slf4jLogger.trace(msg, t);
     }
   }
 
-  public void warn(String msg)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, null);
-    }
-    else
-    {
+  public void warn(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, null);
+    } else {
       slf4jLogger.error(msg);
     }
   }
 
-  public void warn(String msg, Object... arguments)
-  {
-    if (isWarnEnabled())
-    {
+  public void warn(String msg, Object... arguments) {
+    if (isWarnEnabled()) {
       FormattingTuple ft = MessageFormatter.arrayFormat(msg, arguments);
       this.warn(ft.getMessage());
     }
   }
 
-  public void warn(String msg, Throwable t)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, t);
-    }
-    else
-    {
+  public void warn(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, t);
+    } else {
       slf4jLogger.error(msg, t);
     }
   }

--- a/src/main/java/net/snowflake/client/util/SFPair.java
+++ b/src/main/java/net/snowflake/client/util/SFPair.java
@@ -2,67 +2,53 @@ package net.snowflake.client.util;
 
 import java.util.Objects;
 
-/**
- * Created by hyu on 2/1/18.
- */
-public class SFPair<L, R>
-{
+/** Created by hyu on 2/1/18. */
+public class SFPair<L, R> {
   public L left;
 
   public R right;
 
-  public static <L, R>SFPair<L, R> of(L l, R r)
-  {
+  public static <L, R> SFPair<L, R> of(L l, R r) {
     return new SFPair<>(l, r);
   }
 
-  private SFPair(L left, R right)
-  {
+  private SFPair(L left, R right) {
     this.left = left;
     this.right = right;
   }
 
   @Override
-  public boolean equals(Object other)
-  {
-    if (other == null)
-    {
+  public boolean equals(Object other) {
+    if (other == null) {
       return false;
     }
 
-    if (other == this)
-    {
+    if (other == this) {
       return true;
     }
 
-    if (!(SFPair.class.isInstance(other)))
-    {
+    if (!(SFPair.class.isInstance(other))) {
       return false;
     }
 
     SFPair<L, R> pair2 = (SFPair<L, R>) other;
-    return Objects.equals(this.left, pair2.left) &&
-        Objects.equals(this.right, pair2.right);
+    return Objects.equals(this.left, pair2.left) && Objects.equals(this.right, pair2.right);
   }
 
   @Override
-  public int hashCode()
-  {
+  public int hashCode() {
     int result = 0;
-    if (left != null)
-    {
+    if (left != null) {
       result += 37 * left.hashCode();
     }
-    if (right != null)
-    {
+    if (right != null) {
       result += right.hashCode();
     }
     return result;
   }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
     return "[ " + left + ", " + right + " ]";
   }
 }

--- a/src/test/java/net/snowflake/client/AbstractDriverIT.java
+++ b/src/test/java/net/snowflake/client/AbstractDriverIT.java
@@ -3,9 +3,9 @@
  */
 package net.snowflake.client;
 
-import com.google.common.base.Strings;
-import org.junit.Rule;
+import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.google.common.base.Strings;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -19,30 +19,24 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Rule;
 
 /**
  * Base test class with common constants, data structures and methods
  *
  * @author jhuang
  */
-public class AbstractDriverIT
-{
+public class AbstractDriverIT {
   public static final String DRIVER_CLASS = "net.snowflake.client.jdbc.SnowflakeDriver";
   static final int DONT_INJECT_SOCKET_TIMEOUT = 0;
 
-  private static Logger logger =
-      Logger.getLogger(AbstractDriverIT.class.getName());
+  private static Logger logger = Logger.getLogger(AbstractDriverIT.class.getName());
 
-  static
-  {
+  static {
     // Load Snowflake JDBC class
-    try
-    {
+    try {
       Class.forName(DRIVER_CLASS);
-    } catch (Exception e)
-    {
+    } catch (Exception e) {
       logger.log(Level.SEVERE, "Cannot find Driver", e);
       throw new RuntimeException(e.getCause());
     }
@@ -50,70 +44,57 @@ public class AbstractDriverIT
 
   protected final int ERROR_CODE_UNACCEPTABLE_PREPARED_STATEMENT = 7;
 
-  protected final int ERROR_CODE_BIND_VARIABLE_NOT_ALLOWED_IN_VIEW_OR_UDF_DEF
-      = 2210;
+  protected final int ERROR_CODE_BIND_VARIABLE_NOT_ALLOWED_IN_VIEW_OR_UDF_DEF = 2210;
 
   protected final int ERROR_CODE_DOMAIN_OBJECT_DOES_NOT_EXIST = 2003;
 
-  @Rule
-  public ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
+  @Rule public ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
 
-  public static Map<String, String> getConnectionParameters()
-      throws SQLException
-  {
+  public static Map<String, String> getConnectionParameters() throws SQLException {
     Map<String, String> params = new HashMap<>();
     String account = System.getenv("SNOWFLAKE_TEST_ACCOUNT");
-    assertThat("set SNOWFLAKE_TEST_ACCOUNT environment variable.",
-        !Strings.isNullOrEmpty(account));
+    assertThat("set SNOWFLAKE_TEST_ACCOUNT environment variable.", !Strings.isNullOrEmpty(account));
     params.put("account", account);
 
     String user = System.getenv("SNOWFLAKE_TEST_USER");
-    assertThat("set SNOWFLAKE_TEST_USER environment variable.",
-        !Strings.isNullOrEmpty(user));
+    assertThat("set SNOWFLAKE_TEST_USER environment variable.", !Strings.isNullOrEmpty(user));
     params.put("user", user);
 
     String password = System.getenv("SNOWFLAKE_TEST_PASSWORD");
-    assertThat("set SNOWFLAKE_TEST_PASSWORD environment variable.",
-        !Strings.isNullOrEmpty(password));
+    assertThat(
+        "set SNOWFLAKE_TEST_PASSWORD environment variable.", !Strings.isNullOrEmpty(password));
     params.put("password", password);
 
     String host = System.getenv("SNOWFLAKE_TEST_HOST");
-    assertThat("set SNOWFLAKE_TEST_HOST environment variable.",
-        !Strings.isNullOrEmpty(host));
+    assertThat("set SNOWFLAKE_TEST_HOST environment variable.", !Strings.isNullOrEmpty(host));
     params.put("host", host);
 
     String port = System.getenv("SNOWFLAKE_TEST_PORT");
-    assertThat("set SNOWFLAKE_TEST_PORT environment variable.",
-        !Strings.isNullOrEmpty(port));
+    assertThat("set SNOWFLAKE_TEST_PORT environment variable.", !Strings.isNullOrEmpty(port));
     params.put("port", port);
 
     String database = System.getenv("SNOWFLAKE_TEST_DATABASE");
-    assertThat("set SNOWFLAKE_TEST_DATABASE environment variable.",
-        !Strings.isNullOrEmpty(database));
+    assertThat(
+        "set SNOWFLAKE_TEST_DATABASE environment variable.", !Strings.isNullOrEmpty(database));
     params.put("database", database);
 
     String schema = System.getenv("SNOWFLAKE_TEST_SCHEMA");
-    assertThat("set SNOWFLAKE_TEST_SCHEMA environment variable.",
-        !Strings.isNullOrEmpty(schema));
+    assertThat("set SNOWFLAKE_TEST_SCHEMA environment variable.", !Strings.isNullOrEmpty(schema));
     params.put("schema", schema);
 
     String role = System.getenv("SNOWFLAKE_TEST_ROLE");
-    assertThat("set SNOWFLAKE_TEST_ROLE environment variable.",
-        !Strings.isNullOrEmpty(role));
+    assertThat("set SNOWFLAKE_TEST_ROLE environment variable.", !Strings.isNullOrEmpty(role));
     params.put("role", role);
 
     String warehouse = System.getenv("SNOWFLAKE_TEST_WAREHOUSE");
-    assertThat("set SNOWFLAKE_TEST_WAREHOUSE environment variable.",
-        !Strings.isNullOrEmpty(role));
+    assertThat("set SNOWFLAKE_TEST_WAREHOUSE environment variable.", !Strings.isNullOrEmpty(role));
     params.put("warehouse", warehouse);
 
     String protocol = System.getenv("SNOWFLAKE_TEST_PROTOCOL");
     String ssl;
-    if (Strings.isNullOrEmpty(protocol) || "http".equals(protocol))
-    {
+    if (Strings.isNullOrEmpty(protocol) || "http".equals(protocol)) {
       ssl = "off";
-    } else
-    {
+    } else {
       ssl = "on";
     }
     params.put("ssl", ssl);
@@ -133,17 +114,14 @@ public class AbstractDriverIT
   }
 
   /**
-   * Gets a connection with default session parameter settings,
-   * but tunable query api version and socket timeout setting
+   * Gets a connection with default session parameter settings, but tunable query api version and
+   * socket timeout setting
    *
    * @param paramProperties connection properties
    * @return Connection a database connection
    * @throws SQLException raised if any error occurs
    */
-
-  public static Connection getConnection(Properties paramProperties)
-      throws SQLException
-  {
+  public static Connection getConnection(Properties paramProperties) throws SQLException {
     return getConnection(DONT_INJECT_SOCKET_TIMEOUT, paramProperties, false);
   }
 
@@ -153,23 +131,19 @@ public class AbstractDriverIT
    * @return Connection a database connection
    * @throws SQLException raised if any error occurs
    */
-  public static Connection getConnection()
-      throws SQLException
-  {
+  public static Connection getConnection() throws SQLException {
     return getConnection(DONT_INJECT_SOCKET_TIMEOUT, null, false);
   }
 
   /**
-   * Gets a connection with default session parameter settings,
-   * but tunable query api version and socket timeout setting
+   * Gets a connection with default session parameter settings, but tunable query api version and
+   * socket timeout setting
    *
    * @param injectSocketTimeout number of seconds to inject in connection
    * @return Connection a database connection
    * @throws SQLException raised if any error occurs
    */
-  public static Connection getConnection(int injectSocketTimeout)
-      throws SQLException
-  {
+  public static Connection getConnection(int injectSocketTimeout) throws SQLException {
     return getConnection(injectSocketTimeout, null, false);
   }
 
@@ -179,9 +153,7 @@ public class AbstractDriverIT
    * @return Connection a database connection
    * @throws SQLException raised if any error occurs
    */
-  public static Connection getSnowflakeAdminConnection()
-      throws SQLException
-  {
+  public static Connection getSnowflakeAdminConnection() throws SQLException {
     return getConnection(DONT_INJECT_SOCKET_TIMEOUT, null, true);
   }
 
@@ -193,42 +165,39 @@ public class AbstractDriverIT
    * @throws SQLException raised if any error occurs
    */
   public static Connection getSnowflakeAdminConnection(Properties paramProperties)
-      throws SQLException
-  {
+      throws SQLException {
     return getConnection(DONT_INJECT_SOCKET_TIMEOUT, paramProperties, true);
   }
 
   /**
-   * Gets a connection for the custom session parameter settings and
-   * tunable query api version and socket timeout setting
+   * Gets a connection for the custom session parameter settings and tunable query api version and
+   * socket timeout setting
    *
    * @param injectSocketTimeout number of seconds to inject in connection
-   * @param paramProperties     connection properties
-   * @param isAdmin             is Snowflake admin user?
+   * @param paramProperties connection properties
+   * @param isAdmin is Snowflake admin user?
    * @return Connectiona database connection
    * @throws SQLException raised if any error occurs
    */
   public static Connection getConnection(
-      int injectSocketTimeout, Properties paramProperties, boolean isAdmin)
-      throws SQLException
-  {
+      int injectSocketTimeout, Properties paramProperties, boolean isAdmin) throws SQLException {
     Map<String, String> params = getConnectionParameters();
 
     // build connection properties
     Properties properties = new Properties();
-    if (isAdmin)
-    {
-      assertThat("set SNOWFLAKE_TEST_ADMIN_USER environment variable.",
+    if (isAdmin) {
+      assertThat(
+          "set SNOWFLAKE_TEST_ADMIN_USER environment variable.",
           !Strings.isNullOrEmpty(params.get("adminUser")));
-      assertThat("set SNOWFLAKE_TEST_ADMIN_PASSWORD environment variable.",
+      assertThat(
+          "set SNOWFLAKE_TEST_ADMIN_PASSWORD environment variable.",
           !Strings.isNullOrEmpty(params.get("adminPassword")));
 
       properties.put("user", params.get("adminUser"));
       properties.put("password", params.get("adminPassword"));
       properties.put("role", "accountadmin");
       properties.put("account", "snowflake");
-    } else
-    {
+    } else {
       properties.put("user", params.get("user"));
       properties.put("password", params.get("password"));
       properties.put("role", params.get("role"));
@@ -243,17 +212,13 @@ public class AbstractDriverIT
 
     properties.put("insecureMode", false); // use OCSP for all tests.
 
-    if (injectSocketTimeout > 0)
-    {
-      properties.put(
-          "injectSocketTimeout", String.valueOf(injectSocketTimeout));
+    if (injectSocketTimeout > 0) {
+      properties.put("injectSocketTimeout", String.valueOf(injectSocketTimeout));
     }
 
     // Set the session parameter properties
-    if (paramProperties != null)
-    {
-      for (Map.Entry entry : paramProperties.entrySet())
-      {
+    if (paramProperties != null) {
+      for (Map.Entry entry : paramProperties.entrySet()) {
         properties.put(entry.getKey(), entry.getValue());
       }
     }
@@ -263,32 +228,26 @@ public class AbstractDriverIT
   /**
    * Close SQL Objects
    *
-   * @param resultSet  a result set object
-   * @param statement  a statement object
+   * @param resultSet a result set object
+   * @param statement a statement object
    * @param connection a connection
    * @throws SQLException raised if any error occurs
    */
-  public void closeSQLObjects(ResultSet resultSet, Statement statement,
-                              Connection connection) throws SQLException
-  {
-    if (resultSet != null)
-    {
+  public void closeSQLObjects(ResultSet resultSet, Statement statement, Connection connection)
+      throws SQLException {
+    if (resultSet != null) {
       resultSet.close();
     }
-    if (statement != null)
-    {
+    if (statement != null) {
       statement.close();
     }
-    if (connection != null)
-    {
+    if (connection != null) {
       connection.close();
     }
   }
 
-  protected static String getSFProjectRoot() throws UnsupportedEncodingException
-  {
-    URL location =
-        AbstractDriverIT.class.getProtectionDomain().getCodeSource().getLocation();
+  protected static String getSFProjectRoot() throws UnsupportedEncodingException {
+    URL location = AbstractDriverIT.class.getProtectionDomain().getCodeSource().getLocation();
     String testDir = URLDecoder.decode(location.getPath(), "UTF-8");
 
     return testDir.substring(0, testDir.indexOf("Client"));

--- a/src/test/java/net/snowflake/client/ConditionalIgnoreRule.java
+++ b/src/test/java/net/snowflake/client/ConditionalIgnoreRule.java
@@ -1,25 +1,21 @@
 package net.snowflake.client;
 
+/** Created by hyu on 1/22/18. */
 /**
- * Created by hyu on 1/22/18.
- */
-/*******************************************************************************
- * Copyright (c) 2013,2014 Rüdiger Herrmann
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * ***************************************************************************** Copyright (c)
+ * 2013,2014 Rüdiger Herrmann All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
  *
- * Contributors:
- *   Rüdiger Herrmann - initial API and implementation
- *   Matt Morrissette - allow to use non-static inner IgnoreConditions
- ******************************************************************************/
+ * <p>Contributors: Rüdiger Herrmann - initial API and implementation Matt Morrissette - allow to
+ * use non-static inner IgnoreConditions
+ * ****************************************************************************
+ */
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Modifier;
-
 import org.junit.Assume;
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
@@ -38,31 +34,31 @@ public class ConditionalIgnoreRule implements MethodRule {
   }
 
   @Override
-  public Statement apply( Statement base, FrameworkMethod method, Object target ) {
+  public Statement apply(Statement base, FrameworkMethod method, Object target) {
     Statement result = base;
-    if( hasConditionalIgnoreAnnotation( method ) ) {
-      IgnoreCondition condition = getIgnoreContition( target, method );
-      if( condition.isSatisfied() ) {
-        result = new IgnoreStatement( condition );
+    if (hasConditionalIgnoreAnnotation(method)) {
+      IgnoreCondition condition = getIgnoreContition(target, method);
+      if (condition.isSatisfied()) {
+        result = new IgnoreStatement(condition);
       }
     }
     return result;
   }
 
-  private static boolean hasConditionalIgnoreAnnotation( FrameworkMethod method ) {
-    return method.getAnnotation( ConditionalIgnore.class ) != null;
+  private static boolean hasConditionalIgnoreAnnotation(FrameworkMethod method) {
+    return method.getAnnotation(ConditionalIgnore.class) != null;
   }
 
-  private static IgnoreCondition getIgnoreContition( Object target, FrameworkMethod method ) {
-    ConditionalIgnore annotation = method.getAnnotation( ConditionalIgnore.class );
-    return new IgnoreConditionCreator( target, annotation ).create();
+  private static IgnoreCondition getIgnoreContition(Object target, FrameworkMethod method) {
+    ConditionalIgnore annotation = method.getAnnotation(ConditionalIgnore.class);
+    return new IgnoreConditionCreator(target, annotation).create();
   }
 
   private static class IgnoreConditionCreator {
     private final Object target;
     private final Class<? extends IgnoreCondition> conditionType;
 
-    IgnoreConditionCreator( Object target, ConditionalIgnore annotation ) {
+    IgnoreConditionCreator(Object target, ConditionalIgnore annotation) {
       this.target = target;
       this.conditionType = annotation.condition();
     }
@@ -71,55 +67,54 @@ public class ConditionalIgnoreRule implements MethodRule {
       checkConditionType();
       try {
         return createCondition();
-      } catch( RuntimeException re ) {
+      } catch (RuntimeException re) {
         throw re;
-      } catch( Exception e ) {
-        throw new RuntimeException( e );
+      } catch (Exception e) {
+        throw new RuntimeException(e);
       }
     }
 
     private IgnoreCondition createCondition() throws Exception {
       IgnoreCondition result;
-      if( isConditionTypeStandalone() ) {
+      if (isConditionTypeStandalone()) {
         result = conditionType.newInstance();
       } else {
-        result = conditionType.getDeclaredConstructor( target.getClass() ).newInstance( target );
+        result = conditionType.getDeclaredConstructor(target.getClass()).newInstance(target);
       }
       return result;
     }
 
     private void checkConditionType() {
-      if( !isConditionTypeStandalone() && !isConditionTypeDeclaredInTarget() ) {
-        String msg
-            = "Conditional class '%s' is a member class "
-            + "but was not declared inside the test case using it.\n"
-            + "Either make this class a static class, "
-            + "standalone class (by declaring it in it's own file) "
-            + "or move it inside the test case using it";
-        throw new IllegalArgumentException( String.format ( msg, conditionType.getName() ) );
+      if (!isConditionTypeStandalone() && !isConditionTypeDeclaredInTarget()) {
+        String msg =
+            "Conditional class '%s' is a member class "
+                + "but was not declared inside the test case using it.\n"
+                + "Either make this class a static class, "
+                + "standalone class (by declaring it in it's own file) "
+                + "or move it inside the test case using it";
+        throw new IllegalArgumentException(String.format(msg, conditionType.getName()));
       }
     }
 
     private boolean isConditionTypeStandalone() {
-      return !conditionType.isMemberClass() || Modifier.isStatic( conditionType.getModifiers() );
+      return !conditionType.isMemberClass() || Modifier.isStatic(conditionType.getModifiers());
     }
 
     private boolean isConditionTypeDeclaredInTarget() {
-      return target.getClass().isAssignableFrom( conditionType.getDeclaringClass() );
+      return target.getClass().isAssignableFrom(conditionType.getDeclaringClass());
     }
   }
 
   private static class IgnoreStatement extends Statement {
     private final IgnoreCondition condition;
 
-    IgnoreStatement( IgnoreCondition condition ) {
+    IgnoreStatement(IgnoreCondition condition) {
       this.condition = condition;
     }
 
     @Override
     public void evaluate() {
-      Assume.assumeTrue( "Ignored by " + condition.getClass().getSimpleName(), false );
+      Assume.assumeTrue("Ignored by " + condition.getClass().getSimpleName(), false);
     }
   }
-
 }

--- a/src/test/java/net/snowflake/client/RunningOnTravisCI.java
+++ b/src/test/java/net/snowflake/client/RunningOnTravisCI.java
@@ -1,15 +1,10 @@
 package net.snowflake.client;
 
-/**
- * Created by hyu on 1/22/18.
- */
-public class RunningOnTravisCI implements
-    ConditionalIgnoreRule.IgnoreCondition
-{
-  //TODO Right now always return false. After we open source the tests, this
-  //TODO method will be changed to conditional ignore running some tests on travis
-  public boolean isSatisfied()
-  {
+/** Created by hyu on 1/22/18. */
+public class RunningOnTravisCI implements ConditionalIgnoreRule.IgnoreCondition {
+  // TODO Right now always return false. After we open source the tests, this
+  // TODO method will be changed to conditional ignore running some tests on travis
+  public boolean isSatisfied() {
     return System.getenv("TRAVIS_JOB_ID") != null;
   }
 }

--- a/src/test/java/net/snowflake/client/core/SFSessionPropertyTest.java
+++ b/src/test/java/net/snowflake/client/core/SFSessionPropertyTest.java
@@ -4,42 +4,32 @@
 
 package net.snowflake.client.core;
 
-import net.snowflake.client.jdbc.ErrorCode;
-import org.junit.Assert;
-import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class SFSessionPropertyTest
-{
+import net.snowflake.client.jdbc.ErrorCode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SFSessionPropertyTest {
   @Test
-  public void testCheckApplicationName() throws SFException
-  {
-    String[] validApplicationName = {"test1234", "test_1234", "test-1234",
-        "test.1234"} ;
+  public void testCheckApplicationName() throws SFException {
+    String[] validApplicationName = {"test1234", "test_1234", "test-1234", "test.1234"};
 
     String[] invalidApplicationName = {"1234test", "test$A", "test<script>"};
 
-    for (String valid : validApplicationName)
-    {
-      Object value = SFSessionProperty.checkPropertyValue(
-          SFSessionProperty.APPLICATION, valid);
+    for (String valid : validApplicationName) {
+      Object value = SFSessionProperty.checkPropertyValue(SFSessionProperty.APPLICATION, valid);
 
-      assertThat((String)value, is(valid));
+      assertThat((String) value, is(valid));
     }
 
-    for (String invalid : invalidApplicationName)
-    {
-      try
-      {
-        SFSessionProperty.checkPropertyValue(
-            SFSessionProperty.APPLICATION, invalid);
+    for (String invalid : invalidApplicationName) {
+      try {
+        SFSessionProperty.checkPropertyValue(SFSessionProperty.APPLICATION, invalid);
         Assert.fail();
-      }
-      catch(SFException e)
-      {
-        assertThat(e.getVendorCode(),
-            is(ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode()));
+      } catch (SFException e) {
+        assertThat(e.getVendorCode(), is(ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode()));
       }
     }
   }

--- a/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
+++ b/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
@@ -3,12 +3,11 @@
  */
 package net.snowflake.client.core;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.AnyOf.anyOf;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,150 +19,127 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import static junit.framework.TestCase.fail;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.AnyOf.anyOf;
-
-public class SFTrustManagerIT
-{
+public class SFTrustManagerIT {
   private static final String[] TARGET_HOSTS = {
-      "sfcsupport.snowflakecomputing.com",
-      "sfcsupport.us-east-1.snowflakecomputing.com",
-      "sfcsupport.eu-central-1.snowflakecomputing.com",
-      "sfc-dev1-regression.s3.amazonaws.com",
-      "sfc-ds2-customer-stage.s3.amazonaws.com",
-      "snowflake.okta.com",
-      "sfcdev1.blob.core.windows.net"
+    "sfcsupport.snowflakecomputing.com",
+    "sfcsupport.us-east-1.snowflakecomputing.com",
+    "sfcsupport.eu-central-1.snowflakecomputing.com",
+    "sfc-dev1-regression.s3.amazonaws.com",
+    "sfc-ds2-customer-stage.s3.amazonaws.com",
+    "snowflake.okta.com",
+    "sfcdev1.blob.core.windows.net"
   };
 
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   /**
    * OCSP tests for the Snowflake and AWS S3 HTTPS connections.
-   * <p>
-   * Whatever the default method is used.
+   *
+   * <p>Whatever the default method is used.
    */
   @Test
-  public void testOcsp() throws Throwable
-  {
-    for (String host : TARGET_HOSTS)
-    {
-      HttpClient client = HttpUtil.buildHttpClient(
-          false, // NOT insecure mode
-          null, // default OCSP response cache file
-          true // use OCSP response cache server
-      );
+  public void testOcsp() throws Throwable {
+    for (String host : TARGET_HOSTS) {
+      HttpClient client =
+          HttpUtil.buildHttpClient(
+              false, // NOT insecure mode
+              null, // default OCSP response cache file
+              true // use OCSP response cache server
+              );
       accessHost(host, client);
     }
   }
 
   /**
-   * OCSP tests for the Snowflake and AWS S3 HTTPS connections using the
-   * file cache.
-   * <p>
-   * Specifying an non-existing file will force to fetch OCSP response.
+   * OCSP tests for the Snowflake and AWS S3 HTTPS connections using the file cache.
+   *
+   * <p>Specifying an non-existing file will force to fetch OCSP response.
    */
   @Test
-  public void testOcspWithFileCache() throws Throwable
-  {
+  public void testOcspWithFileCache() throws Throwable {
     File ocspCacheFile = tmpFolder.newFile();
-    for (String host : TARGET_HOSTS)
-    {
-      HttpClient client = HttpUtil.buildHttpClient(
-          false, // NOT insecure mode
-          ocspCacheFile, // a temp OCSP response cache file
-          false // NOT use OCSP response cache server
-      );
+    for (String host : TARGET_HOSTS) {
+      HttpClient client =
+          HttpUtil.buildHttpClient(
+              false, // NOT insecure mode
+              ocspCacheFile, // a temp OCSP response cache file
+              false // NOT use OCSP response cache server
+              );
       accessHost(host, client);
     }
   }
 
-  /**
-   * OCSP tests for the Snowflake and AWS S3 HTTPS connections using the
-   * server cache.
-   */
+  /** OCSP tests for the Snowflake and AWS S3 HTTPS connections using the server cache. */
   @Test
-  public void testOcspWithServerCache() throws Throwable
-  {
+  public void testOcspWithServerCache() throws Throwable {
     File ocspCacheFile = tmpFolder.newFile();
-    for (String host : TARGET_HOSTS)
-    {
-      HttpClient client = HttpUtil.buildHttpClient(
-          false, // NOT insecure mode
-          ocspCacheFile, // a temp OCSP response cache file
-          true // use OCSP response cache server
-      );
+    for (String host : TARGET_HOSTS) {
+      HttpClient client =
+          HttpUtil.buildHttpClient(
+              false, // NOT insecure mode
+              ocspCacheFile, // a temp OCSP response cache file
+              true // use OCSP response cache server
+              );
       accessHost(host, client);
     }
   }
 
-  /**
-   * OCSP tests for the Snowflake and AWS S3 HTTPS connections using the
-   * server cache.
-   */
+  /** OCSP tests for the Snowflake and AWS S3 HTTPS connections using the server cache. */
   @Test
-  public void testInvalidCacheFile() throws Throwable
-  {
+  public void testInvalidCacheFile() throws Throwable {
     // a file under never exists.
     File ocspCacheFile = new File("NEVER_EXISTS", "NEVER_EXISTS");
     String host = TARGET_HOSTS[0];
-    HttpClient client = HttpUtil.buildHttpClient(
-        false, // NOT insecure mode
-        ocspCacheFile, // a temp OCSP response cache file
-        true // use OCSP response cache server
-    );
+    HttpClient client =
+        HttpUtil.buildHttpClient(
+            false, // NOT insecure mode
+            ocspCacheFile, // a temp OCSP response cache file
+            true // use OCSP response cache server
+            );
     accessHost(host, client);
   }
 
-  private static void accessHost(String host, HttpClient client) throws IOException
-  {
+  private static void accessHost(String host, HttpClient client) throws IOException {
     final int maxRetry = 10;
     int statusCode = -1;
-    for (int retry = 0; retry < maxRetry; ++retry)
-    {
+    for (int retry = 0; retry < maxRetry; ++retry) {
       HttpGet httpRequest = new HttpGet(String.format("https://%s:443/", host));
       HttpResponse response = client.execute(httpRequest);
       statusCode = response.getStatusLine().getStatusCode();
-      if (statusCode != 503 && statusCode != 504)
-      {
+      if (statusCode != 503 && statusCode != 504) {
         break;
       }
-      try
-      {
+      try {
         Thread.sleep(1000L);
-      }
-      catch (InterruptedException ex)
-      {
+      } catch (InterruptedException ex) {
       }
     }
-    assertThat(String.format("response code for %s", host),
+    assertThat(
+        String.format("response code for %s", host),
         statusCode,
         anyOf(equalTo(200), equalTo(403), equalTo(400)));
   }
 
-  /**
-   * Revoked certificate test.
-   */
+  /** Revoked certificate test. */
   @Test
-  public void testRevokedCertificate() throws Throwable
-  {
+  public void testRevokedCertificate() throws Throwable {
     File ocspCacheFile = tmpFolder.newFile();
-    List<X509Certificate> certList = getX509CertificatesFromFile(
-        "revoked_certs.pem");
-    SFTrustManager sft = new SFTrustManager(
-        ocspCacheFile,  // a temp OCSP response cache file
-        true);
-    try
-    {
+    List<X509Certificate> certList = getX509CertificatesFromFile("revoked_certs.pem");
+    SFTrustManager sft =
+        new SFTrustManager(
+            ocspCacheFile, // a temp OCSP response cache file
+            true);
+    try {
       sft.validateRevocationStatus(certList.toArray(new X509Certificate[0]));
       fail();
-    }
-    catch (CertificateEncodingException ex)
-    {
+    } catch (CertificateEncodingException ex) {
       assertThat(ex.getMessage(), containsString("has been revoked"));
     }
   }
@@ -175,20 +151,16 @@ public class SFTrustManagerIT
    * @return an array of X509Certificate
    * @throws Throwable raise if any error occurs
    */
-  private List<X509Certificate> getX509CertificatesFromFile(String filename) throws Throwable
-  {
+  private List<X509Certificate> getX509CertificatesFromFile(String filename) throws Throwable {
     CertificateFactory fact = CertificateFactory.getInstance("X.509");
     List<X509Certificate> certList = new ArrayList<>();
-    for (Certificate cert : fact.generateCertificates(
-        getFile(filename)))
-    {
+    for (Certificate cert : fact.generateCertificates(getFile(filename))) {
       certList.add((X509Certificate) cert);
     }
     return certList;
   }
 
-  private InputStream getFile(String fileName) throws Throwable
-  {
+  private InputStream getFile(String fileName) throws Throwable {
     ClassLoader classLoader = getClass().getClassLoader();
     URL url = classLoader.getResource(fileName);
     return url.openStream();

--- a/src/test/java/net/snowflake/client/core/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilTest.java
@@ -4,42 +4,44 @@
 
 package net.snowflake.client.core;
 
-import org.junit.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class SessionUtilTest
-{
+import org.junit.Test;
 
-  /**
-   * Test isPrefixEqual
-   */
+public class SessionUtilTest {
+
+  /** Test isPrefixEqual */
   @Test
-  public void testIsPrefixEqual() throws Exception
-  {
-    assertThat("no port number",
+  public void testIsPrefixEqual() throws Exception {
+    assertThat(
+        "no port number",
         SessionUtil.isPrefixEqual(
             "https://testaccount.snowflakecomputing.com/blah",
             "https://testaccount.snowflakecomputing.com/"));
-    assertThat("no port number with a slash",
+    assertThat(
+        "no port number with a slash",
         SessionUtil.isPrefixEqual(
             "https://testaccount.snowflakecomputing.com/blah",
             "https://testaccount.snowflakecomputing.com"));
-    assertThat("including a port number on one of them",
+    assertThat(
+        "including a port number on one of them",
         SessionUtil.isPrefixEqual(
             "https://testaccount.snowflakecomputing.com/blah",
             "https://testaccount.snowflakecomputing.com:443/"));
 
     // negative
-    assertThat("different hostnames",
+    assertThat(
+        "different hostnames",
         !SessionUtil.isPrefixEqual(
             "https://testaccount1.snowflakecomputing.com/blah",
             "https://testaccount2.snowflakecomputing.com/"));
-    assertThat("different port numbers",
+    assertThat(
+        "different port numbers",
         !SessionUtil.isPrefixEqual(
             "https://testaccount.snowflakecomputing.com:123/blah",
             "https://testaccount.snowflakecomputing.com:443/"));
-    assertThat("different protocols",
+    assertThat(
+        "different protocols",
         !SessionUtil.isPrefixEqual(
             "http://testaccount.snowflakecomputing.com/blah",
             "https://testaccount.snowflakecomputing.com/"));

--- a/src/test/java/net/snowflake/client/jdbc/BaseJDBCTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/BaseJDBCTest.java
@@ -3,8 +3,6 @@
  */
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.AbstractDriverIT;
-
 import java.net.URL;
 import java.net.URLDecoder;
 import java.sql.Connection;
@@ -13,41 +11,33 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.logging.Logger;
+import net.snowflake.client.AbstractDriverIT;
 
-/**
- * @author hyu
- */
-public class BaseJDBCTest extends AbstractDriverIT
-{
+/** @author hyu */
+public class BaseJDBCTest extends AbstractDriverIT {
   private static Logger logger = Logger.getLogger(BaseJDBCTest.class.getName());
 
-  int getSizeOfResultSet(ResultSet rs) throws SQLException
-  {
+  int getSizeOfResultSet(ResultSet rs) throws SQLException {
     int count = 0;
-    while (rs.next())
-    {
+    while (rs.next()) {
       count++;
     }
     return count;
   }
 
-  String getSFProjectRootString() throws Exception
-  {
-    URL location =
-        BaseJDBCTest.class.getProtectionDomain().getCodeSource().getLocation();
+  String getSFProjectRootString() throws Exception {
+    URL location = BaseJDBCTest.class.getProtectionDomain().getCodeSource().getLocation();
     String testDir = URLDecoder.decode(location.getPath(), "UTF-8");
     System.out.println(testDir);
     return testDir.substring(0, testDir.indexOf("Client"));
   }
 
-  ArrayList<String> getInfoViaSQLCmd(String sqlCmd) throws SQLException
-  {
+  ArrayList<String> getInfoViaSQLCmd(String sqlCmd) throws SQLException {
     Connection con = getConnection();
     Statement st = con.createStatement();
     ArrayList<String> result = new ArrayList<>();
     ResultSet rs = st.executeQuery(sqlCmd);
-    while (rs.next())
-    {
+    while (rs.next()) {
       result.add(rs.getString(1));
     }
     return result;

--- a/src/test/java/net/snowflake/client/jdbc/ComSnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ComSnowflakeDriverIT.java
@@ -3,24 +3,20 @@
  */
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.AbstractDriverIT;
-import org.junit.Test;
-
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import net.snowflake.client.AbstractDriverIT;
+import org.junit.Test;
 
 /**
- * This is just a simple test class for compatibility check. Make sure that
- * customer can load com.snowflake.client.jdbc.SnowflakeDriver class
- * Created by hyu on 10/10/16.
+ * This is just a simple test class for compatibility check. Make sure that customer can load
+ * com.snowflake.client.jdbc.SnowflakeDriver class Created by hyu on 10/10/16.
  */
-public class ComSnowflakeDriverIT extends AbstractDriverIT
-{
+public class ComSnowflakeDriverIT extends AbstractDriverIT {
   @Test
-  public void testSimpleConnection() throws SQLException
-  {
+  public void testSimpleConnection() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     ResultSet resultSet = statement.executeQuery("show parameters");

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -3,13 +3,12 @@
  */
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.ConditionalIgnoreRule.ConditionalIgnore;
-import net.snowflake.client.RunningOnTravisCI;
-import net.snowflake.common.core.SqlState;
-import org.apache.commons.codec.binary.Base64;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -25,22 +24,18 @@ import java.sql.Statement;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
+import net.snowflake.client.ConditionalIgnoreRule.ConditionalIgnore;
+import net.snowflake.client.RunningOnTravisCI;
+import net.snowflake.common.core.SqlState;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-/**
- * Connection integration tests
- */
-public class ConnectionIT extends BaseJDBCTest
-{
+/** Connection integration tests */
+public class ConnectionIT extends BaseJDBCTest {
   @Test
-  public void testSimpleConnection() throws SQLException
-  {
+  public void testSimpleConnection() throws SQLException {
     Connection con = getConnection();
     Statement statement = con.createStatement();
     ResultSet resultSet = statement.executeQuery("show parameters");
@@ -57,8 +52,7 @@ public class ConnectionIT extends BaseJDBCTest
    * @throws SQLException
    */
   @Test
-  public void testLoginTimeoutViaDataSource() throws SQLException
-  {
+  public void testLoginTimeoutViaDataSource() throws SQLException {
     SnowflakeBasicDataSource ds = new SnowflakeBasicDataSource();
     ds.setUrl("jdbc:snowflake://fakeaccount.snowflakecomputing.com");
     ds.setUser("fakeUser");
@@ -67,13 +61,10 @@ public class ConnectionIT extends BaseJDBCTest
     ds.setLoginTimeout(10);
 
     long startLoginTime = System.currentTimeMillis();
-    try
-    {
+    try {
       ds.getConnection();
       fail();
-    }
-    catch (SQLException e)
-    {
+    } catch (SQLException e) {
       assertThat(e.getErrorCode(), is(ErrorCode.NETWORK_ERROR.getMessageCode()));
     }
     long endLoginTime = System.currentTimeMillis();
@@ -82,17 +73,17 @@ public class ConnectionIT extends BaseJDBCTest
   }
 
   /**
-   * Test production connectivity in case cipher suites or tls protocol change
-   * Use fake username and password but correct url
-   * Expectation is receiving incorrect username or password response from server
+   * Test production connectivity in case cipher suites or tls protocol change Use fake username and
+   * password but correct url Expectation is receiving incorrect username or password response from
+   * server
    */
   @Test
-  public void testProdConnectivity() throws SQLException
-  {
+  public void testProdConnectivity() throws SQLException {
     String[] deploymentUrls = {
-        "jdbc:snowflake://sfcsupport.snowflakecomputing.com",
-        "jdbc:snowflake://sfcsupportva.us-east-1.snowflakecomputing.com",
-        "jdbc:snowflake://sfcsupporteu.eu-central-1.snowflakecomputing.com"};
+      "jdbc:snowflake://sfcsupport.snowflakecomputing.com",
+      "jdbc:snowflake://sfcsupportva.us-east-1.snowflakecomputing.com",
+      "jdbc:snowflake://sfcsupporteu.eu-central-1.snowflakecomputing.com"
+    };
 
     Properties properties = new Properties();
 
@@ -100,25 +91,19 @@ public class ConnectionIT extends BaseJDBCTest
     properties.put("password", "fakepwd");
     properties.put("account", "fakeaccount");
 
-    for (String url : deploymentUrls)
-    {
-      try
-      {
+    for (String url : deploymentUrls) {
+      try {
         DriverManager.getConnection(url, properties);
         fail();
-      }
-      catch (SQLException e)
-      {
-        assertThat(e.getErrorCode(), is(
-            ErrorCode.CONNECTION_ERROR.getMessageCode()));
+      } catch (SQLException e) {
+        assertThat(e.getErrorCode(), is(ErrorCode.CONNECTION_ERROR.getMessageCode()));
       }
     }
   }
 
   @Test
   @ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testConnectionGetAndSetDBAndSchema() throws SQLException
-  {
+  public void testConnectionGetAndSetDBAndSchema() throws SQLException {
     Connection con = getConnection();
 
     final String database = System.getenv("SNOWFLAKE_TEST_DATABASE").toUpperCase();
@@ -153,8 +138,7 @@ public class ConnectionIT extends BaseJDBCTest
   }
 
   @Test
-  public void testConnectionClientInfo() throws SQLException
-  {
+  public void testConnectionClientInfo() throws SQLException {
     Connection con = getConnection();
     Properties property = con.getClientInfo();
     assertEquals(0, property.size());
@@ -173,8 +157,7 @@ public class ConnectionIT extends BaseJDBCTest
 
   @Ignore("not supported yet")
   @Test
-  public void testReadOnlyConneciton() throws SQLException
-  {
+  public void testReadOnlyConneciton() throws SQLException {
     Connection con = getConnection();
     assertTrue(!con.isReadOnly());
     con.setReadOnly(true);
@@ -188,8 +171,7 @@ public class ConnectionIT extends BaseJDBCTest
 
   // only support get and set
   @Test
-  public void testNetworkTimeout() throws SQLException
-  {
+  public void testNetworkTimeout() throws SQLException {
     Connection con = getConnection();
     int millis = con.getNetworkTimeout();
     assertEquals(0, millis);
@@ -199,8 +181,7 @@ public class ConnectionIT extends BaseJDBCTest
   }
 
   @Test
-  public void testAbort() throws SQLException
-  {
+  public void testAbort() throws SQLException {
     Connection con = getConnection();
     assertTrue(!con.isClosed());
     con.abort(null);
@@ -208,18 +189,14 @@ public class ConnectionIT extends BaseJDBCTest
   }
 
   @Test
-  public void testSetQueryTimeoutInConnectionStr() throws SQLException
-  {
+  public void testSetQueryTimeoutInConnectionStr() throws SQLException {
     Properties properties = new Properties();
     properties.put("queryTimeout", "5");
     Connection connection = getConnection(properties);
     Statement statement = connection.createStatement();
-    try
-    {
+    try {
       statement.executeQuery("select count(*) from table(generator(timeLimit => 1000000))");
-    }
-    catch (SQLException e)
-    {
+    } catch (SQLException e) {
       assertTrue(true);
       assertEquals(SqlState.QUERY_CANCELED, e.getSQLState());
       assertEquals("SQL execution canceled", e.getMessage());
@@ -229,64 +206,56 @@ public class ConnectionIT extends BaseJDBCTest
   }
 
   @Test
-  public void testLoginTimeout() throws SQLException
-  {
+  public void testLoginTimeout() throws SQLException {
     long connStart = 0, conEnd;
     Properties properties = new Properties();
     properties.put("account", "wrongaccount");
     properties.put("loginTimeout", "20");
     properties.put("user", "fakeuser");
     properties.put("password", "fakepassword");
-    try
-    {
+    try {
       connStart = System.currentTimeMillis();
       DriverManager.getConnection(
           "jdbc:snowflake://wrongaccount.snowflakecomputing.com", properties);
-    }
-    catch (SQLException e)
-    {
-      assertThat("Communication error", e.getErrorCode(),
+    } catch (SQLException e) {
+      assertThat(
+          "Communication error",
+          e.getErrorCode(),
           equalTo(ErrorCode.NETWORK_ERROR.getMessageCode()));
 
       conEnd = System.currentTimeMillis();
-      assertThat("Login time out not taking effective",
-          conEnd - connStart < 60000);
+      assertThat("Login time out not taking effective", conEnd - connStart < 60000);
       return;
     }
     fail();
   }
 
   @Test
-  public void testWrongHostNameTimeout() throws SQLException
-  {
+  public void testWrongHostNameTimeout() throws SQLException {
     long connStart = 0, conEnd;
     Properties properties = new Properties();
     properties.put("account", "testaccount");
     properties.put("loginTimeout", "20");
     properties.put("user", "fakeuser");
     properties.put("password", "fakepassword");
-    try
-    {
+    try {
       connStart = System.currentTimeMillis();
-      DriverManager.getConnection(
-          "jdbc:snowflake://testaccount.wronghostname.com", properties);
-    }
-    catch (SQLException e)
-    {
-      assertThat("Communication error", e.getErrorCode(),
+      DriverManager.getConnection("jdbc:snowflake://testaccount.wronghostname.com", properties);
+    } catch (SQLException e) {
+      assertThat(
+          "Communication error",
+          e.getErrorCode(),
           equalTo(ErrorCode.NETWORK_ERROR.getMessageCode()));
 
       conEnd = System.currentTimeMillis();
-      assertThat("Login time out not taking effective",
-          conEnd - connStart < 60000);
+      assertThat("Login time out not taking effective", conEnd - connStart < 60000);
       return;
     }
     fail();
   }
 
   @Test
-  public void testInvalidDbOrSchemaOrRole() throws SQLException
-  {
+  public void testInvalidDbOrSchemaOrRole() throws SQLException {
     Properties properties = new Properties();
 
     properties.put("db", "invalid_db");
@@ -305,8 +274,7 @@ public class ConnectionIT extends BaseJDBCTest
   }
 
   @Test
-  public void testConnectViaDataSource() throws SQLException
-  {
+  public void testConnectViaDataSource() throws SQLException {
     SnowflakeBasicDataSource ds = new SnowflakeBasicDataSource();
 
     Map<String, String> params = getConnectionParameters();
@@ -324,8 +292,7 @@ public class ConnectionIT extends BaseJDBCTest
     ds.setSsl("on".equals(ssl));
 
     Connection connection = ds.getConnection(user, password);
-    ResultSet resultSet = connection.createStatement()
-        .executeQuery("select 1");
+    ResultSet resultSet = connection.createStatement().executeQuery("select 1");
     resultSet.next();
     assertThat("select 1", resultSet.getInt(1), equalTo(1));
 
@@ -339,8 +306,7 @@ public class ConnectionIT extends BaseJDBCTest
     ds.setAccount(account);
     ds.setPortNumber(Integer.parseInt(port));
     connection = ds.getConnection(params.get("user"), params.get("password"));
-    resultSet = connection.createStatement()
-        .executeQuery("select 1");
+    resultSet = connection.createStatement().executeQuery("select 1");
     resultSet.next();
     assertThat("select 1", resultSet.getInt(1), equalTo(1));
 
@@ -349,8 +315,7 @@ public class ConnectionIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testConnectUsingKeyPair() throws Exception
-  {
+  public void testConnectUsingKeyPair() throws Exception {
     Map<String, String> parameters = getConnectionParameters();
     String testUser = parameters.get("user");
 
@@ -368,8 +333,8 @@ public class ConnectionIT extends BaseJDBCTest
 
     String encodePublicKey = Base64.encodeBase64String(publicKey.getEncoded());
 
-    statement.execute(String.format(
-        "alter user %s set rsa_public_key='%s'", testUser, encodePublicKey));
+    statement.execute(
+        String.format("alter user %s set rsa_public_key='%s'", testUser, encodePublicKey));
 
     connection.close();
 
@@ -391,13 +356,10 @@ public class ConnectionIT extends BaseJDBCTest
     PublicKey publicKey2 = keyPair.getPublic();
     PrivateKey privateKey2 = keyPair.getPrivate();
     properties.put("privateKey", privateKey2);
-    try
-    {
+    try {
       connection = DriverManager.getConnection(uri, properties);
       fail();
-    }
-    catch (SQLException e)
-    {
+    } catch (SQLException e) {
       Assert.assertEquals(200002, e.getErrorCode());
     }
 
@@ -408,8 +370,8 @@ public class ConnectionIT extends BaseJDBCTest
 
     String encodePublicKey2 = Base64.encodeBase64String(publicKey2.getEncoded());
 
-    statement.execute(String.format(
-        "alter user %s set rsa_public_key_2='%s'", testUser, encodePublicKey2));
+    statement.execute(
+        String.format("alter user %s set rsa_public_key_2='%s'", testUser, encodePublicKey2));
     connection.close();
 
     connection = DriverManager.getConnection(uri, properties);
@@ -423,8 +385,7 @@ public class ConnectionIT extends BaseJDBCTest
   }
 
   @Test
-  public void testBadPrivateKey() throws Exception
-  {
+  public void testBadPrivateKey() throws Exception {
     Map<String, String> parameters = getConnectionParameters();
     String testUser = parameters.get("user");
 
@@ -438,35 +399,27 @@ public class ConnectionIT extends BaseJDBCTest
     KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("DSA");
     PrivateKey dsaPrivateKey = keyPairGenerator.generateKeyPair().getPrivate();
 
-    try
-    {
+    try {
       properties.put("privateKey", "bad string");
       DriverManager.getConnection(uri, properties);
       fail();
-    }
-    catch (SQLException e)
-    {
-      assertThat(e.getErrorCode(), is(
-          ErrorCode.INVALID_PARAMETER_TYPE.getMessageCode()));
+    } catch (SQLException e) {
+      assertThat(e.getErrorCode(), is(ErrorCode.INVALID_PARAMETER_TYPE.getMessageCode()));
     }
 
-    try
-    {
+    try {
       properties.put("privateKey", dsaPrivateKey);
       DriverManager.getConnection(uri, properties);
       fail();
-    }
-    catch (SQLException e)
-    {
-      assertThat(e.getErrorCode(), is(
-          ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY.getMessageCode()));
+    } catch (SQLException e) {
+      assertThat(
+          e.getErrorCode(), is(ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY.getMessageCode()));
     }
   }
 
   @Test
   @ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testDifferentKeyLength() throws Exception
-  {
+  public void testDifferentKeyLength() throws Exception {
     Map<String, String> parameters = getConnectionParameters();
     String testUser = parameters.get("user");
 
@@ -475,8 +428,7 @@ public class ConnectionIT extends BaseJDBCTest
     KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
     SecureRandom random = SecureRandom.getInstance("SHA1PRNG", "SUN");
 
-    for (Integer keyLength : testCases)
-    {
+    for (Integer keyLength : testCases) {
       keyPairGenerator.initialize(keyLength, random);
 
       KeyPair keyPair = keyPairGenerator.generateKeyPair();
@@ -489,8 +441,8 @@ public class ConnectionIT extends BaseJDBCTest
 
       String encodePublicKey = Base64.encodeBase64String(publicKey.getEncoded());
 
-      statement.execute(String.format(
-          "alter user %s set rsa_public_key='%s'", testUser, encodePublicKey));
+      statement.execute(
+          String.format("alter user %s set rsa_public_key='%s'", testUser, encodePublicKey));
 
       connection.close();
 
@@ -507,20 +459,17 @@ public class ConnectionIT extends BaseJDBCTest
       properties.put("privateKey", privateKey);
       connection = DriverManager.getConnection(uri, properties);
 
-      connection.createStatement().execute(
-          String.format("alter user %s unset rsa_public_key", testUser));
+      connection
+          .createStatement()
+          .execute(String.format("alter user %s unset rsa_public_key", testUser));
       connection.close();
     }
   }
 
-  /**
-   * Test production connectivity with insecure mode disabled.
-   */
+  /** Test production connectivity with insecure mode disabled. */
   @Test
-  public void testInsecureMode() throws SQLException
-  {
-    String deploymentUrl =
-        "jdbc:snowflake://sfcsupport.snowflakecomputing.com";
+  public void testInsecureMode() throws SQLException {
+    String deploymentUrl = "jdbc:snowflake://sfcsupport.snowflakecomputing.com";
 
     Properties properties = new Properties();
 
@@ -528,43 +477,31 @@ public class ConnectionIT extends BaseJDBCTest
     properties.put("password", "fakepwd");
     properties.put("account", "fakeaccount");
     properties.put("insecureMode", false);
-    try
-    {
+    try {
       DriverManager.getConnection(deploymentUrl, properties);
       fail();
-    }
-    catch (SQLException e)
-    {
-      assertThat(e.getErrorCode(), is(
-          ErrorCode.CONNECTION_ERROR.getMessageCode()));
+    } catch (SQLException e) {
+      assertThat(e.getErrorCode(), is(ErrorCode.CONNECTION_ERROR.getMessageCode()));
     }
 
-    deploymentUrl =
-        "jdbc:snowflake://sfcsupport.snowflakecomputing.com?insecureMode=false";
+    deploymentUrl = "jdbc:snowflake://sfcsupport.snowflakecomputing.com?insecureMode=false";
 
     properties = new Properties();
 
     properties.put("user", "fakesuer");
     properties.put("password", "fakepwd");
     properties.put("account", "fakeaccount");
-    try
-    {
+    try {
       DriverManager.getConnection(deploymentUrl, properties);
       fail();
-    }
-    catch (SQLException e)
-    {
-      assertThat(e.getErrorCode(), is(
-          ErrorCode.CONNECTION_ERROR.getMessageCode()));
+    } catch (SQLException e) {
+      assertThat(e.getErrorCode(), is(ErrorCode.CONNECTION_ERROR.getMessageCode()));
     }
   }
 
-  /**
-   * Verify the passed memory parameters are set in the session
-   */
+  /** Verify the passed memory parameters are set in the session */
   @Test
-  public void testClientMemoryParameters() throws Exception
-  {
+  public void testClientMemoryParameters() throws Exception {
     Properties paramProperties = new Properties();
     paramProperties.put("CLIENT_PREFETCH_THREADS", "6");
     paramProperties.put("CLIENT_RESULT_CHUNK_SIZE", 48);
@@ -572,53 +509,52 @@ public class ConnectionIT extends BaseJDBCTest
     Connection connection = getConnection(paramProperties);
 
     for (Enumeration<String> enums = (Enumeration<String>) paramProperties.propertyNames();
-         enums.hasMoreElements(); )
-    {
+        enums.hasMoreElements(); ) {
       String key = enums.nextElement();
-      ResultSet rs = connection.createStatement().executeQuery(
-          String.format("show parameters like '%s'", key));
+      ResultSet rs =
+          connection
+              .createStatement()
+              .executeQuery(String.format("show parameters like '%s'", key));
       rs.next();
       String value = rs.getString("value");
       assertThat(key, value, equalTo(paramProperties.get(key).toString()));
     }
   }
 
-  /**
-   * Verify the JVM memory parameters are set in the session
-   */
+  /** Verify the JVM memory parameters are set in the session */
   @Test
-  public void testClientMemoryJvmParameteres() throws Exception
-  {
+  public void testClientMemoryJvmParameteres() throws Exception {
     Properties paramProperties = new Properties();
     paramProperties.put("CLIENT_PREFETCH_THREADS", "6");
     paramProperties.put("CLIENT_RESULT_CHUNK_SIZE", 48);
     paramProperties.put("CLIENT_MEMORY_LIMIT", 1000L);
 
     // set JVM parameters
-    System.setProperty("net.snowflake.jdbc.clientPrefetchThreads",
+    System.setProperty(
+        "net.snowflake.jdbc.clientPrefetchThreads",
         paramProperties.get("CLIENT_PREFETCH_THREADS").toString());
-    System.setProperty("net.snowflake.jdbc.clientResultChunkSize",
+    System.setProperty(
+        "net.snowflake.jdbc.clientResultChunkSize",
         paramProperties.get("CLIENT_RESULT_CHUNK_SIZE").toString());
-    System.setProperty("net.snowflake.jdbc.clientMemoryLimit",
+    System.setProperty(
+        "net.snowflake.jdbc.clientMemoryLimit",
         paramProperties.get("CLIENT_MEMORY_LIMIT").toString());
 
-    try
-    {
+    try {
       Connection connection = getConnection();
 
       for (Enumeration<String> enums = (Enumeration<String>) paramProperties.propertyNames();
-           enums.hasMoreElements(); )
-      {
+          enums.hasMoreElements(); ) {
         String key = enums.nextElement();
-        ResultSet rs = connection.createStatement().executeQuery(
-            String.format("show parameters like '%s'", key));
+        ResultSet rs =
+            connection
+                .createStatement()
+                .executeQuery(String.format("show parameters like '%s'", key));
         rs.next();
         String value = rs.getString("value");
         assertThat(key, value, equalTo(paramProperties.get(key).toString()));
       }
-    }
-    finally
-    {
+    } finally {
       System.clearProperty("net.snowflake.jdbc.clientPrefetchThreads");
       System.clearProperty("net.snowflake.jdbc.clientResultChunkSize");
       System.clearProperty("net.snowflake.jdbc.clientMemoryLimit");
@@ -626,46 +562,46 @@ public class ConnectionIT extends BaseJDBCTest
   }
 
   /**
-   * Verify the connection and JVM memory parameters are set in the session.
-   * The connection parameters take precedence over JVM.
+   * Verify the connection and JVM memory parameters are set in the session. The connection
+   * parameters take precedence over JVM.
    */
   @Test
-  public void testClientMixedMemoryJvmParameteres() throws Exception
-  {
+  public void testClientMixedMemoryJvmParameteres() throws Exception {
     Properties paramProperties = new Properties();
     paramProperties.put("CLIENT_PREFETCH_THREADS", "6");
     paramProperties.put("CLIENT_RESULT_CHUNK_SIZE", 48);
     paramProperties.put("CLIENT_MEMORY_LIMIT", 1000L);
 
     // set JVM parameters
-    System.setProperty("net.snowflake.jdbc.clientPrefetchThreads",
+    System.setProperty(
+        "net.snowflake.jdbc.clientPrefetchThreads",
         paramProperties.get("CLIENT_PREFETCH_THREADS").toString());
-    System.setProperty("net.snowflake.jdbc.clientResultChunkSize",
+    System.setProperty(
+        "net.snowflake.jdbc.clientResultChunkSize",
         paramProperties.get("CLIENT_RESULT_CHUNK_SIZE").toString());
-    System.setProperty("net.snowflake.jdbc.clientMemoryLimit",
+    System.setProperty(
+        "net.snowflake.jdbc.clientMemoryLimit",
         paramProperties.get("CLIENT_MEMORY_LIMIT").toString());
 
     paramProperties.put("CLIENT_PREFETCH_THREADS", "8");
     paramProperties.put("CLIENT_RESULT_CHUNK_SIZE", 64);
     paramProperties.put("CLIENT_MEMORY_LIMIT", 2000L);
 
-    try
-    {
+    try {
       Connection connection = getConnection(paramProperties);
 
       for (Enumeration<String> enums = (Enumeration<String>) paramProperties.propertyNames();
-           enums.hasMoreElements(); )
-      {
+          enums.hasMoreElements(); ) {
         String key = enums.nextElement();
-        ResultSet rs = connection.createStatement().executeQuery(
-            String.format("show parameters like '%s'", key));
+        ResultSet rs =
+            connection
+                .createStatement()
+                .executeQuery(String.format("show parameters like '%s'", key));
         rs.next();
         String value = rs.getString("value");
         assertThat(key, value, equalTo(paramProperties.get(key).toString()));
       }
-    }
-    finally
-    {
+    } finally {
       System.clearProperty("net.snowflake.jdbc.clientPrefetchThreads");
       System.clearProperty("net.snowflake.jdbc.clientResultChunkSize");
       System.clearProperty("net.snowflake.jdbc.clientMemoryLimit");

--- a/src/test/java/net/snowflake/client/jdbc/PutUnescapeBackslashIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PutUnescapeBackslashIT.java
@@ -3,42 +3,35 @@
  */
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.AbstractDriverIT;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
-import java.io.File;
-import java.io.Writer;
 import java.io.BufferedWriter;
-import java.io.OutputStreamWriter;
+import java.io.File;
 import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import net.snowflake.client.AbstractDriverIT;
 import org.apache.commons.io.FileUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.*;
-
-
-public class PutUnescapeBackslashIT extends AbstractDriverIT
-{
+public class PutUnescapeBackslashIT extends AbstractDriverIT {
   @BeforeClass
-  public static void setUpClass() throws Exception
-  {
-  }
+  public static void setUpClass() throws Exception {}
 
   /**
-   * Test PUT command for a file name including backslashes. The file name
-   * should be unescaped to match the name. SNOW-25974
+   * Test PUT command for a file name including backslashes. The file name should be unescaped to
+   * match the name. SNOW-25974
    */
   @Test
-  public void testPutFileUnescapeBackslashes() throws Exception
-  {
+  public void testPutFileUnescapeBackslashes() throws Exception {
     String remoteSubDir = "testPut";
     String testDataFileName = "testdata.txt";
 
@@ -47,57 +40,47 @@ public class PutUnescapeBackslashIT extends AbstractDriverIT
     ResultSet resultSet = null;
     Writer writer = null;
     Path topDataDir = null;
-    try
-    {
+    try {
       topDataDir = Files.createTempDirectory("testPutFileUnescapeBackslashes");
       topDataDir.toFile().deleteOnExit();
 
       // create sub directory where the name includes spaces and
       // backslashes
-      Path subDir = Files.createDirectories(
-          Paths.get(topDataDir.toString(), "test dir\\\\3"));
+      Path subDir = Files.createDirectories(Paths.get(topDataDir.toString(), "test dir\\\\3"));
 
       // create a test data
       File dataFile = new File(subDir.toFile(), testDataFileName);
-      writer = new BufferedWriter(new OutputStreamWriter(
-          new FileOutputStream(
-              dataFile.getCanonicalPath()),
-          "UTF-8"));
+      writer =
+          new BufferedWriter(
+              new OutputStreamWriter(new FileOutputStream(dataFile.getCanonicalPath()), "UTF-8"));
       writer.write("1,test1");
       writer.close();
 
       // run PUT command
       connection = getConnection();
       statement = connection.createStatement();
-      String sql = String.format(
-          "PUT 'file://%s' @~/%s/",
-          dataFile.getCanonicalPath(),
-          remoteSubDir);
+      String sql =
+          String.format("PUT 'file://%s' @~/%s/", dataFile.getCanonicalPath(), remoteSubDir);
 
       // Escape backslaches. This must be done by the application.
       sql = sql.replaceAll("\\\\", "\\\\\\\\");
       statement.execute(sql);
 
-      resultSet = connection.createStatement().executeQuery(
-          String.format("LS @~/%s/", remoteSubDir));
-      while (resultSet.next())
-      {
-        assertThat("File name doesn't match",
+      resultSet =
+          connection.createStatement().executeQuery(String.format("LS @~/%s/", remoteSubDir));
+      while (resultSet.next()) {
+        assertThat(
+            "File name doesn't match",
             resultSet.getString(1),
-            startsWith(String.format("%s/%s",
-                remoteSubDir, testDataFileName)));
+            startsWith(String.format("%s/%s", remoteSubDir, testDataFileName)));
       }
 
-    } finally
-    {
-      if (connection != null)
-      {
-        connection.createStatement().execute(
-            String.format("RM @~/%s", remoteSubDir));
+    } finally {
+      if (connection != null) {
+        connection.createStatement().execute(String.format("RM @~/%s", remoteSubDir));
       }
       closeSQLObjects(resultSet, statement, connection);
-      if (writer != null)
-      {
+      if (writer != null) {
         writer.close();
       }
       FileUtils.deleteDirectory(topDataDir.toFile());

--- a/src/test/java/net/snowflake/client/jdbc/RestRequestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestIT.java
@@ -1,5 +1,10 @@
 package net.snowflake.client.jdbc;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -9,44 +14,29 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
-
-public class RestRequestIT
-{
-  private CloseableHttpResponse retryResponse()
-  {
+public class RestRequestIT {
+  private CloseableHttpResponse retryResponse() {
     StatusLine retryStatusLine = mock(StatusLine.class);
-    when(retryStatusLine.getStatusCode())
-        .thenReturn(503);
+    when(retryStatusLine.getStatusCode()).thenReturn(503);
 
     CloseableHttpResponse retryResponse = mock(CloseableHttpResponse.class);
-    when(retryResponse.getStatusLine())
-        .thenReturn(retryStatusLine);
+    when(retryResponse.getStatusLine()).thenReturn(retryStatusLine);
 
     return retryResponse;
   }
 
-  private CloseableHttpResponse successResponse()
-  {
+  private CloseableHttpResponse successResponse() {
     StatusLine successStatusLine = mock(StatusLine.class);
-    when(successStatusLine.getStatusCode())
-        .thenReturn(200);
+    when(successStatusLine.getStatusCode()).thenReturn(200);
 
     CloseableHttpResponse successResponse = mock(CloseableHttpResponse.class);
-    when(successResponse.getStatusLine())
-        .thenReturn(successStatusLine);
+    when(successResponse.getStatusLine()).thenReturn(successStatusLine);
 
     return successResponse;
   }
 
-  private void execute(CloseableHttpClient client, String uri,
-                       boolean includeRetryParameters)
-      throws IOException, SnowflakeSQLException
-  {
+  private void execute(CloseableHttpClient client, String uri, boolean includeRetryParameters)
+      throws IOException, SnowflakeSQLException {
     RestRequest.execute(
         client,
         new HttpGet(uri),
@@ -59,83 +49,67 @@ public class RestRequestIT
   }
 
   @Test
-  public void testRetryParamsInRequest() throws IOException, SnowflakeSQLException
-  {
+  public void testRetryParamsInRequest() throws IOException, SnowflakeSQLException {
     CloseableHttpClient client = mock(CloseableHttpClient.class);
     when(client.execute(any(HttpUriRequest.class)))
-        .thenAnswer(new Answer<CloseableHttpResponse>()
-        {
-          int callCount = 0;
+        .thenAnswer(
+            new Answer<CloseableHttpResponse>() {
+              int callCount = 0;
 
-          @Override
-          public CloseableHttpResponse answer(InvocationOnMock invocation)
-              throws Throwable
-          {
-            HttpUriRequest arg = (HttpUriRequest) invocation.getArguments()[0];
-            String params = arg.getURI().getQuery();
+              @Override
+              public CloseableHttpResponse answer(InvocationOnMock invocation) throws Throwable {
+                HttpUriRequest arg = (HttpUriRequest) invocation.getArguments()[0];
+                String params = arg.getURI().getQuery();
 
-            if (callCount == 0)
-            {
-              assertFalse(params.contains("retryCount="));
-              assertFalse(params.contains("clientStartTime="));
-              assertTrue(params.contains("request_guid="));
-            }
-            else
-            {
-              assertTrue(params.contains("retryCount=" + callCount));
-              assertTrue(params.contains("clientStartTime="));
-              assertTrue(params.contains("request_guid="));
-            }
+                if (callCount == 0) {
+                  assertFalse(params.contains("retryCount="));
+                  assertFalse(params.contains("clientStartTime="));
+                  assertTrue(params.contains("request_guid="));
+                } else {
+                  assertTrue(params.contains("retryCount=" + callCount));
+                  assertTrue(params.contains("clientStartTime="));
+                  assertTrue(params.contains("request_guid="));
+                }
 
-            callCount += 1;
-            if (callCount >= 3)
-            {
-              return successResponse();
-            }
-            else
-            {
-              return retryResponse();
-            }
-          }
-        });
+                callCount += 1;
+                if (callCount >= 3) {
+                  return successResponse();
+                } else {
+                  return retryResponse();
+                }
+              }
+            });
 
-   execute(client, "fakeurl.com/?requestId=abcd-1234", true);
+    execute(client, "fakeurl.com/?requestId=abcd-1234", true);
   }
 
   @Test
-  public void testRetryNoParamsInRequest() throws IOException, SnowflakeSQLException
-  {
+  public void testRetryNoParamsInRequest() throws IOException, SnowflakeSQLException {
     CloseableHttpClient client = mock(CloseableHttpClient.class);
     when(client.execute(any(HttpUriRequest.class)))
-        .thenAnswer(new Answer<CloseableHttpResponse>()
-        {
-          int callCount = 0;
+        .thenAnswer(
+            new Answer<CloseableHttpResponse>() {
+              int callCount = 0;
 
-          @Override
-          public CloseableHttpResponse answer(InvocationOnMock invocation)
-              throws Throwable
-          {
-            HttpUriRequest arg = (HttpUriRequest) invocation.getArguments()[0];
-            String params = arg.getURI().getQuery();
+              @Override
+              public CloseableHttpResponse answer(InvocationOnMock invocation) throws Throwable {
+                HttpUriRequest arg = (HttpUriRequest) invocation.getArguments()[0];
+                String params = arg.getURI().getQuery();
 
-            if (callCount > 0)
-            {
-              assertTrue(params.contains("retryCount=" + callCount));
-            }
-            assertFalse(params.contains("clientStartTime="));
-            assertTrue(params.contains("request_guid="));
+                if (callCount > 0) {
+                  assertTrue(params.contains("retryCount=" + callCount));
+                }
+                assertFalse(params.contains("clientStartTime="));
+                assertTrue(params.contains("request_guid="));
 
-            callCount += 1;
-            if (callCount >= 3)
-            {
-              return successResponse();
-            }
-            else
-            {
-              return retryResponse();
-            }
-          }
-        });
+                callCount += 1;
+                if (callCount >= 3) {
+                  return successResponse();
+                } else {
+                  return retryResponse();
+                }
+              }
+            });
 
     execute(client, "fakeurl.com/?requestId=abcd-1234", false);
   }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeBasicDataSourceTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeBasicDataSourceTest.java
@@ -3,23 +3,17 @@
  */
 package net.snowflake.client.jdbc;
 
-import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.sql.SQLException;
+import org.junit.Test;
 
-/**
- * Data source unit test
- */
-public class SnowflakeBasicDataSourceTest
-{
-  /**
-   * snow-37186
-   */
+/** Data source unit test */
+public class SnowflakeBasicDataSourceTest {
+  /** snow-37186 */
   @Test
-  public void testSetLoginTimeout() throws SQLException
-  {
+  public void testSetLoginTimeout() throws SQLException {
     SnowflakeBasicDataSource ds = new SnowflakeBasicDataSource();
 
     ds.setLoginTimeout(10);

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeConnectionV1Test.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeConnectionV1Test.java
@@ -1,20 +1,16 @@
 package net.snowflake.client.jdbc;
 
-import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
 import java.util.Properties;
+import org.junit.Test;
 
-/**
- * Created by hyu on 2/2/18.
- */
-public class SnowflakeConnectionV1Test
-{
+/** Created by hyu on 2/2/18. */
+public class SnowflakeConnectionV1Test {
   @Test
-  public void testMergeProperties()
-  {
+  public void testMergeProperties() {
     // testcase 1
     String url = "jdbc:snowflake://testaccount.localhost:8080";
     Properties prop = new Properties();
@@ -24,9 +20,9 @@ public class SnowflakeConnectionV1Test
     Map<String, Object> result = SnowflakeConnectionV1.mergeProperties(url, prop);
 
     assertThat(result.size(), is(3));
-    assertThat((String)result.get("ACCOUNT"), is("s3testaccount"));
-    assertThat((String)result.get("USER"), is("snowman"));
-    assertThat((String)result.get("SERVERURL"), is("https://testaccount.localhost:8080"));
+    assertThat((String) result.get("ACCOUNT"), is("s3testaccount"));
+    assertThat((String) result.get("USER"), is("snowman"));
+    assertThat((String) result.get("SERVERURL"), is("https://testaccount.localhost:8080"));
 
     // testcase 2
     url = "jdbc:snowflake://testaccount.localhost:8080/?";
@@ -37,9 +33,9 @@ public class SnowflakeConnectionV1Test
     result = SnowflakeConnectionV1.mergeProperties(url, prop);
 
     assertThat(result.size(), is(3));
-    assertThat((String)result.get("ACCOUNT"), is("s3testaccount"));
-    assertThat((String)result.get("USER"), is("snowman"));
-    assertThat((String)result.get("SERVERURL"), is("https://testaccount.localhost:8080/"));
+    assertThat((String) result.get("ACCOUNT"), is("s3testaccount"));
+    assertThat((String) result.get("USER"), is("snowman"));
+    assertThat((String) result.get("SERVERURL"), is("https://testaccount.localhost:8080/"));
 
     // testcase 3
     url = "jdbc:snowflake://testaccount.localhost:8080/?aaaa";
@@ -50,9 +46,9 @@ public class SnowflakeConnectionV1Test
     result = SnowflakeConnectionV1.mergeProperties(url, prop);
 
     assertThat(result.size(), is(3));
-    assertThat((String)result.get("ACCOUNT"), is("s3testaccount"));
-    assertThat((String)result.get("USER"), is("snowman"));
-    assertThat((String)result.get("SERVERURL"), is("https://testaccount.localhost:8080/"));
+    assertThat((String) result.get("ACCOUNT"), is("s3testaccount"));
+    assertThat((String) result.get("USER"), is("snowman"));
+    assertThat((String) result.get("SERVERURL"), is("https://testaccount.localhost:8080/"));
 
     // testcase 4
     url = "jdbc:snowflake://testaccount.localhost:8080/?prop1=value1";
@@ -63,10 +59,10 @@ public class SnowflakeConnectionV1Test
     result = SnowflakeConnectionV1.mergeProperties(url, prop);
 
     assertThat(result.size(), is(4));
-    assertThat((String)result.get("ACCOUNT"), is("s3testaccount"));
-    assertThat((String)result.get("USER"), is("snowman"));
-    assertThat((String)result.get("SERVERURL"), is("https://testaccount.localhost:8080/"));
-    assertThat((String)result.get("PROP1"), is("value1"));
+    assertThat((String) result.get("ACCOUNT"), is("s3testaccount"));
+    assertThat((String) result.get("USER"), is("snowman"));
+    assertThat((String) result.get("SERVERURL"), is("https://testaccount.localhost:8080/"));
+    assertThat((String) result.get("PROP1"), is("value1"));
 
     // testcase 5
     url = "jdbc:snowflake://testaccount.localhost:8080/?prop1=value1&ssl=off";
@@ -77,10 +73,10 @@ public class SnowflakeConnectionV1Test
     result = SnowflakeConnectionV1.mergeProperties(url, prop);
 
     assertThat(result.size(), is(4));
-    assertThat((String)result.get("ACCOUNT"), is("s3testaccount"));
-    assertThat((String)result.get("USER"), is("snowman"));
-    assertThat((String)result.get("SERVERURL"), is("http://testaccount.localhost:8080/"));
-    assertThat((String)result.get("PROP1"), is("value1"));
+    assertThat((String) result.get("ACCOUNT"), is("s3testaccount"));
+    assertThat((String) result.get("USER"), is("snowman"));
+    assertThat((String) result.get("SERVERURL"), is("http://testaccount.localhost:8080/"));
+    assertThat((String) result.get("PROP1"), is("value1"));
 
     // testcase 6
     url = "jdbc:snowflake://testaccount.localhost:8080/?prop1=value1";
@@ -92,10 +88,10 @@ public class SnowflakeConnectionV1Test
     result = SnowflakeConnectionV1.mergeProperties(url, prop);
 
     assertThat(result.size(), is(4));
-    assertThat((String)result.get("ACCOUNT"), is("s3testaccount"));
-    assertThat((String)result.get("USER"), is("snowman"));
-    assertThat((String)result.get("SERVERURL"), is("http://testaccount.localhost:8080/"));
-    assertThat((String)result.get("PROP1"), is("value1"));
+    assertThat((String) result.get("ACCOUNT"), is("s3testaccount"));
+    assertThat((String) result.get("USER"), is("snowman"));
+    assertThat((String) result.get("SERVERURL"), is("http://testaccount.localhost:8080/"));
+    assertThat((String) result.get("PROP1"), is("value1"));
 
     // testcase 7
     url = "jdbc:snowflake://testaccount.localhost:8080/?prop1=value1";
@@ -107,9 +103,9 @@ public class SnowflakeConnectionV1Test
     result = SnowflakeConnectionV1.mergeProperties(url, prop);
 
     assertThat(result.size(), is(4));
-    assertThat((String)result.get("ACCOUNT"), is("testaccount"));
-    assertThat((String)result.get("USER"), is("snowman"));
-    assertThat((String)result.get("SERVERURL"), is("http://testaccount.localhost:8080/"));
-    assertThat((String)result.get("PROP1"), is("value2"));
+    assertThat((String) result.get("ACCOUNT"), is("testaccount"));
+    assertThat((String) result.get("USER"), is("snowman"));
+    assertThat((String) result.get("SERVERURL"), is("http://testaccount.localhost:8080/"));
+    assertThat((String) result.get("PROP1"), is("value2"));
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
@@ -3,18 +3,14 @@
  */
 package net.snowflake.client.jdbc;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertTrue;
 
-/**
- * Driver unit test
- */
-public class SnowflakeDriverTest
-{
+import org.junit.Test;
+
+/** Driver unit test */
+public class SnowflakeDriverTest {
   @Test
-  public void testAcceptUrls() throws Exception
-  {
+  public void testAcceptUrls() throws Exception {
     SnowflakeDriver snowflakeDriver = SnowflakeDriver.INSTANCE;
 
     // positive tests

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeFileUploaderTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeFileUploaderTest.java
@@ -3,34 +3,19 @@
  */
 package net.snowflake.client.jdbc;
 
-import java.sql.Timestamp;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Set;
-import java.util.TimeZone;
+import static org.junit.Assert.*;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.junit.Assert.*;
-
-/**
- * @author jhuang
- */
-public class SnowflakeFileUploaderTest
-{
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+/** @author jhuang */
+public class SnowflakeFileUploaderTest {
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   @Test
-  public void testProcessFileNames() throws Exception
-  {
+  public void testProcessFileNames() throws Exception {
     folder.newFile("TestFileA");
     folder.newFile("TestFileB");
 
@@ -38,12 +23,9 @@ public class SnowflakeFileUploaderTest
     System.setProperty("user.dir", folderName);
     System.setProperty("user.home", folderName);
 
-    String[] locations =
-        {
-            folderName + "/Tes*Fil*A",
-            folderName + "/TestFil?B",
-            "~/TestFileC", "TestFileD"
-        };
+    String[] locations = {
+      folderName + "/Tes*Fil*A", folderName + "/TestFil?B", "~/TestFileC", "TestFileD"
+    };
 
     Set<String> files = SnowflakeFileTransferAgent.expandFileNames(locations);
 

--- a/src/test/java/net/snowflake/client/jdbc/StatementIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/StatementIT.java
@@ -3,14 +3,14 @@
  */
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.AbstractDriverIT;
-import net.snowflake.client.ConditionalIgnoreRule;
-import net.snowflake.client.RunningOnTravisCI;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.jdbc.telemetry.Telemetry;
-import net.snowflake.common.core.SqlState;
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URL;
@@ -20,39 +20,31 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
+import net.snowflake.client.AbstractDriverIT;
+import net.snowflake.client.ConditionalIgnoreRule;
+import net.snowflake.client.RunningOnTravisCI;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.jdbc.telemetry.Telemetry;
+import net.snowflake.common.core.SqlState;
+import org.junit.Ignore;
+import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-/**
- * Statement integration tests
- */
-public class StatementIT extends BaseJDBCTest
-{
-  public void enableMultiStmt(Connection connection) throws SQLException
-  {
+/** Statement integration tests */
+public class StatementIT extends BaseJDBCTest {
+  public void enableMultiStmt(Connection connection) throws SQLException {
     Statement statement = connection.createStatement();
     statement.execute("alter session set ENABLE_MULTISTATEMENT=true");
     statement.close();
   }
 
   @Test
-  public void testFetchDirection() throws SQLException
-  {
+  public void testFetchDirection() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     assertEquals(ResultSet.FETCH_FORWARD, statement.getFetchDirection());
-    try
-    {
+    try {
       statement.setFetchDirection(ResultSet.FETCH_REVERSE);
-    } catch (SQLFeatureNotSupportedException e)
-    {
+    } catch (SQLFeatureNotSupportedException e) {
       assertTrue(true);
     }
     statement.close();
@@ -61,8 +53,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Ignore("Not working for setFetchSize")
   @Test
-  public void testFetchSize() throws SQLException
-  {
+  public void testFetchSize() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     assertEquals(50, statement.getFetchSize());
@@ -75,8 +66,7 @@ public class StatementIT extends BaseJDBCTest
   }
 
   @Test
-  public void testMaxRows() throws SQLException
-  {
+  public void testMaxRows() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     String sqlSelect = "select seq4() from table(generator(rowcount=>3))";
@@ -103,18 +93,15 @@ public class StatementIT extends BaseJDBCTest
   }
 
   @Test
-  public void testQueryTimeOut() throws SQLException
-  {
+  public void testQueryTimeOut() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     assertEquals(0, statement.getQueryTimeout());
     statement.setQueryTimeout(5);
     assertEquals(5, statement.getQueryTimeout());
-    try
-    {
+    try {
       statement.executeQuery("select count(*) from table(generator(timeLimit => 100))");
-    } catch (SQLException e)
-    {
+    } catch (SQLException e) {
       assertTrue(true);
       assertEquals(SqlState.QUERY_CANCELED, e.getSQLState());
       assertEquals("SQL execution canceled", e.getMessage());
@@ -124,8 +111,7 @@ public class StatementIT extends BaseJDBCTest
   }
 
   @Test
-  public void testStatementClose() throws SQLException
-  {
+  public void testStatementClose() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     assertEquals(connection, statement.getConnection());
@@ -137,8 +123,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testExecuteSelect() throws SQLException
-  {
+  public void testExecuteSelect() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     statement.execute("alter session set JDBC_EXECUTE_RETURN_COUNT_FOR_DML = true");
@@ -160,8 +145,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testExecuteCreateAndDrop() throws SQLException
-  {
+  public void testExecuteCreateAndDrop() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     statement.execute("alter session set JDBC_EXECUTE_RETURN_COUNT_FOR_DML = true");
@@ -171,7 +155,8 @@ public class StatementIT extends BaseJDBCTest
     assertEquals(0, statement.getUpdateCount());
     assertNull(statement.getResultSet());
 
-    int updateCount = statement.executeUpdate("create or replace table test_create_2(colA integer)");
+    int updateCount =
+        statement.executeUpdate("create or replace table test_create_2(colA integer)");
     assertEquals(0, updateCount);
 
     success = statement.execute("drop table if exists TEST_CREATE");
@@ -189,8 +174,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testExecuteInsert() throws SQLException
-  {
+  public void testExecuteInsert() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     statement.execute("alter session set JDBC_EXECUTE_RETURN_COUNT_FOR_DML = true");
@@ -221,14 +205,13 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testExecuteUpdateAndDelete() throws SQLException
-  {
+  public void testExecuteUpdateAndDelete() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     statement.execute("alter session set JDBC_EXECUTE_RETURN_COUNT_FOR_DML = true");
 
-    statement.execute("create or replace table test_update(cola number, colb string) " +
-        "as select 1, 'str1'");
+    statement.execute(
+        "create or replace table test_update(cola number, colb string) " + "as select 1, 'str1'");
 
     statement.execute("insert into test_update values(2, 'str2')");
 
@@ -257,12 +240,12 @@ public class StatementIT extends BaseJDBCTest
   }
 
   @Test
-  public void testExecuteMerge() throws SQLException
-  {
+  public void testExecuteMerge() throws SQLException {
     Connection connection = getConnection();
-    String mergeSQL = "merge into target using source on target.id = source.id "
-        + "when matched and source.sb =22 then update set ta = 'newStr' "
-        + "when not matched then insert (ta, tb) values (source.sa, source.sb)";
+    String mergeSQL =
+        "merge into target using source on target.id = source.id "
+            + "when matched and source.sb =22 then update set ta = 'newStr' "
+            + "when not matched then insert (ta, tb) values (source.sa, source.sb)";
     Statement statement = connection.createStatement();
     statement.execute("create or replace table target(id integer, ta string, tb integer)");
     statement.execute("create or replace table source(id integer, sa string, sb integer)");
@@ -284,14 +267,14 @@ public class StatementIT extends BaseJDBCTest
   }
 
   @Test
-  public void testExecuteMultiInsert() throws SQLException
-  {
+  public void testExecuteMultiInsert() throws SQLException {
     Connection connection = getConnection();
-    String multiInsertionSQL = " insert all "
-        + "into foo "
-        + "into foo1 "
-        + "into bar (b1, b2, b3) values (s3, s2, s1) "
-        + "select s1, s2, s3 from source";
+    String multiInsertionSQL =
+        " insert all "
+            + "into foo "
+            + "into foo1 "
+            + "into bar (b1, b2, b3) values (s3, s2, s1) "
+            + "select s1, s2, s3 from source";
 
     Statement statement = connection.createStatement();
     statement.execute("create or replace table foo (f1 integer, f2 integer, f3 integer)");
@@ -315,8 +298,7 @@ public class StatementIT extends BaseJDBCTest
   }
 
   @Test
-  public void testCopyAndUpload() throws Exception
-  {
+  public void testCopyAndUpload() throws Exception {
     URL resource = StatementIT.class.getResource("test_copy.csv");
 
     Connection connection = getConnection();
@@ -325,13 +307,11 @@ public class StatementIT extends BaseJDBCTest
     statement.execute("create or replace table test_copy(c1 number, c2 number, c3 string)");
 
     // put files
-    boolean status =
-        statement.execute("PUT file://" + resource.getFile() + " @%test_copy");
+    boolean status = statement.execute("PUT file://" + resource.getFile() + " @%test_copy");
 
     assertTrue("put command fails", status);
 
-    int numRows =
-        statement.executeUpdate("copy into test_copy");
+    int numRows = statement.executeUpdate("copy into test_copy");
     assertEquals(2, numRows);
 
     statement.execute("drop table if exists test_copy");
@@ -341,8 +321,7 @@ public class StatementIT extends BaseJDBCTest
   }
 
   @Test
-  public void testExecuteBatch() throws SQLException
-  {
+  public void testExecuteBatch() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
 
@@ -350,8 +329,9 @@ public class StatementIT extends BaseJDBCTest
     // mixed of ddl/dml in batch
     statement.addBatch("create or replace table test_batch(a string, b integer)");
     statement.addBatch("insert into test_batch values('str1', 1), ('str2', 2)");
-    statement.addBatch("update test_batch set test_batch.b = src.b + 5 from " +
-        "(select 'str1' as a, 2 as b) src where test_batch.a = src.a");
+    statement.addBatch(
+        "update test_batch set test_batch.b = src.b + 5 from "
+            + "(select 'str1' as a, 2 as b) src where test_batch.a = src.a");
 
     int updateCounts[] = statement.executeBatch();
     connection.commit();
@@ -371,8 +351,7 @@ public class StatementIT extends BaseJDBCTest
 
     // one of the batch is query instead of ddl/dml
     // it should continuing processing
-    try
-    {
+    try {
       statement.addBatch("insert into test_batch values('str3', 3)");
       statement.addBatch("select * from test_batch");
       statement.addBatch("insert into test_batch values('str4', 4)");
@@ -380,12 +359,11 @@ public class StatementIT extends BaseJDBCTest
       statement.executeBatch();
 
       fail();
-    } catch (BatchUpdateException e)
-    {
+    } catch (BatchUpdateException e) {
       updateCounts = e.getUpdateCounts();
-      assertThat(e.getErrorCode(), is(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API
-              .getMessageCode()));
+      assertThat(
+          e.getErrorCode(),
+          is(ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API.getMessageCode()));
       assertThat(updateCounts[0], is(1));
       assertThat(updateCounts[1], is(Statement.EXECUTE_FAILED));
       assertThat(updateCounts[0], is(1));
@@ -408,43 +386,38 @@ public class StatementIT extends BaseJDBCTest
    */
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testExecuteUpdateZeroCount() throws SQLException
-  {
+  public void testExecuteUpdateZeroCount() throws SQLException {
     Connection connection = getConnection();
 
     String testCommands[] = {
-        "use role accountadmin",
-        "use database testdb",
-        "use schema testschema",
-        "create or replace table testExecuteUpdate(cola number)",
-        "comment on table testExecuteUpdate is 'comments'",
-        "alter table testExecuteUpdate rename column cola to colb",
-        "create or replace role testRole",
-        "create or replace user testuser",
-        "grant SELECT on table testExecuteUpdate to role testrole",
-        "grant role testrole to user testuser",
-        "revoke SELECT on table testExecuteUpdate from role testrole",
-        "revoke role testrole from user testuser",
-        "truncate table testExecuteUpdate",
-        "alter session set autocommit=false",
-        "alter session unset autocommit",
-        "drop table if exists testExecuteUpdate",
-        "set v1 = 10",
-        "unset v1",
-        "undrop table testExecuteUpdate"
+      "use role accountadmin",
+      "use database testdb",
+      "use schema testschema",
+      "create or replace table testExecuteUpdate(cola number)",
+      "comment on table testExecuteUpdate is 'comments'",
+      "alter table testExecuteUpdate rename column cola to colb",
+      "create or replace role testRole",
+      "create or replace user testuser",
+      "grant SELECT on table testExecuteUpdate to role testrole",
+      "grant role testrole to user testuser",
+      "revoke SELECT on table testExecuteUpdate from role testrole",
+      "revoke role testrole from user testuser",
+      "truncate table testExecuteUpdate",
+      "alter session set autocommit=false",
+      "alter session unset autocommit",
+      "drop table if exists testExecuteUpdate",
+      "set v1 = 10",
+      "unset v1",
+      "undrop table testExecuteUpdate"
     };
-    try
-    {
-      for (String testCommand : testCommands)
-      {
+    try {
+      for (String testCommand : testCommands) {
         Statement statement = connection.createStatement();
         int updateCount = statement.executeUpdate(testCommand);
         assertThat(updateCount, is(0));
         statement.close();
       }
-    }
-    finally
-    {
+    } finally {
       Statement statement = connection.createStatement();
       statement.execute("use role accountadmin");
       statement.execute("drop table if exists testExecuteUpdate");
@@ -455,41 +428,37 @@ public class StatementIT extends BaseJDBCTest
   }
 
   @Test
-  public void testExecuteUpdateFail() throws SQLException, IOException
-  {
+  public void testExecuteUpdateFail() throws SQLException, IOException {
     Connection connection = getConnection();
 
     String testCommands[] = {
-        "put file:///tmp/testfile @~",
-        "list @~",
-        "ls @~",
-        "get @~/testfile file:///tmp",
-        "remove @~/testfile",
-        "rm @~/testfile",
-        "select 1",
-        "show databases",
-        "desc database " + AbstractDriverIT.getConnectionParameters().get("database")
+      "put file:///tmp/testfile @~",
+      "list @~",
+      "ls @~",
+      "get @~/testfile file:///tmp",
+      "remove @~/testfile",
+      "rm @~/testfile",
+      "select 1",
+      "show databases",
+      "desc database " + AbstractDriverIT.getConnectionParameters().get("database")
     };
 
-    for (String testCommand : testCommands)
-    {
-      try
-      {
+    for (String testCommand : testCommands) {
+      try {
         Statement statement = connection.createStatement();
         statement.executeUpdate(testCommand);
         fail("TestCommand: " + testCommand + " is expected to be failed to execute");
-      } catch (SQLException e)
-      {
-        assertThat(e.getErrorCode(), is(ErrorCode.
-            UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API.getMessageCode()));
+      } catch (SQLException e) {
+        assertThat(
+            e.getErrorCode(),
+            is(ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API.getMessageCode()));
       }
     }
     connection.close();
   }
 
   @Test
-  public void testTelemetryBatch() throws SQLException
-  {
+  public void testTelemetryBatch() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
 
@@ -505,7 +474,8 @@ public class StatementIT extends BaseJDBCTest
     assertEquals(3, getSizeOfResultSet(rs));
     rs.close();
 
-    Telemetry telemetryClient = ((SnowflakeStatementV1) statement).connection.getSfSession().getTelemetryClient();
+    Telemetry telemetryClient =
+        ((SnowflakeStatementV1) statement).connection.getSfSession().getTelemetryClient();
     assertTrue(telemetryClient.bufferSize() > 0); // there should be logs ready to be sent
 
     statement.close();
@@ -517,19 +487,19 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtTransaction() throws SQLException
-  {
+  public void testMultiStmtTransaction() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
 
-    statement.execute("create or replace table test_multi_txn(c1 number, c2 string)" +
-        " as select 10, 'z'");
+    statement.execute(
+        "create or replace table test_multi_txn(c1 number, c2 string)" + " as select 10, 'z'");
 
-    String multiStmtQuery = "begin;\n" +
-        "delete from test_multi_txn;\n" +
-        "insert into test_multi_txn values (1, 'a'), (2, 'b');\n" +
-        "commit";
+    String multiStmtQuery =
+        "begin;\n"
+            + "delete from test_multi_txn;\n"
+            + "insert into test_multi_txn values (1, 'a'), (2, 'b');\n"
+            + "commit";
 
     boolean hasResultSet = statement.execute(multiStmtQuery);
     // first statement
@@ -563,19 +533,19 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtTransactionRollback() throws SQLException
-  {
+  public void testMultiStmtTransactionRollback() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
 
-    statement.execute("create or replace table test_multi_txn_rb(c1 number, c2 string)" +
-        " as select 10, 'z'");
+    statement.execute(
+        "create or replace table test_multi_txn_rb(c1 number, c2 string)" + " as select 10, 'z'");
 
-    String multiStmtQuery = "begin;\n" +
-        "delete from test_multi_txn_rb;\n" +
-        "rollback;\n" +
-        "select count(*) from test_multi_txn_rb";
+    String multiStmtQuery =
+        "begin;\n"
+            + "delete from test_multi_txn_rb;\n"
+            + "rollback;\n"
+            + "select count(*) from test_multi_txn_rb";
 
     boolean hasResultSet = statement.execute(multiStmtQuery);
     // first statement
@@ -611,14 +581,14 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtExecute() throws SQLException
-  {
+  public void testMultiStmtExecute() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
-    String multiStmtQuery = "create or replace temporary table test_multi (cola int);\n" +
-        "insert into test_multi VALUES (1), (2);\n" +
-        "select cola from test_multi order by cola asc";
+    String multiStmtQuery =
+        "create or replace temporary table test_multi (cola int);\n"
+            + "insert into test_multi VALUES (1), (2);\n"
+            + "select cola from test_multi order by cola asc";
 
     boolean hasResultSet = statement.execute(multiStmtQuery);
     // first statement
@@ -650,14 +620,14 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtExecuteUpdate() throws SQLException
-  {
+  public void testMultiStmtExecuteUpdate() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
-    String multiStmtQuery = "create or replace temporary table test_multi (cola int);\n" +
-        "insert into test_multi VALUES (1), (2);\n" +
-        "select cola from test_multi order by cola asc";
+    String multiStmtQuery =
+        "create or replace temporary table test_multi (cola int);\n"
+            + "insert into test_multi VALUES (1), (2);\n"
+            + "select cola from test_multi order by cola asc";
 
     int updateCount = statement.executeUpdate(multiStmtQuery);
     // first statement
@@ -689,15 +659,15 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtExecuteQuery() throws SQLException
-  {
+  public void testMultiStmtExecuteQuery() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
-    String multiStmtQuery = "select 1;\n" +
-        "create or replace temporary table test_multi (cola int);\n" +
-        "insert into test_multi VALUES (1), (2);\n" +
-        "select cola from test_multi order by cola asc";
+    String multiStmtQuery =
+        "select 1;\n"
+            + "create or replace temporary table test_multi (cola int);\n"
+            + "insert into test_multi VALUES (1), (2);\n"
+            + "select cola from test_multi order by cola asc";
 
     ResultSet rs = statement.executeQuery(multiStmtQuery);
     // first statement
@@ -737,22 +707,22 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtExecuteUpdateFail() throws SQLException
-  {
+  public void testMultiStmtExecuteUpdateFail() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
-    String multiStmtQuery = "select 1;\n" +
-        "create or replace temporary table test_multi (cola int);\n" +
-        "insert into test_multi VALUES (1), (2);\n" +
-        "select cola from test_multi order by cola asc";
+    String multiStmtQuery =
+        "select 1;\n"
+            + "create or replace temporary table test_multi (cola int);\n"
+            + "insert into test_multi VALUES (1), (2);\n"
+            + "select cola from test_multi order by cola asc";
 
     try {
       statement.executeUpdate(multiStmtQuery);
       fail("executeUpdate should have failed because the first statement yields a result set");
     } catch (SQLException ex) {
-      assertThat(ex.getErrorCode(),
-          is(ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT.getMessageCode()));
+      assertThat(
+          ex.getErrorCode(), is(ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT.getMessageCode()));
     }
 
     statement.close();
@@ -761,21 +731,21 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtExecuteQueryFail() throws SQLException
-  {
+  public void testMultiStmtExecuteQueryFail() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
-    String multiStmtQuery = "create or replace temporary table test_multi (cola int);\n" +
-        "insert into test_multi VALUES (1), (2);\n" +
-        "select cola from test_multi order by cola asc";
+    String multiStmtQuery =
+        "create or replace temporary table test_multi (cola int);\n"
+            + "insert into test_multi VALUES (1), (2);\n"
+            + "select cola from test_multi order by cola asc";
 
     try {
       statement.executeQuery(multiStmtQuery);
       fail("executeQuery should have failed because the first statement yields an update count");
     } catch (SQLException ex) {
-      assertThat(ex.getErrorCode(),
-          is(ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET.getMessageCode()));
+      assertThat(
+          ex.getErrorCode(), is(ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET.getMessageCode()));
     }
 
     statement.close();
@@ -784,8 +754,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtSetUnset() throws SQLException
-  {
+  public void testMultiStmtSetUnset() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
@@ -797,24 +766,18 @@ public class StatementIT extends BaseJDBCTest
     assertEquals(1, rs.getInt(1));
 
     // selecting unset variable should cause error
-    try
-    {
+    try {
       statement.execute("unset testvar; select $testvar");
       fail("Expected a failure");
-    }
-    catch (SQLException ex)
-    {
+    } catch (SQLException ex) {
       assertEquals(SqlState.PLSQL_ERROR, ex.getSQLState());
     }
 
     // unsetting session variable should propagate outside of query
-    try
-    {
+    try {
       statement.execute("select $testvar");
       fail("Expected a failure");
-    }
-    catch (SQLException ex)
-    {
+    } catch (SQLException ex) {
       assertEquals(SqlState.NO_DATA, ex.getSQLState());
     }
 
@@ -824,20 +787,17 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtParseError() throws SQLException
-  {
+  public void testMultiStmtParseError() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
 
     statement.execute("set testvar = 1");
-    try
-    {
+    try {
       // fails in the antlr parser
       statement.execute("garbage text; set testvar = 2");
       fail("Expected a compiler error to be thrown");
-    }
-    catch (SQLException ex) {
+    } catch (SQLException ex) {
       assertEquals(SqlState.SYNTAX_ERROR_OR_ACCESS_RULE_VIOLATION, ex.getSQLState());
     }
 
@@ -851,25 +811,23 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtExecError() throws SQLException
-  {
+  public void testMultiStmtExecError() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
 
-    try
-    {
+    try {
       // fails during execution (javascript invokes statement where it gets typechecked)
-      statement.execute("set testvar = 1; select nonexistent_column from nonexistent_table; set testvar = 2");
+      statement.execute(
+          "set testvar = 1; select nonexistent_column from nonexistent_table; set testvar = 2");
       fail("Expected an execution error to be thrown");
-    }
-    catch (SQLException ex) {
+    } catch (SQLException ex) {
       assertEquals(SqlState.PLSQL_ERROR, ex.getSQLState());
     }
 
     ResultSet rs = statement.executeQuery("select $testvar");
     rs.next();
-    assertEquals( 1, rs.getInt(1));
+    assertEquals(1, rs.getInt(1));
 
     statement.close();
     connection.close();
@@ -877,14 +835,16 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtTempTable() throws SQLException
-  {
+  public void testMultiStmtTempTable() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
 
     String entry = "success";
-    statement.execute("create or replace temporary table test_multi (cola string); insert into test_multi values ('" + entry + "')");
+    statement.execute(
+        "create or replace temporary table test_multi (cola string); insert into test_multi values ('"
+            + entry
+            + "')");
     // temporary table should persist outside of the above statement
     ResultSet rs = statement.executeQuery("select * from test_multi");
     rs.next();
@@ -896,8 +856,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtUseStmt() throws SQLException
-  {
+  public void testMultiStmtUseStmt() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
@@ -926,8 +885,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtAlterSessionParams() throws SQLException
-  {
+  public void testMultiStmtAlterSessionParams() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
@@ -947,8 +905,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtMultiLine() throws SQLException
-  {
+  public void testMultiStmtMultiLine() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
@@ -964,15 +921,16 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtQuotes() throws SQLException
-  {
+  public void testMultiStmtQuotes() throws SQLException {
     // test various quotation usage and ensure they succeed
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
 
-    statement.execute("create or replace temporary table \"test_multi\" (cola string); select * from \"test_multi\"");
-    statement.execute("create or replace temporary table `test_multi` (cola string); select * from `test_multi`");
+    statement.execute(
+        "create or replace temporary table \"test_multi\" (cola string); select * from \"test_multi\"");
+    statement.execute(
+        "create or replace temporary table `test_multi` (cola string); select * from `test_multi`");
     statement.execute("select 'str'; select 'str2'");
     statement.execute("select '\\` backticks'; select '\\\\` more `backticks`'");
 
@@ -982,8 +940,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtCommitRollback() throws SQLException
-  {
+  public void testMultiStmtCommitRollback() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     Statement statement = connection.createStatement();
@@ -1032,8 +989,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtCommitRollbackNoAutocommit() throws SQLException
-  {
+  public void testMultiStmtCommitRollbackNoAutocommit() throws SQLException {
     Connection connection = getConnection();
     enableMultiStmt(connection);
     connection.setAutoCommit(false);
@@ -1059,7 +1015,8 @@ public class StatementIT extends BaseJDBCTest
 
     statement.execute("create or replace table test_multi (cola string)");
     // open transaction inside multistatement continues after
-    statement.execute("insert into test_multi values ('abc'); insert into test_multi values ('def')");
+    statement.execute(
+        "insert into test_multi values ('abc'); insert into test_multi values ('def')");
     statement.execute("commit");
     rs = statement.executeQuery("select count(*) from test_multi");
     assertTrue(rs.next());
@@ -1067,7 +1024,8 @@ public class StatementIT extends BaseJDBCTest
 
     statement.execute("create or replace table test_multi (cola string)");
     // open transaction inside multistatement continues after
-    statement.execute("insert into test_multi values ('abc'); insert into test_multi values ('def')");
+    statement.execute(
+        "insert into test_multi values ('abc'); insert into test_multi values ('def')");
     statement.execute("rollback");
     rs = statement.executeQuery("select count(*) from test_multi");
     assertTrue(rs.next());
@@ -1077,23 +1035,19 @@ public class StatementIT extends BaseJDBCTest
     connection.close();
   }
 
-
   @Test
-  public void testMultiStmtNotEnabled() throws SQLException
-  {
+  public void testMultiStmtNotEnabled() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
-    String multiStmtQuery = "create or replace temporary table test_multi (cola int);\n" +
-        "insert into test_multi VALUES (1), (2);\n" +
-        "select cola from test_multi order by cola asc";
+    String multiStmtQuery =
+        "create or replace temporary table test_multi (cola int);\n"
+            + "insert into test_multi VALUES (1), (2);\n"
+            + "select cola from test_multi order by cola asc";
 
-    try
-    {
+    try {
       statement.execute(multiStmtQuery);
       fail("Using a multi-statement query without the parameter set should fail");
-    }
-    catch (SnowflakeSQLException ex)
-    {
+    } catch (SnowflakeSQLException ex) {
       assertEquals(SqlState.FEATURE_NOT_SUPPORTED, ex.getSQLState());
     }
 
@@ -1103,8 +1057,7 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testMultiStmtLarge() throws SQLException
-  {
+  public void testMultiStmtLarge() throws SQLException {
     // this test verifies that multiple-statement support does not break
     // with many statements
     // it also ensures that results are returned in the correct order
@@ -1113,14 +1066,12 @@ public class StatementIT extends BaseJDBCTest
     Statement statement = connection.createStatement();
     StringBuilder multiStmtBuilder = new StringBuilder();
     String query = "SELECT %d;";
-    for (int i = 0; i < 100; i++)
-    {
+    for (int i = 0; i < 100; i++) {
       multiStmtBuilder.append(String.format(query, i));
     }
 
     assertTrue(statement.execute(multiStmtBuilder.toString()));
-    for (int i = 0; i < 100; i++)
-    {
+    for (int i = 0; i < 100; i++) {
       ResultSet rs = statement.getResultSet();
       assertNotNull(rs);
       assertEquals(-1, statement.getUpdateCount());
@@ -1128,15 +1079,11 @@ public class StatementIT extends BaseJDBCTest
       assertEquals(i, rs.getInt(1));
       assertFalse(rs.next());
 
-      if (i != 99)
-      {
+      if (i != 99) {
         assertTrue(statement.getMoreResults());
-      }
-      else
-      {
+      } else {
         assertFalse(statement.getMoreResults());
       }
-
     }
 
     statement.close();
@@ -1145,19 +1092,19 @@ public class StatementIT extends BaseJDBCTest
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnTravisCI.class)
-  public void testCallStoredProcedure() throws SQLException
-  {
+  public void testCallStoredProcedure() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
     statement.execute("alter session set ENABLE_JAVASCRIPT_STORED_PROCEDURE_CREATION=true");
 
-    statement.execute("create or replace procedure SP()\n"
-    + "returns string not null\n"
-    + "language javascript\n"
-    + "as $$\n"
-    + "  snowflake.execute({sqlText:'select seq4() from table(generator(rowcount=>5))'});\n"
-    + "  return 'done';\n"
-    + "$$");
+    statement.execute(
+        "create or replace procedure SP()\n"
+            + "returns string not null\n"
+            + "language javascript\n"
+            + "as $$\n"
+            + "  snowflake.execute({sqlText:'select seq4() from table(generator(rowcount=>5))'});\n"
+            + "  return 'done';\n"
+            + "$$");
 
     assertTrue(statement.execute("call SP()"));
     ResultSet rs = statement.getResultSet();

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -1,61 +1,56 @@
 package net.snowflake.client.jdbc.telemetry;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import net.snowflake.client.AbstractDriverIT;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class TelemetryIT extends AbstractDriverIT
-{
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import net.snowflake.client.AbstractDriverIT;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TelemetryIT extends AbstractDriverIT {
   private Connection connection = null;
   private static ObjectMapper mapper = new ObjectMapper();
 
   @Before
-  public void init() throws SQLException
-  {
+  public void init() throws SQLException {
     this.connection = getConnection();
   }
 
   @Test
-  public void test() throws IOException
-  {
+  public void test() throws IOException {
     Telemetry telemetry = Telemetry.createTelemetry(connection, 100);
     ObjectNode node1 = mapper.createObjectNode();
-    node1.put("type","query");
-    node1.put("query_id","sdasdasdasdasds");
+    node1.put("type", "query");
+    node1.put("query_id", "sdasdasdasdasds");
     ObjectNode node2 = mapper.createObjectNode();
-    node2.put("type","query");
-    node2.put("query_id","eqweqweqweqwe");
+    node2.put("type", "query");
+    node2.put("query_id", "eqweqweqweqwe");
     telemetry.addLogToBatch(node1, 1234567);
-    telemetry.addLogToBatch(new TelemetryData(node2,22345678));
-    assertEquals(telemetry.bufferSize(),2);
+    telemetry.addLogToBatch(new TelemetryData(node2, 22345678));
+    assertEquals(telemetry.bufferSize(), 2);
 
     assertTrue(telemetry.sendBatch());
-    assertEquals(telemetry.bufferSize(),0);
+    assertEquals(telemetry.bufferSize(), 0);
 
-    assertTrue(telemetry.sendLog(node1,1234567));
-    assertEquals(telemetry.bufferSize(),0);
+    assertTrue(telemetry.sendLog(node1, 1234567));
+    assertEquals(telemetry.bufferSize(), 0);
 
     assertTrue(telemetry.sendLog(new TelemetryData(node2, 22345678)));
-    assertEquals(telemetry.bufferSize(),0);
+    assertEquals(telemetry.bufferSize(), 0);
 
-    //reach flush threshold
-    for (int i = 0; i < 99; i++)
-    {
+    // reach flush threshold
+    for (int i = 0; i < 99; i++) {
       telemetry.addLogToBatch(node1, 1111);
     }
-    assertEquals(telemetry.bufferSize(),99);
-    telemetry.addLogToBatch(node1,222);
-    assertEquals(telemetry.bufferSize(),0);
+    assertEquals(telemetry.bufferSize(), 99);
+    telemetry.addLogToBatch(node1, 222);
+    assertEquals(telemetry.bufferSize(), 0);
 
     telemetry.addLogToBatch(node1, 111);
     assertEquals(telemetry.bufferSize(), 1);
@@ -63,69 +58,63 @@ public class TelemetryIT extends AbstractDriverIT
     assertTrue(!telemetry.isClosed());
     telemetry.close();
     assertTrue(telemetry.isClosed());
-    //close function sends the metrics to the server
+    // close function sends the metrics to the server
     assertEquals(telemetry.bufferSize(), 0);
   }
 
   @Test(expected = IOException.class)
-  public void close1() throws IOException
-  {
+  public void close1() throws IOException {
     Telemetry telemetry = Telemetry.createTelemetry(connection);
     telemetry.close();
     ObjectNode node = mapper.createObjectNode();
-    node.put("type","query");
-    node.put("query_id","sdasdasdasdasds");
+    node.put("type", "query");
+    node.put("query_id", "sdasdasdasdasds");
     telemetry.addLogToBatch(node, 1234567);
   }
 
   @Test(expected = IOException.class)
-  public void close2() throws IOException
-  {
+  public void close2() throws IOException {
     Telemetry telemetry = Telemetry.createTelemetry(connection);
     telemetry.close();
     ObjectNode node = mapper.createObjectNode();
-    node.put("type","query");
-    node.put("query_id","sdasdasdasdasds");
+    node.put("type", "query");
+    node.put("query_id", "sdasdasdasdasds");
     telemetry.addLogToBatch(new TelemetryData(node, 1234567));
   }
 
   @Test(expected = IOException.class)
-  public void close3() throws IOException
-  {
+  public void close3() throws IOException {
     Telemetry telemetry = Telemetry.createTelemetry(connection);
     telemetry.close();
     telemetry.close();
   }
 
   @Test
-  public void test4() throws IOException
-  {
+  public void test4() throws IOException {
     Telemetry telemetry = Telemetry.createTelemetry(connection, 100);
 
     ObjectNode node1 = mapper.createObjectNode();
-    node1.put("type","query");
-    node1.put("query_id","sdasdasdasdasds");
+    node1.put("type", "query");
+    node1.put("query_id", "sdasdasdasdasds");
     ObjectNode node2 = mapper.createObjectNode();
-    node2.put("type","query");
-    node2.put("query_id","eqweqweqweqwe");
+    node2.put("type", "query");
+    node2.put("query_id", "eqweqweqweqwe");
     telemetry.addLogToBatch(node1, 1234567);
 
-    assertEquals(telemetry.bufferSize(),1);
+    assertEquals(telemetry.bufferSize(), 1);
     telemetry.disableTelemetry();
     assertFalse(telemetry.isTelemetryEnabled());
 
-    telemetry.addLogToBatch(new TelemetryData(node2,22345678));
-    assertEquals(telemetry.bufferSize(),1);
+    telemetry.addLogToBatch(new TelemetryData(node2, 22345678));
+    assertEquals(telemetry.bufferSize(), 1);
 
     assertFalse(telemetry.sendBatch());
-    assertEquals(telemetry.bufferSize(),1);
+    assertEquals(telemetry.bufferSize(), 1);
 
-    assertFalse(telemetry.sendLog(node1,1234567));
-    assertEquals(telemetry.bufferSize(),1);
+    assertFalse(telemetry.sendLog(node1, 1234567));
+    assertEquals(telemetry.bufferSize(), 1);
 
     assertFalse(telemetry.sendLog(new TelemetryData(node2, 22345678)));
-    assertEquals(telemetry.bufferSize(),1);
-
+    assertEquals(telemetry.bufferSize(), 1);
   }
-
 }

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryTest.java
@@ -1,22 +1,18 @@
 package net.snowflake.client.jdbc.telemetry;
 
+import static org.junit.Assert.assertEquals;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.LinkedList;
 import org.junit.Test;
 
-import java.util.LinkedList;
-
-
-import static org.junit.Assert.assertEquals;
-
-public class TelemetryTest
-{
+public class TelemetryTest {
   private ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  public void testJsonConversion()
-  {
+  public void testJsonConversion() {
 
     ObjectNode log1 = mapper.createObjectNode();
     log1.put("type", "query");
@@ -36,14 +32,14 @@ public class TelemetryTest
     ObjectNode expect = mapper.createObjectNode();
     ArrayNode logs = mapper.createArrayNode();
     ObjectNode message1 = mapper.createObjectNode();
-    message1.put("timestamp",timestamp1+"");
-    message1.set("message",log1);
+    message1.put("timestamp", timestamp1 + "");
+    message1.set("message", log1);
     logs.add(message1);
     ObjectNode message2 = mapper.createObjectNode();
-    message2.put("timestamp",timestamp2+"");
-    message2.set("message",log2);
+    message2.put("timestamp", timestamp2 + "");
+    message2.set("message", log2);
     logs.add(message2);
-    expect.set("logs",logs);
+    expect.set("logs", logs);
 
     assertEquals(expect.toString(), result);
   }

--- a/src/test/java/net/snowflake/client/loader/OnErrorTest.java
+++ b/src/test/java/net/snowflake/client/loader/OnErrorTest.java
@@ -3,16 +3,14 @@
  */
 package net.snowflake.client.loader;
 
-import org.junit.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-public class OnErrorTest
-{
+import org.junit.Test;
+
+public class OnErrorTest {
   @Test
-  public void testValidate()
-  {
+  public void testValidate() {
     // positive
     assertThat(OnError.validate("ABORT_STATEMENT"), is(Boolean.TRUE));
     assertThat(OnError.validate("ABORT_STATeMENT"), is(Boolean.TRUE));

--- a/src/test/java/net/snowflake/client/loader/TestDataConfigBuilder.java
+++ b/src/test/java/net/snowflake/client/loader/TestDataConfigBuilder.java
@@ -3,7 +3,8 @@
  */
 package net.snowflake.client.loader;
 
-import net.snowflake.client.jdbc.SnowflakeConnectionV1;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -15,13 +16,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-class TestDataConfigBuilder
-{
-  final static String TARGET_TABLE_NAME = "LOADER_test_TABLE";
+class TestDataConfigBuilder {
+  static final String TARGET_TABLE_NAME = "LOADER_test_TABLE";
 
   private StreamLoader streamLoader;
   private final Connection testConnection;
@@ -32,9 +30,7 @@ class TestDataConfigBuilder
   private int numberOfRows = 10000;
   private List<Object[]> dataSet;
 
-  private List<String> columns = Arrays.asList(
-      "ID", "C1", "C3", "C4", "C5"
-  );
+  private List<String> columns = Arrays.asList("ID", "C1", "C3", "C4", "C5");
   private List<String> keys;
   private String tableName = TARGET_TABLE_NAME;
   private String schemaName = "LOADER";
@@ -55,200 +51,161 @@ class TestDataConfigBuilder
 
   private ResultListener listener;
 
-  TestDataConfigBuilder(Connection testConnection, Connection putConnection)
-  {
+  TestDataConfigBuilder(Connection testConnection, Connection putConnection) {
     this.testConnection = testConnection;
     this.putConnection = putConnection;
   }
 
-  TestDataConfigBuilder setTestMode(boolean testMode)
-  {
+  TestDataConfigBuilder setTestMode(boolean testMode) {
     this.testMode = testMode;
     return this;
   }
 
-  TestDataConfigBuilder setTableName(String tableName)
-  {
+  TestDataConfigBuilder setTableName(String tableName) {
     this.tableName = tableName;
     return this;
   }
 
-  TestDataConfigBuilder setSchemaName(String schemaName)
-  {
+  TestDataConfigBuilder setSchemaName(String schemaName) {
     this.schemaName = schemaName;
     return this;
   }
 
-  TestDataConfigBuilder setDatabaseName(String databaseName)
-  {
+  TestDataConfigBuilder setDatabaseName(String databaseName) {
     this.databaseName = databaseName;
     return this;
   }
 
-  TestDataConfigBuilder setRemoteStage(String remoteStage)
-  {
+  TestDataConfigBuilder setRemoteStage(String remoteStage) {
     this.remoteStage = remoteStage;
     return this;
   }
 
-  TestDataConfigBuilder setCsvFileBucketSize(long csvFileBucketSize)
-  {
+  TestDataConfigBuilder setCsvFileBucketSize(long csvFileBucketSize) {
     this.csvFileBucketSize = csvFileBucketSize;
     return this;
   }
 
-  TestDataConfigBuilder setCsvFileSize(long csvFileSize)
-  {
+  TestDataConfigBuilder setCsvFileSize(long csvFileSize) {
     this.csvFileSize = csvFileSize;
     return this;
   }
 
-  TestDataConfigBuilder setOnError(String onError)
-  {
+  TestDataConfigBuilder setOnError(String onError) {
     this.onError = onError;
     return this;
   }
 
-  TestDataConfigBuilder setNumberOfRows(int numberOfRows)
-  {
+  TestDataConfigBuilder setNumberOfRows(int numberOfRows) {
     this.numberOfRows = numberOfRows;
     return this;
   }
 
-  TestDataConfigBuilder setDataSet(List<Object[]> dataSet)
-  {
+  TestDataConfigBuilder setDataSet(List<Object[]> dataSet) {
     this.dataSet = dataSet;
     return this;
   }
 
-  TestDataConfigBuilder setColumns(List<String> columns)
-  {
+  TestDataConfigBuilder setColumns(List<String> columns) {
     this.columns = columns;
     return this;
   }
 
-  TestDataConfigBuilder setKeys(List<String> keys)
-  {
+  TestDataConfigBuilder setKeys(List<String> keys) {
     this.keys = keys;
     return this;
   }
 
-  TestDataConfigBuilder setOperation(Operation operation)
-  {
+  TestDataConfigBuilder setOperation(Operation operation) {
     this.operation = operation;
     return this;
   }
 
-  TestDataConfigBuilder setTruncateTable(boolean truncateTable)
-  {
+  TestDataConfigBuilder setTruncateTable(boolean truncateTable) {
     this.truncateTable = truncateTable;
     return this;
   }
 
-  TestDataConfigBuilder setPreserveStageFile(boolean preserveStageFile)
-  {
+  TestDataConfigBuilder setPreserveStageFile(boolean preserveStageFile) {
     this.preserveStageFile = preserveStageFile;
     return this;
   }
 
-  TestDataConfigBuilder setUseLocalTimezone(boolean useLocalTimezone)
-  {
+  TestDataConfigBuilder setUseLocalTimezone(boolean useLocalTimezone) {
     this.useLocalTimezone = useLocalTimezone;
     return this;
   }
 
-  TestDataConfigBuilder setMapTimeToTimestamp(boolean mapTimeToTimestamp)
-  {
+  TestDataConfigBuilder setMapTimeToTimestamp(boolean mapTimeToTimestamp) {
     this.mapTimeToTimestamp = mapTimeToTimestamp;
     return this;
   }
 
-  TestDataConfigBuilder setStartTransaction(boolean startTransaction)
-  {
+  TestDataConfigBuilder setStartTransaction(boolean startTransaction) {
     this.startTransaction = startTransaction;
     return this;
   }
 
-  TestDataConfigBuilder setCopyEmptyFieldAsEmpty(boolean copyEmptyFieldAsEmpty)
-  {
+  TestDataConfigBuilder setCopyEmptyFieldAsEmpty(boolean copyEmptyFieldAsEmpty) {
     this.copyEmptyFieldAsEmpty = copyEmptyFieldAsEmpty;
     return this;
   }
 
-  TestDataConfigBuilder setCompressFileByPut(boolean compressFileByPut)
-  {
+  TestDataConfigBuilder setCompressFileByPut(boolean compressFileByPut) {
     this.compressFileByPut = compressFileByPut;
     return this;
   }
 
-  TestDataConfigBuilder setCompressDataBeforePut(boolean compressDataBeforePut)
-  {
+  TestDataConfigBuilder setCompressDataBeforePut(boolean compressDataBeforePut) {
     this.compressDataBeforePut = compressDataBeforePut;
     return this;
   }
 
-  TestDataConfigBuilder setCompressLevel(long compressLevel)
-  {
+  TestDataConfigBuilder setCompressLevel(long compressLevel) {
     this.compressLevel = compressLevel;
     return this;
   }
 
-  StreamLoader getStreamLoader() throws Exception
-  {
+  StreamLoader getStreamLoader() throws Exception {
     getListener();
     return streamLoader;
   }
 
-  synchronized ResultListener getListener() throws Exception
-  {
-    if (listener == null)
-    {
+  synchronized ResultListener getListener() throws Exception {
+    if (listener == null) {
       Map<LoaderProperty, Object> prop = this.initLoaderProperties();
       listener = this.initLoader(prop);
     }
     return listener;
   }
 
-  void populate() throws Exception
-  {
+  void populate() throws Exception {
     populate(false);
   }
 
-  List<Object[]> populateReturnData() throws Exception
-  {
+  List<Object[]> populateReturnData() throws Exception {
     return populate(true);
   }
 
-  List<Object[]> populate(boolean returnDataSet) throws Exception
-  {
+  List<Object[]> populate(boolean returnDataSet) throws Exception {
     getListener();
     streamLoader.start();
     Random rnd = new Random();
 
     List<Object[]> newDataSet = new ArrayList<>();
-    if (dataSet == null)
-    {
+    if (dataSet == null) {
       // generates a new data set and ingest
-      for (int i = 0; i < numberOfRows; i++)
-      {
-        final String json = "{\"key\":" + String.valueOf(rnd.nextInt()) + ","
-            + "\"bar\":" + i + "}";
-        Object[] row = new Object[]
-            {
-                i, "foo_" + i, rnd.nextInt() / 3, new Date(),
-                json
-            };
-        if (returnDataSet)
-        {
+      for (int i = 0; i < numberOfRows; i++) {
+        final String json =
+            "{\"key\":" + String.valueOf(rnd.nextInt()) + "," + "\"bar\":" + i + "}";
+        Object[] row = new Object[] {i, "foo_" + i, rnd.nextInt() / 3, new Date(), json};
+        if (returnDataSet) {
           newDataSet.add(row);
         }
         streamLoader.submitRow(row);
       }
-    }
-    else
-    {
-      for (Object[] row : dataSet)
-      {
+    } else {
+      for (Object[] row : dataSet) {
         // ingest the same data set
         streamLoader.submitRow(row);
       }
@@ -256,33 +213,33 @@ class TestDataConfigBuilder
     streamLoader.finish();
     int submitted = listener.getSubmittedRowCount();
 
-    assertThat("submitted rows",
-        submitted, equalTo(numberOfRows));
-    assertThat("_resultListener.counter is not correct",
-        listener.counter.get(), equalTo(numberOfRows));
-    assertThat("_resultListener.getErrors() was not 0",
-        listener.getErrors().size(), equalTo(0));
+    assertThat("submitted rows", submitted, equalTo(numberOfRows));
+    assertThat(
+        "_resultListener.counter is not correct", listener.counter.get(), equalTo(numberOfRows));
+    assertThat("_resultListener.getErrors() was not 0", listener.getErrors().size(), equalTo(0));
 
-    ResultSet rs = testConnection.createStatement().executeQuery(
-        String.format("SELECT COUNT(*) AS N"
-            + " FROM LOADER.\"%s\"", tableName));
+    ResultSet rs =
+        testConnection
+            .createStatement()
+            .executeQuery(String.format("SELECT COUNT(*) AS N" + " FROM LOADER.\"%s\"", tableName));
 
     rs.next();
     int count = rs.getInt("N");
     assertThat("count is not correct", count, equalTo(numberOfRows));
-    assertThat("_resultListener.processed didn't match count",
-        listener.processed.get(), equalTo(count));
-    assertThat("_resultListener.counter didn't match count",
-        listener.counter.get(), equalTo(count));
-    assertThat("_resultListener.getErrors().size() was not 0",
-        listener.getErrors().size(), equalTo(0));
-    assertThat("_resultListener.getLastRecord()[0] was not 9999",
-        (Integer) listener.getLastRecord()[0], equalTo(numberOfRows - 1));
+    assertThat(
+        "_resultListener.processed didn't match count", listener.processed.get(), equalTo(count));
+    assertThat(
+        "_resultListener.counter didn't match count", listener.counter.get(), equalTo(count));
+    assertThat(
+        "_resultListener.getErrors().size() was not 0", listener.getErrors().size(), equalTo(0));
+    assertThat(
+        "_resultListener.getLastRecord()[0] was not 9999",
+        (Integer) listener.getLastRecord()[0],
+        equalTo(numberOfRows - 1));
     return newDataSet;
   }
 
-  private Map<LoaderProperty, Object> initLoaderProperties()
-  {
+  private Map<LoaderProperty, Object> initLoaderProperties() {
     Map<LoaderProperty, Object> prop = new HashMap<>();
     prop.put(LoaderProperty.tableName, tableName);
     prop.put(LoaderProperty.schemaName, schemaName);
@@ -294,14 +251,11 @@ class TestDataConfigBuilder
     return prop;
   }
 
-  private ResultListener initLoader(
-      Map<LoaderProperty, Object> prop) throws Exception
-  {
+  private ResultListener initLoader(Map<LoaderProperty, Object> prop) throws Exception {
     ResultListener _resultListener = new ResultListener();
 
     // Set up Test parameters
-    streamLoader = (StreamLoader) LoaderFactory.createLoader(
-        prop, putConnection, testConnection);
+    streamLoader = (StreamLoader) LoaderFactory.createLoader(prop, putConnection, testConnection);
 
     streamLoader.setProperty(LoaderProperty.startTransaction, startTransaction);
     streamLoader.setProperty(LoaderProperty.truncateTable, truncateTable);
@@ -310,11 +264,9 @@ class TestDataConfigBuilder
     streamLoader.setProperty(LoaderProperty.mapTimeToTimestamp, mapTimeToTimestamp);
     streamLoader.setProperty(LoaderProperty.copyEmptyFieldAsEmpty, copyEmptyFieldAsEmpty);
     // file bucket size
-    streamLoader.setProperty(LoaderProperty.csvFileBucketSize,
-        Long.toString(csvFileBucketSize));
+    streamLoader.setProperty(LoaderProperty.csvFileBucketSize, Long.toString(csvFileBucketSize));
     // file batch
-    streamLoader.setProperty(LoaderProperty.csvFileSize,
-        Long.toString(csvFileSize));
+    streamLoader.setProperty(LoaderProperty.csvFileSize, Long.toString(csvFileSize));
     streamLoader.setProperty(LoaderProperty.compressFileByPut, compressFileByPut);
     streamLoader.setProperty(LoaderProperty.compressDataBeforePut, compressDataBeforePut);
     streamLoader.setProperty(LoaderProperty.compressLevel, compressLevel);
@@ -333,137 +285,114 @@ class TestDataConfigBuilder
     return _resultListener;
   }
 
-  class ResultListener implements LoadResultListener
-  {
+  class ResultListener implements LoadResultListener {
 
-    final private List<LoadingError> errors = new ArrayList<>();
+    private final List<LoadingError> errors = new ArrayList<>();
 
-    final private AtomicInteger errorCount = new AtomicInteger(0);
-    final private AtomicInteger errorRecordCount = new AtomicInteger(0);
+    private final AtomicInteger errorCount = new AtomicInteger(0);
+    private final AtomicInteger errorRecordCount = new AtomicInteger(0);
 
-    final public AtomicInteger counter = new AtomicInteger(0);
-    final public AtomicInteger processed = new AtomicInteger(0);
-    final public AtomicInteger deleted = new AtomicInteger(0);
-    final public AtomicInteger updated = new AtomicInteger(0);
-    final private AtomicInteger submittedRowCount = new AtomicInteger(0);
+    public final AtomicInteger counter = new AtomicInteger(0);
+    public final AtomicInteger processed = new AtomicInteger(0);
+    public final AtomicInteger deleted = new AtomicInteger(0);
+    public final AtomicInteger updated = new AtomicInteger(0);
+    private final AtomicInteger submittedRowCount = new AtomicInteger(0);
 
     private Object[] lastRecord = null;
 
     public boolean throwOnError = false; // should not trigger rollback
 
     @Override
-    public boolean needErrors()
-    {
+    public boolean needErrors() {
       return true;
     }
 
     @Override
-    public boolean needSuccessRecords()
-    {
+    public boolean needSuccessRecords() {
       return true;
     }
 
     @Override
-    public void addError(LoadingError error)
-    {
+    public void addError(LoadingError error) {
       errors.add(error);
     }
 
     @Override
-    public boolean throwOnError()
-    {
+    public boolean throwOnError() {
       return throwOnError;
     }
 
-    public List<LoadingError> getErrors()
-    {
+    public List<LoadingError> getErrors() {
       return errors;
     }
 
     @Override
-    public void recordProvided(Operation op, Object[] record)
-    {
+    public void recordProvided(Operation op, Object[] record) {
       lastRecord = record;
     }
 
     @Override
-    public void addProcessedRecordCount(Operation op, int i)
-    {
+    public void addProcessedRecordCount(Operation op, int i) {
       processed.addAndGet(i);
     }
 
     @Override
-    public void addOperationRecordCount(Operation op, int i)
-    {
+    public void addOperationRecordCount(Operation op, int i) {
       counter.addAndGet(i);
-      if (op == Operation.DELETE)
-      {
+      if (op == Operation.DELETE) {
         deleted.addAndGet(i);
-      }
-      else if (op == Operation.MODIFY || op == Operation.UPSERT)
-      {
+      } else if (op == Operation.MODIFY || op == Operation.UPSERT) {
         updated.addAndGet(i);
       }
     }
 
-    public Object[] getLastRecord()
-    {
+    public Object[] getLastRecord() {
       return lastRecord;
     }
 
     @Override
-    public int getErrorCount()
-    {
+    public int getErrorCount() {
       return errorCount.get();
     }
 
     @Override
-    public int getErrorRecordCount()
-    {
+    public int getErrorRecordCount() {
       return errorRecordCount.get();
     }
 
     @Override
-    public void resetErrorCount()
-    {
+    public void resetErrorCount() {
       errorCount.set(0);
     }
 
     @Override
-    public void resetErrorRecordCount()
-    {
+    public void resetErrorRecordCount() {
       errorRecordCount.set(0);
     }
 
     @Override
-    public void addErrorCount(int count)
-    {
+    public void addErrorCount(int count) {
       errorCount.addAndGet(count);
     }
 
     @Override
-    public void addErrorRecordCount(int count)
-    {
+    public void addErrorRecordCount(int count) {
       errorRecordCount.addAndGet(count);
     }
 
     @Override
-    public void resetSubmittedRowCount()
-    {
+    public void resetSubmittedRowCount() {
       submittedRowCount.set(0);
     }
 
     @Override
-    public void addSubmittedRowCount(int count)
-    {
+    public void addSubmittedRowCount(int count) {
       submittedRowCount.addAndGet(count);
     }
 
     @Override
-    public int getSubmittedRowCount()
-    {
+    public int getSubmittedRowCount() {
       return submittedRowCount.get();
     }
   }
-
 }

--- a/src/test/java/net/snowflake/client/log/SFFormatterTest.java
+++ b/src/test/java/net/snowflake/client/log/SFFormatterTest.java
@@ -4,8 +4,7 @@
 
 package net.snowflake.client.log;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -16,28 +15,21 @@ import java.util.TimeZone;
 import java.util.logging.Formatter;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
 
-public class SFFormatterTest
-{
+public class SFFormatterTest {
   // Change these numbers if necessary
-  /**
-   * The maximum time difference in millisecond allowed for timestamp and now
-   */
+  /** The maximum time difference in millisecond allowed for timestamp and now */
   private static final long TIME_DIFFERENCE_BOUNDARY = 100;
-  /**
-   * Number of iterations for the stress test
-   */
+  /** Number of iterations for the stress test */
   private static final int STRESS_TEST_ITERATION = 2000;
 
-  /**
-   * Log record generator
-   */
+  /** Log record generator */
   private LRGenerator recordGenerator;
 
   @Before
-  public void setUp()
-  {
+  public void setUp() {
     recordGenerator = new LRGenerator(SFFormatter.CLASS_NAME_PREFIX + "TestClass", "TestMethod");
     recordGenerator.setFormatter(new SFFormatter());
   }
@@ -45,51 +37,51 @@ public class SFFormatterTest
   /**
    * This test intends to check if the timestamp generated in the SFFormatter is in UTC timezone
    *
-   * It would extract the timestamp from a log record using the SFFormatter and compare it against now;
+   * <p>It would extract the timestamp from a log record using the SFFormatter and compare it
+   * against now;
    *
-   * Since the time difference between the log record's generated time and the current time is small,
-   * their difference would be limited within TIME_DIFFERENCE_BOUNDARY if the log record's timestamp
-   * is in UTC timezone
+   * <p>Since the time difference between the log record's generated time and the current time is
+   * small, their difference would be limited within TIME_DIFFERENCE_BOUNDARY if the log record's
+   * timestamp is in UTC timezone
+   *
    * @throws ParseException
    */
   @Test
-  public void testUTCTimeStampSimple() throws ParseException
-  {
+  public void testUTCTimeStampSimple() throws ParseException {
     TimeZone originalTz = TimeZone.getDefault();
     TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"));
-    try
-    {
+    try {
       String record = recordGenerator.generateLogRecordString(Level.INFO, "TestMessage");
 
       Date date = extractDate(record);
       long nowInMs = Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTimeInMillis();
-      assertTrue("Time difference boundary should be less than " + TIME_DIFFERENCE_BOUNDARY + "ms",
+      assertTrue(
+          "Time difference boundary should be less than " + TIME_DIFFERENCE_BOUNDARY + "ms",
           nowInMs - date.getTime() < TIME_DIFFERENCE_BOUNDARY);
-    }
-    finally
-    {
+    } finally {
       TimeZone.setDefault(originalTz);
     }
   }
 
   /**
    * The bulk version test of testUTCTimeStampSimple()
+   *
    * @throws ParseException
    */
   @Test
-  public void testUTCTimeStampStress() throws ParseException
-  {
+  public void testUTCTimeStampStress() throws ParseException {
     for (int i = 0; i < STRESS_TEST_ITERATION; i++) {
       testUTCTimeStampSimple();
     }
   }
 
   /**
-   * A log generator could generate log record directly and fill in necessary field specified by constructor
+   * A log generator could generate log record directly and fill in necessary field specified by
+   * constructor
    */
-  private class LRGenerator
-  {
-    // Required by SFFormatter as a log record without these fiels would cause NullPointerException in
+  private class LRGenerator {
+    // Required by SFFormatter as a log record without these fiels would cause NullPointerException
+    // in
     // our SF formatter
     // add more fields to plug in the log record if required for testing
     private String srcClassName;
@@ -97,8 +89,7 @@ public class SFFormatterTest
 
     private Formatter formatter;
 
-    public LRGenerator(String srcClassName, String srcMethodName)
-    {
+    public LRGenerator(String srcClassName, String srcMethodName) {
       this.srcClassName = srcClassName;
       this.srcMethodName = srcMethodName;
       formatter = null;
@@ -106,12 +97,12 @@ public class SFFormatterTest
 
     /**
      * No formatter is needed
+     *
      * @param level level of log record priority
      * @param message message of log record
      * @return A LogRecord instance
      */
-    public LogRecord generateLogRecord(Level level, String message)
-    {
+    public LogRecord generateLogRecord(Level level, String message) {
       LogRecord record = new LogRecord(Level.INFO, "null");
       record.setSourceClassName(this.srcClassName);
       record.setSourceMethodName(this.srcMethodName);
@@ -119,40 +110,38 @@ public class SFFormatterTest
     }
 
     /**
-     * Generate the string representation of the log record
-     * formatter is required to be not null!!
+     * Generate the string representation of the log record formatter is required to be not null!!
+     *
      * @param level level of log record priority
      * @param message message of log record
      * @return A LogRecord instance
      */
-    public String generateLogRecordString(Level level, String message)
-    {
+    public String generateLogRecordString(Level level, String message) {
       return formatter.format(this.generateLogRecord(level, message));
     }
 
     /**
      * Formatter setter
+     *
      * @param formatter
      */
-    public void setFormatter(Formatter formatter)
-    {
+    public void setFormatter(Formatter formatter) {
       this.formatter = formatter;
     }
   }
 
   /**
    * Helper function to extract the date from the log record
+   *
    * @param string log record representation
    * @return a date specified by the log record
    * @throws ParseException
    */
-  private Date extractDate(String string) throws ParseException
-  {
+  private Date extractDate(String string) throws ParseException {
     DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     df.setCalendar(cal);
     Date date = df.parse(string);
     return date;
   }
-
 }


### PR DESCRIPTION
The driver currently seems to assume that `next()` will never be called again after a result set has been read completely. This is not compliant with the JDBC specification and is causing problems with some integration work I am doing where I have no control over when these methods are called. This PR simply adds some null checks to fix the issue.