### PR TITLE
Add null checks before closing statements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,18 +269,6 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.6.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,18 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1355,8 +1355,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
                   }
                 }
 
-                statement.close();
-                statement = null;
+                if (statement != null) {
+                  statement.close();
+                  statement = null;
+                }
 
                 return false;
               }
@@ -1395,8 +1397,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
                   return true;
                 }
 
-                statement.close();
-                statement = null;
+                if (statement != null) {
+                  statement.close();
+                  statement = null;
+                }
 
                 return false;
               }
@@ -1654,8 +1658,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
                   }
                 }
 
-                statement.close();
-                statement = null;
+                if (statement != null) {
+                  statement.close();
+                  statement = null;
+                }
                 return false;
               }
             };
@@ -1823,8 +1829,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
           }
         }
 
-        statement.close();
-        statement = null;
+        if (statement != null) {
+          statement.close();
+          statement = null;
+        }
 
         return false;
       }
@@ -1990,8 +1998,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
           }
         }
 
-        statement.close();
-        statement = null;
+        if (statement != null) {
+          statement.close();
+          statement = null;
+        }
 
         return false;
       }
@@ -2542,8 +2552,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
           }
         }
 
-        statement.close();
-        statement = null;
+        if (statement != null) {
+          statement.close();
+          statement = null;
+        }
 
         return false;
       }
@@ -2670,8 +2682,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
             return true;
           }
         }
-        statement.close();
-        statement = null;
+        if (statement != null) {
+          statement.close();
+          statement = null;
+        }
         return false;
       }
     };


### PR DESCRIPTION
The driver currently seems to assume that next() will never be called again after a result set has been read completely. This is not compliant with the JDBC specification and is causing problems with some integration work I am doing where I have no control over when these methods are called. This PR simply adds some null checks to fix the issue.