### PR TITLE
SNOW-164505 Refactor internal error exceptions to be SnowflakeSQLLoggedExceptions

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -4,11 +4,8 @@
 package net.snowflake.client.core;
 
 import net.snowflake.client.core.arrow.ArrowVectorConverter;
-import net.snowflake.client.jdbc.ArrowResultChunk;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.ArrowResultChunk.ArrowChunkIterator;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeResultSetSerializableV1;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.client.jdbc.telemetry.TelemetryData;
 import net.snowflake.client.jdbc.telemetry.TelemetryField;
@@ -277,9 +274,9 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
 
           if (nextChunk == null)
           {
-            throw new SnowflakeSQLException(
+            throw new SnowflakeSQLLoggedException(
                 SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                 "Expect chunk but got null for chunk index " + nextChunkIndex);
           }
 

--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -342,7 +342,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
 
     // create a result chunk
-    ArrowResultChunk resultChunk = new ArrowResultChunk("", 0, 0, 0, rootAllocator);
+    ArrowResultChunk resultChunk = new ArrowResultChunk("", 0, 0, 0, rootAllocator, session);
 
     try
     {

--- a/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
@@ -8,14 +8,14 @@ import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeFileTransferAgent.CommandType;
 import net.snowflake.client.jdbc.SnowflakeFixedView;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.SnowflakeSQLLoggedException;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.List;
-
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
 
 /**
  * Fixed view result set. This class iterates through any fixed view
@@ -50,8 +50,8 @@ public class SFFixedViewResultSet extends SFJsonResultSet
     }
     catch (Exception ex)
     {
-      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                       "Failed to describe fixed view: "
                                       + fixedView.getClass().getName());
     }

--- a/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
@@ -40,7 +40,7 @@ public class SFFixedViewResultSet extends SFJsonResultSet
     try
     {
       resultSetMetaData
-          = new SFResultSetMetaData(fixedView.describeColumns(), session,
+          = new SFResultSetMetaData(fixedView.describeColumns(session), session,
                                     timestampNTZFormatter,
                                     timestampLTZFormatter,
                                     timestampTZFormatter,

--- a/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
@@ -51,9 +51,9 @@ public class SFFixedViewResultSet extends SFJsonResultSet
     catch (Exception ex)
     {
       throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "Failed to describe fixed view: "
-                                      + fixedView.getClass().getName());
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Failed to describe fixed view: "
+                                            + fixedView.getClass().getName());
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -6,11 +6,7 @@ package net.snowflake.client.core;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.core.BasicEvent.QueryState;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.JsonResultChunk;
-import net.snowflake.client.jdbc.SnowflakeResultChunk;
-import net.snowflake.client.jdbc.SnowflakeResultSetSerializableV1;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.client.jdbc.telemetry.TelemetryData;
 import net.snowflake.client.jdbc.telemetry.TelemetryField;
@@ -227,9 +223,9 @@ public class SFResultSet extends SFJsonResultSet
 
         if (nextChunk == null)
         {
-          throw new SnowflakeSQLException(
+          throw new SnowflakeSQLLoggedException(
               SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
               "Expect chunk but got null for chunk index " + nextChunkIndex);
         }
 

--- a/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
@@ -6,7 +6,7 @@ package net.snowflake.client.core;
 import com.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeResultSetSerializableV1;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.SnowflakeSQLLoggedException;
 
 import java.sql.SQLException;
 
@@ -41,7 +41,7 @@ class SFResultSetFactory
       case JSON:
         return new SFResultSet(resultSetSerializable, statement, sortResult);
       default:
-        throw new SnowflakeSQLException(ErrorCode.INTERNAL_ERROR,
+        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, statement.getSession(),
                                         "Unsupported query result format: " +
                                         resultSetSerializable.getQueryResultFormat().name());
     }

--- a/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
@@ -42,8 +42,8 @@ class SFResultSetFactory
         return new SFResultSet(resultSetSerializable, statement, sortResult);
       default:
         throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, statement.getSession(),
-                                        "Unsupported query result format: " +
-                                        resultSetSerializable.getQueryResultFormat().name());
+                                              "Unsupported query result format: " +
+                                              resultSetSerializable.getQueryResultFormat().name());
     }
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -8,11 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.core.bind.BindException;
 import net.snowflake.client.core.bind.BindUploader;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeDriver;
-import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
-import net.snowflake.client.jdbc.SnowflakeReauthenticationRequest;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetry.TelemetryData;
 import net.snowflake.client.jdbc.telemetry.TelemetryUtil;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
@@ -25,21 +21,14 @@ import org.apache.http.client.methods.HttpRequestBase;
 
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_MEMORY_LIMIT;
-import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_PREFETCH_THREADS;
-import static net.snowflake.client.core.SessionUtil.MAX_CLIENT_CHUNK_SIZE;
-import static net.snowflake.client.core.SessionUtil.MIN_CLIENT_CHUNK_SIZE;
+import static net.snowflake.client.core.SessionUtil.*;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 /**
@@ -271,8 +260,8 @@ public class SFStatement
 
     if (result == null)
     {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                       "got null result");
     }
 
@@ -301,13 +290,13 @@ public class SFStatement
         // ensure first query type matches the calling JDBC method, if exists
         if (caller == CallingMethod.EXECUTE_QUERY && !type.isGenerateResultSet())
         {
-          throw new SnowflakeSQLException(
-              ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET);
+          throw new SnowflakeSQLLoggedException(
+              ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET, session);
         }
         else if (caller == CallingMethod.EXECUTE_UPDATE && type.isGenerateResultSet())
         {
-          throw new SnowflakeSQLException(
-              ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT);
+          throw new SnowflakeSQLLoggedException(
+              ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT, session);
         }
 
         // this will update resultSet to point to the first child result before we return it
@@ -418,8 +407,8 @@ public class SFStatement
 
         if (this.requestId != null)
         {
-          throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                          ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode());
+          throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
+                                          ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(), session);
         }
 
         this.requestId = UUID.randomUUID().toString();

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -261,8 +261,8 @@ public class SFStatement
     if (result == null)
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "got null result");
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "got null result");
     }
 
     /*
@@ -408,7 +408,7 @@ public class SFStatement
         if (this.requestId != null)
         {
           throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
-                                          ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(), session);
+                                                ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(), session);
         }
 
         this.requestId = UUID.randomUUID().toString();

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1111,7 +1111,7 @@ public class SessionUtil
                      loginInput.getAuthenticator(), postBackUrl);
         throw new SnowflakeSQLLoggedException(
             SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-            ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(), null);
+            ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(), /* session = */ null);
       }
     }
     catch (IOException | URISyntaxException ex)

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1209,7 +1209,7 @@ public class SessionUtil
                      loginInput.getAuthenticator());
         throw new SnowflakeSQLLoggedException(
             SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-            ErrorCode.IDP_CONNECTION_ERROR.getMessageCode(), null);
+            ErrorCode.IDP_CONNECTION_ERROR.getMessageCode(), /* session = */ null);
       }
     }
     catch (MalformedURLException ex)

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1109,6 +1109,7 @@ public class SessionUtil
         logger.debug("The specified authenticator {} and the destination URL " +
                      "in the SAML assertion {} do not match.",
                      loginInput.getAuthenticator(), postBackUrl);
+        // Session is in process of getting created, so exception constructor takes in null session value
         throw new SnowflakeSQLLoggedException(
             SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
             ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(), /* session = */ null);
@@ -1207,6 +1208,7 @@ public class SessionUtil
       {
         logger.debug("The specified authenticator {} is not supported.",
                      loginInput.getAuthenticator());
+        // Session is in process of getting created, so exception constructor takes in null session value
         throw new SnowflakeSQLLoggedException(
             SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
             ErrorCode.IDP_CONNECTION_ERROR.getMessageCode(), /* session = */ null);

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -7,12 +7,7 @@ package net.snowflake.client.core;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeDriver;
-import net.snowflake.client.jdbc.SnowflakeReauthenticationRequest;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.SnowflakeType;
-import net.snowflake.client.jdbc.SnowflakeUtil;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.log.ArgSupplier;
 import net.snowflake.client.log.SFLogger;
@@ -39,13 +34,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1120,9 +1109,9 @@ public class SessionUtil
         logger.debug("The specified authenticator {} and the destination URL " +
                      "in the SAML assertion {} do not match.",
                      loginInput.getAuthenticator(), postBackUrl);
-        throw new SnowflakeSQLException(
+        throw new SnowflakeSQLLoggedException(
             SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-            ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode());
+            ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(), null);
       }
     }
     catch (IOException | URISyntaxException ex)
@@ -1218,9 +1207,9 @@ public class SessionUtil
       {
         logger.debug("The specified authenticator {} is not supported.",
                      loginInput.getAuthenticator());
-        throw new SnowflakeSQLException(
+        throw new SnowflakeSQLLoggedException(
             SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-            ErrorCode.IDP_CONNECTION_ERROR.getMessageCode());
+            ErrorCode.IDP_CONNECTION_ERROR.getMessageCode(), null);
       }
     }
     catch (MalformedURLException ex)

--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -304,9 +304,9 @@ public class ArrowResultChunk extends SnowflakeResultChunk
                 converters.add(new BigIntToTimeConverter(vector, i, context));
                 break;
               default:
-                throw new SnowflakeSQLException(
+                throw new SnowflakeSQLLoggedException(
                     SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                     "Unexpected Arrow Field for ",
                     st.name());
             }
