### PR TITLE
SNOW-169174 Bump jackson-databind from 2.9.10.4 to newer version (#261)

### DIFF
--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -41,8 +41,8 @@
     <slf4j.version>1.7.25</slf4j.version>
     <jsoup.version>1.11.3</jsoup.version>
     <tika.version>1.22</tika.version>
-    <jackson.version>2.9.10</jackson.version>
-    <jacksondatabind.version>2.9.10.4</jacksondatabind.version>
+    <jackson.version>2.11.0</jackson.version>
+    <jacksondatabind.version>2.11.0</jacksondatabind.version>
     <httpclient.version>4.5.5</httpclient.version>
     <powermock.version>1.7.4</powermock.version>
     <jacoco.version>0.8.4</jacoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <slf4j.version>1.7.25</slf4j.version>
     <jsoup.version>1.11.3</jsoup.version>
     <tika.version>1.22</tika.version>
-    <jackson.version>2.9.10</jackson.version>
-    <jacksondatabind.version>2.9.10.4</jacksondatabind.version>
+    <jackson.version>2.11.0</jackson.version>
+    <jacksondatabind.version>2.11.0</jacksondatabind.version>
     <httpclient.version>4.5.5</httpclient.version>
     <powermock.version>1.7.4</powermock.version>
     <jacoco.version>0.8.4</jacoco.version>


### PR DESCRIPTION
* Bump jackson-databind from 2.9.10.4 to 2.11.0

Bumps [jackson-databind](https://github.com/FasterXML/jackson) from 2.9.10.4 to 2.11.0.
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Signed-off-by: dependabot[bot] <support@github.com>

* updated the version

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Shige Takeda <shige.takeda@snowflake.com>