### PR TITLE
SNOW-164505 Implement functionality of SnowflakeSQLLoggedException and test case

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -220,7 +220,7 @@ public class HttpUtil
             new SFTrustManager(ocspMode, ocspCacheFile)};
         trustManagers = tm;
       }
-      catch(Exception | Error err)
+      catch (Exception | Error err)
       {
         // dump error stack
         StringWriter errors = new StringWriter();

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -439,8 +439,8 @@ public class RestRequest
     return response != null &&
            (response.getStatusLine().getStatusCode() < 500 || // service unavailable
             response.getStatusLine().getStatusCode() >= 600) && // gateway timeout
-            response.getStatusLine().getStatusCode() != 408 && // request timeout
-            (retryHTTP403 || response.getStatusLine().getStatusCode() != 403);
+           response.getStatusLine().getStatusCode() != 408 && // request timeout
+           (retryHTTP403 || response.getStatusLine().getStatusCode() != 403);
   }
 
   private static boolean isCertificateRevoked(Exception ex)

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -18,12 +18,12 @@ import java.sql.SQLException;
 public class SnowflakeSQLException extends SQLException
 {
   static final SFLogger logger =
-          SFLoggerFactory.getLogger(SnowflakeSQLException.class);
+      SFLoggerFactory.getLogger(SnowflakeSQLException.class);
 
   private static final long serialVersionUID = 1L;
 
   static final ResourceBundleManager errorResourceBundleManager =
-          ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
+      ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
 
   private String queryId = "unknown";
 
@@ -49,7 +49,7 @@ public class SnowflakeSQLException extends SQLException
 
     // log user error from GS at fine level
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}, queryId:{}",
-            reason, sqlState, vendorCode, queryId);
+                 reason, sqlState, vendorCode, queryId);
 
   }
 
@@ -58,40 +58,40 @@ public class SnowflakeSQLException extends SQLException
     super(reason, SQLState);
     // log user error from GS at fine level
     logger.debug("Snowflake exception: {}, sqlState:{}",
-            reason, SQLState);
+                 reason, SQLState);
   }
 
   public SnowflakeSQLException(String sqlState, int vendorCode)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode)), sqlState, vendorCode);
+        String.valueOf(vendorCode)), sqlState, vendorCode);
 
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}",
-            errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
-            sqlState,
-            vendorCode);
+                 errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
+                 sqlState,
+                 vendorCode);
   }
 
   public SnowflakeSQLException(String sqlState, int vendorCode, Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode), params), sqlState, vendorCode);
+        String.valueOf(vendorCode), params), sqlState, vendorCode);
 
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}",
-            errorResourceBundleManager.getLocalizedMessage(
-                    String.valueOf(vendorCode), params),
-            sqlState,
-            vendorCode);
+                 errorResourceBundleManager.getLocalizedMessage(
+                     String.valueOf(vendorCode), params),
+                 sqlState,
+                 vendorCode);
   }
 
   public SnowflakeSQLException(Throwable ex, String sqlState, int vendorCode)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode)), sqlState, vendorCode, ex);
+        String.valueOf(vendorCode)), sqlState, vendorCode, ex);
 
     logger.debug("Snowflake exception: {}" +
-            errorResourceBundleManager.getLocalizedMessage(
-                    String.valueOf(vendorCode)), ex);
+                 errorResourceBundleManager.getLocalizedMessage(
+                     String.valueOf(vendorCode)), ex);
   }
 
   public SnowflakeSQLException(Throwable ex, ErrorCode errorCode, Object... params)
@@ -105,19 +105,19 @@ public class SnowflakeSQLException extends SQLException
                                Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode), params), sqlState, vendorCode, ex);
+        String.valueOf(vendorCode), params), sqlState, vendorCode, ex);
 
     logger.debug("Snowflake exception: " +
-            errorResourceBundleManager.getLocalizedMessage(
-                    String.valueOf(vendorCode), params), ex);
+                 errorResourceBundleManager.getLocalizedMessage(
+                     String.valueOf(vendorCode), params), ex);
   }
 
   public SnowflakeSQLException(ErrorCode errorCode, Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(errorCode.getMessageCode()), params),
-            errorCode.getSqlState(),
-            errorCode.getMessageCode());
+        String.valueOf(errorCode.getMessageCode()), params),
+          errorCode.getSqlState(),
+          errorCode.getMessageCode());
   }
 
   public SnowflakeSQLException(SFException e)

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
  */