@@ -325,9 +325,9 @@ public class ArrowResultChunk extends SnowflakeResultChunk
             }
             else
             {
-              throw new SnowflakeSQLException(
+              throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
@@ -346,9 +346,9 @@ public class ArrowResultChunk extends SnowflakeResultChunk
             }
             else
             {
-              throw new SnowflakeSQLException(
+              throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
@@ -367,27 +367,27 @@ public class ArrowResultChunk extends SnowflakeResultChunk
             }
             else
             {
-              throw new SnowflakeSQLException(
+              throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                   "Unexpected SnowflakeType ",
                   st.name());
             }
             break;
 
           default:
-            throw new SnowflakeSQLException(
+            throw new SnowflakeSQLLoggedException(
                 SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                 "Unexpected Arrow Field for ",
                 st.name());
         }
       }
       else
       {
-        throw new SnowflakeSQLException(
+        throw new SnowflakeSQLLoggedException(
             SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
             "Unexpected Arrow Field for ",
             type.toString());
       }

--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -5,47 +5,13 @@ package net.snowflake.client.jdbc;
 
 import net.snowflake.client.core.DataConversionContext;
 import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.arrow.ArrowResultChunkIndexSorter;
-import net.snowflake.client.core.arrow.ArrowVectorConverter;
-import net.snowflake.client.core.arrow.BigIntToFixedConverter;
-import net.snowflake.client.core.arrow.BigIntToScaledFixedConverter;
-import net.snowflake.client.core.arrow.BigIntToTimeConverter;
-import net.snowflake.client.core.arrow.BigIntToTimestampLTZConverter;
-import net.snowflake.client.core.arrow.BigIntToTimestampNTZConverter;
-import net.snowflake.client.core.arrow.BitToBooleanConverter;
-import net.snowflake.client.core.arrow.DateConverter;
-import net.snowflake.client.core.arrow.DecimalToScaledFixedConverter;
-import net.snowflake.client.core.arrow.DoubleToRealConverter;
-import net.snowflake.client.core.arrow.IntToFixedConverter;
-import net.snowflake.client.core.arrow.IntToScaledFixedConverter;
-import net.snowflake.client.core.arrow.IntToTimeConverter;
-import net.snowflake.client.core.arrow.SmallIntToFixedConverter;
-import net.snowflake.client.core.arrow.SmallIntToScaledFixedConverter;
-import net.snowflake.client.core.arrow.ThreeFieldStructToTimestampTZConverter;
-import net.snowflake.client.core.arrow.TinyIntToFixedConverter;
-import net.snowflake.client.core.arrow.TinyIntToScaledFixedConverter;
-import net.snowflake.client.core.arrow.TwoFieldStructToTimestampLTZConverter;
-import net.snowflake.client.core.arrow.TwoFieldStructToTimestampNTZConverter;
-import net.snowflake.client.core.arrow.TwoFieldStructToTimestampTZConverter;
-import net.snowflake.client.core.arrow.VarBinaryToBinaryConverter;
-import net.snowflake.client.core.arrow.VarCharConverter;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.core.arrow.*;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.BigIntVector;
-import org.apache.arrow.vector.BitVector;
-import org.apache.arrow.vector.DateDayVector;
-import org.apache.arrow.vector.DecimalVector;
-import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.Float8Vector;
-import org.apache.arrow.vector.IntVector;
-import org.apache.arrow.vector.SmallIntVector;
-import org.apache.arrow.vector.TinyIntVector;
-import org.apache.arrow.vector.ValueVector;
-import org.apache.arrow.vector.VarBinaryVector;
-import org.apache.arrow.vector.VarCharVector;
-import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.*;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.types.Types;
@@ -82,13 +48,15 @@ public class ArrowResultChunk extends SnowflakeResultChunk
   private boolean enableSortFirstResultChunk;
   private IntVector firstResultChunkSortedIndices;
   private VectorSchemaRoot root;
+  private static SFSession session;
 
   public ArrowResultChunk(String url, int rowCount, int colCount,
-                          int uncompressedSize, RootAllocator rootAllocator)
+                          int uncompressedSize, RootAllocator rootAllocator, SFSession session)
   {
     super(url, rowCount, colCount, uncompressedSize);
     this.batchOfVectors = new ArrayList<>();
     this.rootAllocator = rootAllocator;
+    this.session = session;
   }
 
   private void addBatchData(List<ValueVector> batch)
@@ -327,7 +295,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
             {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
@@ -888,7 +856,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
   {
     EmptyArrowResultChunk()
     {
-      super("", 0, 0, 0, null);
+      super("", 0, 0, 0, null, null);
     }
 
     @Override

--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -274,7 +274,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
               default:
                 throw new SnowflakeSQLLoggedException(
                     SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                     "Unexpected Arrow Field for ",
                     st.name());
             }
@@ -316,7 +316,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
             {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
@@ -337,7 +337,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
             {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                   "Unexpected SnowflakeType ",
                   st.name());
             }
@@ -346,7 +346,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
           default:
             throw new SnowflakeSQLLoggedException(
                 SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                 "Unexpected Arrow Field for ",
                 st.name());
         }
@@ -355,7 +355,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
       {
         throw new SnowflakeSQLLoggedException(
             SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
             "Unexpected Arrow Field for ",
             type.toString());
       }

--- a/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
@@ -78,10 +78,10 @@ public class JsonResultChunk extends SnowflakeResultChunk
   {
     if (row.length != colCount)
     {
-      throw new SnowflakeSQLException(
+      throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR
-              .getMessageCode(),
+              .getMessageCode(), null,
           "Exception: expected " +
           colCount +
           " columns and received " +
@@ -106,9 +106,9 @@ public class JsonResultChunk extends SnowflakeResultChunk
         }
         else
         {
-          throw new SnowflakeSQLException(
+          throw new SnowflakeSQLLoggedException(
               SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
               "unknown data type in JSON row " + cell.getClass().toString());
         }
       }
@@ -415,10 +415,10 @@ public class JsonResultChunk extends SnowflakeResultChunk
     @Override
     public void add(String string) throws SnowflakeSQLException
     {
-      throw new SnowflakeSQLException(
+      throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR
-              .getMessageCode(),
+              .getMessageCode(), null,
           "Unimplemented");
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
@@ -5,6 +5,7 @@
 package net.snowflake.client.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.client.core.SFSession;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
@@ -27,12 +28,15 @@ public class JsonResultChunk extends SnowflakeResultChunk
 
   private int currentRow;
 
+  private SFSession session;
+
   public JsonResultChunk(String url, int rowCount, int colCount,
-                         int uncompressedSize)
+                         int uncompressedSize, SFSession session)
   {
     super(url, rowCount, colCount, uncompressedSize);
     data = new BlockResultChunkDataV2(computeCharactersNeeded(),
                                       rowCount, colCount);
+    this.session = session;
   }
 
   public static Object extractCell(JsonNode resultData, int rowIdx, int colIdx)
@@ -81,7 +85,7 @@ public class JsonResultChunk extends SnowflakeResultChunk
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR
-              .getMessageCode(), null,
+              .getMessageCode(), this.session,
           "Exception: expected " +
           colCount +
           " columns and received " +

--- a/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
@@ -35,7 +35,7 @@ public class JsonResultChunk extends SnowflakeResultChunk
   {
     super(url, rowCount, colCount, uncompressedSize);
     data = new BlockResultChunkDataV2(computeCharactersNeeded(),
-                                      rowCount, colCount);
+                                      rowCount, colCount, session);
     this.session = session;
   }
 
@@ -112,7 +112,7 @@ public class JsonResultChunk extends SnowflakeResultChunk
         {
           throw new SnowflakeSQLLoggedException(
               SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
               "unknown data type in JSON row " + cell.getClass().toString());
         }
       }
@@ -319,12 +319,13 @@ public class JsonResultChunk extends SnowflakeResultChunk
    */
   private static class BlockResultChunkDataV2 implements ResultChunkData
   {
-    BlockResultChunkDataV2(int totalLength, int rowCount, int colCount)
+    BlockResultChunkDataV2(int totalLength, int rowCount, int colCount, SFSession session)
     {
       this.blockCount = getBlock(totalLength - 1) + 1;
       this.rowCount = rowCount;
       this.colCount = colCount;
       this.metaBlockCount = getMetaBlock(this.rowCount * this.colCount - 1) + 1;
+      this.session = session;
     }
 
     @Override
@@ -422,7 +423,7 @@ public class JsonResultChunk extends SnowflakeResultChunk
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR
-              .getMessageCode(), null,
+              .getMessageCode(), this.session,
           "Unimplemented");
     }
 
@@ -544,6 +545,7 @@ public class JsonResultChunk extends SnowflakeResultChunk
     private static final int blockLengthBits = 23;
     private static int blockLength = 1 << blockLengthBits;
     private final ArrayList<byte[]> data = new ArrayList<>();
+    SFSession session;
 
     // blocks for storing offsets and lengths
     int metaBlockCount;

--- a/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
+++ b/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
@@ -45,8 +45,8 @@ public class ResultJsonParserV2
     this.resultChunk = resultChunk;
     if (state != State.UNINITIALIZED)
     {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                       "Json parser is already used!");
     }
     state = State.NEXT_ROW;
@@ -81,8 +81,8 @@ public class ResultJsonParserV2
 
     if (state != State.ROW_FINISHED)
     {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                       "SFResultJsonParser2Failed: Chunk is truncated!");
     }
     currentColumn = 0;
@@ -98,8 +98,8 @@ public class ResultJsonParserV2
   {
     if (state == State.UNINITIALIZED)
     {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                       "Json parser hasn't been initialized!");
     }
 
@@ -167,15 +167,15 @@ public class ResultJsonParserV2
     {
       if (outputPosition >= outputDataLength)
       {
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                         "column chunk longer than expected");
       }
       switch (state)
       {
         case UNINITIALIZED:
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                           "parser is in inconsistent state");
         case NEXT_ROW:
           switch (in.get())
@@ -192,9 +192,9 @@ public class ResultJsonParserV2
               break;
             default:
             {
-              throw new SnowflakeSQLException(
+              throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                   String.format("encountered unexpected character 0x%x between rows",
                                 in.get(((Buffer) in).position() - 1)));
             }
@@ -214,9 +214,9 @@ public class ResultJsonParserV2
               break;
             default:
             {
-              throw new SnowflakeSQLException(
+              throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                   String.format("encountered unexpected character 0x%x after array",
                                 in.get(((Buffer) in).position() - 1)));
             }
@@ -378,8 +378,8 @@ public class ResultJsonParserV2
               {
                 if (!parseCodepoint(in))
                 {
-                  throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                                   "SFResultJsonParser2Failed: invalid escaped unicode character");
 
                 }
@@ -403,8 +403,8 @@ public class ResultJsonParserV2
               break;
             default:
             {
-              throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                               "SFResultJsonParser2Failed: encountered unexpected escape character " +
                                               "0x%x", in.get(((Buffer) in).position() - 1));
 
@@ -419,8 +419,8 @@ public class ResultJsonParserV2
               resultChunk.nextIndex();
               if (currentColumn >= resultChunk.getColCount())
               {
-                throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                                 "SFResultJsonParser2Failed: Too many columns!");
               }
               state = State.WAIT_FOR_VALUE;
