### PR TITLE
Snow 169416 fix race condition in creating cachedir

### DIFF
--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -35,8 +35,7 @@ class FileCacheManager
   /**
    * Object mapper for JSON encoding and decoding
    */
-  private static final ObjectMapper OBJECT_MAPPER =
-      ObjectMapperFactory.getObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
 
   private static final Charset DEFAULT_FILE_ENCODING = StandardCharsets.UTF_8;
 
@@ -168,14 +167,15 @@ class FileCacheManager
     // attempt to create the directory up to 10 times
     for (int cnt = 0; !this.cacheDir.exists() && cnt < 10; ++cnt)
     {
-      LOGGER.debug(("Not exists directory. Creating: {}", this.cacheDir.getAbsolutePath());
+      LOGGER.debug("Not exists directory. Creating: {}", this.cacheDir.getAbsolutePath());
       if (this.cacheDir.mkdirs())
       {
-        LOGGER.debug(("Successfully created: {}", this.cacheDir.getAbsolutePath());
+        LOGGER.debug("Successfully created: {}", this.cacheDir.getAbsolutePath());
         break;
       }
-      LOGGER.debug(("Failed to create, maybe already created by other process/thread? Checking again, cnt: {}, {}", cnt,
-                  this.cacheDir.getAbsolutePath());
+      LOGGER.debug(
+          "Failed to create, maybe already created by other process/thread? Checking again, cnt: {}, {}", cnt,
+          this.cacheDir.getAbsolutePath());
       try
       {
         LOGGER.debug("Sleeping {}ms", sleep);
@@ -183,41 +183,38 @@ class FileCacheManager
       }
       catch (InterruptedException e)
       {
-        LOGGER.debug(("Sleep interrupted. Ignored.");
+        LOGGER.debug("Sleep interrupted. Ignored.");
       }
     }
 
     if (!this.cacheDir.exists())
     {
-      LOGGER.debug(("Still Not exists %s. Giving up.");
-      // still the directory doesn't exists
-      throw new RuntimeException(
-          String.format(
-              "Failed to locate or create the cache directory: %s", this.cacheDir)
-      );
+      LOGGER.debug("Still Not exists %s. Giving up.");
+      return this;
     }
-    LOGGER.debug(("Verified Directory {}", this.cacheDir.getAbsolutePath());
+    LOGGER.debug("Verified Directory {}", this.cacheDir.getAbsolutePath());
 
-    File cacheFileTmp = new File(
-        this.cacheDir, this.baseCacheFileName).getAbsoluteFile();
+    File cacheFileTmp = new File(this.cacheDir, this.baseCacheFileName).getAbsoluteFile();
     try
     {
       // create an empty file if not exists and return true.
       // If exists. the method returns false.
       // In this particular case, it doesn't matter as long as the file is
       // writable.
-      cacheFileTmp.createNewFile();
+      if (cacheFileTmp.createNewFile())
+      {
+        LOGGER.debug("Successfully created a cache file {}", cacheFileTmp);
+      }
+      else
+      {
+        LOGGER.debug("Cache file already exists {}", cacheFileTmp);
+      }
       this.cacheFile = cacheFileTmp.getCanonicalFile();
-      this.cacheLockFile = new File(
-          this.cacheFile.getParentFile(), this.baseCacheFileName + ".lck");
+      this.cacheLockFile = new File(this.cacheFile.getParentFile(), this.baseCacheFileName + ".lck");
     }
     catch (IOException | SecurityException ex)
     {
-      throw new RuntimeException(
-          String.format(
-              "Failed to touch the cache file: %s",
-              cacheFileTmp.getAbsoluteFile())
-      );
+      LOGGER.info("Failed to touch the cache file. Ignored. {}", cacheFileTmp.getAbsoluteFile());
     }
     return this;
   }
@@ -249,9 +246,7 @@ class FileCacheManager
     }
     catch (IOException ex)
     {
-      LOGGER.debug(
-          "Failed to read the cache file. No worry. File: {}, Err: {}",
-          cacheFile, ex);
+      LOGGER.debug("Failed to read the cache file. No worry. File: {}, Err: {}", cacheFile, ex);
     }
     return null;
   }

--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -166,12 +166,27 @@ class FileCacheManager
         this.cacheDir = new File(new File(homeDir, ".cache"), "snowflake");
       }
     }
-    if (!this.cacheDir.exists() && !this.cacheDir.mkdirs())
+    final int sleep = 10;
+    // attempt to create the directory up to 10 times
+    for (int cnt = 0; !this.cacheDir.exists() && cnt < 10; ++cnt)
     {
-      throw new RuntimeException(
-          String.format(
-              "Failed to locate or create the cache directory: %s", this.cacheDir)
-      );
+      LOGGER.info("Not exists directory. Creating: {}", this.cacheDir.getAbsolutePath());
+      if (this.cacheDir.mkdirs())
+      {
+        LOGGER.info("Successfully created: {}", this.cacheDir.getAbsolutePath());
+        break;
+      }
+      LOGGER.info("Failed to create, maybe already created by other process/thread? Checking again, cnt: {}, {}", cnt,
+                  this.cacheDir.getAbsolutePath());
+      try
+      {
+        LOGGER.info("Sleeping {}ms", sleep);
+        Thread.sleep(sleep);
+      }
+      catch (InterruptedException e)
+      {
+        LOGGER.info("Sleep interrupted. Ignored.");
+      }
     }
 
     File cacheFileTmp = new File(

--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -234,6 +234,7 @@ class FileCacheManager
     if (cacheFile == null || !tryLockCacheFile())
     {
       // no cache file or it failed to lock file
+      LOGGER.debug("No cache file exists or failed to lock the file. Skipping writing the cache");
       return;
     }
     // NOTE: must unlock cache file

--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -163,33 +163,10 @@ class FileCacheManager
         this.cacheDir = new File(new File(homeDir, ".cache"), "snowflake");
       }
     }