@@ -17,12 +18,12 @@ import java.sql.SQLException;
 public class SnowflakeSQLException extends SQLException
 {
   static final SFLogger logger =
-      SFLoggerFactory.getLogger(SnowflakeSQLException.class);
+          SFLoggerFactory.getLogger(SnowflakeSQLException.class);
 
   private static final long serialVersionUID = 1L;
 
   static final ResourceBundleManager errorResourceBundleManager =
-      ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
+          ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
 
   private String queryId = "unknown";
 
@@ -48,41 +49,49 @@ public class SnowflakeSQLException extends SQLException
 
     // log user error from GS at fine level
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}, queryId:{}",
-                 reason, sqlState, vendorCode, queryId);
+            reason, sqlState, vendorCode, queryId);
 
+  }
+
+  public SnowflakeSQLException(String reason, String SQLState)
+  {
+    super(reason, SQLState);
+    // log user error from GS at fine level
+    logger.debug("Snowflake exception: {}, sqlState:{}",
+            reason, SQLState);
   }
 
   public SnowflakeSQLException(String sqlState, int vendorCode)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-        String.valueOf(vendorCode)), sqlState, vendorCode);
+            String.valueOf(vendorCode)), sqlState, vendorCode);
 
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}",
-                 errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
-                 sqlState,
-                 vendorCode);
+            errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
+            sqlState,
+            vendorCode);
   }
 
   public SnowflakeSQLException(String sqlState, int vendorCode, Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-        String.valueOf(vendorCode), params), sqlState, vendorCode);
+            String.valueOf(vendorCode), params), sqlState, vendorCode);
 
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}",
-                 errorResourceBundleManager.getLocalizedMessage(
-                     String.valueOf(vendorCode), params),
-                 sqlState,
-                 vendorCode);
+            errorResourceBundleManager.getLocalizedMessage(
+                    String.valueOf(vendorCode), params),
+            sqlState,
+            vendorCode);
   }
 
   public SnowflakeSQLException(Throwable ex, String sqlState, int vendorCode)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-        String.valueOf(vendorCode)), sqlState, vendorCode, ex);
+            String.valueOf(vendorCode)), sqlState, vendorCode, ex);
 
     logger.debug("Snowflake exception: {}" +
-                 errorResourceBundleManager.getLocalizedMessage(
-                     String.valueOf(vendorCode)), ex);
+            errorResourceBundleManager.getLocalizedMessage(
+                    String.valueOf(vendorCode)), ex);
   }
 
   public SnowflakeSQLException(Throwable ex, ErrorCode errorCode, Object... params)
@@ -96,24 +105,29 @@ public class SnowflakeSQLException extends SQLException
                                Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-        String.valueOf(vendorCode), params), sqlState, vendorCode, ex);
+            String.valueOf(vendorCode), params), sqlState, vendorCode, ex);
 
     logger.debug("Snowflake exception: " +
-                 errorResourceBundleManager.getLocalizedMessage(
-                     String.valueOf(vendorCode), params), ex);
+            errorResourceBundleManager.getLocalizedMessage(
+                    String.valueOf(vendorCode), params), ex);
   }
 
   public SnowflakeSQLException(ErrorCode errorCode, Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-        String.valueOf(errorCode.getMessageCode()), params),
-          errorCode.getSqlState(),
-          errorCode.getMessageCode());
+            String.valueOf(errorCode.getMessageCode()), params),
+            errorCode.getSqlState(),
+            errorCode.getMessageCode());
   }
 
   public SnowflakeSQLException(SFException e)
   {
     this(e.getQueryId(), e.getMessage(), e.getSqlState(), e.getVendorCode());
+  }
+
+  public SnowflakeSQLException(String reason)
+  {
+    super(reason);
   }
 
   public String getQueryId()

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -14,131 +14,134 @@ import java.io.StringWriter;
 
 /**
  * @author mknister
- *
+ * <p>
  * This SnowflakeSQLLoggedException class extends the SnowflakeSQLException class to add OOB telemetry data for sql
  * exceptions. Not all sql exceptions require OOB telemetry logging so the exceptions in this class should only be
  * thrown if there is a need for logging the exception with OOB telemetry.
  */
 