@@ -438,9 +438,9 @@ public class ResultJsonParserV2
               break;
             default:
             {
-              throw new SnowflakeSQLException(
+              throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                   String.format("encountered unexpected character 0x%x between columns",
                                 in.get(((Buffer) in).position() - 1)));
 

--- a/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
+++ b/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
@@ -1,9 +1,10 @@
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.SFSession;
 import net.snowflake.common.core.SqlState;
 
-import java.nio.ByteBuffer;
 import java.nio.Buffer;
+import java.nio.ByteBuffer;
 
 /**
  * Copyright (c) 2018-2019 Snowflake Computing Inc. All rights reserved.
@@ -40,13 +41,13 @@ public class ResultJsonParserV2
   //  private int currentRow;
   private JsonResultChunk resultChunk;
 
-  public void startParsing(JsonResultChunk resultChunk) throws SnowflakeSQLException
+  public void startParsing(JsonResultChunk resultChunk, SFSession session) throws SnowflakeSQLException
   {
     this.resultChunk = resultChunk;
     if (state != State.UNINITIALIZED)
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                       "Json parser is already used!");
     }
     state = State.NEXT_ROW;

--- a/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
+++ b/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
@@ -100,7 +100,7 @@ public class ResultJsonParserV2
     if (state == State.UNINITIALIZED)
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                       "Json parser hasn't been initialized!");
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
+++ b/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
@@ -47,8 +47,8 @@ public class ResultJsonParserV2
     if (state != State.UNINITIALIZED)
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "Json parser is already used!");
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Json parser is already used!");
     }
     state = State.NEXT_ROW;
     outputPosition = 0;
@@ -83,8 +83,8 @@ public class ResultJsonParserV2
     if (state != State.ROW_FINISHED)
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "SFResultJsonParser2Failed: Chunk is truncated!");
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "SFResultJsonParser2Failed: Chunk is truncated!");
     }
     currentColumn = 0;
     state = State.UNINITIALIZED;
@@ -100,8 +100,8 @@ public class ResultJsonParserV2
     if (state == State.UNINITIALIZED)
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "Json parser hasn't been initialized!");
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Json parser hasn't been initialized!");
     }
 
     // If stopped during a \\u, continue here
@@ -125,7 +125,7 @@ public class ResultJsonParserV2
       continueParsingInternal(toBeParsed, false, session);
       ((Buffer) partialEscapedUnicode).clear();
     }
-    continueParsingInternal(in, false,  session);
+    continueParsingInternal(in, false, session);
   }
 
   private void resizePartialEscapedUnicode(int lenToCopy)
@@ -169,15 +169,15 @@ public class ResultJsonParserV2
       if (outputPosition >= outputDataLength)
       {
         throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                        "column chunk longer than expected");
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                              "column chunk longer than expected");
       }
       switch (state)
       {
         case UNINITIALIZED:
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "parser is in inconsistent state");
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "parser is in inconsistent state");
         case NEXT_ROW:
           switch (in.get())
           {
@@ -380,8 +380,8 @@ public class ResultJsonParserV2
                 if (!parseCodepoint(in))
                 {
                   throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                  "SFResultJsonParser2Failed: invalid escaped unicode character");
+                                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                        "SFResultJsonParser2Failed: invalid escaped unicode character");
 
                 }
                 state = State.IN_STRING;
@@ -405,9 +405,9 @@ public class ResultJsonParserV2
             default:
             {
               throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                              "SFResultJsonParser2Failed: encountered unexpected escape character " +
-                                              "0x%x", in.get(((Buffer) in).position() - 1));
+                                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                    "SFResultJsonParser2Failed: encountered unexpected escape character " +
+                                                    "0x%x", in.get(((Buffer) in).position() - 1));
 
             }
           }
@@ -421,8 +421,8 @@ public class ResultJsonParserV2
               if (currentColumn >= resultChunk.getColCount())
               {
                 throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "SFResultJsonParser2Failed: Too many columns!");
+                                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                      "SFResultJsonParser2Failed: Too many columns!");
               }
               state = State.WAIT_FOR_VALUE;
               break;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -234,7 +234,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
 
     if (resultSetSerializable.getChunkFileCount() < 1)
     {
-      throw new SnowflakeSQLException(ErrorCode.INTERNAL_ERROR,
+      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, null,
                                       "Incorrect chunk count: " +
                                       resultSetSerializable.getChunkFileCount());
     }
@@ -263,7 +263,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
           break;
 
         default:
-          throw new SnowflakeSQLException(ErrorCode.INTERNAL_ERROR,
+          throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, null,
                                           "Invalid result format: " + queryResultFormat.name());
       }
 
@@ -571,8 +571,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
             logOutOfMemoryError();
           }
 
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                           currentChunk.getDownloadError());
         }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -226,7 +226,9 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
     logger.debug("qrmk = {}", this.qrmk);
     this.chunkHeadersMap = resultSetSerializable.getChunkHeadersMap();
     // session may be null. Its only use is for in-band telemetry in this class
-    this.session = resultSetSerializable.getSession().orElse(null);
+    this.session = (resultSetSerializable.getSession() != null)?
+                    resultSetSerializable.getSession().orElse(null) : null;
+
 
     // create the chunks array
     this.chunks = new ArrayList<>(resultSetSerializable.getChunkFileCount());

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -226,8 +226,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
     logger.debug("qrmk = {}", this.qrmk);
     this.chunkHeadersMap = resultSetSerializable.getChunkHeadersMap();
     // session may be null. Its only use is for in-band telemetry in this class
-    this.session = (resultSetSerializable.getSession() != null)?
-                    resultSetSerializable.getSession().orElse(null) : null;
+    this.session = (resultSetSerializable.getSession() != null) ?
+                   resultSetSerializable.getSession().orElse(null) : null;
 
 
     // create the chunks array
@@ -236,8 +236,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
     if (resultSetSerializable.getChunkFileCount() < 1)
     {
       throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
-                                      "Incorrect chunk count: " +
-                                      resultSetSerializable.getChunkFileCount());
+                                            "Incorrect chunk count: " +
+                                            resultSetSerializable.getChunkFileCount());
     }
 
     // initialize chunks with url and row count
@@ -265,7 +265,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
 
         default:
           throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
-                                          "Invalid result format: " + queryResultFormat.name());
+                                                "Invalid result format: " + queryResultFormat.name());
       }
 
       logger.debug("add chunk, url={} rowCount={} uncompressedSize={} " +
@@ -573,8 +573,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
           }
 
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
-                                          currentChunk.getDownloadError());
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
+                                                currentChunk.getDownloadError());
         }
 
         logger.debug("#chunk{} is ready to consume",

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -81,6 +81,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
   private static final long SHUTDOWN_TIME = 3;
   private final SnowflakeConnectString snowflakeConnectionString;
   private final OCSPMode ocspMode;
+
+  // Session object, used solely for throwing exceptions. CAUTION: MAY BE NULL!
   private SFSession session;
 
   private JsonResultChunk.ResultChunkDataCache chunkDataCache
@@ -221,10 +223,9 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
     this.prefetchSlots = resultSetSerializable.getResultPrefetchThreads() * 2;
     this.memoryLimit = resultSetSerializable.getMemoryLimit();
     this.queryResultFormat = resultSetSerializable.getQueryResultFormat();
-    this.session = resultSetSerializable.getSession();
     logger.debug("qrmk = {}", this.qrmk);
     this.chunkHeadersMap = resultSetSerializable.getChunkHeadersMap();
-    this.session = resultSetSerializable.getSession();
+    this.session = resultSetSerializable.getSession().orElse(null);
 
     // create the chunks array
     this.chunks = new ArrayList<>(resultSetSerializable.getChunkFileCount());

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -225,6 +225,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
     this.queryResultFormat = resultSetSerializable.getQueryResultFormat();
     logger.debug("qrmk = {}", this.qrmk);
     this.chunkHeadersMap = resultSetSerializable.getChunkHeadersMap();
+    // session may be null. Its only use is for in-band telemetry in this class
     this.session = resultSetSerializable.getSession().orElse(null);
 
     // create the chunks array

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -260,7 +260,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
           break;
 
         default:
-          throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, null,
+          throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
                                           "Invalid result format: " + queryResultFormat.name());
       }
 
@@ -569,7 +569,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
           }
 
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
                                           currentChunk.getDownloadError());
         }
 
@@ -1126,11 +1126,11 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
                      Thread.currentThread().getId(), chunkIndex);
         while ((len = jsonInputStream.read(buf)) != -1)
         {
-          jp.continueParsing(ByteBuffer.wrap(buf, 0, len));
+          jp.continueParsing(ByteBuffer.wrap(buf, 0, len), session);
         }
         logger.debug("Thread {} finish reading inputstream for #chunk{}",
                      Thread.currentThread().getId(), chunkIndex);
-        jp.endParsing();
+        jp.endParsing(session);
       }
 
       private HttpResponse getResultChunk(String chunkUrl)

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -1096,17 +1096,17 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
 
     if (stageName == null)
     {
-      throw new SnowflakeSQLException(
+      throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
           "stage name is null");
     }
 
     if (destFileName == null)
     {
-      throw new SnowflakeSQLException(
+      throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
           "stage name is null");
     }
 
@@ -1167,17 +1167,17 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
 
     if (Strings.isNullOrEmpty(stageName))
     {
-      throw new SnowflakeSQLException(
+      throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
           "stage name is null or empty");
     }
 
     if (Strings.isNullOrEmpty(sourceFileName))
     {
-      throw new SnowflakeSQLException(
+      throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
           "source file name is null or empty");
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1930,7 +1930,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData
 
             SnowflakeColumnMetadata columnMetadata = SnowflakeUtil
                 .extractColumnMetadata(jsonNode,
-                                       session.isJdbcTreatDecimalAsInt());
+                                       session.isJdbcTreatDecimalAsInt(), session);
 
             logger.debug("nullable: {}",
                          columnMetadata.isNullable());

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -103,15 +103,15 @@ public class SnowflakeDriver implements Driver
         }
         else
         {
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                           "Invalid Snowflake JDBC Version: " + implementVersion);
         }
       }
       else
       {
         throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                         "Snowflake JDBC Version is not set. " +
                                         "Ensure version.properties is included.");
       }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -104,8 +104,8 @@ public class SnowflakeDriver implements Driver
         else
         {
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), /*session = */ null,
-                                          "Invalid Snowflake JDBC Version: " + implementVersion);
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), /*session = */ null,
+                                                "Invalid Snowflake JDBC Version: " + implementVersion);
         }
       }
       else

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -104,14 +104,14 @@ public class SnowflakeDriver implements Driver
         else
         {
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), /*session = */ null,
                                           "Invalid Snowflake JDBC Version: " + implementVersion);
         }
       }
       else
       {
         throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), /*session = */ null,
                                         "Snowflake JDBC Version is not set. " +
                                         "Ensure version.properties is included.");
       }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -630,8 +630,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         // this shouldn't happen
         if (metadata == null)
         {
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                           "missing file metadata for: " + srcFilePath);
         }
 
@@ -832,8 +832,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         // this shouldn't happen
         if (metadata == null)
         {
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                           "missing file metadata for: " + srcFilePath);
         }
 
@@ -1031,8 +1031,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       // it should not contain any ~ after the above replacement
       if (localLocation.contains("~"))
       {
-        throw new SnowflakeSQLException(SqlState.IO_ERROR,
-                                        ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(),
+        throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
+                                        ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), connection,
                                         localLocation);
       }
 
@@ -1054,8 +1054,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       // local location should be a directory
       if ((new File(localLocation)).isFile())
       {
-        throw new SnowflakeSQLException(SqlState.IO_ERROR,
-                                        ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), localLocation);
+        throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
+                                        ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), connection, localLocation);
       }
     }
 
@@ -1202,8 +1202,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
     if (!localFilePath.isEmpty() && !localFilePath.equals(localFilePathFromGS))
     {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                       "Unexpected local file path from GS. From GS: " +
                                       localFilePathFromGS + ", expected: " + localFilePath);
     }
@@ -1378,15 +1378,15 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     List<SnowflakeFileTransferMetadata> result = new ArrayList<>();
     if (stageInfo.getStageType() != StageInfo.StageType.GCS)
     {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                       "This API only supports GCS");
     }
 
     if (commandType != CommandType.UPLOAD)
     {
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                       "This API only supports PUT command");
     }
 
@@ -1534,8 +1534,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       }
       else if (commandType == CommandType.DOWNLOAD)
       {
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode());
+        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), connection);
       }
 
       threadExecutor.shutdown();
@@ -1572,7 +1572,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       logger.error("downloadStream function doesn't support local file system");
 
       throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                       "downloadStream function only supported in remote stages");
     }
 
@@ -2803,8 +2803,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
           {
             logger.debug("File doesn't exist: {}", sourceFile);
 
-            throw new SnowflakeSQLException(SqlState.DATA_EXCEPTION,
-                                            ErrorCode.FILE_NOT_FOUND.getMessageCode(),
+            throw new SnowflakeSQLLoggedException(SqlState.DATA_EXCEPTION,
+                                            ErrorCode.FILE_NOT_FOUND.getMessageCode(), connection,
                                             sourceFile);
           }
           else if (file.isDirectory())
@@ -2812,7 +2812,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
             logger.debug("Not a file, but directory: {}", sourceFile);
 
             throw new SnowflakeSQLException(SqlState.DATA_EXCEPTION,
-                                            ErrorCode.FILE_IS_DIRECTORY.getMessageCode(),
+                                            ErrorCode.FILE_IS_DIRECTORY.getMessageCode(), connection,
                                             sourceFile);
           }
         }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -577,7 +577,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
    * @param srcFilePath      source file path
    * @param metadata         file metadata
    * @param client           client object used to communicate with c3
