### PR TITLE
SNOW-176125: Add two debug log

### DIFF
--- a/ci/container/change_snowflake_test_pwd.py
+++ b/ci/container/change_snowflake_test_pwd.py
@@ -2,6 +2,7 @@
 #
 # Set a complex password for test user snowman
 #
+
 import os
 import sys
 import snowflake.connector

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -20,6 +20,7 @@ import net.snowflake.client.core.SFSession;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.client.jdbc.telemetry.TelemetryData;
 import net.snowflake.client.jdbc.telemetry.TelemetryField;
+import net.snowflake.client.jdbc.telemetry.TelemetryUtil;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryEvent;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
 
@@ -79,7 +80,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     String stackTrace = sw.toString();
     value.put("Stacktrace", stackTrace);
     value.put("Exception", ex.getClass().getSimpleName());
-    ibInstance.addLogToBatch(new TelemetryData(value, System.currentTimeMillis()));
+    ibInstance.addLogToBatch(TelemetryUtil.buildJobData(value));
     return ibInstance.sendBatchAsync();
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -18,7 +18,6 @@ import net.snowflake.client.core.ObjectMapperFactory;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
-import net.snowflake.client.jdbc.telemetry.TelemetryData;
 import net.snowflake.client.jdbc.telemetry.TelemetryField;
 import net.snowflake.client.jdbc.telemetry.TelemetryUtil;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryEvent;

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -234,9 +234,12 @@ public class TelemetryClient implements Telemetry {
     if (!tmpList.isEmpty()) {
       // session shared with JDBC
       String sessionToken = this.session.getSessionToken();
+      String payload = logsToString(tmpList);
+
+      logger.debug("Payload of telemetry is : " + payload);
 
       HttpPost post = new HttpPost(this.telemetryUrl);
-      post.setEntity(new StringEntity(logsToString(tmpList)));
+      post.setEntity(new StringEntity(payload));
       post.setHeader("Content-type", "application/json");
       post.setHeader("Authorization", "Snowflake Token=\"" + sessionToken + "\"");
 

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -236,7 +236,7 @@ public class TelemetryClient implements Telemetry {
       String sessionToken = this.session.getSessionToken();
       String payload = logsToString(tmpList);
 
-      logger.debug("Payload of telemetry is : " + payload);
+      logger.debugNoMask("Payload of telemetry is : " + payload);
 
       HttpPost post = new HttpPost(this.telemetryUrl);
       post.setEntity(new StringEntity(payload));

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryData.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryData.java
@@ -6,6 +6,7 @@ package net.snowflake.client.jdbc.telemetry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import net.snowflake.client.core.ObjectMapperFactory;
+import net.snowflake.client.util.SecretDetector;
 
 /** Copyright (c) 2018-2019 Snowflake Computing Inc. All rights reserved. */
 public class TelemetryData {
@@ -14,8 +15,10 @@ public class TelemetryData {
   private final long timeStamp;
   private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
 
-  public TelemetryData(ObjectNode message, long timeStamp) {
-    this.message = message;
+  // Only allow code in same package to construct TelemetryData
+  TelemetryData(ObjectNode message, long timeStamp)
+  {
+    this.message = (ObjectNode) SecretDetector.maskJacksonNode(message);
     this.timeStamp = timeStamp;
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryData.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryData.java
@@ -16,8 +16,7 @@ public class TelemetryData {
   private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
 
   // Only allow code in same package to construct TelemetryData
-  TelemetryData(ObjectNode message, long timeStamp)
-  {
+  TelemetryData(ObjectNode message, long timeStamp) {
     this.message = (ObjectNode) SecretDetector.maskJacksonNode(message);
     this.timeStamp = timeStamp;
   }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryUtil.java
@@ -29,4 +29,9 @@ public class TelemetryUtil {
     obj.put(VALUE, value);
     return new TelemetryData(obj, System.currentTimeMillis());
   }
+
+  public static TelemetryData buildJobData(ObjectNode obj)
+  {
+    return new TelemetryData(obj, System.currentTimeMillis());
+  }
 }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryUtil.java
@@ -30,8 +30,7 @@ public class TelemetryUtil {
     return new TelemetryData(obj, System.currentTimeMillis());
   }
 
-  public static TelemetryData buildJobData(ObjectNode obj)
-  {
+  public static TelemetryData buildJobData(ObjectNode obj) {
     return new TelemetryData(obj, System.currentTimeMillis());
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -349,8 +349,7 @@ public class TelemetryService {
       uploadPayload();
     }
 
-    private void uploadPayload()
-    {
+    private void uploadPayload() {
       logger.debugNoMask("Running telemetry uploader. The payload is: " + payload);
       CloseableHttpResponse response = null;
       boolean success = true;

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -349,8 +349,10 @@ public class TelemetryService {
       uploadPayload();
     }
 
-    private void uploadPayload() {
-      logger.debug("running telemetry uploader");
+    private void uploadPayload()
+    {
+      logger.debug("Running telemetry uploader");
+      logger.debug("Payload of telemetry is: " + payload);
       CloseableHttpResponse response = null;
       boolean success = true;
 

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -1,5 +1,14 @@
 package net.snowflake.client.jdbc.telemetryOOB;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.snowflake.client.jdbc.SnowflakeConnectString;
@@ -14,16 +23,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.security.cert.CertificateException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Copyright (c) 2018-2019 Snowflake Computing Inc. All rights reserved.

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -351,7 +351,7 @@ public class TelemetryService {
 
     private void uploadPayload()
     {
-      logger.debug("Running telemetry uploader. The payload is: " + payload);
+      logger.debugNoMask("Running telemetry uploader. The payload is: " + payload);
       CloseableHttpResponse response = null;
       boolean success = true;
 

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -1,14 +1,5 @@
 package net.snowflake.client.jdbc.telemetryOOB;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.security.cert.CertificateException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.snowflake.client.jdbc.SnowflakeConnectString;
@@ -23,6 +14,16 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Copyright (c) 2018-2019 Snowflake Computing Inc. All rights reserved.
@@ -310,7 +311,7 @@ public class TelemetryService {
   public String exportQueueToString(TelemetryEvent event) {
     JSONArray logs = new JSONArray();
     logs.add(event);
-    return logs.toString();
+    return JSONArray.toJSONString(logs, new SecretDetector.SecretDetectorJSONStyle());
   }
 
   static class TelemetryUploader implements Runnable {

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -351,8 +351,7 @@ public class TelemetryService {
 
     private void uploadPayload()
     {
-      logger.debug("Running telemetry uploader");
-      logger.debug("Payload of telemetry is: " + payload);
+      logger.debug("Running telemetry uploader. The payload is: " + payload);
       CloseableHttpResponse response = null;
       boolean success = true;
 

--- a/src/main/java/net/snowflake/client/log/JDK14Logger.java
+++ b/src/main/java/net/snowflake/client/log/JDK14Logger.java
@@ -30,8 +30,8 @@ import net.snowflake.client.util.SecretDetector;
 public class JDK14Logger implements SFLogger {
   private Logger jdkLogger;
 
-  private Set<String> logMethods = new HashSet<>(Arrays.asList(
-      "debug", "error", "info", "trace", "warn", "debugNoMask"));
+  private Set<String> logMethods =
+      new HashSet<>(Arrays.asList("debug", "error", "info", "trace", "warn", "debugNoMask"));
 
   private static boolean isLegacyLoggerInit = false;
 
@@ -59,14 +59,13 @@ public class JDK14Logger implements SFLogger {
     return this.jdkLogger.isLoggable(Level.WARNING);
   }
 
-  public void debug(String msg)
-  {
+  public void debug(String msg) {
     logInternal(Level.FINE, msg, true);
   }
 
-  // This function is used to display unmasked, potentially sensitive log information for internal regression testing purposes. Do not use otherwise.
-  public void debugNoMask(String msg)
-  {
+  // This function is used to display unmasked, potentially sensitive log information for internal
+  // regression testing purposes. Do not use otherwise.
+  public void debugNoMask(String msg) {
     logInternal(Level.FINE, msg, false);
   }
 
@@ -78,8 +77,7 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.FINE, msg, t);
   }
 
-  public void error(String msg)
-  {
+  public void error(String msg) {
     logInternal(Level.SEVERE, msg, true);
   }
 
@@ -91,8 +89,7 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.SEVERE, msg, t);
   }
 
-  public void info(String msg)
-  {
+  public void info(String msg) {
     logInternal(Level.INFO, msg, true);
   }
 
@@ -104,8 +101,7 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.INFO, msg, t);
   }
 
-  public void trace(String msg)
-  {
+  public void trace(String msg) {
     logInternal(Level.FINEST, msg, true);
   }
 
@@ -117,8 +113,7 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.FINEST, msg, t);
   }
 
-  public void warn(String msg)
-  {
+  public void warn(String msg) {
     logInternal(Level.WARNING, msg, true);
   }
 
@@ -130,12 +125,11 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.WARNING, msg, t);
   }
 
-  private void logInternal(Level level, String msg, boolean masked)
-  {
-    if (jdkLogger.isLoggable(level))
-    {
+  private void logInternal(Level level, String msg, boolean masked) {
+    if (jdkLogger.isLoggable(level)) {
       String[] source = findSourceInStack();
-      jdkLogger.logp(level, source[0], source[1], masked == true ? SecretDetector.maskSecrets(msg) : msg);
+      jdkLogger.logp(
+          level, source[0], source[1], masked == true ? SecretDetector.maskSecrets(msg) : msg);
     }
   }
 

--- a/src/main/java/net/snowflake/client/log/JDK14Logger.java
+++ b/src/main/java/net/snowflake/client/log/JDK14Logger.java
@@ -64,7 +64,7 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.FINE, msg, true);
   }
 
-  // Please don't use this function except you know what you are doing
+  // This function is used to display unmasked, potentially sensitive log information for internal regression testing purposes. Do not use otherwise.
   public void debugNoMask(String msg)
   {
     logInternal(Level.FINE, msg, false);

--- a/src/main/java/net/snowflake/client/log/JDK14Logger.java
+++ b/src/main/java/net/snowflake/client/log/JDK14Logger.java
@@ -30,8 +30,8 @@ import net.snowflake.client.util.SecretDetector;
 public class JDK14Logger implements SFLogger {
   private Logger jdkLogger;
 
-  private Set<String> logMethods =
-      new HashSet<>(Arrays.asList("debug", "error", "info", "trace", "warn"));
+  private Set<String> logMethods = new HashSet<>(Arrays.asList(
+      "debug", "error", "info", "trace", "warn", "debugNoMask"));
 
   private static boolean isLegacyLoggerInit = false;
 
@@ -59,8 +59,15 @@ public class JDK14Logger implements SFLogger {
     return this.jdkLogger.isLoggable(Level.WARNING);
   }
 
-  public void debug(String msg) {
-    logInternal(Level.FINE, msg);
+  public void debug(String msg)
+  {
+    logInternal(Level.FINE, msg, true);
+  }
+
+  // Please don't use this function except you know what you are doing
+  public void debugNoMask(String msg)
+  {
+    logInternal(Level.FINE, msg, false);
   }
 
   public void debug(String msg, Object... arguments) {
@@ -71,8 +78,9 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.FINE, msg, t);
   }
 
-  public void error(String msg) {
-    logInternal(Level.SEVERE, msg);
+  public void error(String msg)
+  {
+    logInternal(Level.SEVERE, msg, true);
   }
 
   public void error(String msg, Object... arguments) {
@@ -83,8 +91,9 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.SEVERE, msg, t);
   }
 
-  public void info(String msg) {
-    logInternal(Level.INFO, msg);
+  public void info(String msg)
+  {
+    logInternal(Level.INFO, msg, true);
   }
 
   public void info(String msg, Object... arguments) {
@@ -95,8 +104,9 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.INFO, msg, t);
   }
 
-  public void trace(String msg) {
-    logInternal(Level.FINEST, msg);
+  public void trace(String msg)
+  {
+    logInternal(Level.FINEST, msg, true);
   }
 
   public void trace(String msg, Object... arguments) {
@@ -107,8 +117,9 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.FINEST, msg, t);
   }
 
-  public void warn(String msg) {
-    logInternal(Level.WARNING, msg);
+  public void warn(String msg)
+  {
+    logInternal(Level.WARNING, msg, true);
   }
 
   public void warn(String msg, Object... arguments) {
@@ -119,10 +130,12 @@ public class JDK14Logger implements SFLogger {
     logInternal(Level.WARNING, msg, t);
   }
 
-  private void logInternal(Level level, String msg) {
-    if (jdkLogger.isLoggable(level)) {
+  private void logInternal(Level level, String msg, boolean masked)
+  {
+    if (jdkLogger.isLoggable(level))
+    {
       String[] source = findSourceInStack();
-      jdkLogger.logp(level, source[0], source[1], SecretDetector.maskSecrets(msg));
+      jdkLogger.logp(level, source[0], source[1], masked == true ? SecretDetector.maskSecrets(msg) : msg);
     }
   }
 

--- a/src/main/java/net/snowflake/client/log/SFLogger.java
+++ b/src/main/java/net/snowflake/client/log/SFLogger.java
@@ -48,6 +48,8 @@ public interface SFLogger {
 
   void debug(String msg);
 
+  void debugNoMask(String msg);
+
   /**
    * Logs message at DEBUG level.
    *

--- a/src/main/java/net/snowflake/client/log/SLF4JLogger.java
+++ b/src/main/java/net/snowflake/client/log/SLF4JLogger.java
@@ -58,7 +58,7 @@ public class SLF4JLogger implements SFLogger {
     }
   }
 
-  // Please don't use this function except you know what you are doing
+  // This function is used to display unmasked, potentially sensitive log information for internal regression testing purposes. Do not use otherwise
   public void debugNoMask(String msg)
   {
     if (isLocationAwareLogger)

--- a/src/main/java/net/snowflake/client/log/SLF4JLogger.java
+++ b/src/main/java/net/snowflake/client/log/SLF4JLogger.java
@@ -58,21 +58,18 @@ public class SLF4JLogger implements SFLogger {
     }
   }
 
-  // This function is used to display unmasked, potentially sensitive log information for internal regression testing purposes. Do not use otherwise
-  public void debugNoMask(String msg)
-  {
-    if (isLocationAwareLogger)
-    {
-      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
-    }
-    else
-    {
+  // This function is used to display unmasked, potentially sensitive log information for internal
+  // regression testing purposes. Do not use otherwise
+  public void debugNoMask(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger)
+          .log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
+    } else {
       slf4jLogger.debug(msg);
     }
   }
 
-  public void debug(String msg, Object... arguments)
-  {
+  public void debug(String msg, Object... arguments) {
     // use this as format example for JDK14Logger.
     if (isDebugEnabled()) {
       FormattingTuple ft = MessageFormatter.arrayFormat(msg, evaluateLambdaArgs(arguments));

--- a/src/main/java/net/snowflake/client/log/SLF4JLogger.java
+++ b/src/main/java/net/snowflake/client/log/SLF4JLogger.java
@@ -58,7 +58,21 @@ public class SLF4JLogger implements SFLogger {
     }
   }
 
-  public void debug(String msg, Object... arguments) {
+  // Please don't use this function except you know what you are doing
+  public void debugNoMask(String msg)
+  {
+    if (isLocationAwareLogger)
+    {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
+    }
+    else
+    {
+      slf4jLogger.debug(msg);
+    }
+  }
+
+  public void debug(String msg, Object... arguments)
+  {
     // use this as format example for JDK14Logger.
     if (isDebugEnabled()) {
       FormattingTuple ft = MessageFormatter.arrayFormat(msg, evaluateLambdaArgs(arguments));

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -331,7 +331,6 @@ public class SecretDetector {
         }
       }
     }
-
     return node;
   }
 }

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -8,11 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import net.minidev.json.JSONArray;
-import net.minidev.json.JSONObject;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -294,39 +289,28 @@ public class SecretDetector {
     return array;
   }
 
-  public static JsonNode maskJacksonNode(JsonNode node)
-  {
-    if (node.isTextual())
-    {
+  public static JsonNode maskJacksonNode(JsonNode node) {
+    if (node.isTextual()) {
       String maskedText = SecretDetector.maskSecrets(node.textValue());
-      if (!maskedText.equals(node.textValue()))
-      {
+      if (!maskedText.equals(node.textValue())) {
         return new TextNode(maskedText);
       }
-    }
-    else if (node.isObject())
-    {
+    } else if (node.isObject()) {
       ObjectNode objNode = (ObjectNode) node;
       Iterator<String> fieldNames = objNode.fieldNames();
 
-      while (fieldNames.hasNext())
-      {
+      while (fieldNames.hasNext()) {
         String fieldName = fieldNames.next();
         JsonNode tmpNode = maskJacksonNode(objNode.get(fieldName));
-        if (objNode.get(fieldName).isTextual())
-        {
+        if (objNode.get(fieldName).isTextual()) {
           objNode.set(fieldName, tmpNode);
         }
       }
-    }
-    else if (node.isArray())
-    {
+    } else if (node.isArray()) {
       ArrayNode arrayNode = (ArrayNode) node;
-      for (int i = 0; i < arrayNode.size(); i++)
-      {
+      for (int i = 0; i < arrayNode.size(); i++) {
         JsonNode tmpNode = maskJacksonNode(arrayNode.get(i));
-        if (arrayNode.get(i).isTextual())
-        {
+        if (arrayNode.get(i).isTextual()) {
           arrayNode.set(i, tmpNode);
         }
       }
@@ -334,4 +318,3 @@ public class SecretDetector {
     return node;
   }
 }
-

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -321,6 +321,7 @@ public class SecretDetector {
     return node;
   }
 
+  // This class aims to parse minidev.json's node better
   public static class SecretDetectorJSONStyle extends JSONStyle {
     public SecretDetectorJSONStyle() {
       super();

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -4,10 +4,16 @@
 
 package net.snowflake.client.util;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minidev.json.JSONArray;
@@ -286,5 +292,46 @@ public class SecretDetector {
     }
 
     return array;
+  }
+
+  public static JsonNode maskJacksonNode(JsonNode node)
+  {
+    if (node.isTextual())
+    {
+      String maskedText = SecretDetector.maskSecrets(node.textValue());
+      if (!maskedText.equals(node.textValue()))
+      {
+        return new TextNode(maskedText);
+      }
+    }
+    else if (node.isObject())
+    {
+      ObjectNode objNode = (ObjectNode) node;
+      Iterator<String> fieldNames = objNode.fieldNames();
+
+      while (fieldNames.hasNext())
+      {
+        String fieldName = fieldNames.next();
+        JsonNode tmpNode = maskJacksonNode(objNode.get(fieldName));
+        if (objNode.get(fieldName).isTextual())
+        {
+          objNode.set(fieldName, tmpNode);
+        }
+      }
+    }
+    else if (node.isArray())
+    {
+      ArrayNode arrayNode = (ArrayNode) node;
+      for (int i = 0; i < arrayNode.size(); i++)
+      {
+        JsonNode tmpNode = maskJacksonNode(arrayNode.get(i));
+        if (arrayNode.get(i).isTextual())
+        {
+          arrayNode.set(i, tmpNode);
+        }
+      }
+    }
+
+    return node;
   }
 }

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -8,13 +8,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONStyle;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+
+import java.io.IOException;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.minidev.json.JSONArray;
-import net.minidev.json.JSONObject;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
 
 /** Search for credentials in sql and/or other text */
 public class SecretDetector {
@@ -318,4 +321,23 @@ public class SecretDetector {
     }
     return node;
   }
+
+  public static class SecretDetectorJSONStyle extends JSONStyle {
+    public SecretDetectorJSONStyle() {
+      super();
+    }
+
+    public void objectNext(Appendable out) throws IOException {
+      out.append(", ");
+    }
+
+    public void arrayStop(Appendable out) throws IOException {
+      out.append("] ");
+    }
+
+    public void arrayNextElm(Appendable out) throws IOException {
+      out.append(", ");
+    }
+  }
+
 }

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -334,3 +334,4 @@ public class SecretDetector {
     return node;
   }
 }
+

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -8,16 +8,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONStyle;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /** Search for credentials in sql and/or other text */
 public class SecretDetector {
@@ -339,5 +338,4 @@ public class SecretDetector {
       out.append(", ");
     }
   }
-
 }

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -45,6 +45,7 @@ public class SecretDetector {
           "(sig|signature|AWSAccessKeyId|password|passcode)=([a-z0-9%/+]{16,})",
           Pattern.CASE_INSENSITIVE);
 
+  // Search for password pattern
   private static final Pattern PASSWORD_PATTERN =
       Pattern.compile(
           "(password|passcode|pwd)"

--- a/src/test/java/net/snowflake/client/util/SecretDetectorTest.java
+++ b/src/test/java/net/snowflake/client/util/SecretDetectorTest.java
@@ -331,10 +331,10 @@ public class SecretDetectorTest {
     ObjectNode objNode = mapper.createObjectNode();
     objNode.put("testInfo", "pwd=HelloWorld!");
 
-    String maskedObjNodeStr = "{\"testInfo\":\"pwd=****\"}";
+    String maskedObjNodeStr = "{\"testInfo\":\"pwd=**** \"}";
     assertThat(
         "Jackson ObjectNode is not masked successfully",
-        maskedObjNodeStr.toString().equals(SecretDetector.maskJacksonNode(objNode).toString()));
+        maskedObjNodeStr.equals(SecretDetector.maskJacksonNode(objNode).toString()));
 
     // test nested object node
     ObjectNode objNode1 = mapper.createObjectNode();
@@ -344,11 +344,11 @@ public class SecretDetectorTest {
     objNodeNested.put("testInfo2", "sig=ajwAWD45%+ajrH92knKfsfakj");
     objNode1.set("testNested", objNodeNested);
 
-    String maskedObjNested =
-        "{\"testInfo\":\"pwd=****\",\"testNested\":{\"dummy\":\"dummy\",\"testInfo2\":\"sig=****\"}}";
+    String maskedObjNestedStr =
+        "{\"testInfo\":\"pwd=**** \",\"testNested\":{\"dummy\":\"dummy\",\"testInfo2\":\"sig=****\"}}";
     assertThat(
         "Nested Jackson ObjectNode is not masked successfully",
-        maskedObjNested.toString().equals(SecretDetector.maskJacksonNode(objNode1).toString()));
+        maskedObjNestedStr.equals(SecretDetector.maskJacksonNode(objNode1).toString()));
 
     // test array node
     ObjectNode objNode2 = mapper.createObjectNode();
@@ -373,7 +373,7 @@ public class SecretDetectorTest {
     objNode4.put("password", "password = HelloWorld!");
 
     String maskedNestedArrayStr =
-        "{\"testArrayNode\":[{\"testInfo\":\"\\\"privateKeyData\\\": \\\"XXXX\\\"\"}],\"hello\":\"world\",\"password\":\"password = ****\"}";
+        "{\"testArrayNode\":[{\"testInfo\":\"\\\"privateKeyData\\\": \\\"XXXX\\\"\"}],\"hello\":\"world\",\"password\":\"password = **** \"}";
     SecretDetector.maskJacksonNode(objNode4);
     assertThat(
         "Nested Jackson array node is not masked successfully",

--- a/src/test/java/net/snowflake/client/util/SecretDetectorTest.java
+++ b/src/test/java/net/snowflake/client/util/SecretDetectorTest.java
@@ -5,8 +5,12 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
+import net.snowflake.client.core.ObjectMapperFactory;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 
@@ -319,5 +323,55 @@ public class SecretDetectorTest {
     assertThat(
         "JSONArray within JSONObject is not masked successfully",
         maskedNestedObjArray.equals(SecretDetector.maskJsonObject(nestedObjArray)));
+  }
+
+  @Test
+  public void testMaskJacksonObject()
+  {
+    final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+    ObjectNode objNode = mapper.createObjectNode();
+    objNode.put("testInfo", "pwd=HelloWorld!");
+
+    String maskedObjNodeStr = "{\"testInfo\":\"pwd=****\"}";
+    assertThat("Jackson ObjectNode is not masked successfully",
+            maskedObjNodeStr.toString().equals(SecretDetector.maskJacksonNode(objNode).toString()));
+
+    // test nested object node
+    ObjectNode objNode1 = mapper.createObjectNode();
+    objNode1.put("testInfo", "pwd=HelloWorld!");
+    ObjectNode objNodeNested = mapper.createObjectNode();
+    objNodeNested.put("dummy", "dummy");
+    objNodeNested.put("testInfo2", "sig=ajwAWD45%+ajrH92knKfsfakj");
+    objNode1.set("testNested", objNodeNested);
+
+    String maskedObjNested = "{\"testInfo\":\"pwd=****\",\"testNested\":{\"dummy\":\"dummy\",\"testInfo2\":\"sig=****\"}}";
+    assertThat("Nested Jackson ObjectNode is not masked successfully",
+            maskedObjNested.toString().equals(SecretDetector.maskJacksonNode(objNode1).toString()));
+
+    // test array node
+    ObjectNode objNode2 = mapper.createObjectNode();
+    objNode2.put("testInfo", "aws_secret_key= 'fakeAWSsecretKey!123'");
+    ArrayNode arrayObj = mapper.createArrayNode();
+    arrayObj.add(objNode2);
+    arrayObj.add("fake token: SDFADAVN4ASD28ASFG3234x");
+
+    String maskedArrayNodeStr = "[{\"testInfo\":\"aws_secret_key= '****'\"},\"fake token: ****\"]";
+    assertThat("Jackson ArrayNode is not masked successfully",
+            maskedArrayNodeStr.equals(SecretDetector.maskJacksonNode(arrayObj).toString()));
+
+    // test nested array node
+    ObjectNode objNode3 = mapper.createObjectNode();
+    objNode3.put("testInfo", "\"privateKeyData\": \"abcdefg012345/=+\"");
+    ArrayNode arrayObj1 = mapper.createArrayNode();
+    arrayObj1.add(objNode3);
+    ObjectNode objNode4 = mapper.createObjectNode();
+    objNode4.set("testArrayNode", arrayObj1);
+    objNode4.put("hello", "world");
+    objNode4.put("password", "password = HelloWorld!");
+
+    String maskedNestedArrayStr = "{\"testArrayNode\":[{\"testInfo\":\"\\\"privateKeyData\\\": \\\"XXXX\\\"\"}],\"hello\":\"world\",\"password\":\"password = ****\"}";
+    SecretDetector.maskJacksonNode(objNode4);
+    assertThat("Nested Jackson array node is not masked successfully",
+            maskedNestedArrayStr.equals(SecretDetector.maskJacksonNode(objNode4).toString()));
   }
 }

--- a/src/test/java/net/snowflake/client/util/SecretDetectorTest.java
+++ b/src/test/java/net/snowflake/client/util/SecretDetectorTest.java
@@ -3,11 +3,11 @@ package net.snowflake.client.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import java.util.HashMap;
-import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.HashMap;
+import java.util.Map;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.snowflake.client.core.ObjectMapperFactory;
@@ -326,15 +326,15 @@ public class SecretDetectorTest {
   }
 
   @Test
-  public void testMaskJacksonObject()
-  {
+  public void testMaskJacksonObject() {
     final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
     ObjectNode objNode = mapper.createObjectNode();
     objNode.put("testInfo", "pwd=HelloWorld!");
 
     String maskedObjNodeStr = "{\"testInfo\":\"pwd=****\"}";
-    assertThat("Jackson ObjectNode is not masked successfully",
-            maskedObjNodeStr.toString().equals(SecretDetector.maskJacksonNode(objNode).toString()));
+    assertThat(
+        "Jackson ObjectNode is not masked successfully",
+        maskedObjNodeStr.toString().equals(SecretDetector.maskJacksonNode(objNode).toString()));
 
     // test nested object node
     ObjectNode objNode1 = mapper.createObjectNode();
@@ -344,9 +344,11 @@ public class SecretDetectorTest {
     objNodeNested.put("testInfo2", "sig=ajwAWD45%+ajrH92knKfsfakj");
     objNode1.set("testNested", objNodeNested);
 
-    String maskedObjNested = "{\"testInfo\":\"pwd=****\",\"testNested\":{\"dummy\":\"dummy\",\"testInfo2\":\"sig=****\"}}";
-    assertThat("Nested Jackson ObjectNode is not masked successfully",
-            maskedObjNested.toString().equals(SecretDetector.maskJacksonNode(objNode1).toString()));
+    String maskedObjNested =
+        "{\"testInfo\":\"pwd=****\",\"testNested\":{\"dummy\":\"dummy\",\"testInfo2\":\"sig=****\"}}";
+    assertThat(
+        "Nested Jackson ObjectNode is not masked successfully",
+        maskedObjNested.toString().equals(SecretDetector.maskJacksonNode(objNode1).toString()));
 
     // test array node
     ObjectNode objNode2 = mapper.createObjectNode();
@@ -356,8 +358,9 @@ public class SecretDetectorTest {
     arrayObj.add("fake token: SDFADAVN4ASD28ASFG3234x");
 
     String maskedArrayNodeStr = "[{\"testInfo\":\"aws_secret_key= '****'\"},\"fake token: ****\"]";
-    assertThat("Jackson ArrayNode is not masked successfully",
-            maskedArrayNodeStr.equals(SecretDetector.maskJacksonNode(arrayObj).toString()));
+    assertThat(
+        "Jackson ArrayNode is not masked successfully",
+        maskedArrayNodeStr.equals(SecretDetector.maskJacksonNode(arrayObj).toString()));
 
     // test nested array node
     ObjectNode objNode3 = mapper.createObjectNode();
@@ -369,9 +372,11 @@ public class SecretDetectorTest {
     objNode4.put("hello", "world");
     objNode4.put("password", "password = HelloWorld!");
 
-    String maskedNestedArrayStr = "{\"testArrayNode\":[{\"testInfo\":\"\\\"privateKeyData\\\": \\\"XXXX\\\"\"}],\"hello\":\"world\",\"password\":\"password = ****\"}";
+    String maskedNestedArrayStr =
+        "{\"testArrayNode\":[{\"testInfo\":\"\\\"privateKeyData\\\": \\\"XXXX\\\"\"}],\"hello\":\"world\",\"password\":\"password = ****\"}";
     SecretDetector.maskJacksonNode(objNode4);
-    assertThat("Nested Jackson array node is not masked successfully",
-            maskedNestedArrayStr.equals(SecretDetector.maskJacksonNode(objNode4).toString()));
+    assertThat(
+        "Nested Jackson array node is not masked successfully",
+        maskedNestedArrayStr.equals(SecretDetector.maskJacksonNode(objNode4).toString()));
   }
 }


### PR DESCRIPTION
Latest Update:
> Two things need to be aware of.    
    1. Now inband telemetry's payload will be masked when it's built. 
    2. `payloadLogStr` was added to solve the following issues.
        The original string of telemetry OOB payload has no space as delimiter, which would cause false positive detection for log analyze ssm detector module. So we added a new smart-json output style class and store the payload with space as delimiter for dump usage.

Update:
    The latest code introduces a function `debugNoMask` to solve the following issue.
    
> Issue: 
        The main target of this pr is to include telemetry payload into our log files for log analyze module to detect potential leakage of sensitive data. The problem is if we use normal `logger.debug`, the payload will be masked by secret detector again. This breaks the idea to check raw msg in telemetry. Also, the payload string has no proper space (delimiter) for secret detector, which leads to unreasonable masking. 

Given factors above, I decided to introduce a ***no masking*** debug function.

Have tested this function with JDK14Logger and SLF4JLogger-logback.

Original comment:
This ticket aims to dump telemetry information to log files at debug level.

Two benefits:
    1. For customer to learn what's being sent to server end.
    2. For log analyze module to check potential leakage in telemetry payload.