-    final int sleep = 10;
-    // attempt to create the directory up to 10 times
-    for (int cnt = 0; !this.cacheDir.exists() && cnt < 10; ++cnt)
-    {
-      LOGGER.debug("Not exists directory. Creating: {}", this.cacheDir.getAbsolutePath());
-      if (this.cacheDir.mkdirs())
-      {
-        LOGGER.debug("Successfully created: {}", this.cacheDir.getAbsolutePath());
-        break;
-      }
-      LOGGER.debug(
-          "Failed to create, maybe already created by other process/thread? Checking again, cnt: {}, {}", cnt,
-          this.cacheDir.getAbsolutePath());
-      try
-      {
-        LOGGER.debug("Sleeping {}ms", sleep);
-        Thread.sleep(sleep);
-      }
-      catch (InterruptedException e)
-      {
-        LOGGER.debug("Sleep interrupted. Ignored.");
-      }
-    }
 
-    if (!this.cacheDir.exists())
+    if (!this.cacheDir.mkdirs() && !this.cacheDir.exists())
     {
-      LOGGER.debug("Still Not exists %s. Giving up.");
+      LOGGER.debug("Cannot create the cache directory {}. Giving up.", this.cacheDir.getAbsolutePath());
       return this;
     }
     LOGGER.debug("Verified Directory {}", this.cacheDir.getAbsolutePath());