-   * @param session       session object
+   * @param session          session object
    * @param command          command string
    * @param inputStream      null if upload source is file
    * @param sourceFromStream whether upload source is file or stream
@@ -631,8 +631,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         if (metadata == null)
         {
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "missing file metadata for: " + srcFilePath);
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "missing file metadata for: " + srcFilePath);
         }
 
         String destFileName = metadata.destFileName;
@@ -833,8 +833,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         if (metadata == null)
         {
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "missing file metadata for: " + srcFilePath);
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "missing file metadata for: " + srcFilePath);
         }
 
         String destFileName = metadata.destFileName;
@@ -1032,8 +1032,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       if (localLocation.contains("~"))
       {
         throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
-                                        ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), session,
-                                        localLocation);
+                                              ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), session,
+                                              localLocation);
       }
 
       // todo: replace ~userid with the home directory of a given userid
@@ -1055,7 +1055,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       if ((new File(localLocation)).isFile())
       {
         throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
-                                        ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), session, localLocation);
+                                              ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), session, localLocation);
       }
     }
 
@@ -1203,9 +1203,9 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     if (!localFilePath.isEmpty() && !localFilePath.equals(localFilePathFromGS))
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "Unexpected local file path from GS. From GS: " +
-                                      localFilePathFromGS + ", expected: " + localFilePath);
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Unexpected local file path from GS. From GS: " +
+                                            localFilePathFromGS + ", expected: " + localFilePath);
     }
     else if (localFilePath.isEmpty())
     {
@@ -1379,15 +1379,15 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     if (stageInfo.getStageType() != StageInfo.StageType.GCS)
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "This API only supports GCS");
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "This API only supports GCS");
     }
 
     if (commandType != CommandType.UPLOAD)
     {
       throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "This API only supports PUT command");
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "This API only supports PUT command");
     }
 
     for (String sourceFilePath : sourceFiles)
@@ -1524,7 +1524,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
                 fileMetadataMap.get(SRC_FILE_NAME_FOR_STREAM),
                 (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
                 null : storageFactory.createClient(stageInfo, parallel, encMat, session),
-                    session,
+                session,
                 command,
                 sourceStream,
                 true,
@@ -1535,7 +1535,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       else if (commandType == CommandType.DOWNLOAD)
       {
         throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), session);
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session);
       }
 
       threadExecutor.shutdown();
@@ -1627,7 +1627,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
             fileMetadataMap,
             (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
             null : storageFactory.createClient(stageInfo, parallel, encMat, session),
-                session,
+            session,
             command,
             parallel,
             encMat,
@@ -1729,7 +1729,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
             fileMetadata,
             (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
             null : storageFactory.createClient(stageInfo, parallel, encryptionMaterial.get(0), session),
-                session, command,
+            session, command,
             null, false,
             (parallel > 1 ? 1 : this.parallel), srcFileObj, encryptionMaterial.get(0)));
 
@@ -2804,8 +2804,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
             logger.debug("File doesn't exist: {}", sourceFile);
 
             throw new SnowflakeSQLLoggedException(SqlState.DATA_EXCEPTION,
-                                            ErrorCode.FILE_NOT_FOUND.getMessageCode(), session,
-                                            sourceFile);
+                                                  ErrorCode.FILE_NOT_FOUND.getMessageCode(), session,
+                                                  sourceFile);
           }
           else if (file.isDirectory())
           {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFixedView.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFixedView.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.SFSession;
+
 import java.util.List;
 
 /**
@@ -13,7 +15,7 @@ import java.util.List;
  */
 public interface SnowflakeFixedView
 {
-  List<SnowflakeColumnMetadata> describeColumns() throws Exception;
+  List<SnowflakeColumnMetadata> describeColumns(SFSession session) throws Exception;
 
   List<Object> getNextRow() throws Exception;
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -993,7 +993,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
 
     if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null)
     {
-      throw new SQLException("The Result Set serializable is invalid.");
+      throw new SnowflakeSQLLoggedException("The Result Set serializable is invalid.", null);
     }
 
     // In the beginning, only the first data chunk is included in the result
@@ -1087,7 +1087,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
         break;
       }
       default:
-        throw new SnowflakeSQLException(ErrorCode.INTERNAL_ERROR,
+        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, null,
                                         "Unsupported query result format: " +
                                         getQueryResultFormat().name());
     }
@@ -1146,7 +1146,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     else
     {
       // This shouldn't happen
-      throw new SnowflakeSQLException(ErrorCode.INTERNAL_ERROR,
+      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, null,
                                       "setFirstChunkRowCountForArrow() should only be called for Arrow.");
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -171,10 +171,10 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
   List<MetaDataOfBinds> metaDataOfBinds = new ArrayList<>();
   QueryResultFormat queryResultFormat;
   boolean treatNTZAsUTC;
-  Optional<SFSession> possibleSession = Optional.empty();
 
   // Below fields are transient, they are generated from parameters
   transient TimeZone timeZone;
+  transient Optional<SFSession> possibleSession = Optional.empty();
   transient boolean honorClientTZForTimestampNTZ;
   transient SnowflakeDateTimeFormat timestampNTZFormatter;
   transient SnowflakeDateTimeFormat timestampLTZFormatter;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -171,7 +171,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
   List<MetaDataOfBinds> metaDataOfBinds = new ArrayList<>();
   QueryResultFormat queryResultFormat;
   boolean treatNTZAsUTC;
-  SFSession session;
+  Optional<SFSession> possibleSession = Optional.empty();
 
   // Below fields are transient, they are generated from parameters
   transient TimeZone timeZone;
@@ -245,6 +245,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     this.sendResultTime = toCopy.sendResultTime;
     this.metaDataOfBinds = toCopy.metaDataOfBinds;
     this.queryResultFormat = toCopy.queryResultFormat;
+    this.possibleSession = toCopy.possibleSession;
 
     // Below fields are transient, they are generated from parameters
     this.timeZone = toCopy.timeZone;
@@ -262,7 +263,6 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     this.chunkDownloader = toCopy.chunkDownloader;
     this.rootAllocator = toCopy.rootAllocator;
     this.resultSetMetaData = toCopy.resultSetMetaData;
-    this.session = toCopy.session;
   }
 
   public void setRootAllocator(RootAllocator rootAllocator)
@@ -507,7 +507,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     return treatNTZAsUTC;
   }
 
-  public SFSession getSession() { return session; }
+  public Optional<SFSession> getSession() { return possibleSession; }
 
   /**
    * A factory function to create SnowflakeResultSetSerializable object
@@ -557,7 +557,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     resultSetSerializable.totalRowCountTruncated
         = rootNode.path("data").path("totalTruncated").asBoolean();
 
-    resultSetSerializable.session = sfSession;
+    resultSetSerializable.possibleSession = Optional.ofNullable(sfSession);
 
     logger.debug("query id: {}", resultSetSerializable.queryId);
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -171,6 +171,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
   List<MetaDataOfBinds> metaDataOfBinds = new ArrayList<>();
   QueryResultFormat queryResultFormat;
   boolean treatNTZAsUTC;
+  SFSession session;
 
   // Below fields are transient, they are generated from parameters
   transient TimeZone timeZone;
@@ -261,6 +262,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     this.chunkDownloader = toCopy.chunkDownloader;
     this.rootAllocator = toCopy.rootAllocator;
     this.resultSetMetaData = toCopy.resultSetMetaData;
+    this.session = toCopy.session;
   }
 
   public void setRootAllocator(RootAllocator rootAllocator)
@@ -505,6 +507,8 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     return treatNTZAsUTC;
   }
 
+  public SFSession getSession() { return session; }
+
   /**
    * A factory function to create SnowflakeResultSetSerializable object
    * from result JSON node.
@@ -553,6 +557,8 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     resultSetSerializable.totalRowCountTruncated
         = rootNode.path("data").path("totalTruncated").asBoolean();
 
+    resultSetSerializable.session = sfSession;
+
     logger.debug("query id: {}", resultSetSerializable.queryId);
 
     Optional<QueryResultFormat> queryResultFormat = QueryResultFormat
@@ -574,7 +580,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
 
       SnowflakeColumnMetadata columnMetadata
           = SnowflakeUtil.extractColumnMetadata(
-          colNode, sfSession.isJdbcTreatDecimalAsInt());
+          colNode, sfSession.isJdbcTreatDecimalAsInt(), sfSession);
 
       resultSetSerializable.resultColumnMetadata.add(columnMetadata);
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -999,7 +999,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
 
     if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null)
     {
-      throw new SnowflakeSQLLoggedException("The Result Set serializable is invalid.", null);
+      throw new SnowflakeSQLLoggedException("The Result Set serializable is invalid.", this.session);
     }
 
     // In the beginning, only the first data chunk is included in the result
@@ -1093,7 +1093,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
         break;
       }
       default:
-        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, null,
+        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
                                         "Unsupported query result format: " +
                                         getQueryResultFormat().name());
     }
@@ -1152,7 +1152,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     else
     {
       // This shouldn't happen
-      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, null,
+      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
                                       "setFirstChunkRowCountForArrow() should only be called for Arrow.");
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -507,7 +507,10 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     return treatNTZAsUTC;
   }
 
-  public Optional<SFSession> getSession() { return possibleSession; }
+  public Optional<SFSession> getSession()
+  {
+    return possibleSession;
+  }
 
   /**
    * A factory function to create SnowflakeResultSetSerializable object
@@ -1000,7 +1003,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null)
     {
       throw new SnowflakeSQLLoggedException("The Result Set serializable is invalid.",
-              this.possibleSession.orElse(/* session = */null));
+                                            this.possibleSession.orElse(/* session = */null));
     }
 
     // In the beginning, only the first data chunk is included in the result
@@ -1095,9 +1098,9 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
       }
       default:
         throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR,
-                                        this.possibleSession.orElse(/*session = */null),
-                                        "Unsupported query result format: " +
-                                        getQueryResultFormat().name());
+                                              this.possibleSession.orElse(/*session = */null),
+                                              "Unsupported query result format: " +
+                                              getQueryResultFormat().name());
     }
 
     // Create result set
@@ -1155,8 +1158,8 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     {
       // This shouldn't happen
       throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR,
-                                      this.possibleSession.orElse( /*session = */ null),
-                                      "setFirstChunkRowCountForArrow() should only be called for Arrow.");
+                                            this.possibleSession.orElse( /*session = */ null),
+                                            "setFirstChunkRowCountForArrow() should only be called for Arrow.");
     }
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -999,7 +999,8 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
 
     if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null)
     {
-      throw new SnowflakeSQLLoggedException("The Result Set serializable is invalid.", this.session);
+      throw new SnowflakeSQLLoggedException("The Result Set serializable is invalid.",
+              this.possibleSession.orElse(/* session = */null));
     }
 
     // In the beginning, only the first data chunk is included in the result
@@ -1093,7 +1094,8 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
         break;
       }
       default:
-        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
+        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR,
+                                        this.possibleSession.orElse(/*session = */null),
                                         "Unsupported query result format: " +
                                         getQueryResultFormat().name());
     }