-public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
+public class SnowflakeSQLLoggedException extends SnowflakeSQLException
+{
 
-    public TelemetryService telemetryInstance = TelemetryService.getInstance();
+  public TelemetryService telemetryInstance = TelemetryService.getInstance();
 
-    /**
-     *
-     * @param value JSONnode containing relevant information specific to the exception constructor that
-     *              should be included in the telemetry data, such as sqlState or vendorCode
-     * @param ex The exception being thrown
-     */
-    private void buildExceptionTelemetryLog(JSONObject value, SnowflakeSQLLoggedException ex)
-    {
-        TelemetryEvent.LogBuilder logBuilder = new TelemetryEvent.LogBuilder();
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        ex.printStackTrace(pw);
-        String stackTrace = sw.toString();
-        value.put("Stacktrace", stackTrace);
-        TelemetryEvent log = logBuilder
-                .withName("Exception: " + ex.getMessage())
-                .withValue(value)
-                .build();
-        telemetryInstance.report(log);
-    }
+  /**
+   * @param value JSONnode containing relevant information specific to the exception constructor that
+   *              should be included in the telemetry data, such as sqlState or vendorCode
+   * @param ex    The exception being thrown
+   */
+  private void buildExceptionTelemetryLog(JSONObject value, SnowflakeSQLLoggedException ex)
+  {
+    TelemetryEvent.LogBuilder logBuilder = new TelemetryEvent.LogBuilder();
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    ex.printStackTrace(pw);
+    String stackTrace = sw.toString();
+    value.put("Stacktrace", stackTrace);
+    TelemetryEvent log = logBuilder
+        .withName("Exception: " + ex.getMessage())
+        .withValue(value)
+        .build();
+    telemetryInstance.report(log);
+  }
 
-    public SnowflakeSQLLoggedException(String queryId, String reason, String SQLState, int vendorCode)
-    {
-        super(queryId, reason, SQLState, vendorCode);
-        // add telemetry
-        JSONObject value = new JSONObject();
-        value.put("SQLState", SQLState);
-        value.put("Query ID", queryId);
-        value.put("Vendor Code", vendorCode);
-        value.put("reason", reason);
-        buildExceptionTelemetryLog(value, this);
-    }
+  public SnowflakeSQLLoggedException(String queryId, String reason, String SQLState, int vendorCode)
+  {
+    super(queryId, reason, SQLState, vendorCode);
+    // add telemetry
+    JSONObject value = new JSONObject();
+    value.put("SQLState", SQLState);
+    value.put("Query ID", queryId);
+    value.put("Vendor Code", vendorCode);
+    value.put("reason", reason);
+    buildExceptionTelemetryLog(value, this);
+  }
 
-    public SnowflakeSQLLoggedException(String SQLState, int vendorCode)
-    {
-        super(SQLState, vendorCode);
-        // add telemetry
-        JSONObject value = new JSONObject();
-        value.put("SQLState", SQLState);
-        value.put("Vendor Code", vendorCode);
-        buildExceptionTelemetryLog(value, this);
-    }
+  public SnowflakeSQLLoggedException(String SQLState, int vendorCode)
+  {
+    super(SQLState, vendorCode);
+    // add telemetry
+    JSONObject value = new JSONObject();
+    value.put("SQLState", SQLState);
+    value.put("Vendor Code", vendorCode);
+    buildExceptionTelemetryLog(value, this);
+  }
 
-    public SnowflakeSQLLoggedException(String reason, String SQLState)
-    {
-        super(reason, SQLState);
-        // add telemetry
-        JSONObject value = new JSONObject();
-        value.put("SQLState", SQLState);
-        value.put("reason", reason);
-        buildExceptionTelemetryLog(value, this);
-    }
+  public SnowflakeSQLLoggedException(String reason, String SQLState)
+  {
+    super(reason, SQLState);
+    // add telemetry
+    JSONObject value = new JSONObject();
+    value.put("SQLState", SQLState);
+    value.put("reason", reason);
+    buildExceptionTelemetryLog(value, this);
+  }
 
-    public SnowflakeSQLLoggedException(String SQLState, int vendorCode, Object... params)
-    {
-        super(SQLState, vendorCode, params);
-        // add telemetry
-        String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
-        JSONObject value = new JSONObject();
-        value.put("SQLState", SQLState);
-        value.put("error message", errorMessage);
-        value.put("vendorCode", vendorCode);
-        buildExceptionTelemetryLog(value, this);
-    }
+  public SnowflakeSQLLoggedException(String SQLState, int vendorCode, Object... params)
+  {
+    super(SQLState, vendorCode, params);
+    // add telemetry
+    String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
+    JSONObject value = new JSONObject();
+    value.put("SQLState", SQLState);
+    value.put("error message", errorMessage);
+    value.put("vendorCode", vendorCode);
+    buildExceptionTelemetryLog(value, this);
+  }
 
-    public SnowflakeSQLLoggedException(Throwable ex, ErrorCode errorCode, Object... params)
-    {
-        super(ex, errorCode, params);
-        // add telemetry
-        String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(errorCode.getMessageCode()), params);
-        JSONObject value = new JSONObject();
-        value.put("SQLState", errorCode.getSqlState());
-        value.put("error message", errorMessage);
-        value.put("VendorCode", errorCode.getMessageCode());
-        value.put("Error code", errorCode);
-        buildExceptionTelemetryLog(value, this);
-    }
+  public SnowflakeSQLLoggedException(Throwable ex, ErrorCode errorCode, Object... params)
+  {
+    super(ex, errorCode, params);
+    // add telemetry
+    String errorMessage =
+        errorResourceBundleManager.getLocalizedMessage(String.valueOf(errorCode.getMessageCode()), params);
+    JSONObject value = new JSONObject();
+    value.put("SQLState", errorCode.getSqlState());
+    value.put("error message", errorMessage);
+    value.put("VendorCode", errorCode.getMessageCode());
+    value.put("Error code", errorCode);
+    buildExceptionTelemetryLog(value, this);
+  }
 
