### PR TITLE
setObject support Byte

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -483,6 +483,10 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     {
       setBigDecimal(parameterIndex, (BigDecimal) x);
     }
+    else if (x instanceof Byte)
+    {
+      setByte(parameterIndex, (Byte) x);
+    }
     else if (x instanceof Short)
     {
       setShort(parameterIndex, (Short) x);


### PR DESCRIPTION
to fix
>     19:21:29,784  WARN Test worker Exposed:invoke:183 - Transaction attempt #0 failed: Data type not supported for  binding: Object type: class java.lang.Byte.. Statement(s): null
>    net.snowflake.client.jdbc.SnowflakeSQLException: Data type not supported for binding: Object type: class java.lang.Byte.
>        at net.snowflake.client.jdbc.SnowflakePreparedStatementV1.setObject(SnowflakePreparedStatementV1.java:526)
>       at org.jetbrains.exposed.sql.statements.jdbc.JdbcPreparedStatementImpl.set(JdbcPreparedStatementImpl.kt:26)
>      at org.jetbrains.exposed.sql.IColumnType$DefaultImpls.setParameter(ColumnType.kt:65)
>        at org.jetbrains.exposed.sql.ColumnType.setParameter(ColumnType.kt:72)
>        at org.jetbrains.exposed.sql.statements.api.PreparedStatementApi$DefaultImpls.fillParameters(PreparedStatementApi.kt:13)