@@ -1152,7 +1154,8 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     else
     {
       // This shouldn't happen
-      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
+      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR,
+                                      this.possibleSession.orElse( /*session = */ null),
                                       "setFirstChunkRowCountForArrow() should only be called for Arrow.");
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -18,12 +18,12 @@ import java.sql.SQLException;
 public class SnowflakeSQLException extends SQLException
 {
   static final SFLogger logger =
-          SFLoggerFactory.getLogger(SnowflakeSQLException.class);
+      SFLoggerFactory.getLogger(SnowflakeSQLException.class);
 
   private static final long serialVersionUID = 1L;
 
   static final ResourceBundleManager errorResourceBundleManager =
-          ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
+      ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
 
   private String queryId = "unknown";
 
@@ -49,7 +49,7 @@ public class SnowflakeSQLException extends SQLException
 
     // log user error from GS at fine level
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}, queryId:{}",
-            reason, sqlState, vendorCode, queryId);
+                 reason, sqlState, vendorCode, queryId);
 
   }
 
@@ -58,40 +58,40 @@ public class SnowflakeSQLException extends SQLException
     super(reason, SQLState);
     // log user error from GS at fine level
     logger.debug("Snowflake exception: {}, sqlState:{}",
-            reason, SQLState);
+                 reason, SQLState);
   }
 
   public SnowflakeSQLException(String sqlState, int vendorCode)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode)), sqlState, vendorCode);
+        String.valueOf(vendorCode)), sqlState, vendorCode);
 
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}",
-            errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
-            sqlState,
-            vendorCode);
+                 errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
+                 sqlState,
+                 vendorCode);
   }
 
   public SnowflakeSQLException(String sqlState, int vendorCode, Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode), params), sqlState, vendorCode);
+        String.valueOf(vendorCode), params), sqlState, vendorCode);
 
     logger.debug("Snowflake exception: {}, sqlState:{}, vendorCode:{}",
-            errorResourceBundleManager.getLocalizedMessage(
-                    String.valueOf(vendorCode), params),
-            sqlState,
-            vendorCode);
+                 errorResourceBundleManager.getLocalizedMessage(
+                     String.valueOf(vendorCode), params),
+                 sqlState,
+                 vendorCode);
   }
 
   public SnowflakeSQLException(Throwable ex, String sqlState, int vendorCode)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode)), sqlState, vendorCode, ex);
+        String.valueOf(vendorCode)), sqlState, vendorCode, ex);
 
     logger.debug("Snowflake exception: {}" +
-            errorResourceBundleManager.getLocalizedMessage(
-                    String.valueOf(vendorCode)), ex);
+                 errorResourceBundleManager.getLocalizedMessage(
+                     String.valueOf(vendorCode)), ex);
   }
 
   public SnowflakeSQLException(Throwable ex, ErrorCode errorCode, Object... params)
@@ -105,19 +105,19 @@ public class SnowflakeSQLException extends SQLException
                                Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(vendorCode), params), sqlState, vendorCode, ex);
+        String.valueOf(vendorCode), params), sqlState, vendorCode, ex);
 
     logger.debug("Snowflake exception: " +
-            errorResourceBundleManager.getLocalizedMessage(
-                    String.valueOf(vendorCode), params), ex);
+                 errorResourceBundleManager.getLocalizedMessage(
+                     String.valueOf(vendorCode), params), ex);
   }
 
   public SnowflakeSQLException(ErrorCode errorCode, Object... params)
   {
     super(errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(errorCode.getMessageCode()), params),
-            errorCode.getSqlState(),
-            errorCode.getMessageCode());
+        String.valueOf(errorCode.getMessageCode()), params),
+          errorCode.getSqlState(),
+          errorCode.getMessageCode());
   }
 
   public SnowflakeSQLException(SFException e)

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -23,7 +23,7 @@ import java.util.concurrent.*;
 
 /**
  * @author mknister
- *
+ * <p>
  * This SnowflakeSQLLoggedException class extends the SnowflakeSQLException class to add OOB telemetry data for sql
  * exceptions. Not all sql exceptions require OOB telemetry logging so the exceptions in this class should only be
  * thrown if there is a need for logging the exception with OOB telemetry.
@@ -42,7 +42,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException
   private Telemetry ibInstance = null;
 
   private final static ObjectMapper mapper =
-          ObjectMapperFactory.getObjectMapper();
+      ObjectMapperFactory.getObjectMapper();
 
   /**
    * Function to create a TelemetryEvent log from the JSONObject and exception and send it via OOB telemetry
@@ -71,7 +71,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException
    *
    * @param value ObjectNode containing information specific to the exception constructor that should be included in
    *              the telemetry log, such as SQLState or reason for the error
-   * @param ex The exception being thrown
+   * @param ex    The exception being thrown
    * @return true if in-band telemetry log sent successfully or false if it did not
    */
   private Future<Boolean> sendInBandTelemetryMessage(ObjectNode value, SnowflakeSQLLoggedException ex)
@@ -88,6 +88,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException
 
   /**
    * Helper function to create JSONObject node for OOB telemetry log
+   *
    * @param queryId
    * @param reason
    * @param SQLState
@@ -124,13 +125,14 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException
   /**
    * Function to construct log data based on possible exception inputs and send data through in-band telemetry, or oob
    * if in-band does not work
-   * @param queryId query ID if exists
-   * @param reason reason for the exception
-   * @param SQLState SQLState
+   *
+   * @param queryId    query ID if exists
+   * @param reason     reason for the exception
+   * @param SQLState   SQLState
    * @param vendorCode vendor code
-   * @param errorCode error code
-   * @param session session object, which is needed to send in-band telemetry but not oob. Might be null, in which case
-   *                oob is used.
+   * @param errorCode  error code
+   * @param session    session object, which is needed to send in-band telemetry but not oob. Might be null, in which case
+   *                   oob is used.
    */
   public void sendTelemetryData(String queryId, String reason, String SQLState, int vendorCode, ErrorCode errorCode, SFSession session)
   {
@@ -167,26 +169,26 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException
       // try  to send in-band data asynchronously
       ExecutorService threadExecutor = Executors.newSingleThreadExecutor();
       threadExecutor.submit(() ->
-        {
-          boolean inBandSuccess;
-          Future<Boolean> sendInBand = sendInBandTelemetryMessage(ibValue, this);
-          // record whether in band telemetry message sent with boolean value inBandSuccess
-          try
-          {
-            inBandSuccess = sendInBand.get(10, TimeUnit.SECONDS);
-          }
-          catch (Exception e)
-          {
-            inBandSuccess = false;
-          }
-          // In-band failed so send OOB telemetry instead
-          if (!inBandSuccess)
-          {
-            logger.debug("In-band telemetry message failed to send. Sending out-of-band message instead");
-            JSONObject oobValue = createOOBValue(queryId, reason, SQLState, vendorCode, errorCode);
-            sendOutOfBandTelemetryMessage(oobValue, this);
-          }
-        }
+                            {
+                              boolean inBandSuccess;
+                              Future<Boolean> sendInBand = sendInBandTelemetryMessage(ibValue, this);
+                              // record whether in band telemetry message sent with boolean value inBandSuccess
+                              try
+                              {
+                                inBandSuccess = sendInBand.get(10, TimeUnit.SECONDS);
+                              }
+                              catch (Exception e)
+                              {
+                                inBandSuccess = false;
+                              }
+                              // In-band failed so send OOB telemetry instead
+                              if (!inBandSuccess)
+                              {
+                                logger.debug("In-band telemetry message failed to send. Sending out-of-band message instead");
+                                JSONObject oobValue = createOOBValue(queryId, reason, SQLState, vendorCode, errorCode);
+                                sendOutOfBandTelemetryMessage(oobValue, this);
+                              }
+                            }
       );
     }
     // In-band is not possible so send OOB telemetry instead

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -217,8 +217,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
     is not supported for staging commands. */
     if (StmtUtil.checkStageManageCommand(sql) != null && parameterBindings != null)
     {
-      throw new SnowflakeSQLException(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, StmtUtil.truncateSQL(sql));
+      throw new SnowflakeSQLLoggedException(
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, connection.getSfSession(), StmtUtil.truncateSQL(sql));
     }
 
     SFBaseResultSet sfResultSet;
@@ -246,8 +246,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
 
     if (updateCount == NO_UPDATES && updateQueryRequired)
     {
-      throw new SnowflakeSQLException(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, StmtUtil.truncateSQL(sql));
+      throw new SnowflakeSQLLoggedException(
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, connection.getSfSession(), StmtUtil.truncateSQL(sql));
     }
 
     return updateCount;
@@ -512,8 +512,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
         }
         else
         {
-          throw new SnowflakeSQLException(SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
-                                          ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(), i);
+          throw new SnowflakeSQLLoggedException(SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
+                                          ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(), connection.getSfSession(), i);
         }
         batchQueryIDs.add(queryID);
       }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -513,7 +513,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
         else
         {
           throw new SnowflakeSQLLoggedException(SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
-                                          ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(), connection.getSfSession(), i);
+                                                ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(), connection.getSfSession(), i);
         }
         batchQueryIDs.add(queryID);
       }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -254,9 +254,9 @@ public class SnowflakeUtil
         break;
 
       default:
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
                                         ErrorCode.INTERNAL_ERROR
-                                            .getMessageCode(),
+                                            .getMessageCode(), null,
                                         "Unknown column type: " + internalColTypeName);
     }
 
@@ -401,9 +401,9 @@ public class SnowflakeUtil
       }
       else
       {
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
                                         ErrorCode.INTERNAL_ERROR
-                                            .getMessageCode(),
+                                            .getMessageCode(), null,
                                         "Unsupported column type: " + type
                                             .getName());
       }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -252,9 +252,9 @@ public class SnowflakeUtil
 
       default:
         throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR
-                                            .getMessageCode(), session,
-                                        "Unknown column type: " + internalColTypeName);
+                                              ErrorCode.INTERNAL_ERROR
+                                                  .getMessageCode(), session,
+                                              "Unknown column type: " + internalColTypeName);
     }
 
     JsonNode extColTypeNameNode = colNode.path("extTypeName");
@@ -399,10 +399,10 @@ public class SnowflakeUtil
       else
       {
         throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR
-                                            .getMessageCode(), session,
-                                        "Unsupported column type: " + type
-                                            .getName());
+                                              ErrorCode.INTERNAL_ERROR
+                                                  .getMessageCode(), session,
+                                              "Unsupported column type: " + type
+                                                  .getName());
       }
 
       // TODO: we hard code some of the values below but can change them

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -6,6 +6,7 @@ package net.snowflake.client.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.SFSession;
 import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
@@ -16,11 +17,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.*;
 import java.lang.reflect.Field;
 import java.sql.Types;
 import java.util.*;