-    public SnowflakeSQLLoggedException(Throwable ex,
-                                       String SQLState,
-                                       int vendorCode,
-                                       Object... params)
-    {
-        super(ex, SQLState, vendorCode, params);
-        // add telemetry
-        String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
-        JSONObject value = new JSONObject();
-        value.put("error message", errorMessage);
-        value.put("VendorCode", vendorCode);
-        buildExceptionTelemetryLog(value, this);
-    }
+  public SnowflakeSQLLoggedException(Throwable ex,
+                                     String SQLState,
+                                     int vendorCode,
+                                     Object... params)
+  {
+    super(ex, SQLState, vendorCode, params);
+    // add telemetry
+    String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
+    JSONObject value = new JSONObject();
+    value.put("error message", errorMessage);
+    value.put("VendorCode", vendorCode);
+    buildExceptionTelemetryLog(value, this);
+  }
 
-    public SnowflakeSQLLoggedException(ErrorCode errorCode, Object... params)
-    {
-        super (errorCode, params);
-        // add telemetry
-        String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(errorCode.getMessageCode()), params);
-        JSONObject value = new JSONObject();
-        value.put("error message", errorMessage);
-        value.put("errorCode", errorCode);
-        buildExceptionTelemetryLog(value, this);
-    }
+  public SnowflakeSQLLoggedException(ErrorCode errorCode, Object... params)
+  {
+    super(errorCode, params);
+    // add telemetry
+    String errorMessage =
+        errorResourceBundleManager.getLocalizedMessage(String.valueOf(errorCode.getMessageCode()), params);
+    JSONObject value = new JSONObject();
+    value.put("error message", errorMessage);
+    value.put("errorCode", errorCode);
+    buildExceptionTelemetryLog(value, this);
+  }
 
-    public SnowflakeSQLLoggedException(SFException e)
-    {
-        super (e);
-        // add telemetry
-        buildExceptionTelemetryLog(null, this);
-    }
+  public SnowflakeSQLLoggedException(SFException e)
+  {
+    super(e);
+    // add telemetry
+    buildExceptionTelemetryLog(null, this);
+  }
 
-    public SnowflakeSQLLoggedException(String reason) {
-        super(reason);
-        // add telemetry
-        JSONObject value = new JSONObject();
-        value.put("reason", reason);
-        buildExceptionTelemetryLog(value, this);
-    }
+  public SnowflakeSQLLoggedException(String reason)
+  {
+    super(reason);
+    // add telemetry
+    JSONObject value = new JSONObject();
+    value.put("reason", reason);
+    buildExceptionTelemetryLog(value, this);
+  }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -8,7 +8,6 @@ import net.minidev.json.JSONObject;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryEvent;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
-import net.snowflake.client.util.SecretDetector;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -54,7 +53,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
         value.put("SQLState", SQLState);
         value.put("Query ID", queryId);
         value.put("Vendor Code", vendorCode);
-        value.put("reason", SecretDetector.maskSecrets(reason));
+        value.put("reason", reason);
         buildExceptionTelemetryLog(value, this);
     }
 