--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -153,13 +153,11 @@ class FileCacheManager
       if (Constants.getOS() == Constants.OS.WINDOWS)
       {
         this.cacheDir = new File(
-            new File(new File(new File(homeDir,
-                                       "AppData"), "Local"), "Snowflake"), "Caches");
+            new File(new File(new File(homeDir, "AppData"), "Local"), "Snowflake"), "Caches");
       }
       else if (Constants.getOS() == Constants.OS.MAC)
       {
-        this.cacheDir = new File(new File(new File(homeDir,
-                                                   "Library"), "Caches"), "Snowflake");
+        this.cacheDir = new File(new File(new File(homeDir, "Library"), "Caches"), "Snowflake");
       }
       else
       {
@@ -170,24 +168,35 @@ class FileCacheManager
     // attempt to create the directory up to 10 times
     for (int cnt = 0; !this.cacheDir.exists() && cnt < 10; ++cnt)
     {
-      LOGGER.info("Not exists directory. Creating: {}", this.cacheDir.getAbsolutePath());
+      LOGGER.debug(("Not exists directory. Creating: {}", this.cacheDir.getAbsolutePath());
       if (this.cacheDir.mkdirs())
       {
-        LOGGER.info("Successfully created: {}", this.cacheDir.getAbsolutePath());
+        LOGGER.debug(("Successfully created: {}", this.cacheDir.getAbsolutePath());
         break;
       }
-      LOGGER.info("Failed to create, maybe already created by other process/thread? Checking again, cnt: {}, {}", cnt,
+      LOGGER.debug(("Failed to create, maybe already created by other process/thread? Checking again, cnt: {}, {}", cnt,
                   this.cacheDir.getAbsolutePath());
       try
       {
-        LOGGER.info("Sleeping {}ms", sleep);
+        LOGGER.debug("Sleeping {}ms", sleep);
         Thread.sleep(sleep);
       }
       catch (InterruptedException e)
       {
-        LOGGER.info("Sleep interrupted. Ignored.");
+        LOGGER.debug(("Sleep interrupted. Ignored.");
       }
     }
+
+    if (!this.cacheDir.exists())
+    {
+      LOGGER.debug(("Still Not exists %s. Giving up.");
+      // still the directory doesn't exists
+      throw new RuntimeException(
+          String.format(
+              "Failed to locate or create the cache directory: %s", this.cacheDir)
+      );
+    }
+    LOGGER.debug(("Verified Directory {}", this.cacheDir.getAbsolutePath());
 
     File cacheFileTmp = new File(
         this.cacheDir, this.baseCacheFileName).getAbsoluteFile();

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -44,6 +44,7 @@ import javax.net.ssl.TrustManager;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -213,9 +214,20 @@ public class HttpUtil
       // 1) OCSP service is down for reasons, 2) PowerMock test tht doesn't
       // care OCSP checks.
       // OCSP FailOpen is ON by default
-      TrustManager[] tm = {
-          new SFTrustManager(ocspMode, ocspCacheFile)};
-      trustManagers = tm;
+      try
+      {
+        TrustManager[] tm = {
+            new SFTrustManager(ocspMode, ocspCacheFile)};
+        trustManagers = tm;
+      }
+      catch(Exception | Error err)
+      {
+        // dump error stack
+        StringWriter errors = new StringWriter();
+        err.printStackTrace(new PrintWriter(errors));
+        logger.error(errors.toString());
+        throw new RuntimeException(err); // rethrow the exception
+      }
     }
     try
     {

--- a/src/main/java/net/snowflake/client/core/SFTrustManager.java
+++ b/src/main/java/net/snowflake/client/core/SFTrustManager.java
@@ -544,7 +544,7 @@ public class SFTrustManager extends X509ExtendedTrustManager
     JsonNode ocspRespBase64 = elem.getValue();
     if (!ocspRespBase64.isArray() || ocspRespBase64.size() != 2)
     {
-      LOGGER.debug("Invalid cache file format.");
+      LOGGER.debug("Invalid cache file format. Ignored");
       return null;
     }
     long producedAt = ocspRespBase64.get(0).asLong();


### PR DESCRIPTION
When multiple threads/processes attempt to create the same directory in the same timing, one of them will be success but not others. This race condition makes the initialization of `FileCacheManager` fail and stop the process.

The fix is to change the order of 1) check the directory existence and 2) `mkdirp` so that the directory is always guaranteed to be created as long as the process has a write access to avoid the error.

Aside from it, this change completely removes `RuntimeException` from `FileCacheManager` to reduce a chance of unexpected error when `SFTrustManager` is initialized in `HttpUtil`.