### PR TITLE
SNOW-164505 Refactor SQLNotSupportedExceptions to be SnowflakeSQLLoggedExceptions

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -4,11 +4,8 @@
 package net.snowflake.client.core;
 
 import net.snowflake.client.core.arrow.ArrowVectorConverter;
-import net.snowflake.client.jdbc.ArrowResultChunk;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.ArrowResultChunk.ArrowChunkIterator;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeResultSetSerializableV1;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.client.jdbc.telemetry.TelemetryData;
 import net.snowflake.client.jdbc.telemetry.TelemetryField;
@@ -216,9 +213,9 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
         // we don't support sort result when there are offline chunks
         if (resultSetSerializable.getChunkFileCount() > 0)
         {
-          throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+          throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
                                           ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED
-                                              .getMessageCode());
+                                              .getMessageCode(), session);
         }
 
         this.currentChunkIterator = getSortedFirstResultChunk(

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -6,11 +6,7 @@ package net.snowflake.client.core;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.core.BasicEvent.QueryState;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.JsonResultChunk;
-import net.snowflake.client.jdbc.SnowflakeResultChunk;
-import net.snowflake.client.jdbc.SnowflakeResultSetSerializableV1;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.client.jdbc.telemetry.TelemetryData;
 import net.snowflake.client.jdbc.telemetry.TelemetryField;
@@ -165,10 +161,9 @@ public class SFResultSet extends SFJsonResultSet
       // we don't support sort result when there are offline chunks
       if (chunkCount > 0)
       {
-        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                        ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
+        throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
+                                        ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode(), session);
       }
-
       sortResultSet();
     }
   }

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -419,7 +419,7 @@ public class SFStatement
         if (this.requestId != null)
         {
           throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                          ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode());
+                                          ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(), session);
         }
 
         this.requestId = UUID.randomUUID().toString();

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -2892,16 +2892,16 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
           FileCompressionType.lookupByMimeSubType(sourceCompression.toLowerCase());
       if (!foundCompType.isPresent())
       {
-        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                        ErrorCode.COMPRESSION_TYPE_NOT_KNOWN.getMessageCode(),
+        throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
+                                        ErrorCode.COMPRESSION_TYPE_NOT_KNOWN.getMessageCode(), connection,
                                         sourceCompression);
       }
       userSpecifiedSourceCompression = foundCompType.get();
 
       if (!userSpecifiedSourceCompression.isSupported())
       {
-        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                        ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
+        throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
+                                        ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(), connection,
                                         sourceCompression);
       }
 
@@ -3004,8 +3004,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
             else
             {
               // error if not supported
-              throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                              ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
+              throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
+                                              ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(), connection,
                                               currentFileCompressionType.name());
             }
           }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -521,8 +521,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     }
     else
     {
-      throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                      ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
+                                      ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(), connection.getSfSession(),
                                       "Object type: " + x.getClass());
     }
   }
@@ -606,8 +606,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
               values = typeCheckedList;
               row = Integer.toString(values.size() + 1);
             }
-            throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+            throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
                                             ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
+                                            connection.getSfSession(),
                                             SnowflakeType.getJavaType(SnowflakeType.fromString(prevType)).name(),
                                             SnowflakeType.getJavaType(SnowflakeType.fromString(newType)).name(),
                                             binding.getKey(), row);

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -44,6 +44,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException
   private final static ObjectMapper mapper =
           ObjectMapperFactory.getObjectMapper();
 
+
   /**
    * Function to create a TelemetryEvent log from the JSONObject and exception and send it via OOB telemetry
    *

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -467,9 +467,9 @@ public enum SnowflakeType
         return ANY;
 
       default:
-        throw new SnowflakeSQLException(
+        throw new SnowflakeSQLLoggedException(
             SqlState.FEATURE_NOT_SUPPORTED,
-            ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
+            ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(), null,
             javaType);
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -469,7 +469,7 @@ public enum SnowflakeType
       default:
         throw new SnowflakeSQLLoggedException(
             SqlState.FEATURE_NOT_SUPPORTED,
-            ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(), null,
+            ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(), /* session = */ null,
             javaType);
     }
   }


### PR DESCRIPTION
There is a set of exceptions raised when a user tries to call on a JDBC driver feature or function that is not supported.  We want to gather metrics on when these exceptions are raised and these features are attempted to be used. These exceptions have been refactored so that a telemetry message is sent when they are raised by changing them to SnowflakeSQLLoggedExceptions.