@@ -74,7 +73,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
         // add telemetry
         JSONObject value = new JSONObject();
         value.put("SQLState", SQLState);
-        value.put("reason", SecretDetector.maskSecrets(reason));
+        value.put("reason", reason);
         buildExceptionTelemetryLog(value, this);
     }
 
@@ -139,7 +138,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
         super(reason);
         // add telemetry
         JSONObject value = new JSONObject();
-        value.put("reason", SecretDetector.maskSecrets(reason));
+        value.put("reason", reason);
         buildExceptionTelemetryLog(value, this);
     }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.client.jdbc;
+
+import net.minidev.json.JSONObject;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.jdbc.telemetryOOB.TelemetryEvent;
+import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
+import net.snowflake.client.util.SecretDetector;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * @author mknister
+ *
+ * This SnowflakeSQLLoggedException class extends the SnowflakeSQLException class to add OOB telemetry data for sql
+ * exceptions. Not all sql exceptions require OOB telemetry logging so the exceptions in this class should only be
+ * thrown if there is a need for logging the exception with OOB telemetry.
+ */
+
+public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
+
+    public TelemetryService telemetryInstance = TelemetryService.getInstance();
+
+    /**
+     *
+     * @param value JSONnode containing relevant information specific to the exception constructor that
+     *              should be included in the telemetry data, such as sqlState or vendorCode
+     * @param ex The exception being thrown
+     */
+    private void buildExceptionTelemetryLog(JSONObject value, SnowflakeSQLLoggedException ex)
+    {
+        TelemetryEvent.LogBuilder logBuilder = new TelemetryEvent.LogBuilder();
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ex.printStackTrace(pw);
+        String stackTrace = sw.toString();
+        value.put("Stacktrace", stackTrace);
+        TelemetryEvent log = logBuilder
+                .withName("Exception: " + ex.getMessage())
+                .withValue(value)
+                .build();
+        telemetryInstance.report(log);
+    }
+
+    public SnowflakeSQLLoggedException(String queryId, String reason, String SQLState, int vendorCode)
+    {
+        super(queryId, reason, SQLState, vendorCode);
+        // add telemetry
+        JSONObject value = new JSONObject();
+        value.put("SQLState", SQLState);
+        value.put("Query ID", queryId);
+        value.put("Vendor Code", vendorCode);
+        value.put("reason", SecretDetector.maskSecrets(reason));
+        buildExceptionTelemetryLog(value, this);
+    }
+
+    public SnowflakeSQLLoggedException(String SQLState, int vendorCode)
+    {
+        super(SQLState, vendorCode);
+        // add telemetry
+        JSONObject value = new JSONObject();
+        value.put("SQLState", SQLState);
+        value.put("Vendor Code", vendorCode);
+        buildExceptionTelemetryLog(value, this);
+    }
+
+    public SnowflakeSQLLoggedException(String reason, String SQLState)
+    {
+        super(reason, SQLState);
+        // add telemetry
+        JSONObject value = new JSONObject();
+        value.put("SQLState", SQLState);
+        value.put("reason", SecretDetector.maskSecrets(reason));
+        buildExceptionTelemetryLog(value, this);
+    }
+
+    public SnowflakeSQLLoggedException(String SQLState, int vendorCode, Object... params)
+    {
+        super(SQLState, vendorCode, params);
+        // add telemetry
+        String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
+        JSONObject value = new JSONObject();
+        value.put("SQLState", SQLState);
+        value.put("error message", errorMessage);
+        value.put("vendorCode", vendorCode);
+        buildExceptionTelemetryLog(value, this);
+    }
+
+    public SnowflakeSQLLoggedException(Throwable ex, ErrorCode errorCode, Object... params)
+    {
+        super(ex, errorCode, params);
+        // add telemetry
+        String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(errorCode.getMessageCode()), params);
+        JSONObject value = new JSONObject();
+        value.put("SQLState", errorCode.getSqlState());
+        value.put("error message", errorMessage);
+        value.put("VendorCode", errorCode.getMessageCode());
+        value.put("Error code", errorCode);
+        buildExceptionTelemetryLog(value, this);
+    }
+
+    public SnowflakeSQLLoggedException(Throwable ex,
+                                       String SQLState,
+                                       int vendorCode,
+                                       Object... params)
+    {
+        super(ex, SQLState, vendorCode, params);
+        // add telemetry
+        String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
+        JSONObject value = new JSONObject();
+        value.put("error message", errorMessage);
+        value.put("VendorCode", vendorCode);
+        buildExceptionTelemetryLog(value, this);
+    }
+
+    public SnowflakeSQLLoggedException(ErrorCode errorCode, Object... params)
+    {
+        super (errorCode, params);
+        // add telemetry
+        String errorMessage = errorResourceBundleManager.getLocalizedMessage(String.valueOf(errorCode.getMessageCode()), params);
+        JSONObject value = new JSONObject();
+        value.put("error message", errorMessage);
+        value.put("errorCode", errorCode);
+        buildExceptionTelemetryLog(value, this);
+    }
+
+    public SnowflakeSQLLoggedException(SFException e)
+    {
+        super (e);
+        // add telemetry
+        buildExceptionTelemetryLog(null, this);
+    }
+
+    public SnowflakeSQLLoggedException(String reason) {
+        super(reason);
+        // add telemetry
+        JSONObject value = new JSONObject();
+        value.put("reason", SecretDetector.maskSecrets(reason));
+        buildExceptionTelemetryLog(value, this);
+    }
+}

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryField.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryField.java
@@ -15,6 +15,8 @@ public enum TelemetryField
   FAILED_BIND_SERIALIZATION("client_failed_bind_serialization"),
   FAILED_BIND_UPLOAD("client_failed_bind_upload"),
   FAILED_BIND_OTHER("client_failed_bind_other"),