@@ -156,7 +153,7 @@ public class SnowflakeUtil
 
   static public SnowflakeColumnMetadata extractColumnMetadata(
       JsonNode colNode,
-      boolean jdbcTreatDecimalAsInt)
+      boolean jdbcTreatDecimalAsInt, SFSession session)
   throws SnowflakeSQLException
   {
     String colName = colNode.path("name").asText();
@@ -256,7 +253,7 @@ public class SnowflakeUtil
       default:
         throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
                                         ErrorCode.INTERNAL_ERROR
-                                            .getMessageCode(), null,
+                                            .getMessageCode(), session,
                                         "Unknown column type: " + internalColTypeName);
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -356,7 +356,7 @@ public class SnowflakeUtil
   }
 
   static List<SnowflakeColumnMetadata> describeFixedViewColumns(
-      Class<?> clazz) throws SnowflakeSQLException
+      Class<?> clazz, SFSession session) throws SnowflakeSQLException
   {
     Field[] columns
         = ClassUtil.getAnnotatedDeclaredFields(clazz, FixedViewColumn.class,
@@ -400,7 +400,7 @@ public class SnowflakeUtil
       {
         throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
                                         ErrorCode.INTERNAL_ERROR
-                                            .getMessageCode(), null,
+                                            .getMessageCode(), session,
                                         "Unsupported column type: " + type
                                             .getName());
       }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -8,25 +8,12 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.microsoft.azure.storage.OperationContext;
-import com.microsoft.azure.storage.blob.BlobProperties;
-import com.microsoft.azure.storage.blob.CloudBlob;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import com.microsoft.azure.storage.*;
+import com.microsoft.azure.storage.blob.*;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.ObjectMapperFactory;
 import net.snowflake.client.core.SFSession;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.FileBackedOutputStream;
-import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import com.microsoft.azure.storage.StorageCredentials;
-import com.microsoft.azure.storage.StorageCredentialsAnonymous;
-import com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature;
-import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.CloudBlobClient;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.microsoft.azure.storage.blob.ListBlobItem;
-import net.snowflake.client.jdbc.SnowflakeUtil;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.client.util.SFPair;
@@ -34,23 +21,13 @@ import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 import net.snowflake.common.core.SqlState;
 import org.apache.commons.io.IOUtils;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
-import java.util.AbstractMap;
+import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import net.snowflake.client.jdbc.MatDesc;
 
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
@@ -144,8 +121,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
             encryptionKeySize != 192 &&
             encryptionKeySize != 256)
         {
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                           "unsupported key size", encryptionKeySize);
         }
       }
@@ -347,8 +324,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
         {
           if (key == null || iv == null)
           {
-            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                             "File metadata incomplete");
           }
 
@@ -374,8 +351,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
     }
     while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                     "Unexpected: download unsuccessful without exception!");
   }
 
@@ -422,8 +399,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
         {
           if (key == null || iv == null)
           {
-            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                             "File metadata incomplete");
           }
 
@@ -455,8 +432,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
     }
     while (retryCount < getMaxRetries());
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                     "Unexpected: download unsuccessful without exception!");
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -51,6 +51,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
   private final static SFLogger logger =
       SFLoggerFactory.getLogger(SnowflakeAzureClient.class);
   private OperationContext opContext = null;
+  private static SFSession session;
 
   private SnowflakeAzureClient()
   {
@@ -65,9 +66,11 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    *                required to decrypt/encrypt content in stage
    */
   public static SnowflakeAzureClient createSnowflakeAzureClient(StageInfo stage,
-                                                                RemoteStoreFileEncryptionMaterial encMat)
+                                                                RemoteStoreFileEncryptionMaterial encMat,
+                                                                SFSession sfSession)
   throws SnowflakeSQLException
   {
+    session = sfSession;
     SnowflakeAzureClient azureClient = new SnowflakeAzureClient();
     azureClient.setupAzureClient(stage, encMat);
 
@@ -122,7 +125,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
             encryptionKeySize != 256)
         {
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                           "unsupported key size", encryptionKeySize);
         }
       }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -125,8 +125,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
             encryptionKeySize != 256)
         {
           throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "unsupported key size", encryptionKeySize);
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "unsupported key size", encryptionKeySize);
         }
       }
       HttpUtil.setProxyForAzure(opContext);
@@ -328,8 +328,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
           if (key == null || iv == null)
           {
             throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "File metadata incomplete");
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
           // Decrypt file
@@ -355,14 +355,14 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
     while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                    "Unexpected: download unsuccessful without exception!");
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Download a file from remote storage
    *
-   * @param session            session object
+   * @param session               session object
    * @param command               command to download file
    * @param parallelism           number of threads for parallel downloading
    * @param remoteStorageLocation remote storage location, i.e. bucket for s3
@@ -403,8 +403,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
           if (key == null || iv == null)
           {
             throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "File metadata incomplete");
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
           try
@@ -436,14 +436,14 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
     while (retryCount < getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                    "Unexpected: download unsuccessful without exception!");
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file/stream to remote storage
    *
-   * @param session             session object
+   * @param session                session object
    * @param command                upload command
    * @param parallelism            [ not used by the Azure implementation ]
    * @param uploadFromStream       true if upload source is stream
@@ -540,7 +540,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * @param retryCount current number of retries, incremented by the caller before each call
    * @param operation  string that indicates the function/operation that was taking place,
    *                   when the exception was raised, for example "upload"
-   * @param session the current SFSession object used by the client
+   * @param session    the current SFSession object used by the client
    * @param command    the command attempted at the time of the exception
    * @throws SnowflakeSQLException exceptions not handled
    */
@@ -641,7 +641,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * @param retryCount current number of retries, incremented by the caller before each call
    * @param operation  string that indicates the function/operation that was taking place,
    *                   when the exception was raised, for example "upload"
-   * @param session the current SFSession object used by the client
+   * @param session    the current SFSession object used by the client
    * @param command    the command attempted at the time of the exception
    * @param azClient   the current Snowflake Azure client object
    * @throws SnowflakeSQLException exceptions not handled

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -11,43 +11,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.paging.Page;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.BlobId;
-import com.google.cloud.storage.BlobInfo;
-import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.*;
 import com.google.cloud.storage.Storage.BlobListOption;
-import com.google.cloud.storage.StorageException;
-import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Strings;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.SocketTimeoutException;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.core.ObjectMapperFactory;
 import net.snowflake.client.core.SFSession;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.FileBackedOutputStream;
-import net.snowflake.client.jdbc.MatDesc;
-import net.snowflake.client.jdbc.RestRequest;
-import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.SnowflakeUtil;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.log.ArgSupplier;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
@@ -62,6 +33,16 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.*;
+import java.net.SocketTimeoutException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
@@ -361,8 +342,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
         {
           if (key == null || iv == null)
           {
-            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                             "File metadata incomplete");
           }
 
@@ -389,8 +370,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
     }
     while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                     "Unexpected: download unsuccessful without exception!");
   }
 
@@ -539,8 +520,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
     }
     while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                     "Unexpected: download unsuccessful without exception!");
   }
 
@@ -716,8 +697,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
     for (FileInputStream is : toClose)
       IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                     "Unexpected: upload unsuccessful without exception!");
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -343,8 +343,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
           if (key == null || iv == null)
           {
             throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "File metadata incomplete");
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
           // Decrypt file
@@ -371,8 +371,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
     while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                    "Unexpected: download unsuccessful without exception!");
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
@@ -521,8 +521,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
     while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                    "Unexpected: download unsuccessful without exception!");
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
@@ -545,7 +545,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * @throws SnowflakeSQLException if upload failed
    */
   @Override
-  public void uploadWithPresignedUrlWithoutConnection (
+  public void uploadWithPresignedUrlWithoutConnection(
       int networkTimeoutInMilli, OCSPMode ocspMode,
       int parallelism, boolean uploadFromStream,
       String remoteStorageLocation, File srcFile,
@@ -698,8 +698,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
       IOUtils.closeQuietly(is);
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                    "Unexpected: upload unsuccessful without exception!");
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: upload unsuccessful without exception!");
   }
 
   /**

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -211,7 +211,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
   /**
    * Download a file from remote storage.
    *
-   * @param connection            connection object
+   * @param session               session object
    * @param command               command to download file
    * @param localLocation         local file path
    * @param destFileName          destination file name
@@ -223,7 +223,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * @throws SnowflakeSQLException download failure
    **/
   @Override
-  public void download(SFSession connection,
+  public void download(SFSession session,
                        String command,
                        String localLocation,
                        String destFileName,
@@ -254,13 +254,13 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
           logger.debug("Fetching result: {}", scrubPresignedUrl(presignedUrl));
 
           CloseableHttpClient httpClient = HttpUtil.getHttpClientWithoutDecompression(
-              connection.getOCSPMode());
+              session.getOCSPMode());
 
           // Put the file on storage using the presigned url
           HttpResponse response =
               RestRequest.execute(httpClient,
                                   httpRequest,
-                                  connection.getNetworkTimeoutInMilli() / 1000, // retry timeout
+                                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
                                   0, // no socketime injection
                                   null, // no canceling
                                   false, // no cookie
@@ -303,7 +303,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
             catch (IOException ex)
             {
               logger.debug("Download unsuccessful {}", ex);
-              handleStorageException(ex, ++retryCount, "download", connection, command);
+              handleStorageException(ex, ++retryCount, "download", session, command);
             }
           }
         }
@@ -343,7 +343,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
           if (key == null || iv == null)
           {
             throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                             "File metadata incomplete");
           }
 
@@ -365,20 +365,20 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
       catch (Exception ex)
       {
         logger.debug("Download unsuccessful {}", ex);
-        handleStorageException(ex, ++retryCount, "download", connection, command);
+        handleStorageException(ex, ++retryCount, "download", session, command);
       }
     }
     while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                     "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Download a file from remote storage
    *
-   * @param connection            connection object
+   * @param session               session object
    * @param command               command to download file
    * @param parallelism           number of threads for parallel downloading
    * @param remoteStorageLocation remote storage location, i.e. bucket for s3
@@ -389,7 +389,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * @throws SnowflakeSQLException when download failure
    */
   @Override
-  public InputStream downloadToStream(SFSession connection, String command,
+  public InputStream downloadToStream(SFSession session, String command,
                                       int parallelism,
                                       String remoteStorageLocation,
                                       String stageFilePath, String stageRegion,
@@ -416,13 +416,13 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
           logger.debug("Fetching result: {}", scrubPresignedUrl(presignedUrl));
 
           CloseableHttpClient httpClient = HttpUtil.getHttpClientWithoutDecompression(
-              connection.getOCSPMode());
+              session.getOCSPMode());
 
           // Put the file on storage using the presigned url
           HttpResponse response =
               RestRequest.execute(httpClient,
                                   httpRequest,
-                                  connection.getNetworkTimeoutInMilli() / 1000, // retry timeout
+                                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
                                   0, // no socketime injection
                                   null, // no canceling
                                   false, // no cookie
@@ -456,7 +456,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
             catch (IOException ex)
             {
               logger.debug("Download unsuccessful {}", ex);
-              handleStorageException(ex, ++retryCount, "download", connection, command);
+              handleStorageException(ex, ++retryCount, "download", session, command);
             }
           }
         }
@@ -515,19 +515,19 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
       catch (Exception ex)
       {
         logger.debug("Download unsuccessful {}", ex);
-        handleStorageException(ex, ++retryCount, "download", connection, command);
+        handleStorageException(ex, ++retryCount, "download", session, command);
       }
     }
     while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                     "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file (-stream) to remote storage with Pre-signed URL without
-   * JDBC connection.
+   * JDBC session.
    *
    * @param networkTimeoutInMilli  Network timeout for the upload
    * @param ocspMode               OCSP mode for the upload.
@@ -545,7 +545,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * @throws SnowflakeSQLException if upload failed
    */
   @Override
