### PR TITLE
SNOW-163587 Fix sql compilation error for using wildcard % in getFunctionColumns()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>net.snowflake</groupId>
       <artifactId>snowflake-common</artifactId>
-      <version>4.0.1</version>
+      <version>3.1.44</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
@@ -323,9 +323,12 @@ public class DatabaseMetaDataInternalIT extends BaseJDBCTest
     assertEquals("FUNC112() RETURN TABLE (COLA VARCHAR, COLB NUMBER, BIN2 BINARY, SHAREDCOL NUMBER)",
                  resultSet.getString("SPECIFIC_NAME"));
     assertFalse(resultSet.next());
+    resultSet = databaseMetaData.getFunctionColumns(null, "%", "%", "%");
+    // we have 81 columns returned
+    assertEquals(81, getSizeOfResultSet(resultSet));
     resultSet = databaseMetaData.getFunctionColumns("%", "%", "%", "%");
-    assertFalse(resultSet.next());
-
+    // we have 81 columns returned
+    assertEquals(0, getSizeOfResultSet(resultSet));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
@@ -326,8 +326,8 @@ public class DatabaseMetaDataInternalIT extends BaseJDBCTest
     resultSet = databaseMetaData.getFunctionColumns(null, "%", "%", "%");
     // we have 81 columns returned
     assertEquals(81, getSizeOfResultSet(resultSet));
+    // setting catalog to % will result in 0 columns. % does not apply for catalog, only for other params
     resultSet = databaseMetaData.getFunctionColumns("%", "%", "%", "%");
-    // we have 81 columns returned
     assertEquals(0, getSizeOfResultSet(resultSet));
   }
 


### PR DESCRIPTION
SNOW-163587

Calling getFunctionColumns(null, "%", "%", "%") resulted in a sql compilation error. I added more error checking so this does not happen.

However, all calls to "desc function" require the proper database and schema, and this data is not always available. So for built-in functions without a database and schema, getFunctionColumns() will not display their columns.