+
+  SQL_EXCEPTION("client_sql_exception"),
   ;
 
   public final String field;

--- a/src/test/java/net/snowflake/client/jdbc/SessionVariablesIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SessionVariablesIT.java
@@ -80,7 +80,7 @@ public final class SessionVariablesIT extends AbstractDriverIT
     con.close();
 
     con = getSnowflakeAdminConnection(properties);
-    sql(con,"alter system unset enable_assignment_scalar, enable_assignment_statement");
+    sql(con, "alter system unset enable_assignment_scalar, enable_assignment_statement");
     con.close();
 
   }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
+
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -692,7 +693,7 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest
       }
       catch (SQLException ex)
       {
-        assertEquals((long)ErrorCode.INTERNAL_ERROR.getMessageCode(), ex.getErrorCode());
+        assertEquals((long) ErrorCode.INTERNAL_ERROR.getMessageCode(), ex.getErrorCode());
       }
 
       rs.close();
@@ -901,8 +902,8 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest
       rs.close();
     }
     assertEquals(expectedTotalRowCount, rowCount);
-    assertThat(expectedTotalCompressedSize, greaterThan((long)0));
-    assertThat(expectedTotalUncompressedSize, greaterThan((long)0));
+    assertThat(expectedTotalCompressedSize, greaterThan((long) 0));
+    assertThat(expectedTotalUncompressedSize, greaterThan((long) 0));
 
     // Split deserializedResultSet by 3M
     List<String> fileNameSplit3M = splitResultSetSerializables(

--- a/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
@@ -239,7 +239,8 @@ public class TelemetryServiceIT extends BaseJDBCTest
     sw.stop();
   }
 
-  private void generateDummyException(int value) throws SnowflakeSQLLoggedException {
+  private void generateDummyException(int value) throws SnowflakeSQLLoggedException
+  {
     if (value > 0)
     {
       String queryID = "01234567-1234-1234-1234-00001abcdefg";
@@ -249,10 +250,11 @@ public class TelemetryServiceIT extends BaseJDBCTest
       throw new SnowflakeSQLLoggedException(queryID, reason, sqlState, vendorCode);
     }
   }
-  
+
   /**
    * Test case for checking telemetry message for SnowflakeSQLExceptions. Assert that telemetry OOB endpoint is reached
    * after a SnowflakeSQLLoggedException is thrown.
+   *
    * @throws SQLException
    */
   @Test
@@ -262,7 +264,8 @@ public class TelemetryServiceIT extends BaseJDBCTest
     Connection con = getConnection();
     int count = TelemetryService.getInstance().getEventCount();
     int fakeErrorCode = 27;
-    try {
+    try
+    {
       generateDummyException(fakeErrorCode);
     }
     catch (SQLException e)
@@ -270,7 +273,7 @@ public class TelemetryServiceIT extends BaseJDBCTest
       // a connection error response (wrong user and password)
       // with status code 200 is returned in RT
       assertThat("Communication error", e.getErrorCode(),
-              equalTo(fakeErrorCode));
+                 equalTo(fakeErrorCode));
 
       // since it returns normal response,
       // the telemetry does not create new event
@@ -278,8 +281,8 @@ public class TelemetryServiceIT extends BaseJDBCTest
       if (TelemetryService.getInstance().isDeploymentEnabled())
       {
         assertThat("Telemetry event has not been reported successfully. Error: " +
-                        TelemetryService.getInstance().getLastClientError(),
-                TelemetryService.getInstance().getClientFailureCount(), equalTo(0));
+                   TelemetryService.getInstance().getLastClientError(),
+                   TelemetryService.getInstance().getClientFailureCount(), equalTo(0));
       }
       return;
     }