-  public void uploadWithPresignedUrlWithoutConnection(
+  public void uploadWithPresignedUrlWithoutConnection (
       int networkTimeoutInMilli, OCSPMode ocspMode,
       int parallelism, boolean uploadFromStream,
       String remoteStorageLocation, File srcFile,
@@ -591,7 +591,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
   /**
    * Upload a file/stream to remote storage
    *
-   * @param connection             connection object
+   * @param session                session object
    * @param command                upload command
    * @param parallelism            [ not used by the GCP implementation ]
    * @param uploadFromStream       true if upload source is stream
@@ -606,7 +606,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   @Override
-  public void upload(SFSession connection,
+  public void upload(SFSession session,
                      String command,
                      int parallelism,
                      boolean uploadFromStream,
@@ -634,12 +634,12 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
     if (!Strings.isNullOrEmpty(presignedUrl))
     {
       logger.debug("Starting upload");
-      uploadWithPresignedUrl(connection.getNetworkTimeoutInMilli(),
+      uploadWithPresignedUrl(session.getNetworkTimeoutInMilli(),
                              meta.getContentEncoding(),
                              meta.getUserMetadata(),
                              uploadStreamInfo.left,
                              presignedUrl,
-                             connection.getOCSPMode());
+                             session.getOCSPMode());
       logger.debug("Upload successful");
 
       // close any open streams in the "toClose" list and return
@@ -677,7 +677,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
       }
       catch (Exception ex)
       {
-        handleStorageException(ex, ++retryCount, "upload", connection, command);
+        handleStorageException(ex, ++retryCount, "upload", session, command);
 
         if (uploadFromStream && fileBackedOutputStream == null)
         {
@@ -698,7 +698,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
       IOUtils.closeQuietly(is);
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                     "Unexpected: upload unsuccessful without exception!");
   }
 
@@ -884,7 +884,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
   public void handleStorageException(Exception ex,
                                      int retryCount,
                                      String operation,
-                                     SFSession connection,
+                                     SFSession session,
                                      String command)
   throws SnowflakeSQLException
   {
@@ -901,11 +901,11 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
     {
       StorageException se = (StorageException) ex;
 
-      if (se.getCode() == 403 && connection != null && command != null)
+      if (se.getCode() == 403 && session != null && command != null)
       {
         // A 403 indicates that the access token has expired,
         // we need to refresh the GCS client with the new token
-        SnowflakeFileTransferAgent.renewExpiredToken(connection, command, this);
+        SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
       }
 
       // If we have exceeded the max number of retries, propagate the error
@@ -944,11 +944,11 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
           // ignore
         }
 
-        if (se.getCode() == 403 && connection != null && command != null)
+        if (se.getCode() == 403 && session != null && command != null)
         {
           // A 403 indicates that the access token has expired,
           // we need to refresh the GCS client with the new token
-          SnowflakeFileTransferAgent.renewExpiredToken(connection, command, this);
+          SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
         }
       }
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -18,15 +18,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Builder;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.CryptoConfiguration;
-import com.amazonaws.services.s3.model.CryptoMode;
-import com.amazonaws.services.s3.model.EncryptionMaterials;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.StaticEncryptionMaterialsProvider;
+import com.amazonaws.services.s3.model.*;
 import com.amazonaws.services.s3.transfer.Download;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
@@ -35,12 +27,7 @@ import com.amazonaws.util.Base64;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.SFSSLConnectionSocketFactory;
 import net.snowflake.client.core.SFSession;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.FileBackedOutputStream;
-import net.snowflake.client.jdbc.MatDesc;
-import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.SnowflakeUtil;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.client.util.SFPair;
@@ -52,11 +39,7 @@ import org.apache.http.conn.ssl.SSLInitializationException;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.SocketTimeoutException;
 import java.security.InvalidKeyException;
 import java.security.KeyManagementException;
@@ -173,8 +156,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
       }
       else
       {
-        throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
                                         "unsupported key size", encryptionKeySize);
       }
     }
@@ -344,8 +327,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
         {
           if (key == null || iv == null)
           {
-            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),connection,
                                             "File metadata incomplete");
           }
 
@@ -380,8 +363,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
     }
     while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                     "Unexpected: download unsuccessful without exception!");
   }
 
@@ -425,8 +408,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
         {
           if (key == null || iv == null)
           {
-            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                             "File metadata incomplete");
           }
 
@@ -454,8 +437,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
       }
     } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                     "Unexpected: download unsuccessful without exception!");
   }
 
@@ -585,8 +568,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
     for (FileInputStream is : toClose)
       IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), connection,
                                     "Unexpected: upload unsuccessful without exception!");
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -75,6 +75,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
   private ClientConfiguration clientConfig = null;
   private String stageRegion = null;
   private String stageEndPoint = null; // FIPS endpoint, if needed
+  private SFSession session;
 
   // socket factory used by s3 client's http client.
   private static SSLConnectionSocketFactory s3ConnectionSocketFactory = null;
@@ -83,9 +84,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
                            ClientConfiguration clientConfig,
                            RemoteStoreFileEncryptionMaterial encMat,
                            String stageRegion,
-                           String stageEndPoint)
+                           String stageEndPoint, SFSession session)
   throws SnowflakeSQLException
   {
+    this.session = session;
     setupSnowflakeS3Client(stageCredentials, clientConfig,
                            encMat, stageRegion, stageEndPoint);
   }
@@ -157,7 +159,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
       else
       {
         throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                                         "unsupported key size", encryptionKeySize);
       }
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -78,7 +78,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
   private SFSession session;
 
   // socket factory used by s3 client's http client.
-  private static SSLConnectionSocketFactory s3sessionSocketFactory = null;
+  private static SSLConnectionSocketFactory s3ConnectionSocketFactory = null;
 
   public SnowflakeS3Client(Map<?, ?> stageCredentials,
                            ClientConfiguration clientConfig,
@@ -818,17 +818,17 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
 
   private static SSLConnectionSocketFactory getSSLConnectionSocketFactory()
   {
-    if (s3sessionSocketFactory == null)
+    if (s3ConnectionSocketFactory == null)
     {
       synchronized (SnowflakeS3Client.class)
       {
-        if (s3sessionSocketFactory == null)
+        if (s3ConnectionSocketFactory == null)
         {
           try
           {
             // trust manager is set to null, which will use default ones
             // instead of SFTrustManager (which enables ocsp checking)
-            s3sessionSocketFactory = new SFSSLConnectionSocketFactory(null,
+            s3ConnectionSocketFactory = new SFSSLConnectionSocketFactory(null,
                                                                          HttpUtil.isSocksProxyDisabled());
           }
           catch (KeyManagementException | NoSuchAlgorithmException e)
@@ -839,6 +839,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
       }
     }
 
-    return s3sessionSocketFactory;
+    return s3ConnectionSocketFactory;
+
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -159,8 +159,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
       else
       {
         throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                        ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                        "unsupported key size", encryptionKeySize);
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                              "unsupported key size", encryptionKeySize);
       }
     }
     else
@@ -330,8 +330,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
           if (key == null || iv == null)
           {
             throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),session,
-                                            "File metadata incomplete");
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
           // Decrypt file
@@ -366,8 +366,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
     while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                    "Unexpected: download unsuccessful without exception!");
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
@@ -411,8 +411,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
           if (key == null || iv == null)
           {
             throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "File metadata incomplete");
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
           try
@@ -440,14 +440,14 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
     } while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                    "Unexpected: download unsuccessful without exception!");
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file (-stream) to S3.
    *
-   * @param session             session object
+   * @param session                session object
    * @param command                upload command
    * @param parallelism            number of threads do parallel uploading
    * @param uploadFromStream       true if upload source is stream
@@ -571,8 +571,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
       IOUtils.closeQuietly(is);
 
     throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                    "Unexpected: upload unsuccessful without exception!");
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: upload unsuccessful without exception!");
   }
 
   private SFPair<InputStream, Boolean>

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -840,6 +840,5 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
     }
 
     return s3ConnectionSocketFactory;
-
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
@@ -5,16 +5,12 @@ package net.snowflake.client.jdbc.cloud.storage;
 
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.core.SFSession;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.FileBackedOutputStream;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.*;
+import net.snowflake.common.core.SqlState;
 
 import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
-
-import net.snowflake.client.jdbc.MatDesc;
-import net.snowflake.common.core.SqlState;
 
 /**
  * Interface for storage client provider implementations
@@ -189,9 +185,9 @@ public interface SnowflakeStorageClient
   {
     if (!requirePresignedUrl())
     {
-      throw new SnowflakeSQLException(
+      throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
           "uploadWithPresignedUrlWithoutConnection" +
           " only works for pre-signed URL.");
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
@@ -187,7 +187,7 @@ public interface SnowflakeStorageClient
     {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(), null,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), /*session = */ null,
           "uploadWithPresignedUrlWithoutConnection" +
           " only works for pre-signed URL.");
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -166,8 +166,8 @@ public class StorageClientFactory
    * Creates a SnowflakeAzureClientObject which encapsulates
    * the Azure Storage client
    *
-   * @param stage  Stage information
-   * @param encMat encryption material for the client
+   * @param stage   Stage information
+   * @param encMat  encryption material for the client
    * @param session
    * @return the SnowflakeS3Client  instance created
    */

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -3,10 +3,11 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.log.SFLogger;
 import com.amazonaws.ClientConfiguration;
+import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.SFSession;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 
@@ -56,7 +57,7 @@ public class StorageClientFactory
    */
   public SnowflakeStorageClient createClient(StageInfo stage,
                                              int parallel,
-                                             RemoteStoreFileEncryptionMaterial encMat)
+                                             RemoteStoreFileEncryptionMaterial encMat, SFSession session)
   throws SnowflakeSQLException
   {
     logger.debug("createClient client type={}", stage.getStageType().name());
@@ -64,10 +65,10 @@ public class StorageClientFactory
     switch (stage.getStageType())
     {
       case S3:
-        return createS3Client(stage.getCredentials(), parallel, encMat, stage.getRegion(), stage.getEndPoint());
+        return createS3Client(stage.getCredentials(), parallel, encMat, stage.getRegion(), stage.getEndPoint(), session);
 
       case AZURE:
-        return createAzureClient(stage, encMat);
+        return createAzureClient(stage, encMat, session);
 
       case GCS:
         return createGCSClient(stage, encMat);
@@ -97,7 +98,7 @@ public class StorageClientFactory
                                            int parallel,
                                            RemoteStoreFileEncryptionMaterial encMat,
                                            String stageRegion,
-                                           String stageEndPoint)
+                                           String stageEndPoint, SFSession session)
   throws SnowflakeSQLException
   {
     final int S3_TRANSFER_MAX_RETRIES = 3;
@@ -120,7 +121,7 @@ public class StorageClientFactory
 
     try
     {
-      s3Client = new SnowflakeS3Client(stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint);
+      s3Client = new SnowflakeS3Client(stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, session);
     }
     catch (Exception ex)
     {
@@ -167,10 +168,11 @@ public class StorageClientFactory
    *
    * @param stage  Stage information
    * @param encMat encryption material for the client
+   * @param session
    * @return the SnowflakeS3Client  instance created
    */
   private SnowflakeAzureClient createAzureClient(StageInfo stage,
-                                                 RemoteStoreFileEncryptionMaterial encMat)
+                                                 RemoteStoreFileEncryptionMaterial encMat, SFSession session)
   throws SnowflakeSQLException
   {
     logger.debug("createAzureClient encryption={}", (encMat == null ? "no" : "yes"));
@@ -181,7 +183,7 @@ public class StorageClientFactory
 
     try
     {
-      azureClient = SnowflakeAzureClient.createSnowflakeAzureClient(stage, encMat);
+      azureClient = SnowflakeAzureClient.createSnowflakeAzureClient(stage, encMat, session);
     }
     catch (Exception ex)
     {

--- a/src/test/java/net/snowflake/client/core/SFArrowResultSetIT.java
+++ b/src/test/java/net/snowflake/client/core/SFArrowResultSetIT.java
@@ -287,7 +287,7 @@ public class SFArrowResultSetIT
     {
       if (currentFileIndex < resultFileNames.size())
       {
-        ArrowResultChunk resultChunk = new ArrowResultChunk("", 0, 0, 0, rootAllocator);
+        ArrowResultChunk resultChunk = new ArrowResultChunk("", 0, 0, 0, rootAllocator, null);
         try
         {
           InputStream is = new FileInputStream(

--- a/src/test/java/net/snowflake/client/jdbc/ResultJsonParserV2IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultJsonParserV2IT.java
@@ -70,9 +70,9 @@ public class ResultJsonParserV2IT
                     "[\"\\ud841\\udf0e\", \"\\ud841\\udf31\\ud841\\udf79\"]," +
                     "[\"{\\\"date\\\" : \\\"2017-04-28\\\",\\\"dealership\\\" : \\\"Tindel Toyota\\\"}\", \"[1,2,3,4,5]\"]";
     byte[] data = simple.getBytes(StandardCharsets.UTF_8);
-    JsonResultChunk chunk = new JsonResultChunk("", 8, 2, data.length, null);
+    JsonResultChunk chunk = new JsonResultChunk("", 8, 2, data.length, session);
     ResultJsonParserV2 jp = new ResultJsonParserV2();
-    jp.startParsing(chunk, null);
+    jp.startParsing(chunk, session);
     int len = 2;
     for (int i = 0; i < data.length; i += len)
     {
@@ -140,9 +140,9 @@ public class ResultJsonParserV2IT
 
 
     byte[] data = sb.toString().getBytes(StandardCharsets.UTF_8);
-    JsonResultChunk chunk = new JsonResultChunk("", 2, 2, data.length, null);
+    JsonResultChunk chunk = new JsonResultChunk("", 2, 2, data.length, session);
     ResultJsonParserV2 jp = new ResultJsonParserV2();
-    jp.startParsing(chunk, null);
+    jp.startParsing(chunk, session);
     jp.continueParsing(ByteBuffer.wrap(data), session);
     jp.endParsing(session);
     assertEquals(a.toString(), chunk.getCell(0, 0).toString());

--- a/src/test/java/net/snowflake/client/jdbc/ResultJsonParserV2IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultJsonParserV2IT.java
@@ -32,9 +32,9 @@ public class ResultJsonParserV2IT
                     "[\"\\ud841\\udf0e\", \"\\ud841\\udf31\\ud841\\udf79\"]," +
                     "[\"{\\\"date\\\" : \\\"2017-04-28\\\",\\\"dealership\\\" : \\\"Tindel Toyota\\\"}\", \"[1,2,3,4,5]\"]";
     byte[] data = simple.getBytes(StandardCharsets.UTF_8);
-    JsonResultChunk chunk = new JsonResultChunk("", 8, 2, data.length);
+    JsonResultChunk chunk = new JsonResultChunk("", 8, 2, data.length, null);
     ResultJsonParserV2 jp = new ResultJsonParserV2();
-    jp.startParsing(chunk);
+    jp.startParsing(chunk, null);
     jp.continueParsing(ByteBuffer.wrap(data));
     jp.endParsing();
     assertEquals("1", chunk.getCell(0, 0).toString());
@@ -67,9 +67,9 @@ public class ResultJsonParserV2IT
                     "[\"\\ud841\\udf0e\", \"\\ud841\\udf31\\ud841\\udf79\"]," +
                     "[\"{\\\"date\\\" : \\\"2017-04-28\\\",\\\"dealership\\\" : \\\"Tindel Toyota\\\"}\", \"[1,2,3,4,5]\"]";
     byte[] data = simple.getBytes(StandardCharsets.UTF_8);
-    JsonResultChunk chunk = new JsonResultChunk("", 8, 2, data.length);
+    JsonResultChunk chunk = new JsonResultChunk("", 8, 2, data.length, null);
     ResultJsonParserV2 jp = new ResultJsonParserV2();
-    jp.startParsing(chunk);
+    jp.startParsing(chunk, null);
     int len = 2;
     for (int i = 0; i < data.length; i += len)
     {
@@ -136,9 +136,9 @@ public class ResultJsonParserV2IT
 
 
     byte[] data = sb.toString().getBytes(StandardCharsets.UTF_8);
-    JsonResultChunk chunk = new JsonResultChunk("", 2, 2, data.length);
+    JsonResultChunk chunk = new JsonResultChunk("", 2, 2, data.length, null);
     ResultJsonParserV2 jp = new ResultJsonParserV2();
-    jp.startParsing(chunk);
+    jp.startParsing(chunk, null);
     jp.continueParsing(ByteBuffer.wrap(data));
     jp.endParsing();
     assertEquals(a.toString(), chunk.getCell(0, 0).toString());

--- a/src/test/java/net/snowflake/client/jdbc/ResultJsonParserV2IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultJsonParserV2IT.java
@@ -4,6 +4,7 @@
 package net.snowflake.client.jdbc;
 
 import net.snowflake.client.category.TestCategoryResultSet;
+import net.snowflake.client.core.SFSession;
 import org.apache.commons.text.StringEscapeUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -23,6 +24,7 @@ public class ResultJsonParserV2IT
   @Test
   public void simpleTest() throws SnowflakeSQLException
   {
+    SFSession session = null;
     String simple = "[\"1\", \"1.01\"]," +
                     "[null, null]," +
                     "[\"2\", \"0.13\"]," +
@@ -32,11 +34,11 @@ public class ResultJsonParserV2IT
                     "[\"\\ud841\\udf0e\", \"\\ud841\\udf31\\ud841\\udf79\"]," +
                     "[\"{\\\"date\\\" : \\\"2017-04-28\\\",\\\"dealership\\\" : \\\"Tindel Toyota\\\"}\", \"[1,2,3,4,5]\"]";
     byte[] data = simple.getBytes(StandardCharsets.UTF_8);
-    JsonResultChunk chunk = new JsonResultChunk("", 8, 2, data.length, null);
+    JsonResultChunk chunk = new JsonResultChunk("", 8, 2, data.length, session);
     ResultJsonParserV2 jp = new ResultJsonParserV2();
-    jp.startParsing(chunk, null);
-    jp.continueParsing(ByteBuffer.wrap(data));
-    jp.endParsing();
+    jp.startParsing(chunk, session);
+    jp.continueParsing(ByteBuffer.wrap(data), session);
+    jp.endParsing(session);
     assertEquals("1", chunk.getCell(0, 0).toString());
     assertEquals("1.01", chunk.getCell(0, 1).toString());
     assertNull(chunk.getCell(1, 0));
@@ -58,6 +60,7 @@ public class ResultJsonParserV2IT
   @Test
   public void simpleStreamingTest() throws SnowflakeSQLException
   {
+    SFSession session = null;
     String simple = "[\"1\", \"1.01\"]," +
                     "[null, null]," +
                     "[\"2\", \"0.13\"]," +
@@ -75,14 +78,14 @@ public class ResultJsonParserV2IT
     {
       if (i + len < data.length)
       {
-        jp.continueParsing(ByteBuffer.wrap(data, i, len));
+        jp.continueParsing(ByteBuffer.wrap(data, i, len), session);
       }
       else
       {
-        jp.continueParsing(ByteBuffer.wrap(data, i, data.length - i));
+        jp.continueParsing(ByteBuffer.wrap(data, i, data.length - i), session);
       }
     }
-    jp.endParsing();
+    jp.endParsing(session);
     assertEquals("1", chunk.getCell(0, 0).toString());
     assertEquals("1.01", chunk.getCell(0, 1).toString());
     assertNull(chunk.getCell(1, 0));
@@ -110,6 +113,7 @@ public class ResultJsonParserV2IT
   @Test
   public void LargestColumnTest() throws SnowflakeSQLException
   {
+    SFSession session = null;
     StringBuilder sb = new StringBuilder();
     StringBuilder a = new StringBuilder();
     for (int i = 0; i < 16 * 1024 * 1024; i++)
@@ -139,8 +143,8 @@ public class ResultJsonParserV2IT
     JsonResultChunk chunk = new JsonResultChunk("", 2, 2, data.length, null);
     ResultJsonParserV2 jp = new ResultJsonParserV2();
     jp.startParsing(chunk, null);
-    jp.continueParsing(ByteBuffer.wrap(data));
-    jp.endParsing();
+    jp.continueParsing(ByteBuffer.wrap(data), session);
+    jp.endParsing(session);
     assertEquals(a.toString(), chunk.getCell(0, 0).toString());
     assertEquals(b.toString(), chunk.getCell(0, 1).toString());
     assertEquals(c.toString(), chunk.getCell(1, 0).toString());

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -955,7 +955,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest
     Properties _connectionProperties = new Properties();
     _connectionProperties.put("inject_wait_in_put", 5);
     _connectionProperties.put("ssl", "off");
-    Connection connection = getConnection(DONT_INJECT_SOCKET_TIMEOUT, _connectionProperties, false, false, "gcpaccount");
+    Connection connection =
+        getConnection(DONT_INJECT_SOCKET_TIMEOUT, _connectionProperties, false, false, "gcpaccount");
     Statement statement = connection.createStatement();
 
     String sourceFilePath = getFullPathFileInResource(TEST_DATA_FILE);

--- a/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
@@ -248,10 +248,11 @@ public class TelemetryServiceIT extends BaseJDBCTest
     String sqlState = SqlState.NO_DATA;
     throw new SnowflakeSQLLoggedException(queryID, reason, sqlState, vendorCode, session);
   }
-  
+
   /**
    * Test case for checking telemetry message for SnowflakeSQLExceptions. Assert that telemetry OOB endpoint is reached
    * after a SnowflakeSQLLoggedException is thrown.
+   *
    * @throws SQLException
    */
   @Test
@@ -269,7 +270,7 @@ public class TelemetryServiceIT extends BaseJDBCTest
     {
       // The error response has the same code as the the fakeErrorCode
       assertThat("Communication error", e.getErrorCode(),
-              equalTo(fakeVendorCode));
+                 equalTo(fakeVendorCode));
 
       // since it returns normal response,
       // the telemetry does not create new event
@@ -277,8 +278,8 @@ public class TelemetryServiceIT extends BaseJDBCTest
       if (TelemetryService.getInstance().isDeploymentEnabled())
       {
         assertThat("Telemetry event has not been reported successfully. Error: " +
-                        TelemetryService.getInstance().getLastClientError(),
-                TelemetryService.getInstance().getClientFailureCount(), equalTo(0));
+                   TelemetryService.getInstance().getLastClientError(),
+                   TelemetryService.getInstance().getClientFailureCount(), equalTo(0));
       }
     }
   }
@@ -303,7 +304,7 @@ public class TelemetryServiceIT extends BaseJDBCTest
     {
       // The error response has the same code as the fakeErrorCode
       assertThat("Communication error", e.getErrorCode(),
-              equalTo(fakeErrorCode));
+                 equalTo(fakeErrorCode));
     }
   }
 }


### PR DESCRIPTION
There is a set of exceptions in the JDBC driver that are raised due to internal errors.  
These could be caused by:
- Null or out-of-range values from other driver functions
- Invalid conversions of data types (attempt to turn an integer into a timestamp, or something like that)
- Unexpected errors caused by external library functions

This set of exceptions should not include errors due to:
- User-generated error
- Issues caused by a valid JSON response from GS. These are already recorded in Snowhouse

These internal errors have been refactored to send a telemetry message by changing their constructor to be SnowflakeSQLLoggedExceptions.