### PR TITLE
Added in writeable check on file cache.

### DIFF
--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -139,6 +139,14 @@ class FileCacheManager
       {
         // use tmp dir if not exists.
         homeDir = systemGetProperty("java.io.tmpdir");
+      } else 
+      {
+        // Checking if home directory is writable.
+        File homeFile = new File(homeDir);
+        if (!homeFile.canWrite()) {
+          LOGGER.debug("Home directory not writeable, using tmpdir");
+          homeDir = systemGetProperty("java.io.tmpdir");
+        }
       }
       if (Constants.getOS() == Constants.OS.WINDOWS)
       {


### PR DESCRIPTION
This PR relates to internal snowflake case Case#00073398 where in AWS Kinesis Data Analytics the home directory is not writable and environment variables cannot be set.  This change a check to see if the home directory is writable and if not it defaults out to use the temporary directory.  This has been tested in Kinesis Data Analytics as working.