--- a/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
@@ -3,6 +3,7 @@ package net.snowflake.client.jdbc.telemetryOOB;
 
 import net.snowflake.client.category.TestCategoryCore;
 import net.snowflake.client.jdbc.BaseJDBCTest;
+import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.SnowflakeSQLLoggedException;
 import net.snowflake.common.core.SqlState;
 import org.apache.commons.lang3.time.StopWatch;
@@ -247,7 +248,7 @@ public class TelemetryServiceIT extends BaseJDBCTest
       String reason = "This is a test exception.";
       String sqlState = SqlState.NO_DATA;
       int vendorCode = value;
-      throw new SnowflakeSQLLoggedException(queryID, reason, sqlState, vendorCode);
+      throw new SnowflakeSQLLoggedException(queryID, reason, sqlState, vendorCode, null);
     }
   }
 
@@ -262,6 +263,7 @@ public class TelemetryServiceIT extends BaseJDBCTest
   {
     // make a connection to initialize telemetry instance
     Connection con = getConnection();
+    con.unwrap(SnowflakeConnectionV1.class).getSfSession();
     int count = TelemetryService.getInstance().getEventCount();
     int fakeErrorCode = 27;
     try

--- a/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
@@ -4,6 +4,7 @@ package net.snowflake.client.jdbc.telemetryOOB;
 import net.snowflake.client.jdbc.BaseJDBCTest;
 import net.snowflake.client.category.TestCategoryCore;
 import net.snowflake.client.jdbc.SnowflakeSQLLoggedException;
+import net.snowflake.common.core.SqlState;
 import org.apache.commons.lang3.time.StopWatch;
 import org.junit.After;
 import org.junit.Before;
@@ -235,6 +236,17 @@ public class TelemetryServiceIT extends BaseJDBCTest
     sw.stop();
   }
 
+  private void generateDummyException(int value) throws SnowflakeSQLLoggedException {
+    if (value > 0)
+    {
+      String queryID = "01234567-1234-1234-1234-00001abcdefg";
+      String reason = "This is a test exception.";
+      String sqlState = SqlState.NO_DATA;
+      int vendorCode = 0;
+      throw new SnowflakeSQLLoggedException(queryID, reason, sqlState, vendorCode);
+    }
+  }
+  
   /**
    * Manual test case for checking telemetry message for SnowflakeSQLExceptions. Connect to dev or prod account and
    * query client_telemetry table in s3testaccount for results.

--- a/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
@@ -3,6 +3,7 @@ package net.snowflake.client.jdbc.telemetryOOB;
 
 import net.snowflake.client.jdbc.BaseJDBCTest;
 import net.snowflake.client.category.TestCategoryCore;
+import net.snowflake.client.jdbc.SnowflakeSQLLoggedException;
 import org.apache.commons.lang3.time.StopWatch;
 import org.junit.After;
 import org.junit.Before;
@@ -10,6 +11,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -230,5 +233,59 @@ public class TelemetryServiceIT extends BaseJDBCTest
       }
     }
     sw.stop();
+  }
+
+  /**
+   * Manual test case for checking telemetry message for SnowflakeSQLExceptions. Connect to dev or prod account and
+   * query client_telemetry table in s3testaccount for results.
+   * @throws SQLException
+   */
+  @Ignore
+  @Test
+  public void testSnowflakeSQLLoggedExceptionTelemetry() throws SQLException
+  {
+    // make a connection to initialize telemetry instance
+    Connection con = getConnection();
+    try {
+      generateDummyException(5);
+    }
+    catch (SnowflakeSQLLoggedException e)
+    {
+      e.printStackTrace();
+    }
+    /* Telemetry data should look like this when collected:
+    {
+      "Created_On": "2020-07-01 21:48:22",
+      "Enqueued_On": "2020-07-01 21:48:23",
+      "Name": "Exception: This is a test exception.",
+      "SchemaVersion": 1,
+      "Staged_On": "2020-07-01 21:48:44",
+      "Tags": {
+        "UUID": "f5e8ba4e-4136-4a32-9b69-c4824971a460",
+        "connectionString": "http://snowflake.dev.local:8080?ROLE=sysadmin&ACCOUNT=testaccount&PASSWORD=☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺",
+        "ctx_account": "testaccount",
+        "ctx_db": "testdb",
+        "ctx_insecuremode": "false",
+        "ctx_internal": "true",
+        "ctx_role": "sysadmin",
+        "ctx_schema": "testschema",
+        "ctx_ssl": "off",
+        "ctx_user": "snowman",
+        "ctx_warehouse": "regress",
+        "driver": "JDBC",
+        "snowhouseSchema": "dev",
+        "telemetryServerDeployment": "dev",
+        "version": "3.12.8"
+      },
+      "Type": "Log",
+      "UUID": "f5e8ba4e-4136-4a32-9b69-c4824971a460",
+      "Value": {
+        "Query ID": "01234567-1234-1234-1234-00001abcdefg",
+        "SQLState": "02000",
+        "Stacktrace": "net.snowflake.client.jdbc.SnowflakeSQLLoggedException: This is a test exception.\n\tat net.snowflake.client.jdbc.telemetryOOB.TelemetryServiceIT.generateDummyException(TelemetryServiceIT.java:246)\n\tat net.snowflake.client.jdbc.telemetryOOB.TelemetryServiceIT.testSnowflakeSQLLoggedExceptionTelemetry(TelemetryServiceIT.java:262)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:567)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)\n\tat org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)\n\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)\n\tat org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)\n\tat org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:363)\n\tat org.junit.runner.JUnitCore.run(JUnitCore.java:137)\n\tat com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)\n\tat com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)\n\tat com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)\n\tat com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)\n",
+        "Vendor Code": 0
+      }
+    }
+     */
   }
 }


