### PR TITLE
Resolve ConcurrentModificationException when attempting to close resu…

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -45,12 +45,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
@@ -137,7 +137,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
   private static final AtomicLong currentMemoryUsage = new AtomicLong();
 
   // used to track the downloading threads
-  private Map<Integer, Future> downloaderFutures = new HashMap<>();
+  private Map<Integer, Future> downloaderFutures = new ConcurrentHashMap<Integer, Future>();
 
   /**
    * query result format


### PR DESCRIPTION
…ltSets

Resolves issue identified in https://github.com/snowflakedb/snowflake-jdbc/issues/212 by using a ConcurrentHashMap instead of a HashMap.

This does not identify the root cause of why there are concurrent changes to this HashMap to begin with though.