### PR TITLE
SNOW-171834 Remove redundant properties from ClientEnv

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -543,8 +543,14 @@ public class SessionUtil
         * current session into clientEnv. These are the params set via the Properties map or in the
         * connection string. Includes username, password, serverUrl, timeout values, etc
        */
+
       for (Map.Entry<SFSessionProperty, Object> entry : connectionPropertiesMap.entrySet())
       {
+        // exclude client parameters already covered by other runtime parameters that have been added to clientEnv
+        if (entry.getKey().equals(SFSessionProperty.APP_ID) || entry.getKey().equals(SFSessionProperty.APP_VERSION))
+        {
+          continue;
+        }
         String propKey = entry.getKey().getPropertyKey();
         // mask sensitive values like passwords, tokens, etc
         String propVal = SecretDetector.maskParameterValue(propKey, entry.getValue().toString());


### PR DESCRIPTION
The properties of app ID and app version are listed twice in Client_Environment field. They appear both in the list of connection parameters, and also in the list of runtime properties. I have removed these 2 properties from the connection parameters.