### PR DESCRIPTION
This is part 2 to SNOW-164505. The OOB telemetry can be queried in https://s3testaccount.us-east-1.snowflakecomputing.com. Choose the database SNOWHOUSE_IMPORT and the corresponding schema to which deployment your connection is in: prod, dev, reg, va, etc. Then query the **client_telemetry** table with a query similar to this one: **select * from client_telemetry where event:"Tags":"driver"::text = 'JDBC' order by CREATED_ON desc limit 100;** and you should see a telemetry event that looks something like this:
`{
  "Created_On": "2020-07-01 21:52:09",
  "Enqueued_On": "2020-07-01 21:52:10",
  "Name": "Exception: This is a test exception.",
  "SchemaVersion": 1,
  "Staged_On": "2020-07-01 21:52:47",
  "Tags": {
    "UUID": "025b685a-144a-4087-aba6-6710c72c6683",
    "connectionString": "http://snowflake.dev.local:8080?ROLE=sysadmin&ACCOUNT=testaccount&PASSWORD=☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺☺",
    "ctx_account": "testaccount",
    "ctx_db": "testdb",
    "ctx_insecuremode": "false",
    "ctx_internal": "true",
    "ctx_role": "sysadmin",
    "ctx_schema": "testschema",
    "ctx_ssl": "off",
    "ctx_user": "snowman",
    "ctx_warehouse": "regress",
    "driver": "JDBC",
    "snowhouseSchema": "dev",
    "telemetryServerDeployment": "dev",
    "version": "3.12.8"
  },
  "Type": "Log",
  "UUID": "025b685a-144a-4087-aba6-6710c72c6683",
  "Value": {
    "Query ID": "01234567-1234-1234-1234-00001abcdefg",
    "SQLState": "02000",
    "Stacktrace": "net.snowflake.client.jdbc.SnowflakeSQLLoggedException: This is a test exception.\n\tat net.snowflake.client.jdbc.telemetryOOB.TelemetryServiceIT.generateDummyException(TelemetryServiceIT.java:246)\n\tat net.snowflake.client.jdbc.telemetryOOB.TelemetryServiceIT.testSnowflakeSQLLoggedExceptionTelemetry(TelemetryServiceIT.java:262)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:567)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)\n\tat org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)\n\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)\n\tat org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)\n\tat org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:363)\n\tat org.junit.runner.JUnitCore.run(JUnitCore.java:137)\n\tat com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)\n\tat com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)\n\tat com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)\n\tat com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)\n",
    "Vendor Code": 0
  }
}`