### PR TITLE
SNOW-164505 Refactor caught and re-thrown SQLExceptions into SnowflakeSQLLoggedExceptions

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -3,19 +3,6 @@
  */
 package net.snowflake.client.core;
 
-import static net.snowflake.client.core.StmtUtil.eventHandler;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.sql.Date;
-import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.Base64;
-import java.util.TimeZone;
 import net.snowflake.client.core.arrow.ArrowVectorConverter;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.ArrowResultChunk.ArrowChunkIterator;
@@ -30,75 +17,118 @@ import net.snowflake.common.core.SnowflakeDateTimeFormat;
 import net.snowflake.common.core.SqlState;
 import org.apache.arrow.memory.RootAllocator;
 
-/** Arrow result set implementation */
-public class SFArrowResultSet extends SFBaseResultSet implements DataConversionContext {
-  static final SFLogger logger = SFLoggerFactory.getLogger(SFArrowResultSet.class);
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Base64;
+import java.util.TimeZone;
 
-  /** iterator over current arrow result chunk */
+import static net.snowflake.client.core.StmtUtil.eventHandler;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
+/**
+ * Arrow result set implementation
+ */
+public class SFArrowResultSet extends SFBaseResultSet implements DataConversionContext
+{
+  static final SFLogger logger =
+      SFLoggerFactory.getLogger(SFArrowResultSet.class);
+
+  /**
+   * iterator over current arrow result chunk
+   */
   private ArrowChunkIterator currentChunkIterator;
 
-  /** current query id */
+  /**
+   * current query id
+   */
   private String queryId;
 
-  /** type of statement generate this result set */
+  /**
+   * type of statement generate this result set
+   */
   private SFStatementType statementType;
 
   private boolean totalRowCountTruncated;
 
-  /** true if sort first chunk */
+  /**
+   * true if sort first chunk
+   */
   private boolean sortResult;
 
-  /** statement generate current result set */
+  /**
+   * statement generate current result set
+   */
   protected SFStatement statement;
 
-  /** is array bind supported */
+  /**
+   * is array bind supported
+   */
   private final boolean arrayBindSupported;
 
-  /** sesion timezone */
+  /**
+   * sesion timezone
+   */
   private TimeZone timeZone;
 
-  /** index of next chunk to consume */
+  /**
+   * index of next chunk to consume
+   */
   private long nextChunkIndex = 0;
 
-  /** total chunk count, not include first chunk */
+  /**
+   * total chunk count, not include first chunk
+   */
   private final long chunkCount;
 
-  /** chunk downloader */
+  /**
+   * chunk downloader
+   */
   private ChunkDownloader chunkDownloader;
 
-  /** time when first chunk arrived */
+  /**
+   * time when first chunk arrived
+   */
   private final long firstChunkTime;
 
-  /** telemetry client to push stats to server */
+  /**
+   * telemetry client to push stats to server
+   */
   private final Telemetry telemetryClient;
 
   /**
-   * memory allocator for Arrow. Each SFArrowResultSet contains one rootAllocator. This
-   * rootAllocactor will be cleared and closed when the resultSet is closed
+   * memory allocator for Arrow. Each SFArrowResultSet contains one rootAllocator.
+   * This rootAllocactor will be cleared and closed when the resultSet is closed
    */
   private RootAllocator rootAllocator;
 
   /**
-   * If customer wants Timestamp_NTZ values to be stored in UTC time instead of a local/session
-   * timezone, set to true
+   * If customer wants Timestamp_NTZ values to be stored in UTC time
+   * instead of a local/session timezone, set to true
    */
   private boolean treatNTZAsUTC;
 
   /**
-   * Constructor takes a result from the API response that we get from executing a SQL statement.
-   *
-   * <p>The constructor will initialize the ResultSetMetaData.
+   * Constructor takes a result from the API response that we get from
+   * executing a SQL statement.
+   * <p>
+   * The constructor will initialize the ResultSetMetaData.
    *
    * @param resultSetSerializable result data after parsing json
-   * @param statement statement object
-   * @param sortResult true if sort results otherwise false
+   * @param statement             statement object
+   * @param sortResult            true if sort results otherwise false
    * @throws SQLException exception raised from general SQL layers
    */
-  SFArrowResultSet(
-      SnowflakeResultSetSerializableV1 resultSetSerializable,
-      SFStatement statement,
-      boolean sortResult)
-      throws SQLException {
+  SFArrowResultSet(SnowflakeResultSetSerializableV1 resultSetSerializable,
+                   SFStatement statement,
+                   boolean sortResult)
+  throws SQLException
+  {
     this(resultSetSerializable, statement.getSession().getTelemetryClient(), sortResult);
 
     // update the session db/schema/wh/role etc
@@ -111,32 +141,35 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
 
     // update the driver/session with common parameters from GS
-    SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSession());
+    SessionUtil
+        .updateSfDriverParamValues(this.parameters, statement.getSession());
 
     // if server gives a send time, log time it took to arrive
-    if (resultSetSerializable.getSendResultTime() != 0) {
+    if (resultSetSerializable.getSendResultTime() != 0)
+    {
       long timeConsumeFirstResult = this.firstChunkTime - resultSetSerializable.getSendResultTime();
       logMetric(TelemetryField.TIME_CONSUME_FIRST_RESULT, timeConsumeFirstResult);
     }
 
-    eventHandler.triggerStateTransition(
-        BasicEvent.QueryState.CONSUMING_RESULT,
-        String.format(BasicEvent.QueryState.CONSUMING_RESULT.getArgString(), queryId, 0));
+    eventHandler.triggerStateTransition(BasicEvent.QueryState.CONSUMING_RESULT,
+                                        String.format(
+                                            BasicEvent.QueryState.CONSUMING_RESULT
+                                                .getArgString(), queryId, 0));
   }
 
   /**
-   * This is a minimum initialization for SFArrowResult. Mainly used for testing purpose. However,
-   * real prod constructor will call this constructor as well
+   * This is a minimum initialization for SFArrowResult. Mainly used for testing
+   * purpose. However, real prod constructor will call this constructor as well
    *
    * @param resultSetSerializable data returned in query response
-   * @param telemetryClient telemetryClient
+   * @param telemetryClient       telemetryClient
    * @throws SQLException
    */
-  public SFArrowResultSet(
-      SnowflakeResultSetSerializableV1 resultSetSerializable,
-      Telemetry telemetryClient,
-      boolean sortResult)
-      throws SQLException {
+  public SFArrowResultSet(SnowflakeResultSetSerializableV1 resultSetSerializable,
+                          Telemetry telemetryClient,
+                          boolean sortResult)
+  throws SQLException
+  {
     this.resultSetSerializable = resultSetSerializable;
     this.rootAllocator = resultSetSerializable.getRootAllocator();
     this.sortResult = sortResult;
@@ -147,7 +180,8 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     this.chunkCount = resultSetSerializable.getChunkFileCount();
     this.chunkDownloader = resultSetSerializable.getChunkDownloader();
     this.timeZone = resultSetSerializable.getTimeZone();
-    this.honorClientTZForTimestampNTZ = resultSetSerializable.isHonorClientTZForTimestampNTZ();
+    this.honorClientTZForTimestampNTZ =
+        resultSetSerializable.isHonorClientTZForTimestampNTZ();
     this.resultVersion = resultSetSerializable.getResultVersion();
     this.numberOfBinds = resultSetSerializable.getNumberOfBinds();
     this.arrayBindSupported = resultSetSerializable.isArrayBindSupported();
@@ -160,137 +194,180 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     this.dateFormatter = resultSetSerializable.getDateFormatter();
     this.timeFormatter = resultSetSerializable.getTimeFormatter();
     this.timeZone = resultSetSerializable.getTimeZone();
-    this.honorClientTZForTimestampNTZ = resultSetSerializable.isHonorClientTZForTimestampNTZ();
+    this.honorClientTZForTimestampNTZ =
+        resultSetSerializable.isHonorClientTZForTimestampNTZ();
     this.binaryFormatter = resultSetSerializable.getBinaryFormatter();
     this.resultSetMetaData = resultSetSerializable.getSFResultSetMetaData();
     this.treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
 
     // sort result set if needed
     String rowsetBase64 = resultSetSerializable.getFirstChunkStringData();
-    if (rowsetBase64 == null || rowsetBase64.isEmpty()) {
+    if (rowsetBase64 == null || rowsetBase64.isEmpty())
+    {
       this.currentChunkIterator = ArrowResultChunk.getEmptyChunkIterator();
-    } else {
-      if (sortResult) {
+    }
+    else
+    {
+      if (sortResult)
+      {
         // we don't support sort result when there are offline chunks
-        if (resultSetSerializable.getChunkFileCount() > 0) {
-          throw new SnowflakeSQLException(
-              SqlState.FEATURE_NOT_SUPPORTED,
-              ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
+        if (resultSetSerializable.getChunkFileCount() > 0)
+        {
+          throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+                                          ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED
+                                              .getMessageCode());
         }
 
-        this.currentChunkIterator =
-            getSortedFirstResultChunk(resultSetSerializable.getFirstChunkStringData())
-                .getIterator(this);
-      } else {
+        this.currentChunkIterator = getSortedFirstResultChunk(
+            resultSetSerializable.getFirstChunkStringData()).getIterator(this);
+      }
+      else
+      {
         this.currentChunkIterator =
             buildFirstChunk(resultSetSerializable.getFirstChunkStringData()).getIterator(this);
       }
     }
   }
 
-  private boolean fetchNextRow() throws SnowflakeSQLException {
-    if (sortResult) {
+  private boolean fetchNextRow() throws SnowflakeSQLException
+  {
+    if (sortResult)
+    {
       return fetchNextRowSorted();
-    } else {
+    }
+    else
+    {
       return fetchNextRowUnsorted();
     }
   }
 
   /**
-   * Goto next row. If end of current chunk, update currentChunkIterator to the beginning of next
-   * chunk, if any chunk not being consumed yet.
+   * Goto next row. If end of current chunk, update currentChunkIterator to the
+   * beginning of next chunk, if any chunk not being consumed yet.
    *
    * @return true if still have rows otherwise false
    */
-  private boolean fetchNextRowUnsorted() throws SnowflakeSQLException {
+  private boolean fetchNextRowUnsorted()
+  throws SnowflakeSQLException
+  {
     boolean hasNext = currentChunkIterator.next();
 
-    if (hasNext) {
+    if (hasNext)
+    {
       return true;
-    } else {
-      if (nextChunkIndex < chunkCount) {
-        try {
+    }
+    else
+    {
+      if (nextChunkIndex < chunkCount)
+      {
+        try
+        {
           eventHandler.triggerStateTransition(
               BasicEvent.QueryState.CONSUMING_RESULT,
               String.format(
-                  BasicEvent.QueryState.CONSUMING_RESULT.getArgString(), queryId, nextChunkIndex));
+                  BasicEvent.QueryState.CONSUMING_RESULT.getArgString(),
+                  queryId,
+                  nextChunkIndex));
 
-          ArrowResultChunk nextChunk = (ArrowResultChunk) chunkDownloader.getNextChunkToConsume();
+          ArrowResultChunk
+              nextChunk = (ArrowResultChunk) chunkDownloader.getNextChunkToConsume();
 
-          if (nextChunk == null) {
+          if (nextChunk == null)
+          {
             throw new SnowflakeSQLLoggedException(
                 SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                 "Expect chunk but got null for chunk index " + nextChunkIndex);
           }
 
           currentChunkIterator.getChunk().freeData();
           currentChunkIterator = nextChunk.getIterator(this);
-          if (currentChunkIterator.next()) {
+          if (currentChunkIterator.next())
+          {
 
-            logger.debug(
-                "Moving to chunk index {}, row count={}", nextChunkIndex, nextChunk.getRowCount());
+            logger.debug("Moving to chunk index {}, row count={}",
+                         nextChunkIndex, nextChunk.getRowCount());
 
             nextChunkIndex++;
             return true;
-          } else {
+          }
+          else
+          {
             return false;
           }
-        } catch (InterruptedException ex) {
-          throw new SnowflakeSQLException(
-              SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
         }
-      } else {
+        catch (InterruptedException ex)
+        {
+          throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                                ErrorCode.INTERRUPTED.getMessageCode(), session);
+        }
+      }
+      else
+      {
         // always free current chunk
-        try {
+        try
+        {
           currentChunkIterator.getChunk().freeData();
-          if (chunkCount > 0) {
+          if (chunkCount > 0)
+          {
             logger.debug("End of chunks");
             DownloaderMetrics metrics = chunkDownloader.terminate();
             logChunkDownloaderMetrics(metrics);
           }
-        } catch (InterruptedException e) {
-          throw new SnowflakeSQLException(
-              SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
+        }
+        catch (InterruptedException e)
+        {
+          throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                                ErrorCode.INTERRUPTED.getMessageCode(), session);
         }
       }
 
       return false;
+
     }
+
   }
 
   /**
    * Decode rowset returned in query response the load data into arrow vectors
    *
-   * @param rowsetBase64 first chunk of rowset in arrow format and base64 encoded
+   * @param rowsetBase64 first chunk of rowset in arrow format and base64
+   *                     encoded
    * @return result chunk with arrow data already being loaded
    */
-  private ArrowResultChunk buildFirstChunk(String rowsetBase64) throws SQLException {
+  private ArrowResultChunk buildFirstChunk(String rowsetBase64)
+  throws SQLException
+  {
     byte[] bytes = Base64.getDecoder().decode(rowsetBase64);
     ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
 
     // create a result chunk
     ArrowResultChunk resultChunk = new ArrowResultChunk("", 0, 0, 0, rootAllocator, session);
 
-    try {
+    try
+    {
       resultChunk.readArrowStream(inputStream);
-    } catch (IOException e) {
-      throw new SnowflakeSQLException(
-          ErrorCode.INTERNAL_ERROR,
-          "Failed to " + "load data in first chunk into arrow vector ex: " + e.getMessage());
+    }
+    catch (IOException e)
+    {
+      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, session, "Failed to " +
+                                                                               "load data in first chunk into arrow vector ex: " +
+                                                                               e.getMessage());
     }
 
     return resultChunk;
   }
 
   /**
-   * Decode rowset returned in query response the load data into arrow vectors and sort data
+   * Decode rowset returned in query response the load data into arrow vectors
+   * and sort data
    *
-   * @param rowsetBase64 first chunk of rowset in arrow format and base64 encoded
+   * @param rowsetBase64 first chunk of rowset in arrow format and base64
+   *                     encoded
    * @return result chunk with arrow data already being loaded
    */
-  private ArrowResultChunk getSortedFirstResultChunk(String rowsetBase64) throws SQLException {
+  private ArrowResultChunk getSortedFirstResultChunk(String rowsetBase64) throws SQLException
+  {
     ArrowResultChunk resultChunk = buildFirstChunk(rowsetBase64);
 
     // enable sorted chunk, the sorting happens when the result chunk is ready to consume
@@ -298,15 +375,20 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     return resultChunk;
   }
 
+
   /**
-   * Fetch next row of first chunkd in sorted order. If the result set huge, then rest of the chunks
-   * are ignored.
+   * Fetch next row of first chunkd in sorted order. If the result set huge,
+   * then rest of the chunks are ignored.
    */
-  private boolean fetchNextRowSorted() throws SnowflakeSQLException {
+  private boolean fetchNextRowSorted() throws SnowflakeSQLException
+  {
     boolean hasNext = currentChunkIterator.next();
-    if (hasNext) {
+    if (hasNext)
+    {
       return true;
-    } else {
+    }
+    else
+    {
       currentChunkIterator.getChunk().freeData();
 
       // no more chunks as sorted is only supported
@@ -321,33 +403,40 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
    * @return true if next row exists, false otherwise
    */
   @Override
-  public boolean next() throws SFException, SnowflakeSQLException {
-    if (isClosed()) {
+  public boolean next() throws SFException, SnowflakeSQLException
+  {
+    if (isClosed())
+    {
       return false;
     }
 
     // otherwise try to fetch again
-    if (fetchNextRow()) {
+    if (fetchNextRow())
+    {
       row++;
-      if (isLast()) {
+      if (isLast())
+      {
         long timeConsumeLastResult = System.currentTimeMillis() - this.firstChunkTime;
         logMetric(TelemetryField.TIME_CONSUME_LAST_RESULT, timeConsumeLastResult);
       }
       return true;
-    } else {
+    }
+    else
+    {
       logger.debug("end of result");
 
       /*
        * Here we check if the result has been truncated and throw exception if
        * so.
        */
-      if (totalRowCountTruncated
-          || Boolean.TRUE
-              .toString()
-              .equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2"))) {
-        throw (SFException)
-            IncidentUtil.generateIncidentV2WithException(
-                session, new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED), queryId, null);
+      if (totalRowCountTruncated ||
+          Boolean.TRUE.toString().equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2")))
+      {
+        throw (SFException) IncidentUtil.generateIncidentV2WithException(
+            session,
+            new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED),
+            queryId,
+            null);
       }
 
       // mark end of result
@@ -356,104 +445,131 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
   }
 
   @Override
-  public byte getByte(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public byte getByte(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toByte(index);
   }
 
   @Override
-  public String getString(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public String getString(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toString(index);
   }
 
   @Override
-  public boolean getBoolean(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public boolean getBoolean(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toBoolean(index);
   }
 
   @Override
-  public short getShort(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public short getShort(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toShort(index);
   }
 
   @Override
-  public int getInt(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public int getInt(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toInt(index);
   }
 
   @Override
-  public long getLong(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public long getLong(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toLong(index);
   }
 
   @Override
-  public float getFloat(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public float getFloat(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toFloat(index);
   }
 
   @Override
-  public double getDouble(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public double getDouble(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toDouble(index);
   }
 
   @Override
-  public byte[] getBytes(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public byte[] getBytes(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toBytes(index);
   }
 
   @Override
-  public Date getDate(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public Date getDate(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toDate(index);
   }
 
   @Override
-  public Time getTime(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public Time getTime(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toTime(index);
   }
 
   @Override
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz)
+  throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toTimestamp(index, tz);
   }
 
   @Override
-  public Object getObject(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public Object getObject(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     converter.setTreatNTZAsUTC(treatNTZAsUTC);
@@ -461,157 +577,197 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
   }
 
   @Override
-  public BigDecimal getBigDecimal(int columnIndex) throws SFException {
-    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public BigDecimal getBigDecimal(int columnIndex) throws SFException
+  {
+    ArrowVectorConverter converter =
+        currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toBigDecimal(index);
   }
 
   @Override
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SFException {
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SFException
+  {
     return getBigDecimal(columnIndex).setScale(scale, RoundingMode.HALF_UP);
   }
 
   @Override
-  public boolean isLast() {
-    return nextChunkIndex == chunkCount && currentChunkIterator.isLast();
+  public boolean isLast()
+  {
+    return nextChunkIndex == chunkCount &&
+           currentChunkIterator.isLast();
   }
 
   @Override
-  public boolean isAfterLast() {
-    return nextChunkIndex == chunkCount && currentChunkIterator.isAfterLast();
+  public boolean isAfterLast()
+  {
+    return nextChunkIndex == chunkCount &&
+           currentChunkIterator.isAfterLast();
   }
 
   @Override
-  public void close() throws SnowflakeSQLException {
+  public void close() throws SnowflakeSQLException
+  {
     super.close();
 
     // always make sure to free this current chunk
     currentChunkIterator.getChunk().freeData();
 
-    try {
-      if (chunkDownloader != null) {
+    try
+    {
+      if (chunkDownloader != null)
+      {
         DownloaderMetrics metrics = chunkDownloader.terminate();
         logChunkDownloaderMetrics(metrics);
-      } else {
+      }
+      else
+      {
         // always close root allocator
         closeRootAllocator(rootAllocator);
       }
-    } catch (InterruptedException ex) {
-      throw new SnowflakeSQLException(
-          SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
+    }
+    catch (InterruptedException ex)
+    {
+      throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                            ErrorCode.INTERRUPTED.getMessageCode(), session);
     }
   }
 
-  public static void closeRootAllocator(RootAllocator rootAllocator) {
+  public static void closeRootAllocator(RootAllocator rootAllocator)
+  {
     long rest = rootAllocator.getAllocatedMemory();
     int count = 3;
-    try {
-      while (rest > 0 && count-- > 0) {
+    try
+    {
+      while (rest > 0 && count-- > 0)
+      {
         // this case should only happen when the resultSet is closed before consuming all chunks
-        // otherwise, the memory usage for each chunk will be cleared right after it has been fully
-        // consumed
+        // otherwise, the memory usage for each chunk will be cleared right after it has been fully consumed
 
-        // The reason is that it is possible that one downloading thread is pending to close when
-        // the main thread
-        // reaches here. A retry is to wait for the downloading thread to finish closing incoming
-        // streams and arrow
+        // The reason is that it is possible that one downloading thread is pending to close when the main thread
+        // reaches here. A retry is to wait for the downloading thread to finish closing incoming streams and arrow
         // resources.
 
         Thread.sleep(10);
         rest = rootAllocator.getAllocatedMemory();
       }
-      if (rest == 0) {
+      if (rest == 0)
+      {
         rootAllocator.close();
       }
-    } catch (InterruptedException ie) {
+    }
+    catch (InterruptedException ie)
+    {
       logger.debug("interrupted during closing root allocator");
-    } catch (Exception e) {
-      logger.debug("Exception happened when closing rootAllocator: ", e.getLocalizedMessage());
+    }
+    catch (Exception e)
+    {
+      logger.debug("Exception happened when closing rootAllocator: ",
+                   e.getLocalizedMessage());
     }
   }
 
   @Override
-  public SFStatementType getStatementType() {
+  public SFStatementType getStatementType()
+  {
     return statementType;
   }
 
   @Override
-  public void setStatementType(SFStatementType statementType) {
+  public void setStatementType(SFStatementType statementType)
+  {
     this.statementType = statementType;
   }
 
   @Override
-  public boolean isArrayBindSupported() {
+  public boolean isArrayBindSupported()
+  {
     return this.arrayBindSupported;
   }
 
   @Override
-  public String getQueryId() {
+  public String getQueryId()
+  {
     return queryId;
   }
 
-  private void logMetric(TelemetryField field, long value) {
+  private void logMetric(TelemetryField field, long value)
+  {
     TelemetryData data = TelemetryUtil.buildJobData(this.queryId, field, value);
     this.telemetryClient.addLogToBatch(data);
   }
 
-  private void logChunkDownloaderMetrics(DownloaderMetrics metrics) {
-    if (metrics != null) {
-      logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS, metrics.getMillisWaiting());
-      logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS, metrics.getMillisDownloading());
-      logMetric(TelemetryField.TIME_PARSING_CHUNKS, metrics.getMillisParsing());
+  private void logChunkDownloaderMetrics(DownloaderMetrics metrics)
+  {
+    if (metrics != null)
+    {
+      logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS,
+                metrics.getMillisWaiting());
+      logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS,
+                metrics.getMillisDownloading());
+      logMetric(TelemetryField.TIME_PARSING_CHUNKS,
+                metrics.getMillisParsing());
     }
   }
 
   @Override
-  public SnowflakeDateTimeFormat getTimestampLTZFormatter() {
+  public SnowflakeDateTimeFormat getTimestampLTZFormatter()
+  {
     return timestampLTZFormatter;
   }
 
   @Override
-  public SnowflakeDateTimeFormat getTimestampNTZFormatter() {
+  public SnowflakeDateTimeFormat getTimestampNTZFormatter()
+  {
     return timestampNTZFormatter;
   }
 
   @Override
-  public SnowflakeDateTimeFormat getTimestampTZFormatter() {
+  public SnowflakeDateTimeFormat getTimestampTZFormatter()
+  {
     return timestampTZFormatter;
   }
 
   @Override
-  public SnowflakeDateTimeFormat getDateFormatter() {
+  public SnowflakeDateTimeFormat getDateFormatter()
+  {
     return dateFormatter;
   }
 
   @Override
-  public SnowflakeDateTimeFormat getTimeFormatter() {
+  public SnowflakeDateTimeFormat getTimeFormatter()
+  {
     return timeFormatter;
   }
 
   @Override
-  public SFBinaryFormat getBinaryFormatter() {
+  public SFBinaryFormat getBinaryFormatter()
+  {
     return binaryFormatter;
   }
 
   @Override
-  public int getScale(int columnIndex) {
+  public int getScale(int columnIndex)
+  {
     return resultSetMetaData.getScale(columnIndex);
   }
 
   @Override
-  public TimeZone getTimeZone() {
+  public TimeZone getTimeZone()
+  {
     return timeZone;
   }
 
   @Override
-  public boolean getHonorClientTZForTimestampNTZ() {
+  public boolean getHonorClientTZForTimestampNTZ()
+  {
     return honorClientTZForTimestampNTZ;
   }
 
   @Override
-  public long getResultVersion() {
+  public long getResultVersion()
+  {
     return resultVersion;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -3,6 +3,19 @@
  */
 package net.snowflake.client.core;
 
+import static net.snowflake.client.core.StmtUtil.eventHandler;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Base64;
+import java.util.TimeZone;
 import net.snowflake.client.core.arrow.ArrowVectorConverter;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.ArrowResultChunk.ArrowChunkIterator;
@@ -17,118 +30,75 @@ import net.snowflake.common.core.SnowflakeDateTimeFormat;
 import net.snowflake.common.core.SqlState;
 import org.apache.arrow.memory.RootAllocator;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.sql.Date;
-import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.Base64;
-import java.util.TimeZone;
+/** Arrow result set implementation */
+public class SFArrowResultSet extends SFBaseResultSet implements DataConversionContext {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SFArrowResultSet.class);
 
-import static net.snowflake.client.core.StmtUtil.eventHandler;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
-/**
- * Arrow result set implementation
- */
-public class SFArrowResultSet extends SFBaseResultSet implements DataConversionContext
-{
-  static final SFLogger logger =
-      SFLoggerFactory.getLogger(SFArrowResultSet.class);
-
-  /**
-   * iterator over current arrow result chunk
-   */
+  /** iterator over current arrow result chunk */
   private ArrowChunkIterator currentChunkIterator;
 
-  /**
-   * current query id
-   */
+  /** current query id */
   private String queryId;
 
-  /**
-   * type of statement generate this result set
-   */
+  /** type of statement generate this result set */
   private SFStatementType statementType;
 
   private boolean totalRowCountTruncated;
 
-  /**
-   * true if sort first chunk
-   */
+  /** true if sort first chunk */
   private boolean sortResult;
 
-  /**
-   * statement generate current result set
-   */
+  /** statement generate current result set */
   protected SFStatement statement;
 
-  /**
-   * is array bind supported
-   */
+  /** is array bind supported */
   private final boolean arrayBindSupported;
 
-  /**
-   * sesion timezone
-   */
+  /** sesion timezone */
   private TimeZone timeZone;
 
-  /**
-   * index of next chunk to consume
-   */
+  /** index of next chunk to consume */
   private long nextChunkIndex = 0;
 
-  /**
-   * total chunk count, not include first chunk
-   */
+  /** total chunk count, not include first chunk */
   private final long chunkCount;
 
-  /**
-   * chunk downloader
-   */
+  /** chunk downloader */
   private ChunkDownloader chunkDownloader;
 
-  /**
-   * time when first chunk arrived
-   */
+  /** time when first chunk arrived */
   private final long firstChunkTime;
 
-  /**
-   * telemetry client to push stats to server
-   */
+  /** telemetry client to push stats to server */
   private final Telemetry telemetryClient;
 
   /**
-   * memory allocator for Arrow. Each SFArrowResultSet contains one rootAllocator.
-   * This rootAllocactor will be cleared and closed when the resultSet is closed
+   * memory allocator for Arrow. Each SFArrowResultSet contains one rootAllocator. This
+   * rootAllocactor will be cleared and closed when the resultSet is closed
    */
   private RootAllocator rootAllocator;
 
   /**
-   * If customer wants Timestamp_NTZ values to be stored in UTC time
-   * instead of a local/session timezone, set to true
+   * If customer wants Timestamp_NTZ values to be stored in UTC time instead of a local/session
+   * timezone, set to true
    */
   private boolean treatNTZAsUTC;
 
   /**
-   * Constructor takes a result from the API response that we get from
-   * executing a SQL statement.
-   * <p>
-   * The constructor will initialize the ResultSetMetaData.
+   * Constructor takes a result from the API response that we get from executing a SQL statement.
+   *
+   * <p>The constructor will initialize the ResultSetMetaData.
    *
    * @param resultSetSerializable result data after parsing json
-   * @param statement             statement object
-   * @param sortResult            true if sort results otherwise false
+   * @param statement statement object
+   * @param sortResult true if sort results otherwise false
    * @throws SQLException exception raised from general SQL layers
    */
-  SFArrowResultSet(SnowflakeResultSetSerializableV1 resultSetSerializable,
-                   SFStatement statement,
-                   boolean sortResult)
-  throws SQLException
-  {
+  SFArrowResultSet(
+      SnowflakeResultSetSerializableV1 resultSetSerializable,
+      SFStatement statement,
+      boolean sortResult)
+      throws SQLException {
     this(resultSetSerializable, statement.getSession().getTelemetryClient(), sortResult);
 
     // update the session db/schema/wh/role etc
@@ -141,35 +111,32 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
 
     // update the driver/session with common parameters from GS
-    SessionUtil
-        .updateSfDriverParamValues(this.parameters, statement.getSession());
+    SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSession());
 
     // if server gives a send time, log time it took to arrive
-    if (resultSetSerializable.getSendResultTime() != 0)
-    {
+    if (resultSetSerializable.getSendResultTime() != 0) {
       long timeConsumeFirstResult = this.firstChunkTime - resultSetSerializable.getSendResultTime();
       logMetric(TelemetryField.TIME_CONSUME_FIRST_RESULT, timeConsumeFirstResult);
     }
 
-    eventHandler.triggerStateTransition(BasicEvent.QueryState.CONSUMING_RESULT,
-                                        String.format(
-                                            BasicEvent.QueryState.CONSUMING_RESULT
-                                                .getArgString(), queryId, 0));
+    eventHandler.triggerStateTransition(
+        BasicEvent.QueryState.CONSUMING_RESULT,
+        String.format(BasicEvent.QueryState.CONSUMING_RESULT.getArgString(), queryId, 0));
   }
 
   /**
-   * This is a minimum initialization for SFArrowResult. Mainly used for testing
-   * purpose. However, real prod constructor will call this constructor as well
+   * This is a minimum initialization for SFArrowResult. Mainly used for testing purpose. However,
+   * real prod constructor will call this constructor as well
    *
    * @param resultSetSerializable data returned in query response
-   * @param telemetryClient       telemetryClient
+   * @param telemetryClient telemetryClient
    * @throws SQLException
    */
-  public SFArrowResultSet(SnowflakeResultSetSerializableV1 resultSetSerializable,
-                          Telemetry telemetryClient,
-                          boolean sortResult)
-  throws SQLException
-  {
+  public SFArrowResultSet(
+      SnowflakeResultSetSerializableV1 resultSetSerializable,
+      Telemetry telemetryClient,
+      boolean sortResult)
+      throws SQLException {
     this.resultSetSerializable = resultSetSerializable;
     this.rootAllocator = resultSetSerializable.getRootAllocator();
     this.sortResult = sortResult;
@@ -180,8 +147,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     this.chunkCount = resultSetSerializable.getChunkFileCount();
     this.chunkDownloader = resultSetSerializable.getChunkDownloader();
     this.timeZone = resultSetSerializable.getTimeZone();
-    this.honorClientTZForTimestampNTZ =
-        resultSetSerializable.isHonorClientTZForTimestampNTZ();
+    this.honorClientTZForTimestampNTZ = resultSetSerializable.isHonorClientTZForTimestampNTZ();
     this.resultVersion = resultSetSerializable.getResultVersion();
     this.numberOfBinds = resultSetSerializable.getNumberOfBinds();
     this.arrayBindSupported = resultSetSerializable.isArrayBindSupported();
@@ -194,180 +160,138 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     this.dateFormatter = resultSetSerializable.getDateFormatter();
     this.timeFormatter = resultSetSerializable.getTimeFormatter();
     this.timeZone = resultSetSerializable.getTimeZone();
-    this.honorClientTZForTimestampNTZ =
-        resultSetSerializable.isHonorClientTZForTimestampNTZ();
+    this.honorClientTZForTimestampNTZ = resultSetSerializable.isHonorClientTZForTimestampNTZ();
     this.binaryFormatter = resultSetSerializable.getBinaryFormatter();
     this.resultSetMetaData = resultSetSerializable.getSFResultSetMetaData();
     this.treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
 
     // sort result set if needed
     String rowsetBase64 = resultSetSerializable.getFirstChunkStringData();
-    if (rowsetBase64 == null || rowsetBase64.isEmpty())
-    {
+    if (rowsetBase64 == null || rowsetBase64.isEmpty()) {
       this.currentChunkIterator = ArrowResultChunk.getEmptyChunkIterator();
-    }
-    else
-    {
-      if (sortResult)
-      {
+    } else {
+      if (sortResult) {
         // we don't support sort result when there are offline chunks
-        if (resultSetSerializable.getChunkFileCount() > 0)
-        {
-          throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                          ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED
-                                              .getMessageCode());
+        if (resultSetSerializable.getChunkFileCount() > 0) {
+          throw new SnowflakeSQLException(
+              SqlState.FEATURE_NOT_SUPPORTED,
+              ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
         }
 
-        this.currentChunkIterator = getSortedFirstResultChunk(
-            resultSetSerializable.getFirstChunkStringData()).getIterator(this);
-      }
-      else
-      {
+        this.currentChunkIterator =
+            getSortedFirstResultChunk(resultSetSerializable.getFirstChunkStringData())
+                .getIterator(this);
+      } else {
         this.currentChunkIterator =
             buildFirstChunk(resultSetSerializable.getFirstChunkStringData()).getIterator(this);
       }
     }
   }
 
-  private boolean fetchNextRow() throws SnowflakeSQLException
-  {
-    if (sortResult)
-    {
+  private boolean fetchNextRow() throws SnowflakeSQLException {
+    if (sortResult) {
       return fetchNextRowSorted();
-    }
-    else
-    {
+    } else {
       return fetchNextRowUnsorted();
     }
   }
 
   /**
-   * Goto next row. If end of current chunk, update currentChunkIterator to the
-   * beginning of next chunk, if any chunk not being consumed yet.
+   * Goto next row. If end of current chunk, update currentChunkIterator to the beginning of next
+   * chunk, if any chunk not being consumed yet.
    *
    * @return true if still have rows otherwise false
    */
-  private boolean fetchNextRowUnsorted()
-  throws SnowflakeSQLException
-  {
+  private boolean fetchNextRowUnsorted() throws SnowflakeSQLException {
     boolean hasNext = currentChunkIterator.next();
 
-    if (hasNext)
-    {
+    if (hasNext) {
       return true;
-    }
-    else
-    {
-      if (nextChunkIndex < chunkCount)
-      {
-        try
-        {
+    } else {
+      if (nextChunkIndex < chunkCount) {
+        try {
           eventHandler.triggerStateTransition(
               BasicEvent.QueryState.CONSUMING_RESULT,
               String.format(
-                  BasicEvent.QueryState.CONSUMING_RESULT.getArgString(),
-                  queryId,
-                  nextChunkIndex));
+                  BasicEvent.QueryState.CONSUMING_RESULT.getArgString(), queryId, nextChunkIndex));
 
-          ArrowResultChunk
-              nextChunk = (ArrowResultChunk) chunkDownloader.getNextChunkToConsume();
+          ArrowResultChunk nextChunk = (ArrowResultChunk) chunkDownloader.getNextChunkToConsume();
 
-          if (nextChunk == null)
-          {
+          if (nextChunk == null) {
             throw new SnowflakeSQLLoggedException(
                 SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
                 "Expect chunk but got null for chunk index " + nextChunkIndex);
           }
 
           currentChunkIterator.getChunk().freeData();
           currentChunkIterator = nextChunk.getIterator(this);
-          if (currentChunkIterator.next())
-          {
+          if (currentChunkIterator.next()) {
 
-            logger.debug("Moving to chunk index {}, row count={}",
-                         nextChunkIndex, nextChunk.getRowCount());
+            logger.debug(
+                "Moving to chunk index {}, row count={}", nextChunkIndex, nextChunk.getRowCount());
 
             nextChunkIndex++;
             return true;
-          }
-          else
-          {
+          } else {
             return false;
           }
+        } catch (InterruptedException ex) {
+          throw new SnowflakeSQLLoggedException(
+              SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
         }
-        catch (InterruptedException ex)
-        {
-          throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                                ErrorCode.INTERRUPTED.getMessageCode(), session);
-        }
-      }
-      else
-      {
+      } else {
         // always free current chunk
-        try
-        {
+        try {
           currentChunkIterator.getChunk().freeData();
-          if (chunkCount > 0)
-          {
+          if (chunkCount > 0) {
             logger.debug("End of chunks");
             DownloaderMetrics metrics = chunkDownloader.terminate();
             logChunkDownloaderMetrics(metrics);
           }
-        }
-        catch (InterruptedException e)
-        {
-          throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                                ErrorCode.INTERRUPTED.getMessageCode(), session);
+        } catch (InterruptedException e) {
+          throw new SnowflakeSQLLoggedException(
+              SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
         }
       }
 
       return false;
-
     }
-
   }
 
   /**
    * Decode rowset returned in query response the load data into arrow vectors
    *
-   * @param rowsetBase64 first chunk of rowset in arrow format and base64
-   *                     encoded
+   * @param rowsetBase64 first chunk of rowset in arrow format and base64 encoded
    * @return result chunk with arrow data already being loaded
    */
-  private ArrowResultChunk buildFirstChunk(String rowsetBase64)
-  throws SQLException
-  {
+  private ArrowResultChunk buildFirstChunk(String rowsetBase64) throws SQLException {
     byte[] bytes = Base64.getDecoder().decode(rowsetBase64);
     ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
 
     // create a result chunk
     ArrowResultChunk resultChunk = new ArrowResultChunk("", 0, 0, 0, rootAllocator, session);
 
-    try
-    {
+    try {
       resultChunk.readArrowStream(inputStream);
-    }
-    catch (IOException e)
-    {
-      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, session, "Failed to " +
-                                                                               "load data in first chunk into arrow vector ex: " +
-                                                                               e.getMessage());
+    } catch (IOException e) {
+      throw new SnowflakeSQLLoggedException(
+          ErrorCode.INTERNAL_ERROR,
+          session,
+          "Failed to " + "load data in first chunk into arrow vector ex: " + e.getMessage());
     }
 
     return resultChunk;
   }
 
   /**
-   * Decode rowset returned in query response the load data into arrow vectors
-   * and sort data
+   * Decode rowset returned in query response the load data into arrow vectors and sort data
    *
-   * @param rowsetBase64 first chunk of rowset in arrow format and base64
-   *                     encoded
+   * @param rowsetBase64 first chunk of rowset in arrow format and base64 encoded
    * @return result chunk with arrow data already being loaded
    */
-  private ArrowResultChunk getSortedFirstResultChunk(String rowsetBase64) throws SQLException
-  {
+  private ArrowResultChunk getSortedFirstResultChunk(String rowsetBase64) throws SQLException {
     ArrowResultChunk resultChunk = buildFirstChunk(rowsetBase64);
 
     // enable sorted chunk, the sorting happens when the result chunk is ready to consume
@@ -375,20 +299,15 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     return resultChunk;
   }
 
-
   /**
-   * Fetch next row of first chunkd in sorted order. If the result set huge,
-   * then rest of the chunks are ignored.
+   * Fetch next row of first chunkd in sorted order. If the result set huge, then rest of the chunks
+   * are ignored.
    */
-  private boolean fetchNextRowSorted() throws SnowflakeSQLException
-  {
+  private boolean fetchNextRowSorted() throws SnowflakeSQLException {
     boolean hasNext = currentChunkIterator.next();
-    if (hasNext)
-    {
+    if (hasNext) {
       return true;
-    }
-    else
-    {
+    } else {
       currentChunkIterator.getChunk().freeData();
 
       // no more chunks as sorted is only supported
@@ -403,40 +322,33 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
    * @return true if next row exists, false otherwise
    */
   @Override
-  public boolean next() throws SFException, SnowflakeSQLException
-  {
-    if (isClosed())
-    {
+  public boolean next() throws SFException, SnowflakeSQLException {
+    if (isClosed()) {
       return false;
     }
 
     // otherwise try to fetch again
-    if (fetchNextRow())
-    {
+    if (fetchNextRow()) {
       row++;
-      if (isLast())
-      {
+      if (isLast()) {
         long timeConsumeLastResult = System.currentTimeMillis() - this.firstChunkTime;
         logMetric(TelemetryField.TIME_CONSUME_LAST_RESULT, timeConsumeLastResult);
       }
       return true;
-    }
-    else
-    {
+    } else {
       logger.debug("end of result");
 
       /*
        * Here we check if the result has been truncated and throw exception if
        * so.
        */
-      if (totalRowCountTruncated ||
-          Boolean.TRUE.toString().equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2")))
-      {
-        throw (SFException) IncidentUtil.generateIncidentV2WithException(
-            session,
-            new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED),
-            queryId,
-            null);
+      if (totalRowCountTruncated
+          || Boolean.TRUE
+              .toString()
+              .equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2"))) {
+        throw (SFException)
+            IncidentUtil.generateIncidentV2WithException(
+                session, new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED), queryId, null);
       }
 
       // mark end of result
@@ -445,131 +357,104 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
   }
 
   @Override
-  public byte getByte(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public byte getByte(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toByte(index);
   }
 
   @Override
-  public String getString(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public String getString(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toString(index);
   }
 
   @Override
-  public boolean getBoolean(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public boolean getBoolean(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toBoolean(index);
   }
 
   @Override
-  public short getShort(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public short getShort(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toShort(index);
   }
 
   @Override
-  public int getInt(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public int getInt(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toInt(index);
   }
 
   @Override
-  public long getLong(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public long getLong(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toLong(index);
   }
 
   @Override
-  public float getFloat(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public float getFloat(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toFloat(index);
   }
 
   @Override
-  public double getDouble(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public double getDouble(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toDouble(index);
   }
 
   @Override
-  public byte[] getBytes(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public byte[] getBytes(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toBytes(index);
   }
 
   @Override
-  public Date getDate(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public Date getDate(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toDate(index);
   }
 
   @Override
-  public Time getTime(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public Time getTime(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toTime(index);
   }
 
   @Override
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz)
-  throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toTimestamp(index, tz);
   }
 
   @Override
-  public Object getObject(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public Object getObject(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     converter.setTreatNTZAsUTC(treatNTZAsUTC);
@@ -577,197 +462,157 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
   }
 
   @Override
-  public BigDecimal getBigDecimal(int columnIndex) throws SFException
-  {
-    ArrowVectorConverter converter =
-        currentChunkIterator.getCurrentConverter(columnIndex - 1);
+  public BigDecimal getBigDecimal(int columnIndex) throws SFException {
+    ArrowVectorConverter converter = currentChunkIterator.getCurrentConverter(columnIndex - 1);
     int index = currentChunkIterator.getCurrentRowInRecordBatch();
     wasNull = converter.isNull(index);
     return converter.toBigDecimal(index);
   }
 
   @Override
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SFException
-  {
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SFException {
     return getBigDecimal(columnIndex).setScale(scale, RoundingMode.HALF_UP);
   }
 
   @Override
-  public boolean isLast()
-  {
-    return nextChunkIndex == chunkCount &&
-           currentChunkIterator.isLast();
+  public boolean isLast() {
+    return nextChunkIndex == chunkCount && currentChunkIterator.isLast();
   }
 
   @Override
-  public boolean isAfterLast()
-  {
-    return nextChunkIndex == chunkCount &&
-           currentChunkIterator.isAfterLast();
+  public boolean isAfterLast() {
+    return nextChunkIndex == chunkCount && currentChunkIterator.isAfterLast();
   }
 
   @Override
-  public void close() throws SnowflakeSQLException
-  {
+  public void close() throws SnowflakeSQLException {
     super.close();
 
     // always make sure to free this current chunk
     currentChunkIterator.getChunk().freeData();
 
-    try
-    {
-      if (chunkDownloader != null)
-      {
+    try {
+      if (chunkDownloader != null) {
         DownloaderMetrics metrics = chunkDownloader.terminate();
         logChunkDownloaderMetrics(metrics);
-      }
-      else
-      {
+      } else {
         // always close root allocator
         closeRootAllocator(rootAllocator);
       }
-    }
-    catch (InterruptedException ex)
-    {
-      throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                            ErrorCode.INTERRUPTED.getMessageCode(), session);
+    } catch (InterruptedException ex) {
+      throw new SnowflakeSQLLoggedException(
+          SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
     }
   }
 
-  public static void closeRootAllocator(RootAllocator rootAllocator)
-  {
+  public static void closeRootAllocator(RootAllocator rootAllocator) {
     long rest = rootAllocator.getAllocatedMemory();
     int count = 3;
-    try
-    {
-      while (rest > 0 && count-- > 0)
-      {
+    try {
+      while (rest > 0 && count-- > 0) {
         // this case should only happen when the resultSet is closed before consuming all chunks
-        // otherwise, the memory usage for each chunk will be cleared right after it has been fully consumed
+        // otherwise, the memory usage for each chunk will be cleared right after it has been fully
+        // consumed
 
-        // The reason is that it is possible that one downloading thread is pending to close when the main thread
-        // reaches here. A retry is to wait for the downloading thread to finish closing incoming streams and arrow
+        // The reason is that it is possible that one downloading thread is pending to close when
+        // the main thread
+        // reaches here. A retry is to wait for the downloading thread to finish closing incoming
+        // streams and arrow
         // resources.
 
         Thread.sleep(10);
         rest = rootAllocator.getAllocatedMemory();
       }
-      if (rest == 0)
-      {
+      if (rest == 0) {
         rootAllocator.close();
       }
-    }
-    catch (InterruptedException ie)
-    {
+    } catch (InterruptedException ie) {
       logger.debug("interrupted during closing root allocator");
-    }
-    catch (Exception e)
-    {
-      logger.debug("Exception happened when closing rootAllocator: ",
-                   e.getLocalizedMessage());
+    } catch (Exception e) {
+      logger.debug("Exception happened when closing rootAllocator: ", e.getLocalizedMessage());
     }
   }
 
   @Override
-  public SFStatementType getStatementType()
-  {
+  public SFStatementType getStatementType() {
     return statementType;
   }
 
   @Override
-  public void setStatementType(SFStatementType statementType)
-  {
+  public void setStatementType(SFStatementType statementType) {
     this.statementType = statementType;
   }
 
   @Override
-  public boolean isArrayBindSupported()
-  {
+  public boolean isArrayBindSupported() {
     return this.arrayBindSupported;
   }
 
   @Override
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return queryId;
   }
 
-  private void logMetric(TelemetryField field, long value)
-  {
+  private void logMetric(TelemetryField field, long value) {
     TelemetryData data = TelemetryUtil.buildJobData(this.queryId, field, value);
     this.telemetryClient.addLogToBatch(data);
   }
 
-  private void logChunkDownloaderMetrics(DownloaderMetrics metrics)
-  {
-    if (metrics != null)
-    {
-      logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS,
-                metrics.getMillisWaiting());
-      logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS,
-                metrics.getMillisDownloading());
-      logMetric(TelemetryField.TIME_PARSING_CHUNKS,
-                metrics.getMillisParsing());
+  private void logChunkDownloaderMetrics(DownloaderMetrics metrics) {
+    if (metrics != null) {
+      logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS, metrics.getMillisWaiting());
+      logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS, metrics.getMillisDownloading());
+      logMetric(TelemetryField.TIME_PARSING_CHUNKS, metrics.getMillisParsing());
     }
   }
 
   @Override
-  public SnowflakeDateTimeFormat getTimestampLTZFormatter()
-  {
+  public SnowflakeDateTimeFormat getTimestampLTZFormatter() {
     return timestampLTZFormatter;
   }
 
   @Override
-  public SnowflakeDateTimeFormat getTimestampNTZFormatter()
-  {
+  public SnowflakeDateTimeFormat getTimestampNTZFormatter() {
     return timestampNTZFormatter;
   }
 
   @Override
-  public SnowflakeDateTimeFormat getTimestampTZFormatter()
-  {
+  public SnowflakeDateTimeFormat getTimestampTZFormatter() {
     return timestampTZFormatter;
   }
 
   @Override
-  public SnowflakeDateTimeFormat getDateFormatter()
-  {
+  public SnowflakeDateTimeFormat getDateFormatter() {
     return dateFormatter;
   }
 
   @Override
-  public SnowflakeDateTimeFormat getTimeFormatter()
-  {
+  public SnowflakeDateTimeFormat getTimeFormatter() {
     return timeFormatter;
   }
 
   @Override
-  public SFBinaryFormat getBinaryFormatter()
-  {
+  public SFBinaryFormat getBinaryFormatter() {
     return binaryFormatter;
   }
 
   @Override
-  public int getScale(int columnIndex)
-  {
+  public int getScale(int columnIndex) {
     return resultSetMetaData.getScale(columnIndex);
   }
 
   @Override
-  public TimeZone getTimeZone()
-  {
+  public TimeZone getTimeZone() {
     return timeZone;
   }
 
   @Override
-  public boolean getHonorClientTZForTimestampNTZ()
-  {
+  public boolean getHonorClientTZForTimestampNTZ() {
     return honorClientTZForTimestampNTZ;
   }
 
   @Override
-  public long getResultVersion()
-  {
+  public long getResultVersion() {
     return resultVersion;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -4,7 +4,13 @@
 
 package net.snowflake.client.core;
 
+import static net.snowflake.client.core.StmtUtil.eventHandler;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Comparator;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
@@ -15,21 +21,14 @@ import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Comparator;
-
-import static net.snowflake.client.core.StmtUtil.eventHandler;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 /**
  * Snowflake ResultSet implementation
+ *
  * <p>
  *
  * @author jhuang
  */
-public class SFResultSet extends SFJsonResultSet
-{
+public class SFResultSet extends SFJsonResultSet {
   static final SFLogger logger = SFLoggerFactory.getLogger(SFResultSet.class);
 
   private int columnCount = 0;
@@ -72,21 +71,20 @@ public class SFResultSet extends SFJsonResultSet
   private boolean treatNTZAsUTC;
 
   /**
-   * Constructor takes a result from the API response that we get from
-   * executing a SQL statement.
-   * <p>
-   * The constructor will initialize the ResultSetMetaData.
+   * Constructor takes a result from the API response that we get from executing a SQL statement.
+   *
+   * <p>The constructor will initialize the ResultSetMetaData.
    *
    * @param resultSetSerializable result data after parsing
-   * @param statement             statement object
-   * @param sortResult            true if sort results otherwise false
+   * @param statement statement object
+   * @param sortResult true if sort results otherwise false
    * @throws SQLException exception raised from general SQL layers
    */
-  public SFResultSet(SnowflakeResultSetSerializableV1 resultSetSerializable,
-                     SFStatement statement,
-                     boolean sortResult)
-  throws SQLException
-  {
+  public SFResultSet(
+      SnowflakeResultSetSerializableV1 resultSetSerializable,
+      SFStatement statement,
+      boolean sortResult)
+      throws SQLException {
     this(resultSetSerializable, statement.getSession().getTelemetryClient(), sortResult);
 
     this.statement = statement;
@@ -101,29 +99,29 @@ public class SFResultSet extends SFJsonResultSet
     SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSession());
 
     // if server gives a send time, log time it took to arrive
-    if (resultSetSerializable.getSendResultTime() != 0)
-    {
+    if (resultSetSerializable.getSendResultTime() != 0) {
       long timeConsumeFirstResult = this.firstChunkTime - resultSetSerializable.getSendResultTime();
       logMetric(TelemetryField.TIME_CONSUME_FIRST_RESULT, timeConsumeFirstResult);
     }
 
-    eventHandler.triggerStateTransition(BasicEvent.QueryState.CONSUMING_RESULT,
-                                        String.format(QueryState.CONSUMING_RESULT.getArgString(), queryId, 0));
+    eventHandler.triggerStateTransition(
+        BasicEvent.QueryState.CONSUMING_RESULT,
+        String.format(QueryState.CONSUMING_RESULT.getArgString(), queryId, 0));
   }
 
   /**
-   * This is a minimum initialization for SFResultSet. Mainly used for testing
-   * purpose. However, real prod constructor will call this constructor as well
+   * This is a minimum initialization for SFResultSet. Mainly used for testing purpose. However,
+   * real prod constructor will call this constructor as well
    *
    * @param resultSetSerializable data returned in query response
-   * @param telemetryClient       telemetryClient
+   * @param telemetryClient telemetryClient
    * @throws SQLException
    */
-  public SFResultSet(SnowflakeResultSetSerializableV1 resultSetSerializable,
-                     Telemetry telemetryClient,
-                     boolean sortResult)
-  throws SQLException
-  {
+  public SFResultSet(
+      SnowflakeResultSetSerializableV1 resultSetSerializable,
+      Telemetry telemetryClient,
+      boolean sortResult)
+      throws SQLException {
     this.resultSetSerializable = resultSetSerializable;
     this.columnCount = 0;
     this.sortResult = sortResult;
@@ -145,8 +143,7 @@ public class SFResultSet extends SFJsonResultSet
     this.dateFormatter = resultSetSerializable.getDateFormatter();
     this.timeFormatter = resultSetSerializable.getTimeFormatter();
     this.timeZone = resultSetSerializable.getTimeZone();
-    this.honorClientTZForTimestampNTZ =
-        resultSetSerializable.isHonorClientTZForTimestampNTZ();
+    this.honorClientTZForTimestampNTZ = resultSetSerializable.isHonorClientTZForTimestampNTZ();
     this.binaryFormatter = resultSetSerializable.getBinaryFormatter();
     this.resultVersion = resultSetSerializable.getResultVersion();
     this.numberOfBinds = resultSetSerializable.getNumberOfBinds();
@@ -156,37 +153,30 @@ public class SFResultSet extends SFJsonResultSet
     this.treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
 
     // sort result set if needed
-    if (sortResult)
-    {
+    if (sortResult) {
       // we don't support sort result when there are offline chunks
-      if (chunkCount > 0)
-      {
-        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                        ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
+      if (chunkCount > 0) {
+        throw new SnowflakeSQLException(
+            SqlState.FEATURE_NOT_SUPPORTED,
+            ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
       }
 
       sortResultSet();
     }
   }
 
-  private boolean fetchNextRow() throws SFException, SnowflakeSQLException
-  {
-    if (sortResult)
-    {
+  private boolean fetchNextRow() throws SFException, SnowflakeSQLException {
+    if (sortResult) {
       return fetchNextRowSorted();
-    }
-    else
-    {
+    } else {
       return fetchNextRowUnsorted();
     }
   }
 
-  private boolean fetchNextRowSorted()
-  {
+  private boolean fetchNextRowSorted() {
     currentChunkRowIndex++;
 
-    if (currentChunkRowIndex < currentChunkRowCount)
-    {
+    if (currentChunkRowIndex < currentChunkRowCount) {
       return true;
     }
 
@@ -197,35 +187,29 @@ public class SFResultSet extends SFJsonResultSet
     return false;
   }
 
-  private boolean fetchNextRowUnsorted() throws SFException, SnowflakeSQLException
-  {
+  private boolean fetchNextRowUnsorted() throws SFException, SnowflakeSQLException {
     currentChunkRowIndex++;
 
-    if (currentChunkRowIndex < currentChunkRowCount)
-    {
+    if (currentChunkRowIndex < currentChunkRowCount) {
       return true;
     }
 
     // let GC collect first rowset
     firstChunkRowset = null;
 
-    if (nextChunkIndex < chunkCount)
-    {
-      try
-      {
+    if (nextChunkIndex < chunkCount) {
+      try {
         eventHandler.triggerStateTransition(
             BasicEvent.QueryState.CONSUMING_RESULT,
-            String.format(QueryState.CONSUMING_RESULT.getArgString(),
-                          queryId,
-                          nextChunkIndex));
+            String.format(QueryState.CONSUMING_RESULT.getArgString(), queryId, nextChunkIndex));
 
         SnowflakeResultChunk nextChunk = chunkDownloader.getNextChunkToConsume();
 
-        if (nextChunk == null)
-        {
+        if (nextChunk == null) {
           throw new SnowflakeSQLLoggedException(
               SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
               "Expect chunk but got null for chunk index " + nextChunkIndex);
         }
 
@@ -233,53 +217,40 @@ public class SFResultSet extends SFJsonResultSet
         currentChunkRowCount = nextChunk.getRowCount();
         currentChunk = (JsonResultChunk) nextChunk;
 
-        logger.debug("Moving to chunk index {}, row count={}",
-                     nextChunkIndex, currentChunkRowCount);
+        logger.debug(
+            "Moving to chunk index {}, row count={}", nextChunkIndex, currentChunkRowCount);
 
         nextChunkIndex++;
 
         return true;
+      } catch (InterruptedException ex) {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
-      catch (InterruptedException ex)
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
-      }
-    }
-    else if (chunkCount > 0)
-    {
-      try
-      {
+    } else if (chunkCount > 0) {
+      try {
         logger.debug("End of chunks");
         DownloaderMetrics metrics = chunkDownloader.terminate();
         logChunkDownloaderMetrics(metrics);
-      }
-      catch (InterruptedException ex)
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
+      } catch (InterruptedException ex) {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
     }
 
     return false;
   }
 
-  private void logMetric(TelemetryField field, long value)
-  {
+  private void logMetric(TelemetryField field, long value) {
     TelemetryData data = TelemetryUtil.buildJobData(this.queryId, field, value);
     this.telemetryClient.addLogToBatch(data);
   }
 
-  private void logChunkDownloaderMetrics(DownloaderMetrics metrics)
-  {
-    if (metrics != null)
-    {
-      logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS,
-                metrics.getMillisWaiting());
-      logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS,
-                metrics.getMillisDownloading());
-      logMetric(TelemetryField.TIME_PARSING_CHUNKS,
-                metrics.getMillisParsing());
+  private void logChunkDownloaderMetrics(DownloaderMetrics metrics) {
+    if (metrics != null) {
+      logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS, metrics.getMillisWaiting());
+      logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS, metrics.getMillisDownloading());
+      logMetric(TelemetryField.TIME_PARSING_CHUNKS, metrics.getMillisParsing());
     }
   }
 
@@ -289,40 +260,33 @@ public class SFResultSet extends SFJsonResultSet
    * @return true if next row exists, false otherwise
    */
   @Override
-  public boolean next() throws SFException, SnowflakeSQLException
-  {
-    if (isClosed())
-    {
+  public boolean next() throws SFException, SnowflakeSQLException {
+    if (isClosed()) {
       return false;
     }
 
     // otherwise try to fetch again
-    if (fetchNextRow())
-    {
+    if (fetchNextRow()) {
       row++;
-      if (isLast())
-      {
+      if (isLast()) {
         long timeConsumeLastResult = System.currentTimeMillis() - this.firstChunkTime;
         logMetric(TelemetryField.TIME_CONSUME_LAST_RESULT, timeConsumeLastResult);
       }
       return true;
-    }
-    else
-    {
+    } else {
       logger.debug("end of result");
 
       /*
        * Here we check if the result has been truncated and throw exception if
        * so.
        */
-      if (totalRowCountTruncated ||
-          Boolean.TRUE.toString().equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2")))
-      {
-        throw (SFException) IncidentUtil.generateIncidentV2WithException(
-            session,
-            new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED),
-            queryId,
-            null);
+      if (totalRowCountTruncated
+          || Boolean.TRUE
+              .toString()
+              .equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2"))) {
+        throw (SFException)
+            IncidentUtil.generateIncidentV2WithException(
+                session, new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED), queryId, null);
       }
 
       // mark end of result
@@ -331,155 +295,121 @@ public class SFResultSet extends SFJsonResultSet
   }
 
   @Override
-  protected Object getObjectInternal(int columnIndex) throws SFException
-  {
-    if (columnIndex <= 0 || columnIndex > resultSetMetaData.getColumnCount())
-    {
+  protected Object getObjectInternal(int columnIndex) throws SFException {
+    if (columnIndex <= 0 || columnIndex > resultSetMetaData.getColumnCount()) {
       throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
 
     final int internalColumnIndex = columnIndex - 1;
     Object retValue;
-    if (sortResult)
-    {
-      retValue = firstChunkSortedRowSet[
-          currentChunkRowIndex][internalColumnIndex];
-    }
-    else if (firstChunkRowset != null)
-    {
-      retValue = JsonResultChunk.extractCell(firstChunkRowset,
-                                             currentChunkRowIndex,
-                                             internalColumnIndex);
-    }
-    else if (currentChunk != null)
-    {
+    if (sortResult) {
+      retValue = firstChunkSortedRowSet[currentChunkRowIndex][internalColumnIndex];
+    } else if (firstChunkRowset != null) {
+      retValue =
+          JsonResultChunk.extractCell(firstChunkRowset, currentChunkRowIndex, internalColumnIndex);
+    } else if (currentChunk != null) {
       retValue = currentChunk.getCell(currentChunkRowIndex, internalColumnIndex);
-    }
-    else
-    {
+    } else {
       throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
     wasNull = retValue == null;
     return retValue;
   }
 
-  private void sortResultSet()
-  {
+  private void sortResultSet() {
     // first fetch rows into firstChunkSortedRowSet
     firstChunkSortedRowSet = new Object[currentChunkRowCount][];
 
-    for (int rowIdx = 0; rowIdx < currentChunkRowCount; rowIdx++)
-    {
+    for (int rowIdx = 0; rowIdx < currentChunkRowCount; rowIdx++) {
       firstChunkSortedRowSet[rowIdx] = new Object[columnCount];
-      for (int colIdx = 0; colIdx < columnCount; colIdx++)
-      {
+      for (int colIdx = 0; colIdx < columnCount; colIdx++) {
         firstChunkSortedRowSet[rowIdx][colIdx] =
             JsonResultChunk.extractCell(firstChunkRowset, rowIdx, colIdx);
       }
     }
 
     // now sort it
-    Arrays.sort(firstChunkSortedRowSet,
-                new Comparator<Object[]>()
-                {
-                  public int compare(Object[] a, Object[] b)
-                  {
-                    int numCols = a.length;
+    Arrays.sort(
+        firstChunkSortedRowSet,
+        new Comparator<Object[]>() {
+          public int compare(Object[] a, Object[] b) {
+            int numCols = a.length;
 
-                    for (int colIdx = 0; colIdx < numCols; colIdx++)
-                    {
-                      if (a[colIdx] == null && b[colIdx] == null)
-                      {
-                        continue;
-                      }
+            for (int colIdx = 0; colIdx < numCols; colIdx++) {
+              if (a[colIdx] == null && b[colIdx] == null) {
+                continue;
+              }
 
-                      // null is considered bigger than all values
-                      if (a[colIdx] == null)
-                      {
-                        return 1;
-                      }
+              // null is considered bigger than all values
+              if (a[colIdx] == null) {
+                return 1;
+              }
 
-                      if (b[colIdx] == null)
-                      {
-                        return -1;
-                      }
+              if (b[colIdx] == null) {
+                return -1;
+              }
 
-                      int res
-                          = a[colIdx].toString().compareTo(b[colIdx].toString());
+              int res = a[colIdx].toString().compareTo(b[colIdx].toString());
 
-                      // continue to next column if no difference
-                      if (res == 0)
-                      {
-                        continue;
-                      }
+              // continue to next column if no difference
+              if (res == 0) {
+                continue;
+              }
 
-                      return res;
-                    }
+              return res;
+            }
 
-                    // all columns are the same
-                    return 0;
-                  }
-                });
+            // all columns are the same
+            return 0;
+          }
+        });
   }
 
   @Override
-  public boolean isLast()
-  {
-    return nextChunkIndex == chunkCount &&
-           currentChunkRowIndex + 1 == currentChunkRowCount;
+  public boolean isLast() {
+    return nextChunkIndex == chunkCount && currentChunkRowIndex + 1 == currentChunkRowCount;
   }
 
   @Override
-  public boolean isAfterLast()
-  {
-    return nextChunkIndex == chunkCount &&
-           currentChunkRowIndex >= currentChunkRowCount;
+  public boolean isAfterLast() {
+    return nextChunkIndex == chunkCount && currentChunkRowIndex >= currentChunkRowCount;
   }
 
   @Override
-  public void close() throws SnowflakeSQLException
-  {
+  public void close() throws SnowflakeSQLException {
     super.close();
 
-    try
-    {
-      if (chunkDownloader != null)
-      {
+    try {
+      if (chunkDownloader != null) {
         DownloaderMetrics metrics = chunkDownloader.terminate();
         logChunkDownloaderMetrics(metrics);
         firstChunkSortedRowSet = null;
         firstChunkRowset = null;
         currentChunk = null;
       }
-    }
-    catch (InterruptedException ex)
-    {
-      throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                            ErrorCode.INTERRUPTED.getMessageCode(), session);
+    } catch (InterruptedException ex) {
+      throw new SnowflakeSQLLoggedException(
+          SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
     }
   }
 
   @Override
-  public SFStatementType getStatementType()
-  {
+  public SFStatementType getStatementType() {
     return statementType;
   }
 
   @Override
-  public void setStatementType(SFStatementType statementType)
-  {
+  public void setStatementType(SFStatementType statementType) {
     this.statementType = statementType;
   }
 
   @Override
-  public boolean isArrayBindSupported()
-  {
+  public boolean isArrayBindSupported() {
     return this.arrayBindSupported;
   }
 
   @Override
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return queryId;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -4,13 +4,7 @@
 
 package net.snowflake.client.core;
 
-import static net.snowflake.client.core.StmtUtil.eventHandler;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Comparator;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
@@ -21,14 +15,21 @@ import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Comparator;
+
+import static net.snowflake.client.core.StmtUtil.eventHandler;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 /**
  * Snowflake ResultSet implementation
- *
  * <p>
  *
  * @author jhuang
  */
-public class SFResultSet extends SFJsonResultSet {
+public class SFResultSet extends SFJsonResultSet
+{
   static final SFLogger logger = SFLoggerFactory.getLogger(SFResultSet.class);
 
   private int columnCount = 0;
@@ -71,20 +72,21 @@ public class SFResultSet extends SFJsonResultSet {
   private boolean treatNTZAsUTC;
 
   /**
-   * Constructor takes a result from the API response that we get from executing a SQL statement.
-   *
-   * <p>The constructor will initialize the ResultSetMetaData.
+   * Constructor takes a result from the API response that we get from
+   * executing a SQL statement.
+   * <p>
+   * The constructor will initialize the ResultSetMetaData.
    *
    * @param resultSetSerializable result data after parsing
-   * @param statement statement object
-   * @param sortResult true if sort results otherwise false
+   * @param statement             statement object
+   * @param sortResult            true if sort results otherwise false
    * @throws SQLException exception raised from general SQL layers
    */
-  public SFResultSet(
-      SnowflakeResultSetSerializableV1 resultSetSerializable,
-      SFStatement statement,
-      boolean sortResult)
-      throws SQLException {
+  public SFResultSet(SnowflakeResultSetSerializableV1 resultSetSerializable,
+                     SFStatement statement,
+                     boolean sortResult)
+  throws SQLException
+  {
     this(resultSetSerializable, statement.getSession().getTelemetryClient(), sortResult);
 
     this.statement = statement;
@@ -99,29 +101,29 @@ public class SFResultSet extends SFJsonResultSet {
     SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSession());
 
     // if server gives a send time, log time it took to arrive
-    if (resultSetSerializable.getSendResultTime() != 0) {
+    if (resultSetSerializable.getSendResultTime() != 0)
+    {
       long timeConsumeFirstResult = this.firstChunkTime - resultSetSerializable.getSendResultTime();
       logMetric(TelemetryField.TIME_CONSUME_FIRST_RESULT, timeConsumeFirstResult);
     }
 
-    eventHandler.triggerStateTransition(
-        BasicEvent.QueryState.CONSUMING_RESULT,
-        String.format(QueryState.CONSUMING_RESULT.getArgString(), queryId, 0));
+    eventHandler.triggerStateTransition(BasicEvent.QueryState.CONSUMING_RESULT,
+                                        String.format(QueryState.CONSUMING_RESULT.getArgString(), queryId, 0));
   }
 
   /**
-   * This is a minimum initialization for SFResultSet. Mainly used for testing purpose. However,
-   * real prod constructor will call this constructor as well
+   * This is a minimum initialization for SFResultSet. Mainly used for testing
+   * purpose. However, real prod constructor will call this constructor as well
    *
    * @param resultSetSerializable data returned in query response
-   * @param telemetryClient telemetryClient
+   * @param telemetryClient       telemetryClient
    * @throws SQLException
    */
-  public SFResultSet(
-      SnowflakeResultSetSerializableV1 resultSetSerializable,
-      Telemetry telemetryClient,
-      boolean sortResult)
-      throws SQLException {
+  public SFResultSet(SnowflakeResultSetSerializableV1 resultSetSerializable,
+                     Telemetry telemetryClient,
+                     boolean sortResult)
+  throws SQLException
+  {
     this.resultSetSerializable = resultSetSerializable;
     this.columnCount = 0;
     this.sortResult = sortResult;
@@ -143,7 +145,8 @@ public class SFResultSet extends SFJsonResultSet {
     this.dateFormatter = resultSetSerializable.getDateFormatter();
     this.timeFormatter = resultSetSerializable.getTimeFormatter();
     this.timeZone = resultSetSerializable.getTimeZone();
-    this.honorClientTZForTimestampNTZ = resultSetSerializable.isHonorClientTZForTimestampNTZ();
+    this.honorClientTZForTimestampNTZ =
+        resultSetSerializable.isHonorClientTZForTimestampNTZ();
     this.binaryFormatter = resultSetSerializable.getBinaryFormatter();
     this.resultVersion = resultSetSerializable.getResultVersion();
     this.numberOfBinds = resultSetSerializable.getNumberOfBinds();
@@ -153,30 +156,37 @@ public class SFResultSet extends SFJsonResultSet {
     this.treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
 
     // sort result set if needed
-    if (sortResult) {
+    if (sortResult)
+    {
       // we don't support sort result when there are offline chunks
-      if (chunkCount > 0) {
-        throw new SnowflakeSQLException(
-            SqlState.FEATURE_NOT_SUPPORTED,
-            ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
+      if (chunkCount > 0)
+      {
+        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+                                        ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
       }
 
       sortResultSet();
     }
   }
 
-  private boolean fetchNextRow() throws SFException, SnowflakeSQLException {
-    if (sortResult) {
+  private boolean fetchNextRow() throws SFException, SnowflakeSQLException
+  {
+    if (sortResult)
+    {
       return fetchNextRowSorted();
-    } else {
+    }
+    else
+    {
       return fetchNextRowUnsorted();
     }
   }
 
-  private boolean fetchNextRowSorted() {
+  private boolean fetchNextRowSorted()
+  {
     currentChunkRowIndex++;
 
-    if (currentChunkRowIndex < currentChunkRowCount) {
+    if (currentChunkRowIndex < currentChunkRowCount)
+    {
       return true;
     }
 
@@ -187,29 +197,35 @@ public class SFResultSet extends SFJsonResultSet {
     return false;
   }
 
-  private boolean fetchNextRowUnsorted() throws SFException, SnowflakeSQLException {
+  private boolean fetchNextRowUnsorted() throws SFException, SnowflakeSQLException
+  {
     currentChunkRowIndex++;
 
-    if (currentChunkRowIndex < currentChunkRowCount) {
+    if (currentChunkRowIndex < currentChunkRowCount)
+    {
       return true;
     }
 
     // let GC collect first rowset
     firstChunkRowset = null;
 
-    if (nextChunkIndex < chunkCount) {
-      try {
+    if (nextChunkIndex < chunkCount)
+    {
+      try
+      {
         eventHandler.triggerStateTransition(
             BasicEvent.QueryState.CONSUMING_RESULT,
-            String.format(QueryState.CONSUMING_RESULT.getArgString(), queryId, nextChunkIndex));
+            String.format(QueryState.CONSUMING_RESULT.getArgString(),
+                          queryId,
+                          nextChunkIndex));
 
         SnowflakeResultChunk nextChunk = chunkDownloader.getNextChunkToConsume();
 
-        if (nextChunk == null) {
+        if (nextChunk == null)
+        {
           throw new SnowflakeSQLLoggedException(
               SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              session,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
               "Expect chunk but got null for chunk index " + nextChunkIndex);
         }
 
@@ -217,40 +233,53 @@ public class SFResultSet extends SFJsonResultSet {
         currentChunkRowCount = nextChunk.getRowCount();
         currentChunk = (JsonResultChunk) nextChunk;
 
-        logger.debug(
-            "Moving to chunk index {}, row count={}", nextChunkIndex, currentChunkRowCount);
+        logger.debug("Moving to chunk index {}, row count={}",
+                     nextChunkIndex, currentChunkRowCount);
 
         nextChunkIndex++;
 
         return true;
-      } catch (InterruptedException ex) {
-        throw new SnowflakeSQLException(
-            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
       }
-    } else if (chunkCount > 0) {
-      try {
+      catch (InterruptedException ex)
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
+      }
+    }
+    else if (chunkCount > 0)
+    {
+      try
+      {
         logger.debug("End of chunks");
         DownloaderMetrics metrics = chunkDownloader.terminate();
         logChunkDownloaderMetrics(metrics);
-      } catch (InterruptedException ex) {
-        throw new SnowflakeSQLException(
-            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
+      }
+      catch (InterruptedException ex)
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
     }
 
     return false;
   }
 
-  private void logMetric(TelemetryField field, long value) {
+  private void logMetric(TelemetryField field, long value)
+  {
     TelemetryData data = TelemetryUtil.buildJobData(this.queryId, field, value);
     this.telemetryClient.addLogToBatch(data);
   }
 
-  private void logChunkDownloaderMetrics(DownloaderMetrics metrics) {
-    if (metrics != null) {
-      logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS, metrics.getMillisWaiting());
-      logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS, metrics.getMillisDownloading());
-      logMetric(TelemetryField.TIME_PARSING_CHUNKS, metrics.getMillisParsing());
+  private void logChunkDownloaderMetrics(DownloaderMetrics metrics)
+  {
+    if (metrics != null)
+    {
+      logMetric(TelemetryField.TIME_WAITING_FOR_CHUNKS,
+                metrics.getMillisWaiting());
+      logMetric(TelemetryField.TIME_DOWNLOADING_CHUNKS,
+                metrics.getMillisDownloading());
+      logMetric(TelemetryField.TIME_PARSING_CHUNKS,
+                metrics.getMillisParsing());
     }
   }
 
@@ -260,33 +289,40 @@ public class SFResultSet extends SFJsonResultSet {
    * @return true if next row exists, false otherwise
    */
   @Override
-  public boolean next() throws SFException, SnowflakeSQLException {
-    if (isClosed()) {
+  public boolean next() throws SFException, SnowflakeSQLException
+  {
+    if (isClosed())
+    {
       return false;
     }
 
     // otherwise try to fetch again
-    if (fetchNextRow()) {
+    if (fetchNextRow())
+    {
       row++;
-      if (isLast()) {
+      if (isLast())
+      {
         long timeConsumeLastResult = System.currentTimeMillis() - this.firstChunkTime;
         logMetric(TelemetryField.TIME_CONSUME_LAST_RESULT, timeConsumeLastResult);
       }
       return true;
-    } else {
+    }
+    else
+    {
       logger.debug("end of result");
 
       /*
        * Here we check if the result has been truncated and throw exception if
        * so.
        */
-      if (totalRowCountTruncated
-          || Boolean.TRUE
-              .toString()
-              .equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2"))) {
-        throw (SFException)
-            IncidentUtil.generateIncidentV2WithException(
-                session, new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED), queryId, null);
+      if (totalRowCountTruncated ||
+          Boolean.TRUE.toString().equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2")))
+      {
+        throw (SFException) IncidentUtil.generateIncidentV2WithException(
+            session,
+            new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED),
+            queryId,
+            null);
       }
 
       // mark end of result
@@ -295,121 +331,155 @@ public class SFResultSet extends SFJsonResultSet {
   }
 
   @Override
-  protected Object getObjectInternal(int columnIndex) throws SFException {
-    if (columnIndex <= 0 || columnIndex > resultSetMetaData.getColumnCount()) {
+  protected Object getObjectInternal(int columnIndex) throws SFException
+  {
+    if (columnIndex <= 0 || columnIndex > resultSetMetaData.getColumnCount())
+    {
       throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
 
     final int internalColumnIndex = columnIndex - 1;
     Object retValue;
-    if (sortResult) {
-      retValue = firstChunkSortedRowSet[currentChunkRowIndex][internalColumnIndex];
-    } else if (firstChunkRowset != null) {
-      retValue =
-          JsonResultChunk.extractCell(firstChunkRowset, currentChunkRowIndex, internalColumnIndex);
-    } else if (currentChunk != null) {
+    if (sortResult)
+    {
+      retValue = firstChunkSortedRowSet[
+          currentChunkRowIndex][internalColumnIndex];
+    }
+    else if (firstChunkRowset != null)
+    {
+      retValue = JsonResultChunk.extractCell(firstChunkRowset,
+                                             currentChunkRowIndex,
+                                             internalColumnIndex);
+    }
+    else if (currentChunk != null)
+    {
       retValue = currentChunk.getCell(currentChunkRowIndex, internalColumnIndex);
-    } else {
+    }
+    else
+    {
       throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
     wasNull = retValue == null;
     return retValue;
   }
 
-  private void sortResultSet() {
+  private void sortResultSet()
+  {
     // first fetch rows into firstChunkSortedRowSet
     firstChunkSortedRowSet = new Object[currentChunkRowCount][];
 
-    for (int rowIdx = 0; rowIdx < currentChunkRowCount; rowIdx++) {
+    for (int rowIdx = 0; rowIdx < currentChunkRowCount; rowIdx++)
+    {
       firstChunkSortedRowSet[rowIdx] = new Object[columnCount];
-      for (int colIdx = 0; colIdx < columnCount; colIdx++) {
+      for (int colIdx = 0; colIdx < columnCount; colIdx++)
+      {
         firstChunkSortedRowSet[rowIdx][colIdx] =
             JsonResultChunk.extractCell(firstChunkRowset, rowIdx, colIdx);
       }
     }
 
     // now sort it
-    Arrays.sort(
-        firstChunkSortedRowSet,
-        new Comparator<Object[]>() {
-          public int compare(Object[] a, Object[] b) {
-            int numCols = a.length;
+    Arrays.sort(firstChunkSortedRowSet,
+                new Comparator<Object[]>()
+                {
+                  public int compare(Object[] a, Object[] b)
+                  {
+                    int numCols = a.length;
 
-            for (int colIdx = 0; colIdx < numCols; colIdx++) {
-              if (a[colIdx] == null && b[colIdx] == null) {
-                continue;
-              }
+                    for (int colIdx = 0; colIdx < numCols; colIdx++)
+                    {
+                      if (a[colIdx] == null && b[colIdx] == null)
+                      {
+                        continue;
+                      }
 
-              // null is considered bigger than all values
-              if (a[colIdx] == null) {
-                return 1;
-              }
+                      // null is considered bigger than all values
+                      if (a[colIdx] == null)
+                      {
+                        return 1;
+                      }
 
-              if (b[colIdx] == null) {
-                return -1;
-              }
+                      if (b[colIdx] == null)
+                      {
+                        return -1;
+                      }
 
-              int res = a[colIdx].toString().compareTo(b[colIdx].toString());
+                      int res
+                          = a[colIdx].toString().compareTo(b[colIdx].toString());
 
-              // continue to next column if no difference
-              if (res == 0) {
-                continue;
-              }
+                      // continue to next column if no difference
+                      if (res == 0)
+                      {
+                        continue;
+                      }
 
-              return res;
-            }
+                      return res;
+                    }
 
-            // all columns are the same
-            return 0;
-          }
-        });
+                    // all columns are the same
+                    return 0;
+                  }
+                });
   }
 
   @Override
-  public boolean isLast() {
-    return nextChunkIndex == chunkCount && currentChunkRowIndex + 1 == currentChunkRowCount;
+  public boolean isLast()
+  {
+    return nextChunkIndex == chunkCount &&
+           currentChunkRowIndex + 1 == currentChunkRowCount;
   }
 
   @Override
-  public boolean isAfterLast() {
-    return nextChunkIndex == chunkCount && currentChunkRowIndex >= currentChunkRowCount;
+  public boolean isAfterLast()
+  {
+    return nextChunkIndex == chunkCount &&
+           currentChunkRowIndex >= currentChunkRowCount;
   }
 
   @Override
-  public void close() throws SnowflakeSQLException {
+  public void close() throws SnowflakeSQLException
+  {
     super.close();
 
-    try {
-      if (chunkDownloader != null) {
+    try
+    {
+      if (chunkDownloader != null)
+      {
         DownloaderMetrics metrics = chunkDownloader.terminate();
         logChunkDownloaderMetrics(metrics);
         firstChunkSortedRowSet = null;
         firstChunkRowset = null;
         currentChunk = null;
       }
-    } catch (InterruptedException ex) {
-      throw new SnowflakeSQLException(
-          SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
+    }
+    catch (InterruptedException ex)
+    {
+      throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                            ErrorCode.INTERRUPTED.getMessageCode(), session);
     }
   }
 
   @Override
-  public SFStatementType getStatementType() {
+  public SFStatementType getStatementType()
+  {
     return statementType;
   }
 
   @Override
-  public void setStatementType(SFStatementType statementType) {
+  public void setStatementType(SFStatementType statementType)
+  {
     this.statementType = statementType;
   }
 
   @Override
-  public boolean isArrayBindSupported() {
+  public boolean isArrayBindSupported()
+  {
     return this.arrayBindSupported;
   }
 
   @Override
-  public String getQueryId() {
+  public String getQueryId()
+  {
     return queryId;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
@@ -304,8 +304,7 @@ public class SFResultSetMetaData {
    *
    * @return session object
    */
-  public SFSession getSession()
-  {
+  public SFSession getSession() {
     return session;
   }
 

--- a/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
@@ -300,6 +300,16 @@ public class SFResultSetMetaData {
   }
 
   /**
+   * get the session
+   *
+   * @return session object
+   */
+  public SFSession getSession()
+  {
+    return session;
+  }
+
+  /**
    * Get the list of column names
    *
    * @return column names in list

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -4,31 +4,10 @@
 
 package net.snowflake.client.core;
 
-import static net.snowflake.client.core.QueryStatus.getStatusFromString;
-import static net.snowflake.client.core.QueryStatus.isAnError;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import java.security.PrivateKey;
-import java.sql.DriverPropertyInfo;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeConnectString;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.SnowflakeType;
-import net.snowflake.client.jdbc.SnowflakeUtil;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.client.jdbc.telemetry.TelemetryClient;
 import net.snowflake.client.log.JDK14Logger;
@@ -41,9 +20,25 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 
-/** Snowflake session implementation */
-public class SFSession {
-  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
+import java.security.PrivateKey;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+import static net.snowflake.client.core.QueryStatus.getStatusFromString;
+import static net.snowflake.client.core.QueryStatus.isAnError;
+
+/**
+ * Snowflake session implementation
+ */
+public class SFSession
+{
+  private static final ObjectMapper OBJECT_MAPPER =
+      ObjectMapperFactory.getObjectMapper();
 
   static final SFLogger logger = SFLoggerFactory.getLogger(SFSession.class);
 
@@ -61,8 +56,7 @@ public class SFSession {
 
   // temporarily have this variable to avoid hardcode.
   // Need to be removed when a better way to organize session parameter is introduced.
-  private static final String CLIENT_STORE_TEMPORARY_CREDENTIAL =
-      "CLIENT_STORE_TEMPORARY_CREDENTIAL";
+  private static final String CLIENT_STORE_TEMPORARY_CREDENTIAL = "CLIENT_STORE_TEMPORARY_CREDENTIAL";
 
   // increase heartbeat timeout from 60 sec to 300 sec
   // per https://support-snowflake.zendesk.com/agent/tickets/6629
@@ -93,28 +87,32 @@ public class SFSession {
   private List<DriverPropertyInfo> missingProperties = new ArrayList<>();
 
   /**
-   * Amount of seconds a user is willing to tolerate for establishing the connection with database.
-   * In our case, it means the first login request to get authorization token.
-   *
-   * <p>Default:60 seconds
+   * Amount of seconds a user is willing to tolerate for establishing the
+   * connection with database. In our case, it means the first login
+   * request to get authorization token.
+   * <p>
+   * Default:60 seconds
    */
   private int loginTimeout = 60;
 
   /**
-   * Amount of milliseconds a user is willing to tolerate for network related issues (e.g. HTTP
-   * 503/504) or database transient issues (e.g. GS not responding)
-   *
-   * <p>A value of 0 means no timeout
-   *
-   * <p>Default: 0
+   * Amount of milliseconds a user is willing to tolerate for network related
+   * issues (e.g. HTTP 503/504) or database transient issues (e.g. GS
+   * not responding)
+   * <p>
+   * A value of 0 means no timeout
+   * <p>
+   * Default: 0
    */
   private int networkTimeoutInMilli = 0; // in milliseconds
 
   private boolean enableCombineDescribe = false;
 
+
   private Map<String, Object> sessionProperties = new HashMap<>(1);
 
-  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+  private final static ObjectMapper mapper =
+      ObjectMapperFactory.getObjectMapper();
 
   private final Properties clientInfo = new Properties();
 
@@ -122,9 +120,10 @@ public class SFSession {
 
   private static int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 300000; // millisec
 
-  private int httpClientSocketTimeout = DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT; // milliseconds
+  private int httpClientSocketTimeout =
+      DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT; // milliseconds
 
-  // --- Simulated failures for testing
+  //--- Simulated failures for testing
 
   // whether we try to simulate a socket timeout (a default value of 0 means
   // no simulation). The value is in milliseconds
@@ -134,7 +133,7 @@ public class SFSession {
   // call ( a default value of 0 means no pause). The value is in seconds
   private int injectClientPause = 0;
 
-  // Generate exception while uploading file with a given name
+  //Generate exception while uploading file with a given name
   private String injectFileUploadFailure = null;
 
   private Map<SFSessionProperty, Object> connectionPropertiesMap = new HashMap<>();
@@ -142,7 +141,7 @@ public class SFSession {
   // session parameters
   private Map<String, Object> sessionParametersMap = new HashMap<>();
 
-  private static final int MAX_SESSION_PARAMETERS = 1000;
+  final private static int MAX_SESSION_PARAMETERS = 1000;
 
   private boolean passcodeInPassword = false;
 
@@ -184,7 +183,8 @@ public class SFSession {
   // instead of a local/session timezone, set to true
   private boolean treatNTZAsUTC = false;
 
-  private SnowflakeType timestampMappedType = SnowflakeType.TIMESTAMP_LTZ;
+  private SnowflakeType timestampMappedType =
+      SnowflakeType.TIMESTAMP_LTZ;
 
   private boolean jdbcTreatDecimalAsInt = true;
 
@@ -196,7 +196,7 @@ public class SFSession {
   // client to log session metrics to telemetry in GS
   private Telemetry telemetryClient;
 
-  // default value is false will be updated when login
+  //default value is false will be updated when login
   private boolean clientTelemetryEnabled = false;
 
   // The server can read array binds from a stage instead of query payload.
@@ -226,32 +226,39 @@ public class SFSession {
   // validate the default parameters by GS?
   private boolean validateDefaultParameters;
 
-  // list of active asynchronous queries. Used to see if session should be closed when connection
-  // closes
+  // list of active asynchronous queries. Used to see if session should be closed when connection closes
   protected Set<String> activeAsyncQueries = ConcurrentHashMap.newKeySet();
 
   /**
-   * Function that checks if the active session can be closed when the connection is closed. If
-   * there are active asynchronous queries running, the session should stay open even if the
-   * connection closes so that the queries can finish running.
+   * Function that checks if the active session can be closed when the
+   * connection is closed. If there are active asynchronous queries running,
+   * the session should stay open even if the connection closes so that the
+   * queries can finish running.
    *
    * @return true if it is safe to close this session, false if not
    */
-  public boolean isSafeToClose() {
+  public boolean isSafeToClose()
+  {
     boolean canClose = true;
     // if the set of asynchronous queries is empty, return true
-    if (this.activeAsyncQueries.isEmpty()) {
+    if (this.activeAsyncQueries.isEmpty())
+    {
       return canClose;
     }
     // if the set is not empty, iterate through each query and check its status
-    for (String query : this.activeAsyncQueries) {
-      try {
+    for (String query : this.activeAsyncQueries)
+    {
+      try
+      {
         QueryStatus qStatus = getQueryStatus(query);
         //  if any query is still running, it is not safe to close.
-        if (QueryStatus.isStillRunning(qStatus)) {
+        if (QueryStatus.isStillRunning(qStatus))
+        {
           canClose = false;
         }
-      } catch (SQLException e) {
+      }
+      catch (SQLException e)
+      {
         logger.error(e.getMessage());
       }
     }
@@ -263,14 +270,19 @@ public class SFSession {
    * @return enum of type QueryStatus indicating the query's status
    * @throws SQLException
    */
-  public QueryStatus getQueryStatus(String queryID) throws SQLException {
+  public QueryStatus getQueryStatus(String queryID)
+  throws SQLException
+  {
     // create the URL to check the query monitoring endpoint
     String statusUrl = "";
     String sessionUrl = getUrl();
-    if (sessionUrl.endsWith("/")) {
+    if (sessionUrl.endsWith("/"))
+    {
       statusUrl =
           sessionUrl.substring(0, sessionUrl.length() - 1) + SF_PATH_QUERY_MONITOR + queryID;
-    } else {
+    }
+    else
+    {
       statusUrl = sessionUrl + SF_PATH_QUERY_MONITOR + queryID;
     }
     // Create a new HTTP GET object and set appropriate headers
@@ -279,30 +291,32 @@ public class SFSession {
     get.setHeader("Authorization", "Snowflake Token=\"" + this.sessionToken + "\"");
     String response = null;
     JsonNode jsonNode = null;
-    try {
+    try
+    {
       response = HttpUtil.executeGeneralRequest(get, loginTimeout, getOCSPMode());
       jsonNode = OBJECT_MAPPER.readTree(response);
-    } catch (Exception e) {
-      throw new SQLException(
-          "No response or invalid response from GET request. Error: {}", e.getMessage());
+    }
+    catch (Exception e)
+    {
+      throw new SnowflakeSQLLoggedException("No response or invalid response from GET request. Error: {}", e.getMessage(), this);
     }
     // Get response as JSON and parse it to get the query status
     // check the success field first
-    if (!jsonNode.path("success").asBoolean()) {
+    if (!jsonNode.path("success").asBoolean())
+    {
       logger.debug("response = {}", response);
 
       int errorCode = jsonNode.path("code").asInt();
       throw new SnowflakeSQLException(
-          queryID,
-          jsonNode.path("message").asText(),
-          SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-          errorCode);
+          queryID, jsonNode.path("message").asText(),
+          SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION, errorCode);
     }
     JsonNode queryNode = jsonNode.path("data").path("queries");
     String queryStatus = "";
     String errorMessage = "";
     int errorCode = 0;
-    if (queryNode.size() > 0) {
+    if (queryNode.size() > 0)
+    {
       queryStatus = queryNode.get(0).path("status").asText();
       errorMessage = queryNode.get(0).path("errorMessage").asText();
       errorCode = queryNode.get(0).path("errorCode").asInt();
@@ -311,87 +325,116 @@ public class SFSession {
     // Turn string with query response into QueryStatus enum and return it
     QueryStatus result = getStatusFromString(queryStatus);
     // if an error code has been provided, set appropriate error code
-    if (errorCode != 0) {
+    if (errorCode != 0)
+    {
       result.setErrorCode(errorCode);
     }
     // if no code was provided but query status indicates an error, set
     // code to be an internal error and set error message
-    else if (isAnError(result)) {
+    else if (isAnError(result))
+    {
       result.setErrorCode(ErrorCode.INTERNAL_ERROR.getMessageCode());
       result.setErrorMessage("no_error_code_from_server");
     }
     // if an error message has been provided, set appropriate error message.
     // This should override the default error message displayed when there is
     // an error with no code.
-    if (!Strings.isNullOrEmpty(errorMessage) && !errorMessage.equalsIgnoreCase("null")) {
+    if (!Strings.isNullOrEmpty(errorMessage) && !errorMessage.equalsIgnoreCase("null"))
+    {
       result.setErrorMessage(errorMessage);
     }
     return result;
   }
 
-  public void addProperty(SFSessionProperty sfSessionProperty, Object propertyValue)
-      throws SFException {
+
+  public void addProperty(SFSessionProperty sfSessionProperty,
+                          Object propertyValue)
+  throws SFException
+  {
     addProperty(sfSessionProperty.getPropertyKey(), propertyValue);
   }
 
   /**
-   * Add a property If a property is known for connection, add it to connection properties If not,
-   * add it as a dynamic session parameters
+   * Add a property
+   * If a property is known for connection, add it to connection properties
+   * If not, add it as a dynamic session parameters
+   * <p>
+   * Make sure a property is not added more than once and the number of
+   * properties does not exceed limit.
    *
-   * <p>Make sure a property is not added more than once and the number of properties does not
-   * exceed limit.
-   *
-   * @param propertyName property name
+   * @param propertyName  property name
    * @param propertyValue property value
    * @throws SFException exception raised from Snowflake components
    */
-  public void addProperty(String propertyName, Object propertyValue) throws SFException {
-    SFSessionProperty connectionProperty = SFSessionProperty.lookupByKey(propertyName);
+  public void addProperty(String propertyName, Object propertyValue)
+  throws SFException
+  {
+    SFSessionProperty connectionProperty =
+        SFSessionProperty.lookupByKey(propertyName);
 
-    if (connectionProperty != null) {
+    if (connectionProperty != null)
+    {
       // check if the value type is as expected
-      propertyValue = SFSessionProperty.checkPropertyValue(connectionProperty, propertyValue);
+      propertyValue = SFSessionProperty
+          .checkPropertyValue(connectionProperty, propertyValue);
 
-      if (connectionPropertiesMap.containsKey(connectionProperty)) {
-        throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED, propertyName);
-      } else if (propertyValue != null && connectionProperty == SFSessionProperty.AUTHENTICATOR) {
+      if (connectionPropertiesMap.containsKey(connectionProperty))
+      {
+        throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED,
+                              propertyName);
+      }
+      else if (propertyValue != null && connectionProperty == SFSessionProperty.AUTHENTICATOR)
+      {
         String[] authenticatorWithParams = propertyValue.toString().split(";");
-        if (authenticatorWithParams.length == 1) {
+        if (authenticatorWithParams.length == 1)
+        {
           connectionPropertiesMap.put(connectionProperty, propertyValue);
-        } else {
+        }
+        else
+        {
           String[] oktaUserKeyPair = authenticatorWithParams[1].split("=");
-          if (oktaUserKeyPair.length == 2) {
+          if (oktaUserKeyPair.length == 2)
+          {
             connectionPropertiesMap.put(connectionProperty, authenticatorWithParams[0]);
             connectionPropertiesMap.put(SFSessionProperty.OKTA_USERNAME, oktaUserKeyPair[1]);
-          } else {
+          }
+          else
+          {
             throw new SFException(ErrorCode.INVALID_OKTA_USERNAME, propertyName);
           }
         }
-      } else {
+      }
+      else
+      {
         connectionPropertiesMap.put(connectionProperty, propertyValue);
       }
 
-      switch (connectionProperty) {
+      switch (connectionProperty)
+      {
         case LOGIN_TIMEOUT:
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             loginTimeout = (Integer) propertyValue;
           }
           break;
 
         case NETWORK_TIMEOUT:
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             networkTimeoutInMilli = (Integer) propertyValue;
           }
           break;
 
         case INJECT_CLIENT_PAUSE:
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             injectClientPause = (Integer) propertyValue;
           }
           break;
 
         case INJECT_SOCKET_TIMEOUT:
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             injectSocketTimeout = (Integer) propertyValue;
           }
           break;
@@ -401,9 +444,11 @@ public class SFSession {
           break;
 
         case TRACING:
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             tracingLevel = Level.parse(((String) propertyValue).toUpperCase());
-            if (tracingLevel != null && logger instanceof JDK14Logger) {
+            if (tracingLevel != null && logger instanceof JDK14Logger)
+            {
               JDK14Logger.honorTracingParameter(tracingLevel);
             }
           }
@@ -412,25 +457,29 @@ public class SFSession {
         case DISABLE_SOCKS_PROXY:
           // note: if any session has this parameter, it will be used for all
           // sessions on the current JVM.
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             HttpUtil.setSocksProxyDisabled((Boolean) propertyValue);
           }
           break;
 
         case VALIDATE_DEFAULT_PARAMETERS:
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             validateDefaultParameters = SFLoginInput.getBooleanValue(propertyValue);
           }
           break;
 
         case PRIVATE_KEY_FILE:
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             privateKeyFileLocation = (String) propertyValue;
           }
           break;
 
         case PRIVATE_KEY_FILE_PWD:
-          if (propertyValue != null) {
+          if (propertyValue != null)
+          {
             privateKeyPassword = (String) propertyValue;
           }
           break;
@@ -438,51 +487,68 @@ public class SFSession {
         default:
           break;
       }
-    } else {
+    }
+    else
+    {
       // this property does not match any predefined property, treat it as
       // session parameter
-      if (sessionParametersMap.containsKey(propertyName)) {
-        throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED, propertyName);
-      } else {
+      if (sessionParametersMap.containsKey(propertyName))
+      {
+        throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED,
+                              propertyName);
+      }
+      else
+      {
         sessionParametersMap.put(propertyName, propertyValue);
       }
 
       // check if the number of session properties exceed limit
-      if (sessionParametersMap.size() > MAX_SESSION_PARAMETERS) {
-        throw new SFException(ErrorCode.TOO_MANY_SESSION_PARAMETERS, MAX_SESSION_PARAMETERS);
+      if (sessionParametersMap.size() > MAX_SESSION_PARAMETERS)
+      {
+        throw new SFException(ErrorCode.TOO_MANY_SESSION_PARAMETERS,
+                              MAX_SESSION_PARAMETERS);
       }
     }
   }
 
-  public boolean containProperty(String key) {
+  public boolean containProperty(String key)
+  {
     return sessionParametersMap.containsKey(key);
   }
 
-  protected String getServerUrl() {
-    if (connectionPropertiesMap.containsKey(SFSessionProperty.SERVER_URL)) {
+  protected String getServerUrl()
+  {
+    if (connectionPropertiesMap.containsKey(SFSessionProperty.SERVER_URL))
+    {
       return (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL);
     }
     return null;
   }
 
-  public boolean isStringQuoted() {
-    if (connectionPropertiesMap.containsKey(SFSessionProperty.STRINGS_QUOTED)) {
+  public boolean isStringQuoted()
+  {
+    if (connectionPropertiesMap.containsKey(SFSessionProperty.STRINGS_QUOTED))
+    {
       return (Boolean) connectionPropertiesMap.get(SFSessionProperty.STRINGS_QUOTED);
     }
     return false;
   }
 
   /**
-   * If authenticator is null and private key is specified, jdbc will assume key pair authentication
+   * If authenticator is null and private key is specified, jdbc will assume
+   * key pair authentication
    *
    * @return true if authenticator type is SNOWFLAKE (meaning password)
    */
-  private boolean isSnowflakeAuthenticator() {
-    String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
+  private boolean isSnowflakeAuthenticator()
+  {
+    String authenticator = (String) connectionPropertiesMap.get(
+        SFSessionProperty.AUTHENTICATOR);
 
     PrivateKey privateKey = (PrivateKey) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY);
-    return (authenticator == null && privateKey == null && privateKeyFileLocation == null)
-        || ClientAuthnDTO.AuthenticatorType.SNOWFLAKE.name().equalsIgnoreCase(authenticator);
+    return (authenticator == null && privateKey == null && privateKeyFileLocation == null) ||
+           ClientAuthnDTO.AuthenticatorType.SNOWFLAKE.name()
+               .equalsIgnoreCase(authenticator);
   }
 
   /**
@@ -490,9 +556,12 @@ public class SFSession {
    *
    * @return true if authenticator type is EXTERNALBROWSER
    */
-  boolean isExternalbrowserAuthenticator() {
-    String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
-    return ClientAuthnDTO.AuthenticatorType.EXTERNALBROWSER.name().equalsIgnoreCase(authenticator);
+  boolean isExternalbrowserAuthenticator()
+  {
+    String authenticator = (String) connectionPropertiesMap.get(
+        SFSessionProperty.AUTHENTICATOR);
+    return ClientAuthnDTO.AuthenticatorType.EXTERNALBROWSER.name()
+        .equalsIgnoreCase(authenticator);
   }
 
   /**
@@ -500,7 +569,8 @@ public class SFSession {
    *
    * @return true or false
    */
-  boolean isOKTAAuthenticator() {
+  boolean isOKTAAuthenticator()
+  {
     String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
     return !Strings.isNullOrEmpty(authenticator) && authenticator.startsWith("https://");
   }
@@ -508,28 +578,27 @@ public class SFSession {
   /**
    * Open a new database session
    *
-   * @throws SFException this is a runtime exception
+   * @throws SFException           this is a runtime exception
    * @throws SnowflakeSQLException exception raised from Snowflake components
    */
-  public synchronized void open() throws SFException, SnowflakeSQLException {
+  public synchronized void open() throws SFException, SnowflakeSQLException
+  {
     performSanityCheckOnProperties();
 
     HttpUtil.configureCustomProxyProperties(connectionPropertiesMap);
 
     logger.debug(
-        "input: server={}, account={}, user={}, password={}, role={}, "
-            + "database={}, schema={}, warehouse={}, validate_default_parameters={}, authenticator={}, ocsp_mode={}, "
-            + "passcode_in_password={}, passcode={}, private_key={}, "
-            + "use_proxy={}, proxy_host={}, proxy_port={}, proxy_user={}, proxy_password={}, disable_socks_proxy={}, "
-            + "application={}, app_id={}, app_version={}, "
-            + "login_timeout={}, network_timeout={}, query_timeout={}, tracing={}, private_key_file={}, private_key_file_pwd={}. "
-            + "session_parameters: client_store_temporary_credential={}",
+        "input: server={}, account={}, user={}, password={}, role={}, " +
+        "database={}, schema={}, warehouse={}, validate_default_parameters={}, authenticator={}, ocsp_mode={}, " +
+        "passcode_in_password={}, passcode={}, private_key={}, " +
+        "use_proxy={}, proxy_host={}, proxy_port={}, proxy_user={}, proxy_password={}, disable_socks_proxy={}, " +
+        "application={}, app_id={}, app_version={}, " +
+        "login_timeout={}, network_timeout={}, query_timeout={}, tracing={}, private_key_file={}, private_key_file_pwd={}. " +
+        "session_parameters: client_store_temporary_credential={}",
         connectionPropertiesMap.get(SFSessionProperty.SERVER_URL),
         connectionPropertiesMap.get(SFSessionProperty.ACCOUNT),
         connectionPropertiesMap.get(SFSessionProperty.USER),
-        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
-            ? "***"
-            : "(empty)",
+        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD)) ? "***" : "(empty)",
         connectionPropertiesMap.get(SFSessionProperty.ROLE),
         connectionPropertiesMap.get(SFSessionProperty.DATABASE),
         connectionPropertiesMap.get(SFSessionProperty.SCHEMA),
@@ -538,72 +607,81 @@ public class SFSession {
         connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR),
         getOCSPMode().name(),
         connectionPropertiesMap.get(SFSessionProperty.PASSCODE_IN_PASSWORD),
-        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE))
-            ? "***"
-            : "(empty)",
-        connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY) != null
-            ? "(not null)"
-            : "(null)",
+        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE)) ? "***" : "(empty)",
+
+        connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY) != null ? "(not null)" : "(null)",
+
         connectionPropertiesMap.get(SFSessionProperty.USE_PROXY),
         connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST),
         connectionPropertiesMap.get(SFSessionProperty.PROXY_PORT),
         connectionPropertiesMap.get(SFSessionProperty.PROXY_USER),
-        !Strings.isNullOrEmpty(
-                (String) connectionPropertiesMap.get(SFSessionProperty.PROXY_PASSWORD))
-            ? "***"
-            : "(empty)",
+        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PROXY_PASSWORD)) ? "***" :
+        "(empty)",
         connectionPropertiesMap.get(SFSessionProperty.DISABLE_SOCKS_PROXY),
+
         connectionPropertiesMap.get(SFSessionProperty.APPLICATION),
         connectionPropertiesMap.get(SFSessionProperty.APP_ID),
         connectionPropertiesMap.get(SFSessionProperty.APP_VERSION),
+
         connectionPropertiesMap.get(SFSessionProperty.LOGIN_TIMEOUT),
         connectionPropertiesMap.get(SFSessionProperty.NETWORK_TIMEOUT),
         connectionPropertiesMap.get(SFSessionProperty.QUERY_TIMEOUT),
         connectionPropertiesMap.get(SFSessionProperty.TRACING),
         connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE),
-        !Strings.isNullOrEmpty(
-                (String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
-            ? "***"
-            : "(empty)",
-        sessionParametersMap.get(CLIENT_STORE_TEMPORARY_CREDENTIAL));
+        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD)) ? "***" :
+        "(empty)",
+        sessionParametersMap.get(CLIENT_STORE_TEMPORARY_CREDENTIAL)
+    );
     // TODO: temporarily hardcode sessionParameter debug info. will be changed in the future
     SFLoginInput loginInput = new SFLoginInput();
 
-    loginInput
-        .setServerUrl((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
-        .setDatabaseName((String) connectionPropertiesMap.get(SFSessionProperty.DATABASE))
-        .setSchemaName((String) connectionPropertiesMap.get(SFSessionProperty.SCHEMA))
-        .setWarehouse((String) connectionPropertiesMap.get(SFSessionProperty.WAREHOUSE))
+    loginInput.setServerUrl(
+        (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
+        .setDatabaseName(
+            (String) connectionPropertiesMap.get(SFSessionProperty.DATABASE))
+        .setSchemaName(
+            (String) connectionPropertiesMap.get(SFSessionProperty.SCHEMA))
+        .setWarehouse(
+            (String) connectionPropertiesMap.get(SFSessionProperty.WAREHOUSE))
         .setRole((String) connectionPropertiesMap.get(SFSessionProperty.ROLE))
         .setValidateDefaultParameters(
             connectionPropertiesMap.get(SFSessionProperty.VALIDATE_DEFAULT_PARAMETERS))
-        .setAuthenticator((String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR))
-        .setOKTAUserName((String) connectionPropertiesMap.get(SFSessionProperty.OKTA_USERNAME))
-        .setAccountName((String) connectionPropertiesMap.get(SFSessionProperty.ACCOUNT))
+        .setAuthenticator(
+            (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR))
+        .setOKTAUserName(
+            (String) connectionPropertiesMap.get(SFSessionProperty.OKTA_USERNAME))
+        .setAccountName(
+            (String) connectionPropertiesMap.get(SFSessionProperty.ACCOUNT))
         .setLoginTimeout(loginTimeout)
-        .setUserName((String) connectionPropertiesMap.get(SFSessionProperty.USER))
-        .setPassword((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
-        .setToken((String) connectionPropertiesMap.get(SFSessionProperty.TOKEN))
-        .setIdToken((String) connectionPropertiesMap.get(SFSessionProperty.ID_TOKEN))
+        .setUserName(
+            (String) connectionPropertiesMap.get(SFSessionProperty.USER))
+        .setPassword(
+            (String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
+        .setToken(
+            (String) connectionPropertiesMap.get(SFSessionProperty.TOKEN))
+        .setIdToken(
+            (String) connectionPropertiesMap.get(SFSessionProperty.ID_TOKEN))
         .setPasscodeInPassword(passcodeInPassword)
-        .setPasscode((String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE))
+        .setPasscode(
+            (String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE))
         .setConnectionTimeout(httpClientConnectionTimeout)
         .setSocketTimeout(httpClientSocketTimeout)
         .setAppId((String) connectionPropertiesMap.get(SFSessionProperty.APP_ID))
-        .setAppVersion((String) connectionPropertiesMap.get(SFSessionProperty.APP_VERSION))
+        .setAppVersion(
+            (String) connectionPropertiesMap.get(SFSessionProperty.APP_VERSION))
         .setSessionParameters(sessionParametersMap)
         .setPrivateKey((PrivateKey) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY))
         .setPrivateKeyFile((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE))
-        .setPrivateKeyFilePwd(
-            (String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
-        .setApplication((String) connectionPropertiesMap.get(SFSessionProperty.APPLICATION))
+        .setPrivateKeyFilePwd((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
+        .setApplication((String) connectionPropertiesMap.get(
+            SFSessionProperty.APPLICATION))
         .setServiceName(this.getServiceName())
         .setOCSPMode(getOCSPMode());
 
+
     // propagate OCSP mode to SFTrustManager. Note OCSP setting is global on JVM.
     HttpUtil.initHttpClient(loginInput.getOCSPMode(), null);
-    SFLoginOutput loginOutput =
-        SessionUtil.openSession(loginInput, connectionPropertiesMap, tracingLevel.toString());
+    SFLoginOutput loginOutput = SessionUtil.openSession(loginInput, connectionPropertiesMap, tracingLevel.toString());
     isClosed = false;
 
     sessionToken = loginOutput.getSessionToken();
@@ -624,60 +702,70 @@ public class SFSession {
     // Update common parameter values for this session
     SessionUtil.updateSfDriverParamValues(loginOutput.getCommonParams(), this);
 
-    String loginDatabaseName = (String) connectionPropertiesMap.get(SFSessionProperty.DATABASE);
-    String loginSchemaName = (String) connectionPropertiesMap.get(SFSessionProperty.SCHEMA);
-    String loginRole = (String) connectionPropertiesMap.get(SFSessionProperty.ROLE);
-    String loginWarehouse = (String) connectionPropertiesMap.get(SFSessionProperty.WAREHOUSE);
+    String loginDatabaseName = (String) connectionPropertiesMap.get(
+        SFSessionProperty.DATABASE);
+    String loginSchemaName = (String) connectionPropertiesMap.get(
+        SFSessionProperty.SCHEMA);
+    String loginRole = (String) connectionPropertiesMap.get(
+        SFSessionProperty.ROLE);
+    String loginWarehouse = (String) connectionPropertiesMap.get(
+        SFSessionProperty.WAREHOUSE);
 
-    if (loginDatabaseName != null && !loginDatabaseName.equalsIgnoreCase(database)) {
-      sqlWarnings.add(
-          new SFException(
-              ErrorCode.CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
-              "Database",
-              loginDatabaseName,
-              database));
+    if (loginDatabaseName != null && !loginDatabaseName
+        .equalsIgnoreCase(database))
+    {
+      sqlWarnings.add(new SFException(ErrorCode
+                                          .CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
+                                      "Database", loginDatabaseName, database));
     }
 
-    if (loginSchemaName != null && !loginSchemaName.equalsIgnoreCase(schema)) {
-      sqlWarnings.add(
-          new SFException(
-              ErrorCode.CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
-              "Schema",
-              loginSchemaName,
-              schema));
+    if (loginSchemaName != null && !loginSchemaName
+        .equalsIgnoreCase(schema))
+    {
+      sqlWarnings.add(new SFException(ErrorCode.
+                                          CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
+                                      "Schema", loginSchemaName, schema));
     }
 
-    if (loginRole != null && !loginRole.equalsIgnoreCase(role)) {
-      sqlWarnings.add(
-          new SFException(
-              ErrorCode.CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP, "Role", loginRole, role));
+    if (loginRole != null && !loginRole
+        .equalsIgnoreCase(role))
+    {
+      sqlWarnings.add(new SFException(ErrorCode.
+                                          CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
+                                      "Role", loginRole, role));
     }
 
-    if (loginWarehouse != null && !loginWarehouse.equalsIgnoreCase(warehouse)) {
-      sqlWarnings.add(
-          new SFException(
-              ErrorCode.CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
-              "Warehouse",
-              loginWarehouse,
-              warehouse));
+    if (loginWarehouse != null && !loginWarehouse
+        .equalsIgnoreCase(warehouse))
+    {
+      sqlWarnings.add(new SFException(ErrorCode.
+                                          CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
+                                      "Warehouse", loginWarehouse, warehouse));
     }
 
     // start heartbeat for this session so that the master token will not expire
     startHeartbeatForThisSession();
   }
 
-  public OCSPMode getOCSPMode() {
+  public OCSPMode getOCSPMode()
+  {
     OCSPMode ret;
 
-    Boolean insecureMode = (Boolean) connectionPropertiesMap.get(SFSessionProperty.INSECURE_MODE);
-    if (insecureMode != null && insecureMode) {
+    Boolean insecureMode = (Boolean) connectionPropertiesMap.get(
+        SFSessionProperty.INSECURE_MODE);
+    if (insecureMode != null && insecureMode)
+    {
       // skip OCSP checks
       ret = OCSPMode.INSECURE;
-    } else if (!connectionPropertiesMap.containsKey(SFSessionProperty.OCSP_FAIL_OPEN)
-        || (boolean) connectionPropertiesMap.get(SFSessionProperty.OCSP_FAIL_OPEN)) {
+    }
+    else if (!connectionPropertiesMap.containsKey(SFSessionProperty.OCSP_FAIL_OPEN) ||
+             (boolean) connectionPropertiesMap.get(SFSessionProperty.OCSP_FAIL_OPEN))
+    {
       // fail open (by default, not set)
       ret = OCSPMode.FAIL_OPEN;
-    } else {
+    }
+    else
+    {
       // explicitly set ocspFailOpen=false
       ret = OCSPMode.FAIL_CLOSED;
     }
@@ -685,111 +773,133 @@ public class SFSession {
   }
 
   /**
-   * Performs a sanity check on properties. Sanity checking includes: - verifying that a server url
-   * is present - verifying various combinations of properties given the authenticator
+   * Performs a sanity check on properties. Sanity checking includes:
+   * - verifying that a server url is present
+   * - verifying various combinations of properties given the authenticator
    *
-   * @throws SFException Will be thrown if any of the necessary properties are missing
+   * @throws SFException Will be thrown if any of the necessary properties
+   *                     are missing
    */
-  private void performSanityCheckOnProperties() throws SFException {
-    for (SFSessionProperty property : SFSessionProperty.values()) {
-      if (property.isRequired() && !connectionPropertiesMap.containsKey(property)) {
-        switch (property) {
+  private void performSanityCheckOnProperties() throws SFException
+  {
+    for (SFSessionProperty property : SFSessionProperty.values())
+    {
+      if (property.isRequired() &&
+          !connectionPropertiesMap.containsKey(property))
+      {
+        switch (property)
+        {
           case SERVER_URL:
             throw new SFException(ErrorCode.MISSING_SERVER_URL);
 
           default:
-            throw new SFException(ErrorCode.MISSING_CONNECTION_PROPERTY, property.getPropertyKey());
+            throw new SFException(ErrorCode.MISSING_CONNECTION_PROPERTY,
+                                  property.getPropertyKey());
         }
       }
     }
 
-    if (isSnowflakeAuthenticator() || isOKTAAuthenticator()) {
+    if (isSnowflakeAuthenticator() || isOKTAAuthenticator())
+    {
       // userName and password are expected for both Snowflake and Okta.
       String userName = (String) connectionPropertiesMap.get(SFSessionProperty.USER);
-      if (Strings.isNullOrEmpty(userName)) {
+      if (Strings.isNullOrEmpty(userName))
+      {
         throw new SFException(ErrorCode.MISSING_USERNAME);
       }
 
       String password = (String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD);
-      if (Strings.isNullOrEmpty(password)) {
+      if (Strings.isNullOrEmpty(password))
 
+      {
         throw new SFException(ErrorCode.MISSING_PASSWORD);
       }
     }
 
     // perform sanity check on proxy settings
-    boolean useProxy =
-        (boolean) connectionPropertiesMap.getOrDefault(SFSessionProperty.USE_PROXY, false);
-    if (useProxy) {
-      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_HOST)
-          || connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST) == null
-          || ((String) connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST)).isEmpty()
-          || !connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_PORT)
-          || connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST) == null) {
-        throw new SFException(
-            ErrorCode.INVALID_PROXY_PROPERTIES, "Both proxy host and port values are needed.");
+    boolean useProxy = (boolean) connectionPropertiesMap.getOrDefault(
+        SFSessionProperty.USE_PROXY, false);
+    if (useProxy)
+    {
+      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_HOST) ||
+          connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST) == null ||
+          ((String) connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST)).isEmpty() ||
+          !connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_PORT) ||
+          connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST) == null)
+      {
+        throw new SFException(ErrorCode.INVALID_PROXY_PROPERTIES, "Both proxy host and port values are needed.");
       }
     }
   }
 
-  private DriverPropertyInfo addNewDriverProperty(String name, String description) {
+  private DriverPropertyInfo addNewDriverProperty(String name, String description)
+  {
     DriverPropertyInfo info = new DriverPropertyInfo(name, null);
     info.description = description;
     return info;
   }
 
-  public List<DriverPropertyInfo> checkProperties() {
-    for (SFSessionProperty property : SFSessionProperty.values()) {
-      if (property.isRequired() && !connectionPropertiesMap.containsKey(property)) {
+  public List<DriverPropertyInfo> checkProperties()
+  {
+    for (SFSessionProperty property : SFSessionProperty.values())
+    {
+      if (property.isRequired() &&
+          !connectionPropertiesMap.containsKey(property))
+      {
         missingProperties.add(addNewDriverProperty(property.getPropertyKey(), null));
       }
     }
-    if (isSnowflakeAuthenticator() || isOKTAAuthenticator()) {
+    if (isSnowflakeAuthenticator() || isOKTAAuthenticator())
+    {
       // userName and password are expected for both Snowflake and Okta.
       String userName = (String) connectionPropertiesMap.get(SFSessionProperty.USER);
-      if (Strings.isNullOrEmpty(userName)) {
-        missingProperties.add(
-            addNewDriverProperty(SFSessionProperty.USER.getPropertyKey(), "username for account"));
+      if (Strings.isNullOrEmpty(userName))
+      {
+        missingProperties.add(addNewDriverProperty(SFSessionProperty.USER.getPropertyKey(), "username for account"));
       }
 
       String password = (String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD);
-      if (Strings.isNullOrEmpty(password)) {
-        missingProperties.add(
-            addNewDriverProperty(
-                SFSessionProperty.PASSWORD.getPropertyKey(), "password for " + "account"));
+      if (Strings.isNullOrEmpty(password))
+      {
+        missingProperties.add(addNewDriverProperty(SFSessionProperty.PASSWORD.getPropertyKey(), "password for " +
+                                                                                                "account"));
       }
     }
 
-    boolean useProxy =
-        (boolean) connectionPropertiesMap.getOrDefault(SFSessionProperty.USE_PROXY, false);
-    if (useProxy) {
-      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_HOST)) {
-        missingProperties.add(
-            addNewDriverProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "proxy host name"));
+    boolean useProxy = (boolean) connectionPropertiesMap.getOrDefault(
+        SFSessionProperty.USE_PROXY, false);
+    if (useProxy)
+    {
+      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_HOST))
+      {
+        missingProperties.add(addNewDriverProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "proxy host name"));
       }
-      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_PORT)) {
-        missingProperties.add(
-            addNewDriverProperty(
-                SFSessionProperty.PROXY_PORT.getPropertyKey(),
-                "proxy port; " + "should be an integer"));
+      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_PORT))
+      {
+        missingProperties.add(addNewDriverProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "proxy port; " +
+                                                                                                  "should be an integer"));
       }
     }
     return missingProperties;
   }
 
-  public String getDatabaseVersion() {
+  public String getDatabaseVersion()
+  {
     return databaseVersion;
   }
 
-  public int getDatabaseMajorVersion() {
+  public int getDatabaseMajorVersion()
+  {
     return databaseMajorVersion;
   }
 
-  public int getDatabaseMinorVersion() {
+  public int getDatabaseMinorVersion()
+  {
     return databaseMinorVersion;
   }
 
-  public String getSessionId() {
+  public String getSessionId()
+  {
     return sessionId;
   }
 
@@ -798,18 +908,21 @@ public class SFSession {
    *
    * @param prevSessionToken the session token that has expired
    * @throws SnowflakeSQLException if failed to renew the session
-   * @throws SFException if failed to renew the session
+   * @throws SFException           if failed to renew the session
    */
   synchronized void renewSession(String prevSessionToken)
-      throws SFException, SnowflakeSQLException {
-    if (sessionToken != null && !sessionToken.equals(prevSessionToken)) {
+  throws SFException, SnowflakeSQLException
+  {
+    if (sessionToken != null &&
+        !sessionToken.equals(prevSessionToken))
+    {
       logger.debug("not renew session because session token has not been updated.");
       return;
     }
 
     SFLoginInput loginInput = new SFLoginInput();
-    loginInput
-        .setServerUrl((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
+    loginInput.setServerUrl(
+        (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
         .setSessionToken(sessionToken)
         .setMasterToken(masterToken)
         .setIdToken(idToken)
@@ -831,7 +944,8 @@ public class SFSession {
    *
    * @return session token
    */
-  public String getSessionToken() {
+  public String getSessionToken()
+  {
     return sessionToken;
   }
 
@@ -839,21 +953,23 @@ public class SFSession {
    * Close the connection
    *
    * @throws SnowflakeSQLException if failed to close the connection
-   * @throws SFException if failed to close the connection
+   * @throws SFException           if failed to close the connection
    */
-  public void close() throws SFException, SnowflakeSQLException {
+  public void close() throws SFException, SnowflakeSQLException
+  {
     logger.debug(" public void close()");
 
     // stop heartbeat for this session
     stopHeartbeatForThisSession();
 
-    if (isClosed) {
+    if (isClosed)
+    {
       return;
     }
 
     SFLoginInput loginInput = new SFLoginInput();
-    loginInput
-        .setServerUrl((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
+    loginInput.setServerUrl(
+        (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
         .setSessionToken(sessionToken)
         .setLoginTimeout(loginTimeout)
         .setOCSPMode(getOCSPMode());
@@ -864,25 +980,38 @@ public class SFSession {
     isClosed = true;
   }
 
-  /** Start heartbeat for this session */
-  protected void startHeartbeatForThisSession() {
-    if (enableHeartbeat && !Strings.isNullOrEmpty(masterToken)) {
-      logger.debug("start heartbeat, master token validity: " + masterTokenValidityInSeconds);
+  /**
+   * Start heartbeat for this session
+   */
+  protected void startHeartbeatForThisSession()
+  {
+    if (enableHeartbeat && !Strings.isNullOrEmpty(masterToken))
+    {
+      logger.debug("start heartbeat, master token validity: " +
+                   masterTokenValidityInSeconds);
 
-      HeartbeatBackground.getInstance()
-          .addSession(this, masterTokenValidityInSeconds, this.heartbeatFrequency);
-    } else {
+      HeartbeatBackground.getInstance().addSession(this,
+                                                   masterTokenValidityInSeconds, this.heartbeatFrequency);
+    }
+    else
+    {
       logger.debug("heartbeat not enabled for the session");
     }
   }
 
-  /** Stop heartbeat for this session */
-  protected void stopHeartbeatForThisSession() {
-    if (enableHeartbeat && !Strings.isNullOrEmpty(masterToken)) {
+  /**
+   * Stop heartbeat for this session
+   */
+  protected void stopHeartbeatForThisSession()
+  {
+    if (enableHeartbeat && !Strings.isNullOrEmpty(masterToken))
+    {
       logger.debug("stop heartbeat");
 
       HeartbeatBackground.getInstance().removeSession(this);
-    } else {
+    }
+    else
+    {
       logger.debug("heartbeat not enabled for the session");
     }
   }
@@ -890,13 +1019,15 @@ public class SFSession {
   /**
    * Send heartbeat for the session
    *
-   * @throws SFException exception raised from Snowflake
+   * @throws SFException  exception raised from Snowflake
    * @throws SQLException exception raised from SQL generic layers
    */
-  protected void heartbeat() throws SFException, SQLException {
+  protected void heartbeat() throws SFException, SQLException
+  {
     logger.debug(" public void heartbeat()");
 
-    if (isClosed) {
+    if (isClosed)
+    {
       return;
     }
 
@@ -907,12 +1038,14 @@ public class SFSession {
     boolean retry = false;
 
     // the loop for retrying if it runs into session expiration
-    do {
-      try {
+    do
+    {
+      try
+      {
         URIBuilder uriBuilder;
 
-        uriBuilder =
-            new URIBuilder((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL));
+        uriBuilder = new URIBuilder(
+            (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL));
 
         uriBuilder.addParameter(SFSession.SF_QUERY_REQUEST_ID, requestId);
 
@@ -924,20 +1057,19 @@ public class SFSession {
         // the session only when no other thread has renewed it
         String prevSessionToken = sessionToken;
 
-        postRequest.setHeader(
-            SF_HEADER_AUTHORIZATION,
-            SF_HEADER_SNOWFLAKE_AUTHTYPE
-                + " "
-                + SF_HEADER_TOKEN_TAG
-                + "=\""
-                + prevSessionToken
-                + "\"");
+        postRequest.setHeader(SF_HEADER_AUTHORIZATION,
+                              SF_HEADER_SNOWFLAKE_AUTHTYPE + " "
+                              + SF_HEADER_TOKEN_TAG + "=\""
+                              + prevSessionToken + "\"");
 
-        logger.debug("Executing heartbeat request: {}", postRequest.toString());
+        logger.debug("Executing heartbeat request: {}",
+                     postRequest.toString());
 
         // the following will retry transient network issues
-        String theResponse =
-            HttpUtil.executeGeneralRequest(postRequest, SF_HEARTBEAT_TIMEOUT, getOCSPMode());
+        String theResponse = HttpUtil.executeGeneralRequest(
+            postRequest,
+            SF_HEARTBEAT_TIMEOUT,
+            getOCSPMode());
 
         JsonNode rootNode;
 
@@ -946,8 +1078,9 @@ public class SFSession {
         rootNode = mapper.readTree(theResponse);
 
         // check the response to see if it is session expiration response
-        if (rootNode != null
-            && (Constants.SESSION_EXPIRED_GS_CODE == rootNode.path("code").asInt())) {
+        if (rootNode != null &&
+            (Constants.SESSION_EXPIRED_GS_CODE == rootNode.path("code").asInt()))
+        {
           logger.debug("renew session and retry");
           this.renewSession(prevSessionToken);
           retry = true;
@@ -958,26 +1091,30 @@ public class SFSession {
 
         // success
         retry = false;
-      } catch (Throwable ex) {
+      }
+      catch (Throwable ex)
+      {
         // for snowflake exception, just rethrow it
-        if (ex instanceof SnowflakeSQLException) {
+        if (ex instanceof SnowflakeSQLException)
+        {
           throw (SnowflakeSQLException) ex;
         }
 
         logger.error("unexpected exception", ex);
 
-        throw (SFException)
-            IncidentUtil.generateIncidentV2WithException(
-                this,
-                new SFException(
-                    ErrorCode.INTERNAL_ERROR, IncidentUtil.oneLiner("unexpected exception", ex)),
-                null,
-                requestId);
+        throw (SFException) IncidentUtil.generateIncidentV2WithException(
+            this,
+            new SFException(ErrorCode.INTERNAL_ERROR,
+                            IncidentUtil.oneLiner("unexpected exception", ex)),
+            null,
+            requestId);
       }
-    } while (retry);
+    }
+    while (retry);
   }
 
-  public Properties getClientInfo() {
+  public Properties getClientInfo()
+  {
     logger.debug(" public Properties getClientInfo()");
 
     // defensive copy to avoid client from changing the properties
@@ -987,247 +1124,312 @@ public class SFSession {
     return copy;
   }
 
-  public String getClientInfo(String name) {
+  public String getClientInfo(String name)
+  {
     logger.debug(" public String getClientInfo(String name)");
     return this.clientInfo.getProperty(name);
   }
 
-  void setSFSessionProperty(String propertyName, boolean propertyValue) {
+  void setSFSessionProperty(String propertyName, boolean propertyValue)
+  {
     this.sessionProperties.put(propertyName, propertyValue);
   }
 
-  public Object getSFSessionProperty(String propertyName) {
+  public Object getSFSessionProperty(String propertyName)
+  {
     return this.sessionProperties.get(propertyName);
   }
 
-  public void setInjectedDelay(int delay) {
+  public void setInjectedDelay(int delay)
+  {
     this._injectedDelay.set(delay);
   }
 
-  void injectedDelay() {
+  void injectedDelay()
+  {
 
     int d = _injectedDelay.get();
 
-    if (d != 0) {
+    if (d != 0)
+    {
       _injectedDelay.set(0);
-      try {
+      try
+      {
         logger.trace("delayed for {}", d);
 
         Thread.sleep(d);
-      } catch (InterruptedException ex) {
+      }
+      catch (InterruptedException ex)
+      {
       }
     }
   }
 
-  public int getInjectSocketTimeout() {
+  public int getInjectSocketTimeout()
+  {
     return injectSocketTimeout;
   }
 
-  public void setInjectSocketTimeout(int injectSocketTimeout) {
+  public void setInjectSocketTimeout(int injectSocketTimeout)
+  {
     this.injectSocketTimeout = injectSocketTimeout;
   }
 
-  public void setInjectFileUploadFailure(String fileToFail) {
+  public void setInjectFileUploadFailure(String fileToFail)
+  {
     this.injectFileUploadFailure = fileToFail;
   }
 
-  public String getInjectFileUploadFailure() {
+  public String getInjectFileUploadFailure()
+  {
     return this.injectFileUploadFailure;
   }
 
-  public int getNetworkTimeoutInMilli() {
+  public int getNetworkTimeoutInMilli()
+  {
     return networkTimeoutInMilli;
   }
 
-  public boolean isClosed() {
+  public boolean isClosed()
+  {
     return isClosed;
   }
 
-  public int getInjectClientPause() {
+  public int getInjectClientPause()
+  {
     return injectClientPause;
   }
 
-  public void setInjectClientPause(int injectClientPause) {
+  public void setInjectClientPause(int injectClientPause)
+  {
     this.injectClientPause = injectClientPause;
   }
 
-  protected int getHttpClientConnectionTimeout() {
+  protected int getHttpClientConnectionTimeout()
+  {
     return httpClientConnectionTimeout;
   }
 
-  protected int getHttpClientSocketTimeout() {
+  protected int getHttpClientSocketTimeout()
+  {
     return httpClientSocketTimeout;
   }
 
-  protected int getAndIncrementSequenceId() {
+  protected int getAndIncrementSequenceId()
+  {
     return sequenceId.getAndIncrement();
   }
 
-  public void setSfSQLMode(boolean sfSQLMode) {
+  public void setSfSQLMode(boolean sfSQLMode)
+  {
     this.sfSQLMode = sfSQLMode;
   }
 
-  public boolean isSfSQLMode() {
+  public boolean isSfSQLMode()
+  {
     return this.sfSQLMode;
   }
 
-  public boolean isEnableHeartbeat() {
+  public boolean isEnableHeartbeat()
+  {
     return enableHeartbeat;
   }
 
-  public void setEnableHeartbeat(boolean enableHeartbeat) {
+  public void setEnableHeartbeat(boolean enableHeartbeat)
+  {
     this.enableHeartbeat = enableHeartbeat;
   }
 
-  public void setHeartbeatFrequency(int frequency) {
+  public void setHeartbeatFrequency(int frequency)
+  {
     this.heartbeatFrequency = frequency;
   }
 
-  public long getHeartbeatFrequency() {
+  public long getHeartbeatFrequency()
+  {
     return this.heartbeatFrequency;
   }
 
-  public boolean getAutoCommit() {
+  public boolean getAutoCommit()
+  {
     return autoCommit.get();
   }
 
-  public void setAutoCommit(boolean autoCommit) {
+  public void setAutoCommit(boolean autoCommit)
+  {
     this.autoCommit.set(autoCommit);
   }
 
-  public boolean getPreparedStatementLogging() {
+  public boolean getPreparedStatementLogging()
+  {
     return this.preparedStatementLogging;
   }
 
-  public void setPreparedStatementLogging(boolean value) {
+  public void setPreparedStatementLogging(boolean value)
+  {
     this.preparedStatementLogging = value;
   }
 
-  public void setResultColumnCaseInsensitive(boolean resultColumnCaseInsensitive) {
+  public void setResultColumnCaseInsensitive(boolean resultColumnCaseInsensitive)
+  {
     this.resultColumnCaseInsensitive = resultColumnCaseInsensitive;
   }
 
-  public boolean isResultColumnCaseInsensitive() {
+  public boolean isResultColumnCaseInsensitive()
+  {
     return this.resultColumnCaseInsensitive;
   }
 
-  public String getDatabase() {
+  public String getDatabase()
+  {
     return this.database;
   }
 
-  public void setDatabase(String database) {
+  public void setDatabase(String database)
+  {
     this.database = database;
   }
 
-  public String getSchema() {
+  public String getSchema()
+  {
     return this.schema;
   }
 
-  public void setSchema(String schema) {
+  public void setSchema(String schema)
+  {
     this.schema = schema;
   }
 
-  public String getRole() {
+  public String getRole()
+  {
     return role;
   }
 
-  public void setRole(String role) {
+  public void setRole(String role)
+  {
     this.role = role;
   }
 
-  public String getWarehouse() {
+  public String getWarehouse()
+  {
     return warehouse;
   }
 
-  public void setWarehouse(String warehouse) {
+  public void setWarehouse(String warehouse)
+  {
     this.warehouse = warehouse;
   }
 
-  public void setMetadataRequestUseConnectionCtx(boolean enabled) {
+  public void setMetadataRequestUseConnectionCtx(boolean enabled)
+  {
     this.metadataRequestUseConnectionCtx = enabled;
   }
 
-  public void setMetadataRequestUseSessionDatabase(boolean enabled) {
+  public void setMetadataRequestUseSessionDatabase(boolean enabled)
+  {
     this.metadataRequestUseSessionDatabase = enabled;
   }
 
-  public boolean getMetadataRequestUseConnectionCtx() {
+  public boolean getMetadataRequestUseConnectionCtx()
+  {
     return this.metadataRequestUseConnectionCtx;
   }
 
-  public void setTreatNTZAsUTC(boolean enabled) {
+  public void setTreatNTZAsUTC(boolean enabled)
+  {
     this.treatNTZAsUTC = enabled;
   }
 
-  public boolean getTreatNTZAsUTC() {
+  public boolean getTreatNTZAsUTC()
+  {
     return this.treatNTZAsUTC;
   }
 
-  public boolean getMetadataRequestUseSessionDatabase() {
+  public boolean getMetadataRequestUseSessionDatabase()
+  {
     return this.metadataRequestUseSessionDatabase;
   }
 
-  public SnowflakeType getTimestampMappedType() {
+  public SnowflakeType getTimestampMappedType()
+  {
     return timestampMappedType;
   }
 
-  public void setTimestampMappedType(SnowflakeType timestampMappedType) {
+  public void setTimestampMappedType(SnowflakeType timestampMappedType)
+  {
     this.timestampMappedType = timestampMappedType;
   }
 
-  public boolean isJdbcTreatDecimalAsInt() {
+  public boolean isJdbcTreatDecimalAsInt()
+  {
     return jdbcTreatDecimalAsInt;
   }
 
-  public void setJdbcTreatDecimalAsInt(boolean jdbcTreatDecimalAsInt) {
+  public void setJdbcTreatDecimalAsInt(boolean jdbcTreatDecimalAsInt)
+  {
     this.jdbcTreatDecimalAsInt = jdbcTreatDecimalAsInt;
   }
 
-  public void setEnableCombineDescribe(boolean enable) {
+  public void setEnableCombineDescribe(boolean enable)
+  {
     this.enableCombineDescribe = enable;
   }
 
-  public boolean getEnableCombineDescribe() {
+  public boolean getEnableCombineDescribe()
+  {
     return this.enableCombineDescribe;
   }
 
-  public Integer getQueryTimeout() {
+  public Integer getQueryTimeout()
+  {
     return (Integer) this.connectionPropertiesMap.get(SFSessionProperty.QUERY_TIMEOUT);
   }
 
-  public String getUser() {
+  public String getUser()
+  {
     return (String) this.connectionPropertiesMap.get(SFSessionProperty.USER);
   }
 
-  public String getUrl() {
+  public String getUrl()
+  {
     return (String) this.connectionPropertiesMap.get(SFSessionProperty.SERVER_URL);
   }
 
-  public int getInjectWaitInPut() {
+  public int getInjectWaitInPut()
+  {
     Object retVal = this.connectionPropertiesMap.get(SFSessionProperty.INJECT_WAIT_IN_PUT);
-    if (retVal != null) {
-      try {
+    if (retVal != null)
+    {
+      try
+      {
         return (int) retVal;
-      } catch (Exception e) {
+      }
+      catch (Exception e)
+      {
         return 0;
       }
     }
     return 0;
   }
 
-  public List<SFException> getSqlWarnings() {
+  public List<SFException> getSqlWarnings()
+  {
     return sqlWarnings;
   }
 
-  public void clearSqlWarnings() {
+  public void clearSqlWarnings()
+  {
     sqlWarnings.clear();
   }
 
-  public synchronized Telemetry getTelemetryClient() {
+  public synchronized Telemetry getTelemetryClient()
+  {
     // initialize for the first time. this should only be done after session
     // properties have been set, else the client won't properly resolve the URL.
-    if (telemetryClient == null) {
-      if (getUrl() == null) {
+    if (telemetryClient == null)
+    {
+      if (getUrl() == null)
+      {
         logger.error("Telemetry client created before session properties set.");
         return null;
       }
@@ -1236,46 +1438,57 @@ public class SFSession {
     return telemetryClient;
   }
 
-  public void closeTelemetryClient() {
-    if (telemetryClient != null) {
+  public void closeTelemetryClient()
+  {
+    if (telemetryClient != null)
+    {
       telemetryClient.close();
     }
   }
 
-  public boolean isClientTelemetryEnabled() {
+  public boolean isClientTelemetryEnabled()
+  {
     return this.clientTelemetryEnabled;
   }
 
-  public void setClientTelemetryEnabled(boolean clientTelemetryEnabled) {
+  public void setClientTelemetryEnabled(boolean clientTelemetryEnabled)
+  {
     this.clientTelemetryEnabled = clientTelemetryEnabled;
   }
 
-  public int getArrayBindStageThreshold() {
+  public int getArrayBindStageThreshold()
+  {
     return arrayBindStageThreshold;
   }
 
-  public void setArrayBindStageThreshold(int arrayBindStageThreshold) {
+  public void setArrayBindStageThreshold(int arrayBindStageThreshold)
+  {
     this.arrayBindStageThreshold = arrayBindStageThreshold;
   }
 
-  public String getArrayBindStage() {
+  public String getArrayBindStage()
+  {
     return arrayBindStage;
   }
 
-  public void setArrayBindStage(String arrayBindStage) {
-    this.arrayBindStage =
-        String.format("%s.%s.%s", this.getDatabase(), this.getSchema(), arrayBindStage);
+  public void setArrayBindStage(String arrayBindStage)
+  {
+    this.arrayBindStage = String.format("%s.%s.%s",
+                                        this.getDatabase(), this.getSchema(), arrayBindStage);
   }
 
-  public String getIdToken() {
+  public String getIdToken()
+  {
     return idToken;
   }
 
-  public boolean isStoreTemporaryCredential() {
+  public boolean isStoreTemporaryCredential()
+  {
     return this.storeTemporaryCredential;
   }
 
-  public void setStoreTemporaryCredential(boolean storeTemporaryCredential) {
+  public void setStoreTemporaryCredential(boolean storeTemporaryCredential)
+  {
     this.storeTemporaryCredential = storeTemporaryCredential;
   }
 
@@ -1284,7 +1497,8 @@ public class SFSession {
    *
    * @param serviceName service name
    */
-  public void setServiceName(String serviceName) {
+  public void setServiceName(String serviceName)
+  {
     this.serviceName = serviceName;
   }
 
@@ -1293,23 +1507,31 @@ public class SFSession {
    *
    * @return the service name
    */
-  public String getServiceName() {
+  public String getServiceName()
+  {
     return serviceName;
   }
 
   /**
-   * Sets the current objects if the session is not up to date. It can happen if the session is
-   * created by the id token, which doesn't carry the current objects.
+   * Sets the current objects if the session is not up to date. It can happen
+   * if the session is created by the id token, which doesn't carry the current
+   * objects.
    *
-   * @param loginInput The login input to use for this session
+   * @param loginInput  The login input to use for this session
    * @param loginOutput The login output to ose for this session
    */
-  void setCurrentObjects(SFLoginInput loginInput, SFLoginOutput loginOutput) {
+  void setCurrentObjects(
+      SFLoginInput loginInput, SFLoginOutput loginOutput)
+  {
     this.sessionToken = loginOutput.getSessionToken(); // used to run the commands.
-    runInternalCommand("USE ROLE IDENTIFIER(?)", loginInput.getRole());
-    runInternalCommand("USE WAREHOUSE IDENTIFIER(?)", loginInput.getWarehouse());
-    runInternalCommand("USE DATABASE IDENTIFIER(?)", loginInput.getDatabaseName());
-    runInternalCommand("USE SCHEMA IDENTIFIER(?)", loginInput.getSchemaName());
+    runInternalCommand(
+        "USE ROLE IDENTIFIER(?)", loginInput.getRole());
+    runInternalCommand(
+        "USE WAREHOUSE IDENTIFIER(?)", loginInput.getWarehouse());
+    runInternalCommand(
+        "USE DATABASE IDENTIFIER(?)", loginInput.getDatabaseName());
+    runInternalCommand(
+        "USE SCHEMA IDENTIFIER(?)", loginInput.getSchemaName());
     // This ensures the session returns the current objects and refresh
     // the local cache.
     SFBaseResultSet result = runInternalCommand("SELECT ?", "1");
@@ -1322,17 +1544,21 @@ public class SFSession {
     loginOutput.setIdToken(loginInput.getIdToken());
 
     // no common parameter is updated.
-    if (result != null) {
+    if (result != null)
+    {
       loginOutput.setCommonParams(result.parameters);
     }
   }
 
-  private SFBaseResultSet runInternalCommand(String sql, String value) {
-    if (value == null) {
+  private SFBaseResultSet runInternalCommand(String sql, String value)
+  {
+    if (value == null)
+    {
       return null;
     }
 
-    try {
+    try
+    {
       Map<String, ParameterBindingDTO> bindValues = new HashMap<>();
       bindValues.put("1", new ParameterBindingDTO("TEXT", value));
       SFStatement statement = new SFStatement(this);
@@ -1343,68 +1569,85 @@ public class SFSession {
           true, // internal
           false, // asyncExec
           null // caller isn't a JDBC interface method
-          );
-    } catch (SFException | SQLException ex) {
+      );
+    }
+    catch (SFException | SQLException ex)
+    {
       logger.debug("Failed to run a command: {}, err={}", sql, ex);
     }
     return null;
   }
 
-  public boolean isConservativeMemoryUsageEnabled() {
+
+  public boolean isConservativeMemoryUsageEnabled()
+  {
     return enableConservativeMemoryUsage;
   }
 
-  public void setEnableConservativeMemoryUsage(boolean value) {
+  public void setEnableConservativeMemoryUsage(boolean value)
+  {
     enableConservativeMemoryUsage = value;
   }
 
-  public void setConservativeMemoryAdjustStep(int step) {
+  public void setConservativeMemoryAdjustStep(int step)
+  {
     conservativeMemoryAdjustStep = step;
   }
 
-  public int getConservativeMemoryAdjustStep() {
+  public int getConservativeMemoryAdjustStep()
+  {
     return conservativeMemoryAdjustStep;
   }
 
-  public void setClientMemoryLimit(int clientMemoryLimit) {
+  public void setClientMemoryLimit(int clientMemoryLimit)
+  {
     this.clientMemoryLimit = clientMemoryLimit;
   }
 
-  public int getClientMemoryLimit() {
+  public int getClientMemoryLimit()
+  {
     return clientMemoryLimit;
   }
 
-  public void setClientResultChunkSize(int clientResultChunkSize) {
+  public void setClientResultChunkSize(int clientResultChunkSize)
+  {
     this.clientResultChunkSize = clientResultChunkSize;
   }
 
-  public int getClientResultChunkSize() {
+  public int getClientResultChunkSize()
+  {
     return clientResultChunkSize;
   }
 
-  public void setClientPrefetchThreads(int clientPrefetchThreads) {
+  public void setClientPrefetchThreads(int clientPrefetchThreads)
+  {
     this.clientPrefetchThreads = clientPrefetchThreads;
   }
 
-  public int getClientPrefetchThreads() {
+  public int getClientPrefetchThreads()
+  {
     return clientPrefetchThreads;
   }
 
-  public boolean isValidateDefaultParameters() {
+  public boolean isValidateDefaultParameters()
+  {
     return validateDefaultParameters;
   }
 
-  public void setValidateDefaultParameters(boolean v) {
+  public void setValidateDefaultParameters(boolean v)
+  {
     validateDefaultParameters = v;
   }
 
   private SnowflakeConnectString sfConnStr;
 
-  public void setSnowflakeConnectionString(SnowflakeConnectString connStr) {
+  public void setSnowflakeConnectionString(SnowflakeConnectString connStr)
+  {
     sfConnStr = connStr;
   }
 
-  public SnowflakeConnectString getSnowflakeConnectionString() {
+  public SnowflakeConnectString getSnowflakeConnectionString()
+  {
     return sfConnStr;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -4,9 +4,20 @@
 
 package net.snowflake.client.core;
 
+import static net.snowflake.client.core.QueryStatus.getStatusFromString;
+import static net.snowflake.client.core.QueryStatus.isAnError;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import java.security.PrivateKey;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.client.jdbc.telemetry.TelemetryClient;
@@ -20,25 +31,9 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 
-import java.security.PrivateKey;
-import java.sql.DriverPropertyInfo;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-
-import static net.snowflake.client.core.QueryStatus.getStatusFromString;
-import static net.snowflake.client.core.QueryStatus.isAnError;
-
-/**
- * Snowflake session implementation
- */
-public class SFSession
-{
-  private static final ObjectMapper OBJECT_MAPPER =
-      ObjectMapperFactory.getObjectMapper();
+/** Snowflake session implementation */
+public class SFSession {
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
 
   static final SFLogger logger = SFLoggerFactory.getLogger(SFSession.class);
 
@@ -56,7 +51,8 @@ public class SFSession
 
   // temporarily have this variable to avoid hardcode.
   // Need to be removed when a better way to organize session parameter is introduced.
-  private static final String CLIENT_STORE_TEMPORARY_CREDENTIAL = "CLIENT_STORE_TEMPORARY_CREDENTIAL";
+  private static final String CLIENT_STORE_TEMPORARY_CREDENTIAL =
+      "CLIENT_STORE_TEMPORARY_CREDENTIAL";
 
   // increase heartbeat timeout from 60 sec to 300 sec
   // per https://support-snowflake.zendesk.com/agent/tickets/6629
@@ -87,32 +83,28 @@ public class SFSession
   private List<DriverPropertyInfo> missingProperties = new ArrayList<>();
 
   /**
-   * Amount of seconds a user is willing to tolerate for establishing the
-   * connection with database. In our case, it means the first login
-   * request to get authorization token.
-   * <p>
-   * Default:60 seconds
+   * Amount of seconds a user is willing to tolerate for establishing the connection with database.
+   * In our case, it means the first login request to get authorization token.
+   *
+   * <p>Default:60 seconds
    */
   private int loginTimeout = 60;
 
   /**
-   * Amount of milliseconds a user is willing to tolerate for network related
-   * issues (e.g. HTTP 503/504) or database transient issues (e.g. GS
-   * not responding)
-   * <p>
-   * A value of 0 means no timeout
-   * <p>
-   * Default: 0
+   * Amount of milliseconds a user is willing to tolerate for network related issues (e.g. HTTP
+   * 503/504) or database transient issues (e.g. GS not responding)
+   *
+   * <p>A value of 0 means no timeout
+   *
+   * <p>Default: 0
    */
   private int networkTimeoutInMilli = 0; // in milliseconds
 
   private boolean enableCombineDescribe = false;
 
-
   private Map<String, Object> sessionProperties = new HashMap<>(1);
 
-  private final static ObjectMapper mapper =
-      ObjectMapperFactory.getObjectMapper();
+  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
 
   private final Properties clientInfo = new Properties();
 
@@ -120,10 +112,9 @@ public class SFSession
 
   private static int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 300000; // millisec
 
-  private int httpClientSocketTimeout =
-      DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT; // milliseconds
+  private int httpClientSocketTimeout = DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT; // milliseconds
 
-  //--- Simulated failures for testing
+  // --- Simulated failures for testing
 
   // whether we try to simulate a socket timeout (a default value of 0 means
   // no simulation). The value is in milliseconds
@@ -133,7 +124,7 @@ public class SFSession
   // call ( a default value of 0 means no pause). The value is in seconds
   private int injectClientPause = 0;
 
-  //Generate exception while uploading file with a given name
+  // Generate exception while uploading file with a given name
   private String injectFileUploadFailure = null;
 
   private Map<SFSessionProperty, Object> connectionPropertiesMap = new HashMap<>();
@@ -141,7 +132,7 @@ public class SFSession
   // session parameters
   private Map<String, Object> sessionParametersMap = new HashMap<>();
 
-  final private static int MAX_SESSION_PARAMETERS = 1000;
+  private static final int MAX_SESSION_PARAMETERS = 1000;
 
   private boolean passcodeInPassword = false;
 
@@ -183,8 +174,7 @@ public class SFSession
   // instead of a local/session timezone, set to true
   private boolean treatNTZAsUTC = false;
 
-  private SnowflakeType timestampMappedType =
-      SnowflakeType.TIMESTAMP_LTZ;
+  private SnowflakeType timestampMappedType = SnowflakeType.TIMESTAMP_LTZ;
 
   private boolean jdbcTreatDecimalAsInt = true;
 
@@ -196,7 +186,7 @@ public class SFSession
   // client to log session metrics to telemetry in GS
   private Telemetry telemetryClient;
 
-  //default value is false will be updated when login
+  // default value is false will be updated when login
   private boolean clientTelemetryEnabled = false;
 
   // The server can read array binds from a stage instead of query payload.
@@ -226,39 +216,32 @@ public class SFSession
   // validate the default parameters by GS?
   private boolean validateDefaultParameters;
 
-  // list of active asynchronous queries. Used to see if session should be closed when connection closes
+  // list of active asynchronous queries. Used to see if session should be closed when connection
+  // closes
   protected Set<String> activeAsyncQueries = ConcurrentHashMap.newKeySet();
 
   /**
-   * Function that checks if the active session can be closed when the
-   * connection is closed. If there are active asynchronous queries running,
-   * the session should stay open even if the connection closes so that the
-   * queries can finish running.
+   * Function that checks if the active session can be closed when the connection is closed. If
+   * there are active asynchronous queries running, the session should stay open even if the
+   * connection closes so that the queries can finish running.
    *
    * @return true if it is safe to close this session, false if not
    */
-  public boolean isSafeToClose()
-  {
+  public boolean isSafeToClose() {
     boolean canClose = true;
     // if the set of asynchronous queries is empty, return true
-    if (this.activeAsyncQueries.isEmpty())
-    {
+    if (this.activeAsyncQueries.isEmpty()) {
       return canClose;
     }
     // if the set is not empty, iterate through each query and check its status
-    for (String query : this.activeAsyncQueries)
-    {
-      try
-      {
+    for (String query : this.activeAsyncQueries) {
+      try {
         QueryStatus qStatus = getQueryStatus(query);
         //  if any query is still running, it is not safe to close.
-        if (QueryStatus.isStillRunning(qStatus))
-        {
+        if (QueryStatus.isStillRunning(qStatus)) {
           canClose = false;
         }
-      }
-      catch (SQLException e)
-      {
+      } catch (SQLException e) {
         logger.error(e.getMessage());
       }
     }
@@ -270,19 +253,14 @@ public class SFSession
    * @return enum of type QueryStatus indicating the query's status
    * @throws SQLException
    */
-  public QueryStatus getQueryStatus(String queryID)
-  throws SQLException
-  {
+  public QueryStatus getQueryStatus(String queryID) throws SQLException {
     // create the URL to check the query monitoring endpoint
     String statusUrl = "";
     String sessionUrl = getUrl();
-    if (sessionUrl.endsWith("/"))
-    {
+    if (sessionUrl.endsWith("/")) {
       statusUrl =
           sessionUrl.substring(0, sessionUrl.length() - 1) + SF_PATH_QUERY_MONITOR + queryID;
-    }
-    else
-    {
+    } else {
       statusUrl = sessionUrl + SF_PATH_QUERY_MONITOR + queryID;
     }
     // Create a new HTTP GET object and set appropriate headers
@@ -291,32 +269,30 @@ public class SFSession
     get.setHeader("Authorization", "Snowflake Token=\"" + this.sessionToken + "\"");
     String response = null;
     JsonNode jsonNode = null;
-    try
-    {
+    try {
       response = HttpUtil.executeGeneralRequest(get, loginTimeout, getOCSPMode());
       jsonNode = OBJECT_MAPPER.readTree(response);
-    }
-    catch (Exception e)
-    {
-      throw new SnowflakeSQLLoggedException("No response or invalid response from GET request. Error: {}", e.getMessage(), this);
+    } catch (Exception e) {
+      throw new SnowflakeSQLLoggedException(
+          "No response or invalid response from GET request. Error: {}", e.getMessage(), this);
     }
     // Get response as JSON and parse it to get the query status
     // check the success field first
-    if (!jsonNode.path("success").asBoolean())
-    {
+    if (!jsonNode.path("success").asBoolean()) {
       logger.debug("response = {}", response);
 
       int errorCode = jsonNode.path("code").asInt();
       throw new SnowflakeSQLException(
-          queryID, jsonNode.path("message").asText(),
-          SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION, errorCode);
+          queryID,
+          jsonNode.path("message").asText(),
+          SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
+          errorCode);
     }
     JsonNode queryNode = jsonNode.path("data").path("queries");
     String queryStatus = "";
     String errorMessage = "";
     int errorCode = 0;
-    if (queryNode.size() > 0)
-    {
+    if (queryNode.size() > 0) {
       queryStatus = queryNode.get(0).path("status").asText();
       errorMessage = queryNode.get(0).path("errorMessage").asText();
       errorCode = queryNode.get(0).path("errorCode").asInt();
@@ -325,116 +301,87 @@ public class SFSession
     // Turn string with query response into QueryStatus enum and return it
     QueryStatus result = getStatusFromString(queryStatus);
     // if an error code has been provided, set appropriate error code
-    if (errorCode != 0)
-    {
+    if (errorCode != 0) {
       result.setErrorCode(errorCode);
     }
     // if no code was provided but query status indicates an error, set
     // code to be an internal error and set error message
-    else if (isAnError(result))
-    {
+    else if (isAnError(result)) {
       result.setErrorCode(ErrorCode.INTERNAL_ERROR.getMessageCode());
       result.setErrorMessage("no_error_code_from_server");
     }
     // if an error message has been provided, set appropriate error message.
     // This should override the default error message displayed when there is
     // an error with no code.
-    if (!Strings.isNullOrEmpty(errorMessage) && !errorMessage.equalsIgnoreCase("null"))
-    {
+    if (!Strings.isNullOrEmpty(errorMessage) && !errorMessage.equalsIgnoreCase("null")) {
       result.setErrorMessage(errorMessage);
     }
     return result;
   }
 
-
-  public void addProperty(SFSessionProperty sfSessionProperty,
-                          Object propertyValue)
-  throws SFException
-  {
+  public void addProperty(SFSessionProperty sfSessionProperty, Object propertyValue)
+      throws SFException {
     addProperty(sfSessionProperty.getPropertyKey(), propertyValue);
   }
 
   /**
-   * Add a property
-   * If a property is known for connection, add it to connection properties
-   * If not, add it as a dynamic session parameters
-   * <p>
-   * Make sure a property is not added more than once and the number of
-   * properties does not exceed limit.
+   * Add a property If a property is known for connection, add it to connection properties If not,
+   * add it as a dynamic session parameters
    *
-   * @param propertyName  property name
+   * <p>Make sure a property is not added more than once and the number of properties does not
+   * exceed limit.
+   *
+   * @param propertyName property name
    * @param propertyValue property value
    * @throws SFException exception raised from Snowflake components
    */
-  public void addProperty(String propertyName, Object propertyValue)
-  throws SFException
-  {
-    SFSessionProperty connectionProperty =
-        SFSessionProperty.lookupByKey(propertyName);
+  public void addProperty(String propertyName, Object propertyValue) throws SFException {
+    SFSessionProperty connectionProperty = SFSessionProperty.lookupByKey(propertyName);
 
-    if (connectionProperty != null)
-    {
+    if (connectionProperty != null) {
       // check if the value type is as expected
-      propertyValue = SFSessionProperty
-          .checkPropertyValue(connectionProperty, propertyValue);
+      propertyValue = SFSessionProperty.checkPropertyValue(connectionProperty, propertyValue);
 
-      if (connectionPropertiesMap.containsKey(connectionProperty))
-      {
-        throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED,
-                              propertyName);
-      }
-      else if (propertyValue != null && connectionProperty == SFSessionProperty.AUTHENTICATOR)
-      {
+      if (connectionPropertiesMap.containsKey(connectionProperty)) {
+        throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED, propertyName);
+      } else if (propertyValue != null && connectionProperty == SFSessionProperty.AUTHENTICATOR) {
         String[] authenticatorWithParams = propertyValue.toString().split(";");
-        if (authenticatorWithParams.length == 1)
-        {
+        if (authenticatorWithParams.length == 1) {
           connectionPropertiesMap.put(connectionProperty, propertyValue);
-        }
-        else
-        {
+        } else {
           String[] oktaUserKeyPair = authenticatorWithParams[1].split("=");
-          if (oktaUserKeyPair.length == 2)
-          {
+          if (oktaUserKeyPair.length == 2) {
             connectionPropertiesMap.put(connectionProperty, authenticatorWithParams[0]);
             connectionPropertiesMap.put(SFSessionProperty.OKTA_USERNAME, oktaUserKeyPair[1]);
-          }
-          else
-          {
+          } else {
             throw new SFException(ErrorCode.INVALID_OKTA_USERNAME, propertyName);
           }
         }
-      }
-      else
-      {
+      } else {
         connectionPropertiesMap.put(connectionProperty, propertyValue);
       }
 
-      switch (connectionProperty)
-      {
+      switch (connectionProperty) {
         case LOGIN_TIMEOUT:
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             loginTimeout = (Integer) propertyValue;
           }
           break;
 
         case NETWORK_TIMEOUT:
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             networkTimeoutInMilli = (Integer) propertyValue;
           }
           break;
 
         case INJECT_CLIENT_PAUSE:
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             injectClientPause = (Integer) propertyValue;
           }
           break;
 
         case INJECT_SOCKET_TIMEOUT:
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             injectSocketTimeout = (Integer) propertyValue;
           }
           break;
@@ -444,11 +391,9 @@ public class SFSession
           break;
 
         case TRACING:
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             tracingLevel = Level.parse(((String) propertyValue).toUpperCase());
-            if (tracingLevel != null && logger instanceof JDK14Logger)
-            {
+            if (tracingLevel != null && logger instanceof JDK14Logger) {
               JDK14Logger.honorTracingParameter(tracingLevel);
             }
           }
@@ -457,29 +402,25 @@ public class SFSession
         case DISABLE_SOCKS_PROXY:
           // note: if any session has this parameter, it will be used for all
           // sessions on the current JVM.
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             HttpUtil.setSocksProxyDisabled((Boolean) propertyValue);
           }
           break;
 
         case VALIDATE_DEFAULT_PARAMETERS:
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             validateDefaultParameters = SFLoginInput.getBooleanValue(propertyValue);
           }
           break;
 
         case PRIVATE_KEY_FILE:
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             privateKeyFileLocation = (String) propertyValue;
           }
           break;
 
         case PRIVATE_KEY_FILE_PWD:
-          if (propertyValue != null)
-          {
+          if (propertyValue != null) {
             privateKeyPassword = (String) propertyValue;
           }
           break;
@@ -487,68 +428,51 @@ public class SFSession
         default:
           break;
       }
-    }
-    else
-    {
+    } else {
       // this property does not match any predefined property, treat it as
       // session parameter
-      if (sessionParametersMap.containsKey(propertyName))
-      {
-        throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED,
-                              propertyName);
-      }
-      else
-      {
+      if (sessionParametersMap.containsKey(propertyName)) {
+        throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED, propertyName);
+      } else {
         sessionParametersMap.put(propertyName, propertyValue);
       }
 
       // check if the number of session properties exceed limit
-      if (sessionParametersMap.size() > MAX_SESSION_PARAMETERS)
-      {
-        throw new SFException(ErrorCode.TOO_MANY_SESSION_PARAMETERS,
-                              MAX_SESSION_PARAMETERS);
+      if (sessionParametersMap.size() > MAX_SESSION_PARAMETERS) {
+        throw new SFException(ErrorCode.TOO_MANY_SESSION_PARAMETERS, MAX_SESSION_PARAMETERS);
       }
     }
   }
 
-  public boolean containProperty(String key)
-  {
+  public boolean containProperty(String key) {
     return sessionParametersMap.containsKey(key);
   }
 
-  protected String getServerUrl()
-  {
-    if (connectionPropertiesMap.containsKey(SFSessionProperty.SERVER_URL))
-    {
+  protected String getServerUrl() {
+    if (connectionPropertiesMap.containsKey(SFSessionProperty.SERVER_URL)) {
       return (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL);
     }
     return null;
   }
 
-  public boolean isStringQuoted()
-  {
-    if (connectionPropertiesMap.containsKey(SFSessionProperty.STRINGS_QUOTED))
-    {
+  public boolean isStringQuoted() {
+    if (connectionPropertiesMap.containsKey(SFSessionProperty.STRINGS_QUOTED)) {
       return (Boolean) connectionPropertiesMap.get(SFSessionProperty.STRINGS_QUOTED);
     }
     return false;
   }
 
   /**
-   * If authenticator is null and private key is specified, jdbc will assume
-   * key pair authentication
+   * If authenticator is null and private key is specified, jdbc will assume key pair authentication
    *
    * @return true if authenticator type is SNOWFLAKE (meaning password)
    */
-  private boolean isSnowflakeAuthenticator()
-  {
-    String authenticator = (String) connectionPropertiesMap.get(
-        SFSessionProperty.AUTHENTICATOR);
+  private boolean isSnowflakeAuthenticator() {
+    String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
 
     PrivateKey privateKey = (PrivateKey) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY);
-    return (authenticator == null && privateKey == null && privateKeyFileLocation == null) ||
-           ClientAuthnDTO.AuthenticatorType.SNOWFLAKE.name()
-               .equalsIgnoreCase(authenticator);
+    return (authenticator == null && privateKey == null && privateKeyFileLocation == null)
+        || ClientAuthnDTO.AuthenticatorType.SNOWFLAKE.name().equalsIgnoreCase(authenticator);
   }
 
   /**
@@ -556,12 +480,9 @@ public class SFSession
    *
    * @return true if authenticator type is EXTERNALBROWSER
    */
-  boolean isExternalbrowserAuthenticator()
-  {
-    String authenticator = (String) connectionPropertiesMap.get(
-        SFSessionProperty.AUTHENTICATOR);
-    return ClientAuthnDTO.AuthenticatorType.EXTERNALBROWSER.name()
-        .equalsIgnoreCase(authenticator);
+  boolean isExternalbrowserAuthenticator() {
+    String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
+    return ClientAuthnDTO.AuthenticatorType.EXTERNALBROWSER.name().equalsIgnoreCase(authenticator);
   }
 
   /**
@@ -569,8 +490,7 @@ public class SFSession
    *
    * @return true or false
    */
-  boolean isOKTAAuthenticator()
-  {
+  boolean isOKTAAuthenticator() {
     String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
     return !Strings.isNullOrEmpty(authenticator) && authenticator.startsWith("https://");
   }
@@ -578,27 +498,28 @@ public class SFSession
   /**
    * Open a new database session
    *
-   * @throws SFException           this is a runtime exception
+   * @throws SFException this is a runtime exception
    * @throws SnowflakeSQLException exception raised from Snowflake components
    */
-  public synchronized void open() throws SFException, SnowflakeSQLException
-  {
+  public synchronized void open() throws SFException, SnowflakeSQLException {
     performSanityCheckOnProperties();
 
     HttpUtil.configureCustomProxyProperties(connectionPropertiesMap);
 
     logger.debug(
-        "input: server={}, account={}, user={}, password={}, role={}, " +
-        "database={}, schema={}, warehouse={}, validate_default_parameters={}, authenticator={}, ocsp_mode={}, " +
-        "passcode_in_password={}, passcode={}, private_key={}, " +
-        "use_proxy={}, proxy_host={}, proxy_port={}, proxy_user={}, proxy_password={}, disable_socks_proxy={}, " +
-        "application={}, app_id={}, app_version={}, " +
-        "login_timeout={}, network_timeout={}, query_timeout={}, tracing={}, private_key_file={}, private_key_file_pwd={}. " +
-        "session_parameters: client_store_temporary_credential={}",
+        "input: server={}, account={}, user={}, password={}, role={}, "
+            + "database={}, schema={}, warehouse={}, validate_default_parameters={}, authenticator={}, ocsp_mode={}, "
+            + "passcode_in_password={}, passcode={}, private_key={}, "
+            + "use_proxy={}, proxy_host={}, proxy_port={}, proxy_user={}, proxy_password={}, disable_socks_proxy={}, "
+            + "application={}, app_id={}, app_version={}, "
+            + "login_timeout={}, network_timeout={}, query_timeout={}, tracing={}, private_key_file={}, private_key_file_pwd={}. "
+            + "session_parameters: client_store_temporary_credential={}",
         connectionPropertiesMap.get(SFSessionProperty.SERVER_URL),
         connectionPropertiesMap.get(SFSessionProperty.ACCOUNT),
         connectionPropertiesMap.get(SFSessionProperty.USER),
-        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD)) ? "***" : "(empty)",
+        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
+            ? "***"
+            : "(empty)",
         connectionPropertiesMap.get(SFSessionProperty.ROLE),
         connectionPropertiesMap.get(SFSessionProperty.DATABASE),
         connectionPropertiesMap.get(SFSessionProperty.SCHEMA),
@@ -607,81 +528,72 @@ public class SFSession
         connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR),
         getOCSPMode().name(),
         connectionPropertiesMap.get(SFSessionProperty.PASSCODE_IN_PASSWORD),
-        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE)) ? "***" : "(empty)",
-
-        connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY) != null ? "(not null)" : "(null)",
-
+        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE))
+            ? "***"
+            : "(empty)",
+        connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY) != null
+            ? "(not null)"
+            : "(null)",
         connectionPropertiesMap.get(SFSessionProperty.USE_PROXY),
         connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST),
         connectionPropertiesMap.get(SFSessionProperty.PROXY_PORT),
         connectionPropertiesMap.get(SFSessionProperty.PROXY_USER),
-        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PROXY_PASSWORD)) ? "***" :
-        "(empty)",
+        !Strings.isNullOrEmpty(
+                (String) connectionPropertiesMap.get(SFSessionProperty.PROXY_PASSWORD))
+            ? "***"
+            : "(empty)",
         connectionPropertiesMap.get(SFSessionProperty.DISABLE_SOCKS_PROXY),
-
         connectionPropertiesMap.get(SFSessionProperty.APPLICATION),
         connectionPropertiesMap.get(SFSessionProperty.APP_ID),
         connectionPropertiesMap.get(SFSessionProperty.APP_VERSION),
-
         connectionPropertiesMap.get(SFSessionProperty.LOGIN_TIMEOUT),
         connectionPropertiesMap.get(SFSessionProperty.NETWORK_TIMEOUT),
         connectionPropertiesMap.get(SFSessionProperty.QUERY_TIMEOUT),
         connectionPropertiesMap.get(SFSessionProperty.TRACING),
         connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE),
-        !Strings.isNullOrEmpty((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD)) ? "***" :
-        "(empty)",
-        sessionParametersMap.get(CLIENT_STORE_TEMPORARY_CREDENTIAL)
-    );
+        !Strings.isNullOrEmpty(
+                (String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
+            ? "***"
+            : "(empty)",
+        sessionParametersMap.get(CLIENT_STORE_TEMPORARY_CREDENTIAL));
     // TODO: temporarily hardcode sessionParameter debug info. will be changed in the future
     SFLoginInput loginInput = new SFLoginInput();
 
-    loginInput.setServerUrl(
-        (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
-        .setDatabaseName(
-            (String) connectionPropertiesMap.get(SFSessionProperty.DATABASE))
-        .setSchemaName(
-            (String) connectionPropertiesMap.get(SFSessionProperty.SCHEMA))
-        .setWarehouse(
-            (String) connectionPropertiesMap.get(SFSessionProperty.WAREHOUSE))
+    loginInput
+        .setServerUrl((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
+        .setDatabaseName((String) connectionPropertiesMap.get(SFSessionProperty.DATABASE))
+        .setSchemaName((String) connectionPropertiesMap.get(SFSessionProperty.SCHEMA))
+        .setWarehouse((String) connectionPropertiesMap.get(SFSessionProperty.WAREHOUSE))
         .setRole((String) connectionPropertiesMap.get(SFSessionProperty.ROLE))
         .setValidateDefaultParameters(
             connectionPropertiesMap.get(SFSessionProperty.VALIDATE_DEFAULT_PARAMETERS))
-        .setAuthenticator(
-            (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR))
-        .setOKTAUserName(
-            (String) connectionPropertiesMap.get(SFSessionProperty.OKTA_USERNAME))
-        .setAccountName(
-            (String) connectionPropertiesMap.get(SFSessionProperty.ACCOUNT))
+        .setAuthenticator((String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR))
+        .setOKTAUserName((String) connectionPropertiesMap.get(SFSessionProperty.OKTA_USERNAME))
+        .setAccountName((String) connectionPropertiesMap.get(SFSessionProperty.ACCOUNT))
         .setLoginTimeout(loginTimeout)
-        .setUserName(
-            (String) connectionPropertiesMap.get(SFSessionProperty.USER))
-        .setPassword(
-            (String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
-        .setToken(
-            (String) connectionPropertiesMap.get(SFSessionProperty.TOKEN))
-        .setIdToken(
-            (String) connectionPropertiesMap.get(SFSessionProperty.ID_TOKEN))
+        .setUserName((String) connectionPropertiesMap.get(SFSessionProperty.USER))
+        .setPassword((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
+        .setToken((String) connectionPropertiesMap.get(SFSessionProperty.TOKEN))
+        .setIdToken((String) connectionPropertiesMap.get(SFSessionProperty.ID_TOKEN))
         .setPasscodeInPassword(passcodeInPassword)
-        .setPasscode(
-            (String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE))
+        .setPasscode((String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE))
         .setConnectionTimeout(httpClientConnectionTimeout)
         .setSocketTimeout(httpClientSocketTimeout)
         .setAppId((String) connectionPropertiesMap.get(SFSessionProperty.APP_ID))
-        .setAppVersion(
-            (String) connectionPropertiesMap.get(SFSessionProperty.APP_VERSION))
+        .setAppVersion((String) connectionPropertiesMap.get(SFSessionProperty.APP_VERSION))
         .setSessionParameters(sessionParametersMap)
         .setPrivateKey((PrivateKey) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY))
         .setPrivateKeyFile((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE))
-        .setPrivateKeyFilePwd((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
-        .setApplication((String) connectionPropertiesMap.get(
-            SFSessionProperty.APPLICATION))
+        .setPrivateKeyFilePwd(
+            (String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
+        .setApplication((String) connectionPropertiesMap.get(SFSessionProperty.APPLICATION))
         .setServiceName(this.getServiceName())
         .setOCSPMode(getOCSPMode());
 
-
     // propagate OCSP mode to SFTrustManager. Note OCSP setting is global on JVM.
     HttpUtil.initHttpClient(loginInput.getOCSPMode(), null);
-    SFLoginOutput loginOutput = SessionUtil.openSession(loginInput, connectionPropertiesMap, tracingLevel.toString());
+    SFLoginOutput loginOutput =
+        SessionUtil.openSession(loginInput, connectionPropertiesMap, tracingLevel.toString());
     isClosed = false;
 
     sessionToken = loginOutput.getSessionToken();
@@ -702,70 +614,60 @@ public class SFSession
     // Update common parameter values for this session
     SessionUtil.updateSfDriverParamValues(loginOutput.getCommonParams(), this);
 
-    String loginDatabaseName = (String) connectionPropertiesMap.get(
-        SFSessionProperty.DATABASE);
-    String loginSchemaName = (String) connectionPropertiesMap.get(
-        SFSessionProperty.SCHEMA);
-    String loginRole = (String) connectionPropertiesMap.get(
-        SFSessionProperty.ROLE);
-    String loginWarehouse = (String) connectionPropertiesMap.get(
-        SFSessionProperty.WAREHOUSE);
+    String loginDatabaseName = (String) connectionPropertiesMap.get(SFSessionProperty.DATABASE);
+    String loginSchemaName = (String) connectionPropertiesMap.get(SFSessionProperty.SCHEMA);
+    String loginRole = (String) connectionPropertiesMap.get(SFSessionProperty.ROLE);
+    String loginWarehouse = (String) connectionPropertiesMap.get(SFSessionProperty.WAREHOUSE);
 
-    if (loginDatabaseName != null && !loginDatabaseName
-        .equalsIgnoreCase(database))
-    {
-      sqlWarnings.add(new SFException(ErrorCode
-                                          .CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
-                                      "Database", loginDatabaseName, database));
+    if (loginDatabaseName != null && !loginDatabaseName.equalsIgnoreCase(database)) {
+      sqlWarnings.add(
+          new SFException(
+              ErrorCode.CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
+              "Database",
+              loginDatabaseName,
+              database));
     }
 
-    if (loginSchemaName != null && !loginSchemaName
-        .equalsIgnoreCase(schema))
-    {
-      sqlWarnings.add(new SFException(ErrorCode.
-                                          CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
-                                      "Schema", loginSchemaName, schema));
+    if (loginSchemaName != null && !loginSchemaName.equalsIgnoreCase(schema)) {
+      sqlWarnings.add(
+          new SFException(
+              ErrorCode.CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
+              "Schema",
+              loginSchemaName,
+              schema));
     }
 
-    if (loginRole != null && !loginRole
-        .equalsIgnoreCase(role))
-    {
-      sqlWarnings.add(new SFException(ErrorCode.
-                                          CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
-                                      "Role", loginRole, role));
+    if (loginRole != null && !loginRole.equalsIgnoreCase(role)) {
+      sqlWarnings.add(
+          new SFException(
+              ErrorCode.CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP, "Role", loginRole, role));
     }
 
-    if (loginWarehouse != null && !loginWarehouse
-        .equalsIgnoreCase(warehouse))
-    {
-      sqlWarnings.add(new SFException(ErrorCode.
-                                          CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
-                                      "Warehouse", loginWarehouse, warehouse));
+    if (loginWarehouse != null && !loginWarehouse.equalsIgnoreCase(warehouse)) {
+      sqlWarnings.add(
+          new SFException(
+              ErrorCode.CONNECTION_ESTABLISHED_WITH_DIFFERENT_PROP,
+              "Warehouse",
+              loginWarehouse,
+              warehouse));
     }
 
     // start heartbeat for this session so that the master token will not expire
     startHeartbeatForThisSession();
   }
 
-  public OCSPMode getOCSPMode()
-  {
+  public OCSPMode getOCSPMode() {
     OCSPMode ret;
 
-    Boolean insecureMode = (Boolean) connectionPropertiesMap.get(
-        SFSessionProperty.INSECURE_MODE);
-    if (insecureMode != null && insecureMode)
-    {
+    Boolean insecureMode = (Boolean) connectionPropertiesMap.get(SFSessionProperty.INSECURE_MODE);
+    if (insecureMode != null && insecureMode) {
       // skip OCSP checks
       ret = OCSPMode.INSECURE;
-    }
-    else if (!connectionPropertiesMap.containsKey(SFSessionProperty.OCSP_FAIL_OPEN) ||
-             (boolean) connectionPropertiesMap.get(SFSessionProperty.OCSP_FAIL_OPEN))
-    {
+    } else if (!connectionPropertiesMap.containsKey(SFSessionProperty.OCSP_FAIL_OPEN)
+        || (boolean) connectionPropertiesMap.get(SFSessionProperty.OCSP_FAIL_OPEN)) {
       // fail open (by default, not set)
       ret = OCSPMode.FAIL_OPEN;
-    }
-    else
-    {
+    } else {
       // explicitly set ocspFailOpen=false
       ret = OCSPMode.FAIL_CLOSED;
     }
@@ -773,133 +675,111 @@ public class SFSession
   }
 
   /**
-   * Performs a sanity check on properties. Sanity checking includes:
-   * - verifying that a server url is present
-   * - verifying various combinations of properties given the authenticator
+   * Performs a sanity check on properties. Sanity checking includes: - verifying that a server url
+   * is present - verifying various combinations of properties given the authenticator
    *
-   * @throws SFException Will be thrown if any of the necessary properties
-   *                     are missing
+   * @throws SFException Will be thrown if any of the necessary properties are missing
    */
-  private void performSanityCheckOnProperties() throws SFException
-  {
-    for (SFSessionProperty property : SFSessionProperty.values())
-    {
-      if (property.isRequired() &&
-          !connectionPropertiesMap.containsKey(property))
-      {
-        switch (property)
-        {
+  private void performSanityCheckOnProperties() throws SFException {
+    for (SFSessionProperty property : SFSessionProperty.values()) {
+      if (property.isRequired() && !connectionPropertiesMap.containsKey(property)) {
+        switch (property) {
           case SERVER_URL:
             throw new SFException(ErrorCode.MISSING_SERVER_URL);
 
           default:
-            throw new SFException(ErrorCode.MISSING_CONNECTION_PROPERTY,
-                                  property.getPropertyKey());
+            throw new SFException(ErrorCode.MISSING_CONNECTION_PROPERTY, property.getPropertyKey());
         }
       }
     }
 
-    if (isSnowflakeAuthenticator() || isOKTAAuthenticator())
-    {
+    if (isSnowflakeAuthenticator() || isOKTAAuthenticator()) {
       // userName and password are expected for both Snowflake and Okta.
       String userName = (String) connectionPropertiesMap.get(SFSessionProperty.USER);
-      if (Strings.isNullOrEmpty(userName))
-      {
+      if (Strings.isNullOrEmpty(userName)) {
         throw new SFException(ErrorCode.MISSING_USERNAME);
       }
 
       String password = (String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD);
-      if (Strings.isNullOrEmpty(password))
+      if (Strings.isNullOrEmpty(password)) {
 
-      {
         throw new SFException(ErrorCode.MISSING_PASSWORD);
       }
     }
 
     // perform sanity check on proxy settings
-    boolean useProxy = (boolean) connectionPropertiesMap.getOrDefault(
-        SFSessionProperty.USE_PROXY, false);
-    if (useProxy)
-    {
-      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_HOST) ||
-          connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST) == null ||
-          ((String) connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST)).isEmpty() ||
-          !connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_PORT) ||
-          connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST) == null)
-      {
-        throw new SFException(ErrorCode.INVALID_PROXY_PROPERTIES, "Both proxy host and port values are needed.");
+    boolean useProxy =
+        (boolean) connectionPropertiesMap.getOrDefault(SFSessionProperty.USE_PROXY, false);
+    if (useProxy) {
+      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_HOST)
+          || connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST) == null
+          || ((String) connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST)).isEmpty()
+          || !connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_PORT)
+          || connectionPropertiesMap.get(SFSessionProperty.PROXY_HOST) == null) {
+        throw new SFException(
+            ErrorCode.INVALID_PROXY_PROPERTIES, "Both proxy host and port values are needed.");
       }
     }
   }
 
-  private DriverPropertyInfo addNewDriverProperty(String name, String description)
-  {
+  private DriverPropertyInfo addNewDriverProperty(String name, String description) {
     DriverPropertyInfo info = new DriverPropertyInfo(name, null);
     info.description = description;
     return info;
   }
 
-  public List<DriverPropertyInfo> checkProperties()
-  {
-    for (SFSessionProperty property : SFSessionProperty.values())
-    {
-      if (property.isRequired() &&
-          !connectionPropertiesMap.containsKey(property))
-      {
+  public List<DriverPropertyInfo> checkProperties() {
+    for (SFSessionProperty property : SFSessionProperty.values()) {
+      if (property.isRequired() && !connectionPropertiesMap.containsKey(property)) {
         missingProperties.add(addNewDriverProperty(property.getPropertyKey(), null));
       }
     }
-    if (isSnowflakeAuthenticator() || isOKTAAuthenticator())
-    {
+    if (isSnowflakeAuthenticator() || isOKTAAuthenticator()) {
       // userName and password are expected for both Snowflake and Okta.
       String userName = (String) connectionPropertiesMap.get(SFSessionProperty.USER);
-      if (Strings.isNullOrEmpty(userName))
-      {
-        missingProperties.add(addNewDriverProperty(SFSessionProperty.USER.getPropertyKey(), "username for account"));
+      if (Strings.isNullOrEmpty(userName)) {
+        missingProperties.add(
+            addNewDriverProperty(SFSessionProperty.USER.getPropertyKey(), "username for account"));
       }
 
       String password = (String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD);
-      if (Strings.isNullOrEmpty(password))
-      {
-        missingProperties.add(addNewDriverProperty(SFSessionProperty.PASSWORD.getPropertyKey(), "password for " +
-                                                                                                "account"));
+      if (Strings.isNullOrEmpty(password)) {
+        missingProperties.add(
+            addNewDriverProperty(
+                SFSessionProperty.PASSWORD.getPropertyKey(), "password for " + "account"));
       }
     }
 
-    boolean useProxy = (boolean) connectionPropertiesMap.getOrDefault(
-        SFSessionProperty.USE_PROXY, false);
-    if (useProxy)
-    {
-      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_HOST))
-      {
-        missingProperties.add(addNewDriverProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "proxy host name"));
+    boolean useProxy =
+        (boolean) connectionPropertiesMap.getOrDefault(SFSessionProperty.USE_PROXY, false);
+    if (useProxy) {
+      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_HOST)) {
+        missingProperties.add(
+            addNewDriverProperty(SFSessionProperty.PROXY_HOST.getPropertyKey(), "proxy host name"));
       }
-      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_PORT))
-      {
-        missingProperties.add(addNewDriverProperty(SFSessionProperty.PROXY_PORT.getPropertyKey(), "proxy port; " +
-                                                                                                  "should be an integer"));
+      if (!connectionPropertiesMap.containsKey(SFSessionProperty.PROXY_PORT)) {
+        missingProperties.add(
+            addNewDriverProperty(
+                SFSessionProperty.PROXY_PORT.getPropertyKey(),
+                "proxy port; " + "should be an integer"));
       }
     }
     return missingProperties;
   }
 
-  public String getDatabaseVersion()
-  {
+  public String getDatabaseVersion() {
     return databaseVersion;
   }
 
-  public int getDatabaseMajorVersion()
-  {
+  public int getDatabaseMajorVersion() {
     return databaseMajorVersion;
   }
 
-  public int getDatabaseMinorVersion()
-  {
+  public int getDatabaseMinorVersion() {
     return databaseMinorVersion;
   }
 
-  public String getSessionId()
-  {
+  public String getSessionId() {
     return sessionId;
   }
 
@@ -908,21 +788,18 @@ public class SFSession
    *
    * @param prevSessionToken the session token that has expired
    * @throws SnowflakeSQLException if failed to renew the session
-   * @throws SFException           if failed to renew the session
+   * @throws SFException if failed to renew the session
    */
   synchronized void renewSession(String prevSessionToken)
-  throws SFException, SnowflakeSQLException
-  {
-    if (sessionToken != null &&
-        !sessionToken.equals(prevSessionToken))
-    {
+      throws SFException, SnowflakeSQLException {
+    if (sessionToken != null && !sessionToken.equals(prevSessionToken)) {
       logger.debug("not renew session because session token has not been updated.");
       return;
     }
 
     SFLoginInput loginInput = new SFLoginInput();
-    loginInput.setServerUrl(
-        (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
+    loginInput
+        .setServerUrl((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
         .setSessionToken(sessionToken)
         .setMasterToken(masterToken)
         .setIdToken(idToken)
@@ -944,8 +821,7 @@ public class SFSession
    *
    * @return session token
    */
-  public String getSessionToken()
-  {
+  public String getSessionToken() {
     return sessionToken;
   }
 
@@ -953,23 +829,21 @@ public class SFSession
    * Close the connection
    *
    * @throws SnowflakeSQLException if failed to close the connection
-   * @throws SFException           if failed to close the connection
+   * @throws SFException if failed to close the connection
    */
-  public void close() throws SFException, SnowflakeSQLException
-  {
+  public void close() throws SFException, SnowflakeSQLException {
     logger.debug(" public void close()");
 
     // stop heartbeat for this session
     stopHeartbeatForThisSession();
 
-    if (isClosed)
-    {
+    if (isClosed) {
       return;
     }
 
     SFLoginInput loginInput = new SFLoginInput();
-    loginInput.setServerUrl(
-        (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
+    loginInput
+        .setServerUrl((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))
         .setSessionToken(sessionToken)
         .setLoginTimeout(loginTimeout)
         .setOCSPMode(getOCSPMode());
@@ -980,38 +854,25 @@ public class SFSession
     isClosed = true;
   }
 
-  /**
-   * Start heartbeat for this session
-   */
-  protected void startHeartbeatForThisSession()
-  {
-    if (enableHeartbeat && !Strings.isNullOrEmpty(masterToken))
-    {
-      logger.debug("start heartbeat, master token validity: " +
-                   masterTokenValidityInSeconds);
+  /** Start heartbeat for this session */
+  protected void startHeartbeatForThisSession() {
+    if (enableHeartbeat && !Strings.isNullOrEmpty(masterToken)) {
+      logger.debug("start heartbeat, master token validity: " + masterTokenValidityInSeconds);
 
-      HeartbeatBackground.getInstance().addSession(this,
-                                                   masterTokenValidityInSeconds, this.heartbeatFrequency);
-    }
-    else
-    {
+      HeartbeatBackground.getInstance()
+          .addSession(this, masterTokenValidityInSeconds, this.heartbeatFrequency);
+    } else {
       logger.debug("heartbeat not enabled for the session");
     }
   }
 
-  /**
-   * Stop heartbeat for this session
-   */
-  protected void stopHeartbeatForThisSession()
-  {
-    if (enableHeartbeat && !Strings.isNullOrEmpty(masterToken))
-    {
+  /** Stop heartbeat for this session */
+  protected void stopHeartbeatForThisSession() {
+    if (enableHeartbeat && !Strings.isNullOrEmpty(masterToken)) {
       logger.debug("stop heartbeat");
 
       HeartbeatBackground.getInstance().removeSession(this);
-    }
-    else
-    {
+    } else {
       logger.debug("heartbeat not enabled for the session");
     }
   }
@@ -1019,15 +880,13 @@ public class SFSession
   /**
    * Send heartbeat for the session
    *
-   * @throws SFException  exception raised from Snowflake
+   * @throws SFException exception raised from Snowflake
    * @throws SQLException exception raised from SQL generic layers
    */
-  protected void heartbeat() throws SFException, SQLException
-  {
+  protected void heartbeat() throws SFException, SQLException {
     logger.debug(" public void heartbeat()");
 
-    if (isClosed)
-    {
+    if (isClosed) {
       return;
     }
 
@@ -1038,14 +897,12 @@ public class SFSession
     boolean retry = false;
 
     // the loop for retrying if it runs into session expiration
-    do
-    {
-      try
-      {
+    do {
+      try {
         URIBuilder uriBuilder;
 
-        uriBuilder = new URIBuilder(
-            (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL));
+        uriBuilder =
+            new URIBuilder((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL));
 
         uriBuilder.addParameter(SFSession.SF_QUERY_REQUEST_ID, requestId);
 
@@ -1057,19 +914,20 @@ public class SFSession
         // the session only when no other thread has renewed it
         String prevSessionToken = sessionToken;
 
-        postRequest.setHeader(SF_HEADER_AUTHORIZATION,
-                              SF_HEADER_SNOWFLAKE_AUTHTYPE + " "
-                              + SF_HEADER_TOKEN_TAG + "=\""
-                              + prevSessionToken + "\"");
+        postRequest.setHeader(
+            SF_HEADER_AUTHORIZATION,
+            SF_HEADER_SNOWFLAKE_AUTHTYPE
+                + " "
+                + SF_HEADER_TOKEN_TAG
+                + "=\""
+                + prevSessionToken
+                + "\"");
 
-        logger.debug("Executing heartbeat request: {}",
-                     postRequest.toString());
+        logger.debug("Executing heartbeat request: {}", postRequest.toString());
 
         // the following will retry transient network issues
-        String theResponse = HttpUtil.executeGeneralRequest(
-            postRequest,
-            SF_HEARTBEAT_TIMEOUT,
-            getOCSPMode());
+        String theResponse =
+            HttpUtil.executeGeneralRequest(postRequest, SF_HEARTBEAT_TIMEOUT, getOCSPMode());
 
         JsonNode rootNode;
 
@@ -1078,9 +936,8 @@ public class SFSession
         rootNode = mapper.readTree(theResponse);
 
         // check the response to see if it is session expiration response
-        if (rootNode != null &&
-            (Constants.SESSION_EXPIRED_GS_CODE == rootNode.path("code").asInt()))
-        {
+        if (rootNode != null
+            && (Constants.SESSION_EXPIRED_GS_CODE == rootNode.path("code").asInt())) {
           logger.debug("renew session and retry");
           this.renewSession(prevSessionToken);
           retry = true;
@@ -1091,30 +948,26 @@ public class SFSession
 
         // success
         retry = false;
-      }
-      catch (Throwable ex)
-      {
+      } catch (Throwable ex) {
         // for snowflake exception, just rethrow it
-        if (ex instanceof SnowflakeSQLException)
-        {
+        if (ex instanceof SnowflakeSQLException) {
           throw (SnowflakeSQLException) ex;
         }
 
         logger.error("unexpected exception", ex);
 
-        throw (SFException) IncidentUtil.generateIncidentV2WithException(
-            this,
-            new SFException(ErrorCode.INTERNAL_ERROR,
-                            IncidentUtil.oneLiner("unexpected exception", ex)),
-            null,
-            requestId);
+        throw (SFException)
+            IncidentUtil.generateIncidentV2WithException(
+                this,
+                new SFException(
+                    ErrorCode.INTERNAL_ERROR, IncidentUtil.oneLiner("unexpected exception", ex)),
+                null,
+                requestId);
       }
-    }
-    while (retry);
+    } while (retry);
   }
 
-  public Properties getClientInfo()
-  {
+  public Properties getClientInfo() {
     logger.debug(" public Properties getClientInfo()");
 
     // defensive copy to avoid client from changing the properties
@@ -1124,312 +977,247 @@ public class SFSession
     return copy;
   }
 
-  public String getClientInfo(String name)
-  {
+  public String getClientInfo(String name) {
     logger.debug(" public String getClientInfo(String name)");
     return this.clientInfo.getProperty(name);
   }
 
-  void setSFSessionProperty(String propertyName, boolean propertyValue)
-  {
+  void setSFSessionProperty(String propertyName, boolean propertyValue) {
     this.sessionProperties.put(propertyName, propertyValue);
   }
 
-  public Object getSFSessionProperty(String propertyName)
-  {
+  public Object getSFSessionProperty(String propertyName) {
     return this.sessionProperties.get(propertyName);
   }
 
-  public void setInjectedDelay(int delay)
-  {
+  public void setInjectedDelay(int delay) {
     this._injectedDelay.set(delay);
   }
 
-  void injectedDelay()
-  {
+  void injectedDelay() {
 
     int d = _injectedDelay.get();
 
-    if (d != 0)
-    {
+    if (d != 0) {
       _injectedDelay.set(0);
-      try
-      {
+      try {
         logger.trace("delayed for {}", d);
 
         Thread.sleep(d);
-      }
-      catch (InterruptedException ex)
-      {
+      } catch (InterruptedException ex) {
       }
     }
   }
 
-  public int getInjectSocketTimeout()
-  {
+  public int getInjectSocketTimeout() {
     return injectSocketTimeout;
   }
 
-  public void setInjectSocketTimeout(int injectSocketTimeout)
-  {
+  public void setInjectSocketTimeout(int injectSocketTimeout) {
     this.injectSocketTimeout = injectSocketTimeout;
   }
 
-  public void setInjectFileUploadFailure(String fileToFail)
-  {
+  public void setInjectFileUploadFailure(String fileToFail) {
     this.injectFileUploadFailure = fileToFail;
   }
 
-  public String getInjectFileUploadFailure()
-  {
+  public String getInjectFileUploadFailure() {
     return this.injectFileUploadFailure;
   }
 
-  public int getNetworkTimeoutInMilli()
-  {
+  public int getNetworkTimeoutInMilli() {
     return networkTimeoutInMilli;
   }
 
-  public boolean isClosed()
-  {
+  public boolean isClosed() {
     return isClosed;
   }
 
-  public int getInjectClientPause()
-  {
+  public int getInjectClientPause() {
     return injectClientPause;
   }
 
-  public void setInjectClientPause(int injectClientPause)
-  {
+  public void setInjectClientPause(int injectClientPause) {
     this.injectClientPause = injectClientPause;
   }
 
-  protected int getHttpClientConnectionTimeout()
-  {
+  protected int getHttpClientConnectionTimeout() {
     return httpClientConnectionTimeout;
   }
 
-  protected int getHttpClientSocketTimeout()
-  {
+  protected int getHttpClientSocketTimeout() {
     return httpClientSocketTimeout;
   }
 
-  protected int getAndIncrementSequenceId()
-  {
+  protected int getAndIncrementSequenceId() {
     return sequenceId.getAndIncrement();
   }
 
-  public void setSfSQLMode(boolean sfSQLMode)
-  {
+  public void setSfSQLMode(boolean sfSQLMode) {
     this.sfSQLMode = sfSQLMode;
   }
 
-  public boolean isSfSQLMode()
-  {
+  public boolean isSfSQLMode() {
     return this.sfSQLMode;
   }
 
-  public boolean isEnableHeartbeat()
-  {
+  public boolean isEnableHeartbeat() {
     return enableHeartbeat;
   }
 
-  public void setEnableHeartbeat(boolean enableHeartbeat)
-  {
+  public void setEnableHeartbeat(boolean enableHeartbeat) {
     this.enableHeartbeat = enableHeartbeat;
   }
 
-  public void setHeartbeatFrequency(int frequency)
-  {
+  public void setHeartbeatFrequency(int frequency) {
     this.heartbeatFrequency = frequency;
   }
 
-  public long getHeartbeatFrequency()
-  {
+  public long getHeartbeatFrequency() {
     return this.heartbeatFrequency;
   }
 
-  public boolean getAutoCommit()
-  {
+  public boolean getAutoCommit() {
     return autoCommit.get();
   }
 
-  public void setAutoCommit(boolean autoCommit)
-  {
+  public void setAutoCommit(boolean autoCommit) {
     this.autoCommit.set(autoCommit);
   }
 
-  public boolean getPreparedStatementLogging()
-  {
+  public boolean getPreparedStatementLogging() {
     return this.preparedStatementLogging;
   }
 
-  public void setPreparedStatementLogging(boolean value)
-  {
+  public void setPreparedStatementLogging(boolean value) {
     this.preparedStatementLogging = value;
   }
 
-  public void setResultColumnCaseInsensitive(boolean resultColumnCaseInsensitive)
-  {
+  public void setResultColumnCaseInsensitive(boolean resultColumnCaseInsensitive) {
     this.resultColumnCaseInsensitive = resultColumnCaseInsensitive;
   }
 
-  public boolean isResultColumnCaseInsensitive()
-  {
+  public boolean isResultColumnCaseInsensitive() {
     return this.resultColumnCaseInsensitive;
   }
 
-  public String getDatabase()
-  {
+  public String getDatabase() {
     return this.database;
   }
 
-  public void setDatabase(String database)
-  {
+  public void setDatabase(String database) {
     this.database = database;
   }
 
-  public String getSchema()
-  {
+  public String getSchema() {
     return this.schema;
   }
 
-  public void setSchema(String schema)
-  {
+  public void setSchema(String schema) {
     this.schema = schema;
   }
 
-  public String getRole()
-  {
+  public String getRole() {
     return role;
   }
 
-  public void setRole(String role)
-  {
+  public void setRole(String role) {
     this.role = role;
   }
 
-  public String getWarehouse()
-  {
+  public String getWarehouse() {
     return warehouse;
   }
 
-  public void setWarehouse(String warehouse)
-  {
+  public void setWarehouse(String warehouse) {
     this.warehouse = warehouse;
   }
 
-  public void setMetadataRequestUseConnectionCtx(boolean enabled)
-  {
+  public void setMetadataRequestUseConnectionCtx(boolean enabled) {
     this.metadataRequestUseConnectionCtx = enabled;
   }
 
-  public void setMetadataRequestUseSessionDatabase(boolean enabled)
-  {
+  public void setMetadataRequestUseSessionDatabase(boolean enabled) {
     this.metadataRequestUseSessionDatabase = enabled;
   }
 
-  public boolean getMetadataRequestUseConnectionCtx()
-  {
+  public boolean getMetadataRequestUseConnectionCtx() {
     return this.metadataRequestUseConnectionCtx;
   }
 
-  public void setTreatNTZAsUTC(boolean enabled)
-  {
+  public void setTreatNTZAsUTC(boolean enabled) {
     this.treatNTZAsUTC = enabled;
   }
 
-  public boolean getTreatNTZAsUTC()
-  {
+  public boolean getTreatNTZAsUTC() {
     return this.treatNTZAsUTC;
   }
 
-  public boolean getMetadataRequestUseSessionDatabase()
-  {
+  public boolean getMetadataRequestUseSessionDatabase() {
     return this.metadataRequestUseSessionDatabase;
   }
 
-  public SnowflakeType getTimestampMappedType()
-  {
+  public SnowflakeType getTimestampMappedType() {
     return timestampMappedType;
   }
 
-  public void setTimestampMappedType(SnowflakeType timestampMappedType)
-  {
+  public void setTimestampMappedType(SnowflakeType timestampMappedType) {
     this.timestampMappedType = timestampMappedType;
   }
 
-  public boolean isJdbcTreatDecimalAsInt()
-  {
+  public boolean isJdbcTreatDecimalAsInt() {
     return jdbcTreatDecimalAsInt;
   }
 
-  public void setJdbcTreatDecimalAsInt(boolean jdbcTreatDecimalAsInt)
-  {
+  public void setJdbcTreatDecimalAsInt(boolean jdbcTreatDecimalAsInt) {
     this.jdbcTreatDecimalAsInt = jdbcTreatDecimalAsInt;
   }
 
-  public void setEnableCombineDescribe(boolean enable)
-  {
+  public void setEnableCombineDescribe(boolean enable) {
     this.enableCombineDescribe = enable;
   }
 
-  public boolean getEnableCombineDescribe()
-  {
+  public boolean getEnableCombineDescribe() {
     return this.enableCombineDescribe;
   }
 
-  public Integer getQueryTimeout()
-  {
+  public Integer getQueryTimeout() {
     return (Integer) this.connectionPropertiesMap.get(SFSessionProperty.QUERY_TIMEOUT);
   }
 
-  public String getUser()
-  {
+  public String getUser() {
     return (String) this.connectionPropertiesMap.get(SFSessionProperty.USER);
   }
 
-  public String getUrl()
-  {
+  public String getUrl() {
     return (String) this.connectionPropertiesMap.get(SFSessionProperty.SERVER_URL);
   }
 
-  public int getInjectWaitInPut()
-  {
+  public int getInjectWaitInPut() {
     Object retVal = this.connectionPropertiesMap.get(SFSessionProperty.INJECT_WAIT_IN_PUT);
-    if (retVal != null)
-    {
-      try
-      {
+    if (retVal != null) {
+      try {
         return (int) retVal;
-      }
-      catch (Exception e)
-      {
+      } catch (Exception e) {
         return 0;
       }
     }
     return 0;
   }
 
-  public List<SFException> getSqlWarnings()
-  {
+  public List<SFException> getSqlWarnings() {
     return sqlWarnings;
   }
 
-  public void clearSqlWarnings()
-  {
+  public void clearSqlWarnings() {
     sqlWarnings.clear();
   }
 
-  public synchronized Telemetry getTelemetryClient()
-  {
+  public synchronized Telemetry getTelemetryClient() {
     // initialize for the first time. this should only be done after session
     // properties have been set, else the client won't properly resolve the URL.
-    if (telemetryClient == null)
-    {
-      if (getUrl() == null)
-      {
+    if (telemetryClient == null) {
+      if (getUrl() == null) {
         logger.error("Telemetry client created before session properties set.");
         return null;
       }
@@ -1438,57 +1226,46 @@ public class SFSession
     return telemetryClient;
   }
 
-  public void closeTelemetryClient()
-  {
-    if (telemetryClient != null)
-    {
+  public void closeTelemetryClient() {
+    if (telemetryClient != null) {
       telemetryClient.close();
     }
   }
 
-  public boolean isClientTelemetryEnabled()
-  {
+  public boolean isClientTelemetryEnabled() {
     return this.clientTelemetryEnabled;
   }
 
-  public void setClientTelemetryEnabled(boolean clientTelemetryEnabled)
-  {
+  public void setClientTelemetryEnabled(boolean clientTelemetryEnabled) {
     this.clientTelemetryEnabled = clientTelemetryEnabled;
   }
 
-  public int getArrayBindStageThreshold()
-  {
+  public int getArrayBindStageThreshold() {
     return arrayBindStageThreshold;
   }
 
-  public void setArrayBindStageThreshold(int arrayBindStageThreshold)
-  {
+  public void setArrayBindStageThreshold(int arrayBindStageThreshold) {
     this.arrayBindStageThreshold = arrayBindStageThreshold;
   }
 
-  public String getArrayBindStage()
-  {
+  public String getArrayBindStage() {
     return arrayBindStage;
   }
 
-  public void setArrayBindStage(String arrayBindStage)
-  {
-    this.arrayBindStage = String.format("%s.%s.%s",
-                                        this.getDatabase(), this.getSchema(), arrayBindStage);
+  public void setArrayBindStage(String arrayBindStage) {
+    this.arrayBindStage =
+        String.format("%s.%s.%s", this.getDatabase(), this.getSchema(), arrayBindStage);
   }
 
-  public String getIdToken()
-  {
+  public String getIdToken() {
     return idToken;
   }
 
-  public boolean isStoreTemporaryCredential()
-  {
+  public boolean isStoreTemporaryCredential() {
     return this.storeTemporaryCredential;
   }
 
-  public void setStoreTemporaryCredential(boolean storeTemporaryCredential)
-  {
+  public void setStoreTemporaryCredential(boolean storeTemporaryCredential) {
     this.storeTemporaryCredential = storeTemporaryCredential;
   }
 
@@ -1497,8 +1274,7 @@ public class SFSession
    *
    * @param serviceName service name
    */
-  public void setServiceName(String serviceName)
-  {
+  public void setServiceName(String serviceName) {
     this.serviceName = serviceName;
   }
 
@@ -1507,31 +1283,23 @@ public class SFSession
    *
    * @return the service name
    */
-  public String getServiceName()
-  {
+  public String getServiceName() {
     return serviceName;
   }
 
   /**
-   * Sets the current objects if the session is not up to date. It can happen
-   * if the session is created by the id token, which doesn't carry the current
-   * objects.
+   * Sets the current objects if the session is not up to date. It can happen if the session is
+   * created by the id token, which doesn't carry the current objects.
    *
-   * @param loginInput  The login input to use for this session
+   * @param loginInput The login input to use for this session
    * @param loginOutput The login output to ose for this session
    */
-  void setCurrentObjects(
-      SFLoginInput loginInput, SFLoginOutput loginOutput)
-  {
+  void setCurrentObjects(SFLoginInput loginInput, SFLoginOutput loginOutput) {
     this.sessionToken = loginOutput.getSessionToken(); // used to run the commands.
-    runInternalCommand(
-        "USE ROLE IDENTIFIER(?)", loginInput.getRole());
-    runInternalCommand(
-        "USE WAREHOUSE IDENTIFIER(?)", loginInput.getWarehouse());
-    runInternalCommand(
-        "USE DATABASE IDENTIFIER(?)", loginInput.getDatabaseName());
-    runInternalCommand(
-        "USE SCHEMA IDENTIFIER(?)", loginInput.getSchemaName());
+    runInternalCommand("USE ROLE IDENTIFIER(?)", loginInput.getRole());
+    runInternalCommand("USE WAREHOUSE IDENTIFIER(?)", loginInput.getWarehouse());
+    runInternalCommand("USE DATABASE IDENTIFIER(?)", loginInput.getDatabaseName());
+    runInternalCommand("USE SCHEMA IDENTIFIER(?)", loginInput.getSchemaName());
     // This ensures the session returns the current objects and refresh
     // the local cache.
     SFBaseResultSet result = runInternalCommand("SELECT ?", "1");
@@ -1544,21 +1312,17 @@ public class SFSession
     loginOutput.setIdToken(loginInput.getIdToken());
 
     // no common parameter is updated.
-    if (result != null)
-    {
+    if (result != null) {
       loginOutput.setCommonParams(result.parameters);
     }
   }
 
-  private SFBaseResultSet runInternalCommand(String sql, String value)
-  {
-    if (value == null)
-    {
+  private SFBaseResultSet runInternalCommand(String sql, String value) {
+    if (value == null) {
       return null;
     }
 
-    try
-    {
+    try {
       Map<String, ParameterBindingDTO> bindValues = new HashMap<>();
       bindValues.put("1", new ParameterBindingDTO("TEXT", value));
       SFStatement statement = new SFStatement(this);
@@ -1569,85 +1333,68 @@ public class SFSession
           true, // internal
           false, // asyncExec
           null // caller isn't a JDBC interface method
-      );
-    }
-    catch (SFException | SQLException ex)
-    {
+          );
+    } catch (SFException | SQLException ex) {
       logger.debug("Failed to run a command: {}, err={}", sql, ex);
     }
     return null;
   }
 
-
-  public boolean isConservativeMemoryUsageEnabled()
-  {
+  public boolean isConservativeMemoryUsageEnabled() {
     return enableConservativeMemoryUsage;
   }
 
-  public void setEnableConservativeMemoryUsage(boolean value)
-  {
+  public void setEnableConservativeMemoryUsage(boolean value) {
     enableConservativeMemoryUsage = value;
   }
 
-  public void setConservativeMemoryAdjustStep(int step)
-  {
+  public void setConservativeMemoryAdjustStep(int step) {
     conservativeMemoryAdjustStep = step;
   }
 
-  public int getConservativeMemoryAdjustStep()
-  {
+  public int getConservativeMemoryAdjustStep() {
     return conservativeMemoryAdjustStep;
   }
 
-  public void setClientMemoryLimit(int clientMemoryLimit)
-  {
+  public void setClientMemoryLimit(int clientMemoryLimit) {
     this.clientMemoryLimit = clientMemoryLimit;
   }
 
-  public int getClientMemoryLimit()
-  {
+  public int getClientMemoryLimit() {
     return clientMemoryLimit;
   }
 
-  public void setClientResultChunkSize(int clientResultChunkSize)
-  {
+  public void setClientResultChunkSize(int clientResultChunkSize) {
     this.clientResultChunkSize = clientResultChunkSize;
   }
 
-  public int getClientResultChunkSize()
-  {
+  public int getClientResultChunkSize() {
     return clientResultChunkSize;
   }
 
-  public void setClientPrefetchThreads(int clientPrefetchThreads)
-  {
+  public void setClientPrefetchThreads(int clientPrefetchThreads) {
     this.clientPrefetchThreads = clientPrefetchThreads;
   }
 
-  public int getClientPrefetchThreads()
-  {
+  public int getClientPrefetchThreads() {
     return clientPrefetchThreads;
   }
 
-  public boolean isValidateDefaultParameters()
-  {
+  public boolean isValidateDefaultParameters() {
     return validateDefaultParameters;
   }
 
-  public void setValidateDefaultParameters(boolean v)
-  {
+  public void setValidateDefaultParameters(boolean v) {
     validateDefaultParameters = v;
   }
 
   private SnowflakeConnectString sfConnStr;
 
-  public void setSnowflakeConnectionString(SnowflakeConnectString connStr)
-  {
+  public void setSnowflakeConnectionString(SnowflakeConnectString connStr) {
     sfConnStr = connStr;
   }
 
-  public SnowflakeConnectString getSnowflakeConnectionString()
-  {
+  public SnowflakeConnectString getSnowflakeConnectionString() {
     return sfConnStr;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -4,7 +4,18 @@
 
 package net.snowflake.client.core;
 
+import static net.snowflake.client.core.SessionUtil.*;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.core.bind.BindException;
 import net.snowflake.client.core.bind.BindUploader;
@@ -19,25 +30,9 @@ import net.snowflake.client.util.SecretDetector;
 import net.snowflake.common.core.SqlState;
 import org.apache.http.client.methods.HttpRequestBase;
 
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static net.snowflake.client.core.SessionUtil.*;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
-/**
- * Snowflake statement
- */
-public class SFStatement
-{
-  public enum CallingMethod
-  {
+/** Snowflake statement */
+public class SFStatement {
+  public enum CallingMethod {
     EXECUTE,
     EXECUTE_UPDATE,
     EXECUTE_QUERY
@@ -71,13 +66,11 @@ public class SFStatement
   // statement level parameters
   private final Map<String, Object> statementParametersMap = new HashMap<>();
 
-  final private static int MAX_STATEMENT_PARAMETERS = 1000;
+  private static final int MAX_STATEMENT_PARAMETERS = 1000;
 
-  final private static int MAX_BINDING_PARAMS_FOR_LOGGING = 1000;
+  private static final int MAX_BINDING_PARAMS_FOR_LOGGING = 1000;
 
-  /**
-   * id used in combine describe and execute
-   */
+  /** id used in combine describe and execute */
   private String describeJobUUID;
 
   // when uploading binds to stage, we use a table scan which cannot parse times from ms
@@ -94,35 +87,29 @@ public class SFStatement
 
   /**
    * Add a statement parameter
-   * <p>
-   * Make sure a property is not added more than once and the number of
-   * properties does not exceed limit.
    *
-   * @param propertyName  property name
+   * <p>Make sure a property is not added more than once and the number of properties does not
+   * exceed limit.
+   *
+   * @param propertyName property name
    * @param propertyValue property value
    * @throws SFException if too many parameters for a statement
    */
-  public void addProperty(String propertyName, Object propertyValue)
-  throws SFException
-  {
+  public void addProperty(String propertyName, Object propertyValue) throws SFException {
     statementParametersMap.put(propertyName, propertyValue);
 
     // for query timeout, we implement it on client side for now
-    if ("query_timeout".equalsIgnoreCase(propertyName))
-    {
+    if ("query_timeout".equalsIgnoreCase(propertyName)) {
       queryTimeout = (Integer) propertyValue;
     }
 
     // check if the number of session properties exceed limit
-    if (statementParametersMap.size() > MAX_STATEMENT_PARAMETERS)
-    {
-      throw new SFException(
-          ErrorCode.TOO_MANY_STATEMENT_PARAMETERS, MAX_STATEMENT_PARAMETERS);
+    if (statementParametersMap.size() > MAX_STATEMENT_PARAMETERS) {
+      throw new SFException(ErrorCode.TOO_MANY_STATEMENT_PARAMETERS, MAX_STATEMENT_PARAMETERS);
     }
   }
 
-  public SFStatement(SFSession session)
-  {
+  public SFStatement(SFSession session) {
     logger.debug(" public SFStatement(SFSession session)");
 
     this.session = session;
@@ -131,12 +118,10 @@ public class SFStatement
     verifyArrowSupport();
   }
 
-  private void verifyArrowSupport()
-  {
-    if (SnowflakeDriver.isDisableArrowResultFormat())
-    {
-      logger.debug("disable arrow support: {}",
-                   SnowflakeDriver.getDisableArrowResultFormatMessage());
+  private void verifyArrowSupport() {
+    if (SnowflakeDriver.isDisableArrowResultFormat()) {
+      logger.debug(
+          "disable arrow support: {}", SnowflakeDriver.getDisableArrowResultFormatMessage());
       statementParametersMap.put("JDBC_QUERY_RESULT_FORMAT", "JSON");
     }
   }
@@ -147,24 +132,21 @@ public class SFStatement
    * @param sql The SQL statement to check
    * @throws SQLException Will be thrown if sql is null or empty
    */
-  private void sanityCheckQuery(String sql) throws SQLException
-  {
-    if (sql == null || sql.isEmpty())
-    {
-      throw new SnowflakeSQLException(SqlState.SQL_STATEMENT_NOT_YET_COMPLETE,
-                                      ErrorCode.INVALID_SQL.getMessageCode(), sql);
-
+  private void sanityCheckQuery(String sql) throws SQLException {
+    if (sql == null || sql.isEmpty()) {
+      throw new SnowflakeSQLException(
+          SqlState.SQL_STATEMENT_NOT_YET_COMPLETE, ErrorCode.INVALID_SQL.getMessageCode(), sql);
     }
   }
 
   /**
    * Execute SQL query with an option for describe only
    *
-   * @param sql          sql statement
+   * @param sql sql statement
    * @param describeOnly true if describe only
    * @return query result set
    * @throws SQLException if connection is already closed
-   * @throws SFException  if result set is null
+   * @throws SFException if result set is null
    */
   private SFBaseResultSet executeQuery(
       String sql,
@@ -172,15 +154,13 @@ public class SFStatement
       boolean describeOnly,
       boolean asyncExec,
       CallingMethod caller)
-  throws SQLException, SFException
-  {
+      throws SQLException, SFException {
     sanityCheckQuery(sql);
 
     String trimmedSql = sql.trim();
 
     // snowflake specific client side commands
-    if (isFileTransfer(trimmedSql))
-    {
+    if (isFileTransfer(trimmedSql)) {
       // PUT/GET command
       logger.debug("Executing file transfer locally: {}", sql);
 
@@ -194,8 +174,7 @@ public class SFStatement
         describeOnly,
         describeOnly, // internal query if describeOnly is true
         asyncExec,
-        caller
-    );
+        caller);
   }
 
   /**
@@ -204,34 +183,35 @@ public class SFStatement
    * @param sql statement
    * @return metadata of statement including result set metadata and binding information
    * @throws SQLException if connection is already closed
-   * @throws SFException  if result set is null
+   * @throws SFException if result set is null
    */
-  public SFStatementMetaData describe(String sql) throws SFException, SQLException
-  {
+  public SFStatementMetaData describe(String sql) throws SFException, SQLException {
     SFBaseResultSet baseResultSet = executeQuery(sql, null, true, false, null);
 
     describeJobUUID = baseResultSet.getQueryId();
 
-    return new SFStatementMetaData(baseResultSet.getMetaData(),
-                                   baseResultSet.getStatementType(),
-                                   baseResultSet.getNumberOfBinds(),
-                                   baseResultSet.isArrayBindSupported(),
-                                   baseResultSet.getMetaDataOfBinds(),
-                                   true); // valid metadata
+    return new SFStatementMetaData(
+        baseResultSet.getMetaData(),
+        baseResultSet.getStatementType(),
+        baseResultSet.getNumberOfBinds(),
+        baseResultSet.isArrayBindSupported(),
+        baseResultSet.getMetaDataOfBinds(),
+        true); // valid metadata
   }
 
   /**
    * Internal method for executing a query with bindings accepted.
+   *
    * <p>
    *
-   * @param sql               sql statement
+   * @param sql sql statement
    * @param parameterBindings binding information
-   * @param describeOnly      true if just showing result set metadata
-   * @param internal          true if internal command not showing up in the history
-   * @param caller            the JDBC method that called this function, null if none
+   * @param describeOnly true if just showing result set metadata
+   * @param internal true if internal command not showing up in the history
+   * @param caller the JDBC method that called this function, null if none
    * @return snowflake query result set
    * @throws SQLException if connection is already closed
-   * @throws SFException  if result set is null
+   * @throws SFException if result set is null
    */
   SFBaseResultSet executeQueryInternal(
       String sql,
@@ -240,29 +220,25 @@ public class SFStatement
       boolean internal,
       boolean asyncExec,
       CallingMethod caller)
-  throws SQLException, SFException
-  {
+      throws SQLException, SFException {
     resetState();
 
-    logger.debug("executeQuery: {}",
-                 (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
+    logger.debug("executeQuery: {}", (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
 
-    if (session == null || session.isClosed())
-    {
+    if (session == null || session.isClosed()) {
       throw new SQLException("connection is closed");
     }
 
-    Object result = executeHelper(sql,
-                                  StmtUtil.SF_MEDIA_TYPE,
-                                  parameterBindings,
-                                  describeOnly,
-                                  internal, asyncExec);
+    Object result =
+        executeHelper(
+            sql, StmtUtil.SF_MEDIA_TYPE, parameterBindings, describeOnly, internal, asyncExec);
 
-    if (result == null)
-    {
-      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "got null result");
+    if (result == null) {
+      throw new SnowflakeSQLLoggedException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "got null result");
     }
 
     /*
@@ -274,8 +250,7 @@ public class SFStatement
 
     logger.debug("Creating result set");
 
-    try
-    {
+    try {
       JsonNode jsonResult = (JsonNode) result;
       resultSet = SFResultSetFactory.getResultSet(jsonResult, this, sortResult);
       childResults = ResultUtil.getChildResults(session, requestId, jsonResult);
@@ -283,18 +258,14 @@ public class SFStatement
       // if child results are available, skip over this result set and set the
       // current result to the first child's result.
       // we still construct the first result set for its side effects.
-      if (!childResults.isEmpty())
-      {
+      if (!childResults.isEmpty()) {
         SFStatementType type = childResults.get(0).type;
 
         // ensure first query type matches the calling JDBC method, if exists
-        if (caller == CallingMethod.EXECUTE_QUERY && !type.isGenerateResultSet())
-        {
+        if (caller == CallingMethod.EXECUTE_QUERY && !type.isGenerateResultSet()) {
           throw new SnowflakeSQLLoggedException(
               ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET, session);
-        }
-        else if (caller == CallingMethod.EXECUTE_UPDATE && type.isGenerateResultSet())
-        {
+        } else if (caller == CallingMethod.EXECUTE_UPDATE && type.isGenerateResultSet()) {
           throw new SnowflakeSQLLoggedException(
               ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT, session);
         }
@@ -302,29 +273,25 @@ public class SFStatement
         // this will update resultSet to point to the first child result before we return it
         getMoreResults();
       }
-    }
-    catch (SnowflakeSQLException | OutOfMemoryError ex)
-    {
+    } catch (SnowflakeSQLException | OutOfMemoryError ex) {
       // snow-24428: no need to generate incident for exceptions we generate
       // snow-29403: or client OOM
       throw ex;
-    }
-    catch (Throwable ex)
-    {
+    } catch (Throwable ex) {
       // SNOW-22813 log exception
       logger.error("Exception creating result", ex);
 
-      throw (SFException) IncidentUtil.generateIncidentV2WithException(
-          session,
-          new SFException(ErrorCode.INTERNAL_ERROR,
-                          IncidentUtil.oneLiner("exception creating result", ex)),
-          null,
-          null);
+      throw (SFException)
+          IncidentUtil.generateIncidentV2WithException(
+              session,
+              new SFException(
+                  ErrorCode.INTERNAL_ERROR, IncidentUtil.oneLiner("exception creating result", ex)),
+              null,
+              null);
     }
     logger.debug("Done creating result set");
 
-    if (asyncExec)
-    {
+    if (asyncExec) {
       session.activeAsyncQueries.add(resultSet.getQueryId());
     }
     return resultSet;
@@ -335,80 +302,69 @@ public class SFStatement
    *
    * @param executor object to execute statement cancel request
    */
-  private void setTimeBomb(ScheduledExecutorService executor)
-  {
-    class TimeBombTask implements Callable<Void>
-    {
+  private void setTimeBomb(ScheduledExecutorService executor) {
+    class TimeBombTask implements Callable<Void> {
 
       private final SFStatement statement;
 
-      private TimeBombTask(SFStatement statement)
-      {
+      private TimeBombTask(SFStatement statement) {
         this.statement = statement;
       }
 
       @Override
-      public Void call() throws SQLException
-      {
-        try
-        {
+      public Void call() throws SQLException {
+        try {
           statement.cancel();
-        }
-        catch (SFException ex)
-        {
-          throw new SnowflakeSQLLoggedException(ex, ex.getSqlState(),
-                                                ex.getVendorCode(), session, ex.getParams());
+        } catch (SFException ex) {
+          throw new SnowflakeSQLLoggedException(
+              ex, ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
         }
         return null;
       }
     }
 
-    executor.schedule(new TimeBombTask(this), this.queryTimeout,
-                      TimeUnit.SECONDS);
+    executor.schedule(new TimeBombTask(this), this.queryTimeout, TimeUnit.SECONDS);
   }
 
   /**
    * A helper method to build URL and submit the SQL to snowflake for exec
    *
-   * @param sql          sql statement
-   * @param mediaType    media type
-   * @param bindValues   map of binding values
+   * @param sql sql statement
+   * @param mediaType media type
+   * @param bindValues map of binding values
    * @param describeOnly whether only show the result set metadata
-   * @param internal     run internal query not showing up in history
+   * @param internal run internal query not showing up in history
    * @return raw json response
-   * @throws SFException           if query is canceled
+   * @throws SFException if query is canceled
    * @throws SnowflakeSQLException if query is already running
    */
-  public Object executeHelper(String sql,
-                              String mediaType,
-                              Map<String, ParameterBindingDTO> bindValues,
-                              boolean describeOnly,
-                              boolean internal,
-                              boolean asyncExec)
-  throws SnowflakeSQLException, SFException
-  {
+  public Object executeHelper(
+      String sql,
+      String mediaType,
+      Map<String, ParameterBindingDTO> bindValues,
+      boolean describeOnly,
+      boolean internal,
+      boolean asyncExec)
+      throws SnowflakeSQLException, SFException {
     ScheduledExecutorService executor = null;
 
-    try
-    {
-      synchronized (this)
-      {
-        if (isClosed)
-        {
+    try {
+      synchronized (this) {
+        if (isClosed) {
           throw new SFException(ErrorCode.STATEMENT_CLOSED);
         }
 
         // initialize a sequence id if not closed or not for aborting
-        if (canceling.get())
-        {
+        if (canceling.get()) {
           // nothing to do if canceled
           throw new SFException(ErrorCode.QUERY_CANCELED);
         }
 
-        if (this.requestId != null)
-        {
-          throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
-                                                ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(), session);
+        if (this.requestId != null) {
+          throw new SnowflakeSQLLoggedException(
+              SqlState.FEATURE_NOT_SUPPORTED,
+              ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(),
+              session);
         }
 
         this.requestId = UUID.randomUUID().toString();
@@ -417,8 +373,9 @@ public class SFStatement
         this.sqlText = sql;
       }
 
-      EventUtil.triggerStateTransition(BasicEvent.QueryState.QUERY_STARTED,
-                                       String.format(QueryState.QUERY_STARTED.getArgString(), requestId));
+      EventUtil.triggerStateTransition(
+          BasicEvent.QueryState.QUERY_STARTED,
+          String.format(QueryState.QUERY_STARTED.getArgString(), requestId));
 
       // if there are a large number of bind values, we should upload them to stage
       // instead of passing them in the payload (if enabled)
@@ -428,36 +385,34 @@ public class SFStatement
           && session.getArrayBindStageThreshold() <= numBinds
           && !describeOnly
           && !hasUnsupportedStageBind
-          && BindUploader.isArrayBind(bindValues))
-      {
-        try (BindUploader uploader = BindUploader.newInstance(session, requestId))
-        {
+          && BindUploader.isArrayBind(bindValues)) {
+        try (BindUploader uploader = BindUploader.newInstance(session, requestId)) {
           uploader.upload(bindValues);
           bindStagePath = uploader.getStagePath();
-        }
-        catch (BindException ex)
-        {
-          logger.debug("Exception encountered trying to upload binds to stage. Attaching binds in payload instead. ", ex);
+        } catch (BindException ex) {
+          logger.debug(
+              "Exception encountered trying to upload binds to stage. Attaching binds in payload instead. ",
+              ex);
           TelemetryData errorLog = TelemetryUtil.buildJobData(this.requestId, ex.type.field, 1);
           this.session.getTelemetryClient().addLogToBatch(errorLog);
           IncidentUtil.generateIncidentV2WithException(
               session,
-              new SFException(ErrorCode.NON_FATAL_ERROR,
-                              IncidentUtil.oneLiner("Failed to upload binds " +
-                                                    "to stage:", ex)),
+              new SFException(
+                  ErrorCode.NON_FATAL_ERROR,
+                  IncidentUtil.oneLiner("Failed to upload binds " + "to stage:", ex)),
               null,
               requestId);
         }
       }
 
-      if (session.isConservativeMemoryUsageEnabled())
-      {
+      if (session.isConservativeMemoryUsageEnabled()) {
         logger.debug("JDBC conservative memory usage is enabled.");
         calculateConservativeMemoryUsage();
       }
 
       StmtUtil.StmtInput stmtInput = new StmtUtil.StmtInput();
-      stmtInput.setSql(sql)
+      stmtInput
+          .setSql(sql)
           .setMediaType(mediaType)
           .setInternal(internal)
           .setDescribeOnly(describeOnly)
@@ -478,65 +433,49 @@ public class SFStatement
           .setServiceName(session.getServiceName())
           .setOCSPMode(session.getOCSPMode());
 
-      if (bindStagePath != null)
-      {
-        stmtInput.setBindValues(null)
-            .setBindStage(bindStagePath);
+      if (bindStagePath != null) {
+        stmtInput.setBindValues(null).setBindStage(bindStagePath);
         // use the new SQL format for this query so dates/timestamps are parsed correctly
         setUseNewSqlFormat(true);
+      } else {
+        stmtInput.setBindValues(bindValues).setBindStage(null);
       }
-      else
-      {
-        stmtInput.setBindValues(bindValues)
-            .setBindStage(null);
-      }
-      if (numBinds > 0 && session.getPreparedStatementLogging())
-      {
-        if (numBinds > MAX_BINDING_PARAMS_FOR_LOGGING)
-        {
-          logger.info("Number of binds exceeds logging limit. Printing off {} binding parameters.", MAX_BINDING_PARAMS_FOR_LOGGING);
-        }
-        else
-        {
+      if (numBinds > 0 && session.getPreparedStatementLogging()) {
+        if (numBinds > MAX_BINDING_PARAMS_FOR_LOGGING) {
+          logger.info(
+              "Number of binds exceeds logging limit. Printing off {} binding parameters.",
+              MAX_BINDING_PARAMS_FOR_LOGGING);
+        } else {
           logger.info("Printing off {} binding parameters.", numBinds);
         }
         int counter = 0;
         // if it's an array bind, print off the first few rows from each column.
-        if (BindUploader.isArrayBind(bindValues))
-        {
+        if (BindUploader.isArrayBind(bindValues)) {
           int numRowsPrinted = MAX_BINDING_PARAMS_FOR_LOGGING / bindValues.size();
-          if (numRowsPrinted <= 0)
-          {
+          if (numRowsPrinted <= 0) {
             numRowsPrinted = 1;
           }
-          for (Map.Entry<String, ParameterBindingDTO> entry : bindValues.entrySet())
-          {
+          for (Map.Entry<String, ParameterBindingDTO> entry : bindValues.entrySet()) {
             List<String> bindRows = (List<String>) entry.getValue().getValue();
-            if (numRowsPrinted >= bindRows.size())
-            {
+            if (numRowsPrinted >= bindRows.size()) {
               numRowsPrinted = bindRows.size();
             }
             String rows = "[";
-            for (int i = 0; i < numRowsPrinted; i++)
-            {
+            for (int i = 0; i < numRowsPrinted; i++) {
               rows += bindRows.get(i) + ", ";
             }
             rows += "]";
             logger.info("Column {}: {}", entry.getKey(), rows);
             counter += numRowsPrinted;
-            if (counter >= MAX_BINDING_PARAMS_FOR_LOGGING)
-            {
+            if (counter >= MAX_BINDING_PARAMS_FOR_LOGGING) {
               break;
             }
           }
         }
         // not an array, just a bunch of columns
-        else
-        {
-          for (Map.Entry<String, ParameterBindingDTO> entry : bindValues.entrySet())
-          {
-            if (counter >= MAX_BINDING_PARAMS_FOR_LOGGING)
-            {
+        else {
+          for (Map.Entry<String, ParameterBindingDTO> entry : bindValues.entrySet()) {
+            if (counter >= MAX_BINDING_PARAMS_FOR_LOGGING) {
               break;
             }
             counter++;
@@ -545,8 +484,7 @@ public class SFStatement
         }
       }
 
-      if (canceling.get())
-      {
+      if (canceling.get()) {
         logger.debug("Query cancelled");
 
         throw new SFException(ErrorCode.QUERY_CANCELED);
@@ -554,8 +492,7 @@ public class SFStatement
 
       // if timeout is set, start a thread to cancel the request after timeout
       // reached.
-      if (this.queryTimeout > 0)
-      {
+      if (this.queryTimeout > 0) {
         executor = Executors.newScheduledThreadPool(1);
         setTimeBomb(executor);
       }
@@ -563,31 +500,20 @@ public class SFStatement
       StmtUtil.StmtOutput stmtOutput = null;
       boolean sessionRenewed;
 
-      do
-      {
+      do {
         sessionRenewed = false;
-        try
-        {
+        try {
           stmtOutput = StmtUtil.execute(stmtInput);
           break;
-        }
-        catch (SnowflakeSQLException ex)
-        {
-          if (ex.getErrorCode() == Constants.SESSION_EXPIRED_GS_CODE)
-          {
-            try
-            {
+        } catch (SnowflakeSQLException ex) {
+          if (ex.getErrorCode() == Constants.SESSION_EXPIRED_GS_CODE) {
+            try {
               // renew the session
               session.renewSession(stmtInput.sessionToken);
-            }
-            catch (SnowflakeReauthenticationRequest ex0)
-            {
-              if (session.isExternalbrowserAuthenticator())
-              {
+            } catch (SnowflakeReauthenticationRequest ex0) {
+              if (session.isExternalbrowserAuthenticator()) {
                 reauthenticate();
-              }
-              else
-              {
+              } else {
                 throw ex0;
               }
             }
@@ -598,27 +524,22 @@ public class SFStatement
             sessionRenewed = true;
 
             logger.debug("Session got renewed, will retry");
-          }
-          else
-          {
+          } else {
             throw ex;
           }
         }
-      }
-      while (sessionRenewed && !canceling.get());
+      } while (sessionRenewed && !canceling.get());
 
       // Debugging/Testing for incidents
-      if (Boolean.TRUE.toString().equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test1")))
-      {
-        throw (SFException) IncidentUtil.generateIncidentV2WithException(
-            session,
-            new SFException(ErrorCode.STATEMENT_CLOSED),
-            null,
-            this.requestId);
+      if (Boolean.TRUE
+          .toString()
+          .equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test1"))) {
+        throw (SFException)
+            IncidentUtil.generateIncidentV2WithException(
+                session, new SFException(ErrorCode.STATEMENT_CLOSED), null, this.requestId);
       }
 
-      synchronized (this)
-      {
+      synchronized (this) {
         /*
          * done with the remote execution of the query. set sequenceId to -1
          * and request id to null so that we don't try to abort it upon canceling.
@@ -627,8 +548,7 @@ public class SFStatement
         this.requestId = null;
       }
 
-      if (canceling.get())
-      {
+      if (canceling.get()) {
         // If we are here, this is the context for the initial query that
         // is being canceled. Raise an exception anyway here even if
         // the server fails to abort it.
@@ -637,21 +557,15 @@ public class SFStatement
 
       logger.debug("Returning from executeHelper");
 
-      if (stmtOutput != null)
-      {
+      if (stmtOutput != null) {
         return stmtOutput.getResult();
       }
       throw new SFException(ErrorCode.INTERNAL_ERROR);
-    }
-    catch (SFException | SnowflakeSQLException ex)
-    {
+    } catch (SFException | SnowflakeSQLException ex) {
       isClosed = true;
       throw ex;
-    }
-    finally
-    {
-      if (executor != null)
-      {
+    } finally {
+      if (executor != null) {
         executor.shutdownNow();
       }
       // if this query enabled the new SQL format, re-disable it now
@@ -662,66 +576,60 @@ public class SFStatement
   /**
    * calculate conservative memory limit and the number of prefetch threads before query execution
    */
-  private void calculateConservativeMemoryUsage()
-  {
+  private void calculateConservativeMemoryUsage() {
     int clientMemoryLimit = session.getClientMemoryLimit();
     int clientPrefetchThread = session.getClientPrefetchThreads();
     int clientChunkSize = session.getClientResultChunkSize();
 
     long memoryLimitInBytes;
-    if (clientMemoryLimit == DEFAULT_CLIENT_MEMORY_LIMIT)
-    {
+    if (clientMemoryLimit == DEFAULT_CLIENT_MEMORY_LIMIT) {
       // this is all default scenario
       // only allows JDBC use at most 80% of free memory
       long freeMemoryToUse = Runtime.getRuntime().freeMemory() * 8 / 10;
-      memoryLimitInBytes = Math.min((long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024, freeMemoryToUse);
-    }
-    else
-    {
+      memoryLimitInBytes =
+          Math.min(
+              (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024, freeMemoryToUse);
+    } else {
       memoryLimitInBytes = (long) clientMemoryLimit * 1024 * 1024;
     }
     conservativeMemoryLimit = memoryLimitInBytes;
-    reducePrefetchThreadsAndChunkSizeToFitMemoryLimit(conservativeMemoryLimit, clientPrefetchThread, clientChunkSize);
+    reducePrefetchThreadsAndChunkSizeToFitMemoryLimit(
+        conservativeMemoryLimit, clientPrefetchThread, clientChunkSize);
   }
 
-  private void updateConservativeResultChunkSize(int clientChunkSize)
-  {
-    if (clientChunkSize != conservativeResultChunkSize)
-    {
-      logger.debug("conservativeResultChunkSize changed from {} to {}", conservativeResultChunkSize,
-                   clientChunkSize);
+  private void updateConservativeResultChunkSize(int clientChunkSize) {
+    if (clientChunkSize != conservativeResultChunkSize) {
+      logger.debug(
+          "conservativeResultChunkSize changed from {} to {}",
+          conservativeResultChunkSize,
+          clientChunkSize);
       conservativeResultChunkSize = clientChunkSize;
       statementParametersMap.put("CLIENT_RESULT_CHUNK_SIZE", conservativeResultChunkSize);
     }
   }
 
-  private void reducePrefetchThreadsAndChunkSizeToFitMemoryLimit(long clientMemoryLimit, int clientPrefetchThread,
-                                                                 int clientChunkSize)
-  {
-    if (clientPrefetchThread != DEFAULT_CLIENT_PREFETCH_THREADS)
-    {
+  private void reducePrefetchThreadsAndChunkSizeToFitMemoryLimit(
+      long clientMemoryLimit, int clientPrefetchThread, int clientChunkSize) {
+    if (clientPrefetchThread != DEFAULT_CLIENT_PREFETCH_THREADS) {
       // prefetch threads are configured so only reduce chunk size
       conservativePrefetchThreads = clientPrefetchThread;
-      for (; clientChunkSize >= MIN_CLIENT_CHUNK_SIZE; clientChunkSize -= session.getConservativeMemoryAdjustStep())
-      {
-        if (clientMemoryLimit >= (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024)
-        {
+      for (;
+          clientChunkSize >= MIN_CLIENT_CHUNK_SIZE;
+          clientChunkSize -= session.getConservativeMemoryAdjustStep()) {
+        if (clientMemoryLimit >= (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024) {
           updateConservativeResultChunkSize(clientChunkSize);
           return;
         }
       }
       updateConservativeResultChunkSize(MIN_CLIENT_CHUNK_SIZE);
-    }
-    else
-    {
+    } else {
       // reduce both prefetch threads and chunk size
-      while (clientPrefetchThread > 1)
-      {
-        for (clientChunkSize = MAX_CLIENT_CHUNK_SIZE; clientChunkSize >= MIN_CLIENT_CHUNK_SIZE;
-             clientChunkSize -= session.getConservativeMemoryAdjustStep())
-        {
-          if (clientMemoryLimit >= (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024)
-          {
+      while (clientPrefetchThread > 1) {
+        for (clientChunkSize = MAX_CLIENT_CHUNK_SIZE;
+            clientChunkSize >= MIN_CLIENT_CHUNK_SIZE;
+            clientChunkSize -= session.getConservativeMemoryAdjustStep()) {
+          if (clientMemoryLimit
+              >= (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024) {
             conservativePrefetchThreads = clientPrefetchThread;
             updateConservativeResultChunkSize(clientChunkSize);
             return;
@@ -734,30 +642,24 @@ public class SFStatement
     }
   }
 
-  /**
-   * @return conservative prefetch threads before fetching results
-   */
-  public int getConservativePrefetchThreads()
-  {
+  /** @return conservative prefetch threads before fetching results */
+  public int getConservativePrefetchThreads() {
     return conservativePrefetchThreads;
   }
 
-  /**
-   * @return conservative memory limit before fetching results
-   */
-  public long getConservativeMemoryLimit()
-  {
+  /** @return conservative memory limit before fetching results */
+  public long getConservativeMemoryLimit() {
     return conservativeMemoryLimit;
   }
 
-  private void reauthenticate() throws SFException, SnowflakeSQLException
-  {
-    SFLoginInput input = new SFLoginInput()
-        .setRole(session.getRole())
-        .setWarehouse(session.getWarehouse())
-        .setDatabaseName(session.getDatabase())
-        .setSchemaName(session.getSchema())
-        .setOCSPMode(session.getOCSPMode());
+  private void reauthenticate() throws SFException, SnowflakeSQLException {
+    SFLoginInput input =
+        new SFLoginInput()
+            .setRole(session.getRole())
+            .setWarehouse(session.getWarehouse())
+            .setDatabaseName(session.getDatabase())
+            .setSchemaName(session.getSchema())
+            .setOCSPMode(session.getOCSPMode());
 
     session.open();
   }
@@ -765,25 +667,22 @@ public class SFStatement
   /**
    * A helper method to build URL and cancel the SQL for exec
    *
-   * @param sql       sql statement
+   * @param sql sql statement
    * @param mediaType media type
    * @throws SnowflakeSQLException if failed to cancel the statement
-   * @throws SFException           if statement is already closed
+   * @throws SFException if statement is already closed
    */
   private void cancelHelper(String sql, String mediaType)
-  throws SnowflakeSQLException, SFException
-  {
-    synchronized (this)
-    {
-      if (isClosed)
-      {
-        throw new SFException(ErrorCode.INTERNAL_ERROR,
-                              "statement already closed");
+      throws SnowflakeSQLException, SFException {
+    synchronized (this) {
+      if (isClosed) {
+        throw new SFException(ErrorCode.INTERNAL_ERROR, "statement already closed");
       }
     }
 
     StmtUtil.StmtInput stmtInput = new StmtUtil.StmtInput();
-    stmtInput.setServerUrl(session.getServerUrl())
+    stmtInput
+        .setServerUrl(session.getServerUrl())
         .setSql(sql)
         .setMediaType(mediaType)
         .setRequestId(requestId)
@@ -793,8 +692,7 @@ public class SFStatement
 
     StmtUtil.cancel(stmtInput);
 
-    synchronized (this)
-    {
+    synchronized (this) {
       /*
        * done with the remote execution of the query. set sequenceId to -1
        * and request id to null so that we don't try to abort it again upon
@@ -806,69 +704,57 @@ public class SFStatement
   }
 
   /**
-   * A method to check if a sql is file upload statement with consideration for
-   * potential comments in front of put keyword.
+   * A method to check if a sql is file upload statement with consideration for potential comments
+   * in front of put keyword.
+   *
    * <p>
    *
    * @param sql sql statement
    * @return true if the command is upload statement
    */
-  private boolean isFileTransfer(String sql)
-  {
+  private boolean isFileTransfer(String sql) {
     SFStatementType statementType = StmtUtil.checkStageManageCommand(sql);
-    return statementType == SFStatementType.PUT ||
-           statementType == SFStatementType.GET;
+    return statementType == SFStatementType.PUT || statementType == SFStatementType.GET;
   }
 
   /**
    * Execute sql
    *
-   * @param sql               sql statement.
+   * @param sql sql statement.
    * @param parametersBinding parameters to bind
-   * @param caller            the JDBC interface method that called this method, if any
+   * @param caller the JDBC interface method that called this method, if any
    * @return whether there is result set or not
    * @throws SQLException if failed to execute sql
-   * @throws SFException  exception raised from Snowflake components
+   * @throws SFException exception raised from Snowflake components
    * @throws SQLException if SQL error occurs
    */
-  public SFBaseResultSet execute(String sql,
-                                 boolean asyncExec,
-                                 Map<String, ParameterBindingDTO>
-                                     parametersBinding,
-                                 CallingMethod caller)
-  throws SQLException, SFException
-  {
+  public SFBaseResultSet execute(
+      String sql,
+      boolean asyncExec,
+      Map<String, ParameterBindingDTO> parametersBinding,
+      CallingMethod caller)
+      throws SQLException, SFException {
     TelemetryService.getInstance().updateContext(session.getSnowflakeConnectionString());
     sanityCheckQuery(sql);
 
     session.injectedDelay();
 
-    if (session.getPreparedStatementLogging())
-    {
-      logger.info("execute: {}",
-                  (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
-    }
-    else
-    {
-      logger.debug("execute: {}",
-                   (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
+    if (session.getPreparedStatementLogging()) {
+      logger.info("execute: {}", (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
+    } else {
+      logger.debug("execute: {}", (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
     }
 
     String trimmedSql = sql.trim();
 
-    if (trimmedSql.length() >= 20
-        && trimmedSql.toLowerCase().startsWith(
-        "set-sf-property"))
-    {
+    if (trimmedSql.length() >= 20 && trimmedSql.toLowerCase().startsWith("set-sf-property")) {
       executeSetProperty(sql);
       return null;
     }
     return executeQuery(sql, parametersBinding, false, asyncExec, caller);
   }
 
-  private SFBaseResultSet executeFileTransfer(String sql) throws SQLException,
-                                                                 SFException
-  {
+  private SFBaseResultSet executeFileTransfer(String sql) throws SQLException, SFException {
     session.injectedDelay();
 
     resetState();
@@ -878,8 +764,7 @@ public class SFStatement
     isFileTransfer = true;
     transferAgent = new SnowflakeFileTransferAgent(sql, session, this);
 
-    try
-    {
+    try {
       transferAgent.execute();
 
       logger.debug("setting result set");
@@ -887,24 +772,19 @@ public class SFStatement
       resultSet = (SFFixedViewResultSet) transferAgent.getResultSet();
       childResults = Collections.emptyList();
 
-      logger.debug("Number of cols: {}",
-                   resultSet.getMetaData().getColumnCount());
+      logger.debug("Number of cols: {}", resultSet.getMetaData().getColumnCount());
       logger.debug("Completed transferring data");
       return resultSet;
-    }
-    catch (SQLException ex)
-    {
+    } catch (SQLException ex) {
       logger.debug("Exception: {}", ex.getMessage());
       throw ex;
     }
   }
 
-  public void close()
-  {
+  public void close() {
     logger.debug("public void close()");
 
-    if (requestId != null)
-    {
+    if (requestId != null) {
       EventUtil.triggerStateTransition(
           BasicEvent.QueryState.QUERY_ENDED,
           String.format(QueryState.QUERY_ENDED.getArgString(), requestId));
@@ -914,8 +794,7 @@ public class SFStatement
     childResults = null;
     isClosed = true;
 
-    if (httpRequest != null)
-    {
+    if (httpRequest != null) {
       logger.debug("releasing connection for the http request");
 
       httpRequest.releaseConnection();
@@ -928,33 +807,25 @@ public class SFStatement
     transferAgent = null;
   }
 
-  public void cancel() throws SFException, SQLException
-  {
+  public void cancel() throws SFException, SQLException {
     logger.debug("public void cancel()");
 
-    if (canceling.get())
-    {
+    if (canceling.get()) {
       logger.debug("Query is already cancelled");
       return;
     }
 
     canceling.set(true);
 
-    if (isFileTransfer)
-    {
-      if (transferAgent != null)
-      {
+    if (isFileTransfer) {
+      if (transferAgent != null) {
         logger.debug("Cancel file transferring ... ");
         transferAgent.cancel();
       }
-    }
-    else
-    {
-      synchronized (this)
-      {
+    } else {
+      synchronized (this) {
         // the query hasn't been sent to GS yet, just mark the stmt closed
-        if (requestId == null)
-        {
+        if (requestId == null) {
           logger.debug("No remote query outstanding");
 
           return;
@@ -966,13 +837,11 @@ public class SFStatement
     }
   }
 
-  private void resetState()
-  {
+  private void resetState() {
     resultSet = null;
     childResults = null;
 
-    if (httpRequest != null)
-    {
+    if (httpRequest != null) {
       httpRequest.releaseConnection();
       httpRequest = null;
     }
@@ -987,90 +856,71 @@ public class SFStatement
     transferAgent = null;
   }
 
-  public void executeSetProperty(final String sql)
-  {
+  public void executeSetProperty(final String sql) {
     logger.debug("setting property");
 
     // tokenize the sql
     String[] tokens = sql.split("\\s+");
 
-    if (tokens.length < 2)
-    {
+    if (tokens.length < 2) {
       return;
     }
 
-    if ("sort".equalsIgnoreCase(tokens[1]))
-    {
-      if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2]))
-      {
+    if ("sort".equalsIgnoreCase(tokens[1])) {
+      if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2])) {
         logger.debug("setting sort on");
 
         this.session.setSFSessionProperty("sort", true);
-      }
-      else
-      {
+      } else {
         logger.debug("setting sort off");
         this.session.setSFSessionProperty("sort", false);
       }
     }
   }
 
-  protected SFSession getSession()
-  {
+  protected SFSession getSession() {
     return session;
   }
 
-  public void setHasUnsupportedStageBind(boolean hasUnsupportedStageBind)
-  {
+  public void setHasUnsupportedStageBind(boolean hasUnsupportedStageBind) {
     this.hasUnsupportedStageBind = hasUnsupportedStageBind;
   }
 
   // *NOTE* this new SQL format is incomplete. It should only be used under certain circumstances.
-  private void setUseNewSqlFormat(boolean useNewSqlFormat) throws SFException
-  {
+  private void setUseNewSqlFormat(boolean useNewSqlFormat) throws SFException {
     this.addProperty("NEW_SQL_FORMAT", useNewSqlFormat);
   }
 
-  public boolean getMoreResults() throws SQLException
-  {
+  public boolean getMoreResults() throws SQLException {
     return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
   }
 
   /**
    * Sets the result set to the next one, if available.
    *
-   * @param current What to do with the current result.
-   *                One of Statement.CLOSE_CURRENT_RESULT,
-   *                Statement.CLOSE_ALL_RESULTS, or
-   *                Statement.KEEP_CURRENT_RESULT
-   * @return true if there is a next result and it's a result set
-   * false if there are no more results, or there is a next result
-   * and it's an update count
+   * @param current What to do with the current result. One of Statement.CLOSE_CURRENT_RESULT,
+   *     Statement.CLOSE_ALL_RESULTS, or Statement.KEEP_CURRENT_RESULT
+   * @return true if there is a next result and it's a result set false if there are no more
+   *     results, or there is a next result and it's an update count
    * @throws SQLException if something fails while getting the next result
    */
-  public boolean getMoreResults(int current) throws SQLException
-  {
+  public boolean getMoreResults(int current) throws SQLException {
     // clean up current result, if exists
-    if (resultSet != null &&
-        (current == Statement.CLOSE_CURRENT_RESULT ||
-         current == Statement.CLOSE_ALL_RESULTS))
-    {
+    if (resultSet != null
+        && (current == Statement.CLOSE_CURRENT_RESULT || current == Statement.CLOSE_ALL_RESULTS)) {
       resultSet.close();
     }
     resultSet = null;
 
     // verify if more results exist
-    if (childResults == null || childResults.isEmpty())
-    {
+    if (childResults == null || childResults.isEmpty()) {
       return false;
     }
 
     // fetch next result using the query id
     SFChildResult nextResult = childResults.remove(0);
-    try
-    {
-      JsonNode result = StmtUtil.getQueryResultJSON(
-          nextResult.getId(), session);
+    try {
+      JsonNode result = StmtUtil.getQueryResultJSON(nextResult.getId(), session);
       Object sortProperty = session.getSFSessionProperty("sort");
       boolean sortResult = sortProperty != null && (Boolean) sortProperty;
       resultSet = SFResultSetFactory.getResultSet(result, this, sortResult);
@@ -1079,20 +929,16 @@ public class SFStatement
       resultSet.setStatementType(nextResult.getType());
 
       return nextResult.getType().isGenerateResultSet();
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLException(ex);
     }
   }
 
-  public SFBaseResultSet getResultSet()
-  {
+  public SFBaseResultSet getResultSet() {
     return resultSet;
   }
 
-  public boolean hasChildren()
-  {
+  public boolean hasChildren() {
     return !childResults.isEmpty();
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -4,18 +4,7 @@
 
 package net.snowflake.client.core;
 
-import static net.snowflake.client.core.SessionUtil.*;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.core.bind.BindException;
 import net.snowflake.client.core.bind.BindUploader;
@@ -30,9 +19,25 @@ import net.snowflake.client.util.SecretDetector;
 import net.snowflake.common.core.SqlState;
 import org.apache.http.client.methods.HttpRequestBase;
 
-/** Snowflake statement */
-public class SFStatement {
-  public enum CallingMethod {
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static net.snowflake.client.core.SessionUtil.*;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
+/**
+ * Snowflake statement
+ */
+public class SFStatement
+{
+  public enum CallingMethod
+  {
     EXECUTE,
     EXECUTE_UPDATE,
     EXECUTE_QUERY
@@ -66,11 +71,13 @@ public class SFStatement {
   // statement level parameters
   private final Map<String, Object> statementParametersMap = new HashMap<>();
 
-  private static final int MAX_STATEMENT_PARAMETERS = 1000;
+  final private static int MAX_STATEMENT_PARAMETERS = 1000;
 
-  private static final int MAX_BINDING_PARAMS_FOR_LOGGING = 1000;
+  final private static int MAX_BINDING_PARAMS_FOR_LOGGING = 1000;
 
-  /** id used in combine describe and execute */
+  /**
+   * id used in combine describe and execute
+   */
   private String describeJobUUID;
 
   // when uploading binds to stage, we use a table scan which cannot parse times from ms
@@ -87,29 +94,35 @@ public class SFStatement {
 
   /**
    * Add a statement parameter
+   * <p>
+   * Make sure a property is not added more than once and the number of
+   * properties does not exceed limit.
    *
-   * <p>Make sure a property is not added more than once and the number of properties does not
-   * exceed limit.
-   *
-   * @param propertyName property name
+   * @param propertyName  property name
    * @param propertyValue property value
    * @throws SFException if too many parameters for a statement
    */
-  public void addProperty(String propertyName, Object propertyValue) throws SFException {
+  public void addProperty(String propertyName, Object propertyValue)
+  throws SFException
+  {
     statementParametersMap.put(propertyName, propertyValue);
 
     // for query timeout, we implement it on client side for now
-    if ("query_timeout".equalsIgnoreCase(propertyName)) {
+    if ("query_timeout".equalsIgnoreCase(propertyName))
+    {
       queryTimeout = (Integer) propertyValue;
     }
 
     // check if the number of session properties exceed limit
-    if (statementParametersMap.size() > MAX_STATEMENT_PARAMETERS) {
-      throw new SFException(ErrorCode.TOO_MANY_STATEMENT_PARAMETERS, MAX_STATEMENT_PARAMETERS);
+    if (statementParametersMap.size() > MAX_STATEMENT_PARAMETERS)
+    {
+      throw new SFException(
+          ErrorCode.TOO_MANY_STATEMENT_PARAMETERS, MAX_STATEMENT_PARAMETERS);
     }
   }
 
-  public SFStatement(SFSession session) {
+  public SFStatement(SFSession session)
+  {
     logger.debug(" public SFStatement(SFSession session)");
 
     this.session = session;
@@ -118,10 +131,12 @@ public class SFStatement {
     verifyArrowSupport();
   }
 
-  private void verifyArrowSupport() {
-    if (SnowflakeDriver.isDisableArrowResultFormat()) {
-      logger.debug(
-          "disable arrow support: {}", SnowflakeDriver.getDisableArrowResultFormatMessage());
+  private void verifyArrowSupport()
+  {
+    if (SnowflakeDriver.isDisableArrowResultFormat())
+    {
+      logger.debug("disable arrow support: {}",
+                   SnowflakeDriver.getDisableArrowResultFormatMessage());
       statementParametersMap.put("JDBC_QUERY_RESULT_FORMAT", "JSON");
     }
   }
@@ -132,21 +147,24 @@ public class SFStatement {
    * @param sql The SQL statement to check
    * @throws SQLException Will be thrown if sql is null or empty
    */
-  private void sanityCheckQuery(String sql) throws SQLException {
-    if (sql == null || sql.isEmpty()) {
-      throw new SnowflakeSQLException(
-          SqlState.SQL_STATEMENT_NOT_YET_COMPLETE, ErrorCode.INVALID_SQL.getMessageCode(), sql);
+  private void sanityCheckQuery(String sql) throws SQLException
+  {
+    if (sql == null || sql.isEmpty())
+    {
+      throw new SnowflakeSQLException(SqlState.SQL_STATEMENT_NOT_YET_COMPLETE,
+                                      ErrorCode.INVALID_SQL.getMessageCode(), sql);
+
     }
   }
 
   /**
    * Execute SQL query with an option for describe only
    *
-   * @param sql sql statement
+   * @param sql          sql statement
    * @param describeOnly true if describe only
    * @return query result set
    * @throws SQLException if connection is already closed
-   * @throws SFException if result set is null
+   * @throws SFException  if result set is null
    */
   private SFBaseResultSet executeQuery(
       String sql,
@@ -154,13 +172,15 @@ public class SFStatement {
       boolean describeOnly,
       boolean asyncExec,
       CallingMethod caller)
-      throws SQLException, SFException {
+  throws SQLException, SFException
+  {
     sanityCheckQuery(sql);
 
     String trimmedSql = sql.trim();
 
     // snowflake specific client side commands
-    if (isFileTransfer(trimmedSql)) {
+    if (isFileTransfer(trimmedSql))
+    {
       // PUT/GET command
       logger.debug("Executing file transfer locally: {}", sql);
 
@@ -174,7 +194,8 @@ public class SFStatement {
         describeOnly,
         describeOnly, // internal query if describeOnly is true
         asyncExec,
-        caller);
+        caller
+    );
   }
 
   /**
@@ -183,35 +204,34 @@ public class SFStatement {
    * @param sql statement
    * @return metadata of statement including result set metadata and binding information
    * @throws SQLException if connection is already closed
-   * @throws SFException if result set is null
+   * @throws SFException  if result set is null
    */
-  public SFStatementMetaData describe(String sql) throws SFException, SQLException {
+  public SFStatementMetaData describe(String sql) throws SFException, SQLException
+  {
     SFBaseResultSet baseResultSet = executeQuery(sql, null, true, false, null);
 
     describeJobUUID = baseResultSet.getQueryId();
 
-    return new SFStatementMetaData(
-        baseResultSet.getMetaData(),
-        baseResultSet.getStatementType(),
-        baseResultSet.getNumberOfBinds(),
-        baseResultSet.isArrayBindSupported(),
-        baseResultSet.getMetaDataOfBinds(),
-        true); // valid metadata
+    return new SFStatementMetaData(baseResultSet.getMetaData(),
+                                   baseResultSet.getStatementType(),
+                                   baseResultSet.getNumberOfBinds(),
+                                   baseResultSet.isArrayBindSupported(),
+                                   baseResultSet.getMetaDataOfBinds(),
+                                   true); // valid metadata
   }
 
   /**
    * Internal method for executing a query with bindings accepted.
-   *
    * <p>
    *
-   * @param sql sql statement
+   * @param sql               sql statement
    * @param parameterBindings binding information
-   * @param describeOnly true if just showing result set metadata
-   * @param internal true if internal command not showing up in the history
-   * @param caller the JDBC method that called this function, null if none
+   * @param describeOnly      true if just showing result set metadata
+   * @param internal          true if internal command not showing up in the history
+   * @param caller            the JDBC method that called this function, null if none
    * @return snowflake query result set
    * @throws SQLException if connection is already closed
-   * @throws SFException if result set is null
+   * @throws SFException  if result set is null
    */
   SFBaseResultSet executeQueryInternal(
       String sql,
@@ -220,25 +240,29 @@ public class SFStatement {
       boolean internal,
       boolean asyncExec,
       CallingMethod caller)
-      throws SQLException, SFException {
+  throws SQLException, SFException
+  {
     resetState();
 
-    logger.debug("executeQuery: {}", (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
+    logger.debug("executeQuery: {}",
+                 (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
 
-    if (session == null || session.isClosed()) {
+    if (session == null || session.isClosed())
+    {
       throw new SQLException("connection is closed");
     }
 
-    Object result =
-        executeHelper(
-            sql, StmtUtil.SF_MEDIA_TYPE, parameterBindings, describeOnly, internal, asyncExec);
+    Object result = executeHelper(sql,
+                                  StmtUtil.SF_MEDIA_TYPE,
+                                  parameterBindings,
+                                  describeOnly,
+                                  internal, asyncExec);
 
-    if (result == null) {
-      throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
-          "got null result");
+    if (result == null)
+    {
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "got null result");
     }
 
     /*
@@ -250,7 +274,8 @@ public class SFStatement {
 
     logger.debug("Creating result set");
 
-    try {
+    try
+    {
       JsonNode jsonResult = (JsonNode) result;
       resultSet = SFResultSetFactory.getResultSet(jsonResult, this, sortResult);
       childResults = ResultUtil.getChildResults(session, requestId, jsonResult);
@@ -258,14 +283,18 @@ public class SFStatement {
       // if child results are available, skip over this result set and set the
       // current result to the first child's result.
       // we still construct the first result set for its side effects.
-      if (!childResults.isEmpty()) {
+      if (!childResults.isEmpty())
+      {
         SFStatementType type = childResults.get(0).type;
 
         // ensure first query type matches the calling JDBC method, if exists
-        if (caller == CallingMethod.EXECUTE_QUERY && !type.isGenerateResultSet()) {
+        if (caller == CallingMethod.EXECUTE_QUERY && !type.isGenerateResultSet())
+        {
           throw new SnowflakeSQLLoggedException(
               ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET, session);
-        } else if (caller == CallingMethod.EXECUTE_UPDATE && type.isGenerateResultSet()) {
+        }
+        else if (caller == CallingMethod.EXECUTE_UPDATE && type.isGenerateResultSet())
+        {
           throw new SnowflakeSQLLoggedException(
               ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT, session);
         }
@@ -273,25 +302,29 @@ public class SFStatement {
         // this will update resultSet to point to the first child result before we return it
         getMoreResults();
       }
-    } catch (SnowflakeSQLException | OutOfMemoryError ex) {
+    }
+    catch (SnowflakeSQLException | OutOfMemoryError ex)
+    {
       // snow-24428: no need to generate incident for exceptions we generate
       // snow-29403: or client OOM
       throw ex;
-    } catch (Throwable ex) {
+    }
+    catch (Throwable ex)
+    {
       // SNOW-22813 log exception
       logger.error("Exception creating result", ex);
 
-      throw (SFException)
-          IncidentUtil.generateIncidentV2WithException(
-              session,
-              new SFException(
-                  ErrorCode.INTERNAL_ERROR, IncidentUtil.oneLiner("exception creating result", ex)),
-              null,
-              null);
+      throw (SFException) IncidentUtil.generateIncidentV2WithException(
+          session,
+          new SFException(ErrorCode.INTERNAL_ERROR,
+                          IncidentUtil.oneLiner("exception creating result", ex)),
+          null,
+          null);
     }
     logger.debug("Done creating result set");
 
-    if (asyncExec) {
+    if (asyncExec)
+    {
       session.activeAsyncQueries.add(resultSet.getQueryId());
     }
     return resultSet;
@@ -302,68 +335,80 @@ public class SFStatement {
    *
    * @param executor object to execute statement cancel request
    */
-  private void setTimeBomb(ScheduledExecutorService executor) {
-    class TimeBombTask implements Callable<Void> {
+  private void setTimeBomb(ScheduledExecutorService executor)
+  {
+    class TimeBombTask implements Callable<Void>
+    {
 
       private final SFStatement statement;
 
-      private TimeBombTask(SFStatement statement) {
+      private TimeBombTask(SFStatement statement)
+      {
         this.statement = statement;
       }
 
       @Override
-      public Void call() throws SQLException {
-        try {
+      public Void call() throws SQLException
+      {
+        try
+        {
           statement.cancel();
-        } catch (SFException ex) {
-          throw new SnowflakeSQLException(ex, ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+        }
+        catch (SFException ex)
+        {
+          throw new SnowflakeSQLLoggedException(ex, ex.getSqlState(),
+                                                ex.getVendorCode(), session, ex.getParams());
         }
         return null;
       }
     }
 
-    executor.schedule(new TimeBombTask(this), this.queryTimeout, TimeUnit.SECONDS);
+    executor.schedule(new TimeBombTask(this), this.queryTimeout,
+                      TimeUnit.SECONDS);
   }
 
   /**
    * A helper method to build URL and submit the SQL to snowflake for exec
    *
-   * @param sql sql statement
-   * @param mediaType media type
-   * @param bindValues map of binding values
+   * @param sql          sql statement
+   * @param mediaType    media type
+   * @param bindValues   map of binding values
    * @param describeOnly whether only show the result set metadata
-   * @param internal run internal query not showing up in history
+   * @param internal     run internal query not showing up in history
    * @return raw json response
-   * @throws SFException if query is canceled
+   * @throws SFException           if query is canceled
    * @throws SnowflakeSQLException if query is already running
    */
-  public Object executeHelper(
-      String sql,
-      String mediaType,
-      Map<String, ParameterBindingDTO> bindValues,
-      boolean describeOnly,
-      boolean internal,
-      boolean asyncExec)
-      throws SnowflakeSQLException, SFException {
+  public Object executeHelper(String sql,
+                              String mediaType,
+                              Map<String, ParameterBindingDTO> bindValues,
+                              boolean describeOnly,
+                              boolean internal,
+                              boolean asyncExec)
+  throws SnowflakeSQLException, SFException
+  {
     ScheduledExecutorService executor = null;
 
-    try {
-      synchronized (this) {
-        if (isClosed) {
+    try
+    {
+      synchronized (this)
+      {
+        if (isClosed)
+        {
           throw new SFException(ErrorCode.STATEMENT_CLOSED);
         }
 
         // initialize a sequence id if not closed or not for aborting
-        if (canceling.get()) {
+        if (canceling.get())
+        {
           // nothing to do if canceled
           throw new SFException(ErrorCode.QUERY_CANCELED);
         }
 
-        if (this.requestId != null) {
-          throw new SnowflakeSQLLoggedException(
-              SqlState.FEATURE_NOT_SUPPORTED,
-              ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(),
-              session);
+        if (this.requestId != null)
+        {
+          throw new SnowflakeSQLLoggedException(SqlState.FEATURE_NOT_SUPPORTED,
+                                                ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(), session);
         }
 
         this.requestId = UUID.randomUUID().toString();
@@ -372,9 +417,8 @@ public class SFStatement {
         this.sqlText = sql;
       }
 
-      EventUtil.triggerStateTransition(
-          BasicEvent.QueryState.QUERY_STARTED,
-          String.format(QueryState.QUERY_STARTED.getArgString(), requestId));
+      EventUtil.triggerStateTransition(BasicEvent.QueryState.QUERY_STARTED,
+                                       String.format(QueryState.QUERY_STARTED.getArgString(), requestId));
 
       // if there are a large number of bind values, we should upload them to stage
       // instead of passing them in the payload (if enabled)
@@ -384,34 +428,36 @@ public class SFStatement {
           && session.getArrayBindStageThreshold() <= numBinds
           && !describeOnly
           && !hasUnsupportedStageBind
-          && BindUploader.isArrayBind(bindValues)) {
-        try (BindUploader uploader = BindUploader.newInstance(session, requestId)) {
+          && BindUploader.isArrayBind(bindValues))
+      {
+        try (BindUploader uploader = BindUploader.newInstance(session, requestId))
+        {
           uploader.upload(bindValues);
           bindStagePath = uploader.getStagePath();
-        } catch (BindException ex) {
-          logger.debug(
-              "Exception encountered trying to upload binds to stage. Attaching binds in payload instead. ",
-              ex);
+        }
+        catch (BindException ex)
+        {
+          logger.debug("Exception encountered trying to upload binds to stage. Attaching binds in payload instead. ", ex);
           TelemetryData errorLog = TelemetryUtil.buildJobData(this.requestId, ex.type.field, 1);
           this.session.getTelemetryClient().addLogToBatch(errorLog);
           IncidentUtil.generateIncidentV2WithException(
               session,
-              new SFException(
-                  ErrorCode.NON_FATAL_ERROR,
-                  IncidentUtil.oneLiner("Failed to upload binds " + "to stage:", ex)),
+              new SFException(ErrorCode.NON_FATAL_ERROR,
+                              IncidentUtil.oneLiner("Failed to upload binds " +
+                                                    "to stage:", ex)),
               null,
               requestId);
         }
       }
 
-      if (session.isConservativeMemoryUsageEnabled()) {
+      if (session.isConservativeMemoryUsageEnabled())
+      {
         logger.debug("JDBC conservative memory usage is enabled.");
         calculateConservativeMemoryUsage();
       }
 
       StmtUtil.StmtInput stmtInput = new StmtUtil.StmtInput();
-      stmtInput
-          .setSql(sql)
+      stmtInput.setSql(sql)
           .setMediaType(mediaType)
           .setInternal(internal)
           .setDescribeOnly(describeOnly)
@@ -432,49 +478,65 @@ public class SFStatement {
           .setServiceName(session.getServiceName())
           .setOCSPMode(session.getOCSPMode());
 
-      if (bindStagePath != null) {
-        stmtInput.setBindValues(null).setBindStage(bindStagePath);
+      if (bindStagePath != null)
+      {
+        stmtInput.setBindValues(null)
+            .setBindStage(bindStagePath);
         // use the new SQL format for this query so dates/timestamps are parsed correctly
         setUseNewSqlFormat(true);
-      } else {
-        stmtInput.setBindValues(bindValues).setBindStage(null);
       }
-      if (numBinds > 0 && session.getPreparedStatementLogging()) {
-        if (numBinds > MAX_BINDING_PARAMS_FOR_LOGGING) {
-          logger.info(
-              "Number of binds exceeds logging limit. Printing off {} binding parameters.",
-              MAX_BINDING_PARAMS_FOR_LOGGING);
-        } else {
+      else
+      {
+        stmtInput.setBindValues(bindValues)
+            .setBindStage(null);
+      }
+      if (numBinds > 0 && session.getPreparedStatementLogging())
+      {
+        if (numBinds > MAX_BINDING_PARAMS_FOR_LOGGING)
+        {
+          logger.info("Number of binds exceeds logging limit. Printing off {} binding parameters.", MAX_BINDING_PARAMS_FOR_LOGGING);
+        }
+        else
+        {
           logger.info("Printing off {} binding parameters.", numBinds);
         }
         int counter = 0;
         // if it's an array bind, print off the first few rows from each column.
-        if (BindUploader.isArrayBind(bindValues)) {
+        if (BindUploader.isArrayBind(bindValues))
+        {
           int numRowsPrinted = MAX_BINDING_PARAMS_FOR_LOGGING / bindValues.size();
-          if (numRowsPrinted <= 0) {
+          if (numRowsPrinted <= 0)
+          {
             numRowsPrinted = 1;
           }
-          for (Map.Entry<String, ParameterBindingDTO> entry : bindValues.entrySet()) {
+          for (Map.Entry<String, ParameterBindingDTO> entry : bindValues.entrySet())
+          {
             List<String> bindRows = (List<String>) entry.getValue().getValue();
-            if (numRowsPrinted >= bindRows.size()) {
+            if (numRowsPrinted >= bindRows.size())
+            {
               numRowsPrinted = bindRows.size();
             }
             String rows = "[";
-            for (int i = 0; i < numRowsPrinted; i++) {
+            for (int i = 0; i < numRowsPrinted; i++)
+            {
               rows += bindRows.get(i) + ", ";
             }
             rows += "]";
             logger.info("Column {}: {}", entry.getKey(), rows);
             counter += numRowsPrinted;
-            if (counter >= MAX_BINDING_PARAMS_FOR_LOGGING) {
+            if (counter >= MAX_BINDING_PARAMS_FOR_LOGGING)
+            {
               break;
             }
           }
         }
         // not an array, just a bunch of columns
-        else {
-          for (Map.Entry<String, ParameterBindingDTO> entry : bindValues.entrySet()) {
-            if (counter >= MAX_BINDING_PARAMS_FOR_LOGGING) {
+        else
+        {
+          for (Map.Entry<String, ParameterBindingDTO> entry : bindValues.entrySet())
+          {
+            if (counter >= MAX_BINDING_PARAMS_FOR_LOGGING)
+            {
               break;
             }
             counter++;
@@ -483,7 +545,8 @@ public class SFStatement {
         }
       }
 
-      if (canceling.get()) {
+      if (canceling.get())
+      {
         logger.debug("Query cancelled");
 
         throw new SFException(ErrorCode.QUERY_CANCELED);
@@ -491,7 +554,8 @@ public class SFStatement {
 
       // if timeout is set, start a thread to cancel the request after timeout
       // reached.
-      if (this.queryTimeout > 0) {
+      if (this.queryTimeout > 0)
+      {
         executor = Executors.newScheduledThreadPool(1);
         setTimeBomb(executor);
       }
@@ -499,20 +563,31 @@ public class SFStatement {
       StmtUtil.StmtOutput stmtOutput = null;
       boolean sessionRenewed;
 
-      do {
+      do
+      {
         sessionRenewed = false;
-        try {
+        try
+        {
           stmtOutput = StmtUtil.execute(stmtInput);
           break;
-        } catch (SnowflakeSQLException ex) {
-          if (ex.getErrorCode() == Constants.SESSION_EXPIRED_GS_CODE) {
-            try {
+        }
+        catch (SnowflakeSQLException ex)
+        {
+          if (ex.getErrorCode() == Constants.SESSION_EXPIRED_GS_CODE)
+          {
+            try
+            {
               // renew the session
               session.renewSession(stmtInput.sessionToken);
-            } catch (SnowflakeReauthenticationRequest ex0) {
-              if (session.isExternalbrowserAuthenticator()) {
+            }
+            catch (SnowflakeReauthenticationRequest ex0)
+            {
+              if (session.isExternalbrowserAuthenticator())
+              {
                 reauthenticate();
-              } else {
+              }
+              else
+              {
                 throw ex0;
               }
             }
@@ -523,22 +598,27 @@ public class SFStatement {
             sessionRenewed = true;
 
             logger.debug("Session got renewed, will retry");
-          } else {
+          }
+          else
+          {
             throw ex;
           }
         }
-      } while (sessionRenewed && !canceling.get());
+      }
+      while (sessionRenewed && !canceling.get());
 
       // Debugging/Testing for incidents
-      if (Boolean.TRUE
-          .toString()
-          .equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test1"))) {
-        throw (SFException)
-            IncidentUtil.generateIncidentV2WithException(
-                session, new SFException(ErrorCode.STATEMENT_CLOSED), null, this.requestId);
+      if (Boolean.TRUE.toString().equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test1")))
+      {
+        throw (SFException) IncidentUtil.generateIncidentV2WithException(
+            session,
+            new SFException(ErrorCode.STATEMENT_CLOSED),
+            null,
+            this.requestId);
       }
 
-      synchronized (this) {
+      synchronized (this)
+      {
         /*
          * done with the remote execution of the query. set sequenceId to -1
          * and request id to null so that we don't try to abort it upon canceling.
@@ -547,7 +627,8 @@ public class SFStatement {
         this.requestId = null;
       }
 
-      if (canceling.get()) {
+      if (canceling.get())
+      {
         // If we are here, this is the context for the initial query that
         // is being canceled. Raise an exception anyway here even if
         // the server fails to abort it.
@@ -556,15 +637,21 @@ public class SFStatement {
 
       logger.debug("Returning from executeHelper");
 
-      if (stmtOutput != null) {
+      if (stmtOutput != null)
+      {
         return stmtOutput.getResult();
       }
       throw new SFException(ErrorCode.INTERNAL_ERROR);
-    } catch (SFException | SnowflakeSQLException ex) {
+    }
+    catch (SFException | SnowflakeSQLException ex)
+    {
       isClosed = true;
       throw ex;
-    } finally {
-      if (executor != null) {
+    }
+    finally
+    {
+      if (executor != null)
+      {
         executor.shutdownNow();
       }
       // if this query enabled the new SQL format, re-disable it now
@@ -575,60 +662,66 @@ public class SFStatement {
   /**
    * calculate conservative memory limit and the number of prefetch threads before query execution
    */
-  private void calculateConservativeMemoryUsage() {
+  private void calculateConservativeMemoryUsage()
+  {
     int clientMemoryLimit = session.getClientMemoryLimit();
     int clientPrefetchThread = session.getClientPrefetchThreads();
     int clientChunkSize = session.getClientResultChunkSize();
 
     long memoryLimitInBytes;
-    if (clientMemoryLimit == DEFAULT_CLIENT_MEMORY_LIMIT) {
+    if (clientMemoryLimit == DEFAULT_CLIENT_MEMORY_LIMIT)
+    {
       // this is all default scenario
       // only allows JDBC use at most 80% of free memory
       long freeMemoryToUse = Runtime.getRuntime().freeMemory() * 8 / 10;
-      memoryLimitInBytes =
-          Math.min(
-              (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024, freeMemoryToUse);
-    } else {
+      memoryLimitInBytes = Math.min((long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024, freeMemoryToUse);
+    }
+    else
+    {
       memoryLimitInBytes = (long) clientMemoryLimit * 1024 * 1024;
     }
     conservativeMemoryLimit = memoryLimitInBytes;
-    reducePrefetchThreadsAndChunkSizeToFitMemoryLimit(
-        conservativeMemoryLimit, clientPrefetchThread, clientChunkSize);
+    reducePrefetchThreadsAndChunkSizeToFitMemoryLimit(conservativeMemoryLimit, clientPrefetchThread, clientChunkSize);
   }
 
-  private void updateConservativeResultChunkSize(int clientChunkSize) {
-    if (clientChunkSize != conservativeResultChunkSize) {
-      logger.debug(
-          "conservativeResultChunkSize changed from {} to {}",
-          conservativeResultChunkSize,
-          clientChunkSize);
+  private void updateConservativeResultChunkSize(int clientChunkSize)
+  {
+    if (clientChunkSize != conservativeResultChunkSize)
+    {
+      logger.debug("conservativeResultChunkSize changed from {} to {}", conservativeResultChunkSize,
+                   clientChunkSize);
       conservativeResultChunkSize = clientChunkSize;
       statementParametersMap.put("CLIENT_RESULT_CHUNK_SIZE", conservativeResultChunkSize);
     }
   }
 
-  private void reducePrefetchThreadsAndChunkSizeToFitMemoryLimit(
-      long clientMemoryLimit, int clientPrefetchThread, int clientChunkSize) {
-    if (clientPrefetchThread != DEFAULT_CLIENT_PREFETCH_THREADS) {
+  private void reducePrefetchThreadsAndChunkSizeToFitMemoryLimit(long clientMemoryLimit, int clientPrefetchThread,
+                                                                 int clientChunkSize)
+  {
+    if (clientPrefetchThread != DEFAULT_CLIENT_PREFETCH_THREADS)
+    {
       // prefetch threads are configured so only reduce chunk size
       conservativePrefetchThreads = clientPrefetchThread;
-      for (;
-          clientChunkSize >= MIN_CLIENT_CHUNK_SIZE;
-          clientChunkSize -= session.getConservativeMemoryAdjustStep()) {
-        if (clientMemoryLimit >= (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024) {
+      for (; clientChunkSize >= MIN_CLIENT_CHUNK_SIZE; clientChunkSize -= session.getConservativeMemoryAdjustStep())
+      {
+        if (clientMemoryLimit >= (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024)
+        {
           updateConservativeResultChunkSize(clientChunkSize);
           return;
         }
       }
       updateConservativeResultChunkSize(MIN_CLIENT_CHUNK_SIZE);
-    } else {
+    }
+    else
+    {
       // reduce both prefetch threads and chunk size
-      while (clientPrefetchThread > 1) {
-        for (clientChunkSize = MAX_CLIENT_CHUNK_SIZE;
-            clientChunkSize >= MIN_CLIENT_CHUNK_SIZE;
-            clientChunkSize -= session.getConservativeMemoryAdjustStep()) {
-          if (clientMemoryLimit
-              >= (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024) {
+      while (clientPrefetchThread > 1)
+      {
+        for (clientChunkSize = MAX_CLIENT_CHUNK_SIZE; clientChunkSize >= MIN_CLIENT_CHUNK_SIZE;
+             clientChunkSize -= session.getConservativeMemoryAdjustStep())
+        {
+          if (clientMemoryLimit >= (long) 2 * clientPrefetchThread * clientChunkSize * 1024 * 1024)
+          {
             conservativePrefetchThreads = clientPrefetchThread;
             updateConservativeResultChunkSize(clientChunkSize);
             return;
@@ -641,24 +734,30 @@ public class SFStatement {
     }
   }
 
-  /** @return conservative prefetch threads before fetching results */
-  public int getConservativePrefetchThreads() {
+  /**
+   * @return conservative prefetch threads before fetching results
+   */
+  public int getConservativePrefetchThreads()
+  {
     return conservativePrefetchThreads;
   }
 
-  /** @return conservative memory limit before fetching results */
-  public long getConservativeMemoryLimit() {
+  /**
+   * @return conservative memory limit before fetching results
+   */
+  public long getConservativeMemoryLimit()
+  {
     return conservativeMemoryLimit;
   }
 
-  private void reauthenticate() throws SFException, SnowflakeSQLException {
-    SFLoginInput input =
-        new SFLoginInput()
-            .setRole(session.getRole())
-            .setWarehouse(session.getWarehouse())
-            .setDatabaseName(session.getDatabase())
-            .setSchemaName(session.getSchema())
-            .setOCSPMode(session.getOCSPMode());
+  private void reauthenticate() throws SFException, SnowflakeSQLException
+  {
+    SFLoginInput input = new SFLoginInput()
+        .setRole(session.getRole())
+        .setWarehouse(session.getWarehouse())
+        .setDatabaseName(session.getDatabase())
+        .setSchemaName(session.getSchema())
+        .setOCSPMode(session.getOCSPMode());
 
     session.open();
   }
@@ -666,22 +765,25 @@ public class SFStatement {
   /**
    * A helper method to build URL and cancel the SQL for exec
    *
-   * @param sql sql statement
+   * @param sql       sql statement
    * @param mediaType media type
    * @throws SnowflakeSQLException if failed to cancel the statement
-   * @throws SFException if statement is already closed
+   * @throws SFException           if statement is already closed
    */
   private void cancelHelper(String sql, String mediaType)
-      throws SnowflakeSQLException, SFException {
-    synchronized (this) {
-      if (isClosed) {
-        throw new SFException(ErrorCode.INTERNAL_ERROR, "statement already closed");
+  throws SnowflakeSQLException, SFException
+  {
+    synchronized (this)
+    {
+      if (isClosed)
+      {
+        throw new SFException(ErrorCode.INTERNAL_ERROR,
+                              "statement already closed");
       }
     }
 
     StmtUtil.StmtInput stmtInput = new StmtUtil.StmtInput();
-    stmtInput
-        .setServerUrl(session.getServerUrl())
+    stmtInput.setServerUrl(session.getServerUrl())
         .setSql(sql)
         .setMediaType(mediaType)
         .setRequestId(requestId)
@@ -691,7 +793,8 @@ public class SFStatement {
 
     StmtUtil.cancel(stmtInput);
 
-    synchronized (this) {
+    synchronized (this)
+    {
       /*
        * done with the remote execution of the query. set sequenceId to -1
        * and request id to null so that we don't try to abort it again upon
@@ -703,57 +806,69 @@ public class SFStatement {
   }
 
   /**
-   * A method to check if a sql is file upload statement with consideration for potential comments
-   * in front of put keyword.
-   *
+   * A method to check if a sql is file upload statement with consideration for
+   * potential comments in front of put keyword.
    * <p>
    *
    * @param sql sql statement
    * @return true if the command is upload statement
    */
-  private boolean isFileTransfer(String sql) {
+  private boolean isFileTransfer(String sql)
+  {
     SFStatementType statementType = StmtUtil.checkStageManageCommand(sql);
-    return statementType == SFStatementType.PUT || statementType == SFStatementType.GET;
+    return statementType == SFStatementType.PUT ||
+           statementType == SFStatementType.GET;
   }
 
   /**
    * Execute sql
    *
-   * @param sql sql statement.
+   * @param sql               sql statement.
    * @param parametersBinding parameters to bind
-   * @param caller the JDBC interface method that called this method, if any
+   * @param caller            the JDBC interface method that called this method, if any
    * @return whether there is result set or not
    * @throws SQLException if failed to execute sql
-   * @throws SFException exception raised from Snowflake components
+   * @throws SFException  exception raised from Snowflake components
    * @throws SQLException if SQL error occurs
    */
-  public SFBaseResultSet execute(
-      String sql,
-      boolean asyncExec,
-      Map<String, ParameterBindingDTO> parametersBinding,
-      CallingMethod caller)
-      throws SQLException, SFException {
+  public SFBaseResultSet execute(String sql,
+                                 boolean asyncExec,
+                                 Map<String, ParameterBindingDTO>
+                                     parametersBinding,
+                                 CallingMethod caller)
+  throws SQLException, SFException
+  {
     TelemetryService.getInstance().updateContext(session.getSnowflakeConnectionString());
     sanityCheckQuery(sql);
 
     session.injectedDelay();
 
-    if (session.getPreparedStatementLogging()) {
-      logger.info("execute: {}", (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
-    } else {
-      logger.debug("execute: {}", (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
+    if (session.getPreparedStatementLogging())
+    {
+      logger.info("execute: {}",
+                  (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
+    }
+    else
+    {
+      logger.debug("execute: {}",
+                   (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
     }
 
     String trimmedSql = sql.trim();
 
-    if (trimmedSql.length() >= 20 && trimmedSql.toLowerCase().startsWith("set-sf-property")) {
+    if (trimmedSql.length() >= 20
+        && trimmedSql.toLowerCase().startsWith(
+        "set-sf-property"))
+    {
       executeSetProperty(sql);
       return null;
     }
     return executeQuery(sql, parametersBinding, false, asyncExec, caller);
   }
 
-  private SFBaseResultSet executeFileTransfer(String sql) throws SQLException, SFException {
+  private SFBaseResultSet executeFileTransfer(String sql) throws SQLException,
+                                                                 SFException
+  {
     session.injectedDelay();
 
     resetState();
@@ -763,7 +878,8 @@ public class SFStatement {
     isFileTransfer = true;
     transferAgent = new SnowflakeFileTransferAgent(sql, session, this);
 
-    try {
+    try
+    {
       transferAgent.execute();
 
       logger.debug("setting result set");
@@ -771,19 +887,24 @@ public class SFStatement {
       resultSet = (SFFixedViewResultSet) transferAgent.getResultSet();
       childResults = Collections.emptyList();
 
-      logger.debug("Number of cols: {}", resultSet.getMetaData().getColumnCount());
+      logger.debug("Number of cols: {}",
+                   resultSet.getMetaData().getColumnCount());
       logger.debug("Completed transferring data");
       return resultSet;
-    } catch (SQLException ex) {
+    }
+    catch (SQLException ex)
+    {
       logger.debug("Exception: {}", ex.getMessage());
       throw ex;
     }
   }
 
-  public void close() {
+  public void close()
+  {
     logger.debug("public void close()");
 
-    if (requestId != null) {
+    if (requestId != null)
+    {
       EventUtil.triggerStateTransition(
           BasicEvent.QueryState.QUERY_ENDED,
           String.format(QueryState.QUERY_ENDED.getArgString(), requestId));
@@ -793,7 +914,8 @@ public class SFStatement {
     childResults = null;
     isClosed = true;
 
-    if (httpRequest != null) {
+    if (httpRequest != null)
+    {
       logger.debug("releasing connection for the http request");
 
       httpRequest.releaseConnection();
@@ -806,25 +928,33 @@ public class SFStatement {
     transferAgent = null;
   }
 
-  public void cancel() throws SFException, SQLException {
+  public void cancel() throws SFException, SQLException
+  {
     logger.debug("public void cancel()");
 
-    if (canceling.get()) {
+    if (canceling.get())
+    {
       logger.debug("Query is already cancelled");
       return;
     }
 
     canceling.set(true);
 
-    if (isFileTransfer) {
-      if (transferAgent != null) {
+    if (isFileTransfer)
+    {
+      if (transferAgent != null)
+      {
         logger.debug("Cancel file transferring ... ");
         transferAgent.cancel();
       }
-    } else {
-      synchronized (this) {
+    }
+    else
+    {
+      synchronized (this)
+      {
         // the query hasn't been sent to GS yet, just mark the stmt closed
-        if (requestId == null) {
+        if (requestId == null)
+        {
           logger.debug("No remote query outstanding");
 
           return;
@@ -836,11 +966,13 @@ public class SFStatement {
     }
   }
 
-  private void resetState() {
+  private void resetState()
+  {
     resultSet = null;
     childResults = null;
 
-    if (httpRequest != null) {
+    if (httpRequest != null)
+    {
       httpRequest.releaseConnection();
       httpRequest = null;
     }
@@ -855,71 +987,90 @@ public class SFStatement {
     transferAgent = null;
   }
 
-  public void executeSetProperty(final String sql) {
+  public void executeSetProperty(final String sql)
+  {
     logger.debug("setting property");
 
     // tokenize the sql
     String[] tokens = sql.split("\\s+");
 
-    if (tokens.length < 2) {
+    if (tokens.length < 2)
+    {
       return;
     }
 
-    if ("sort".equalsIgnoreCase(tokens[1])) {
-      if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2])) {
+    if ("sort".equalsIgnoreCase(tokens[1]))
+    {
+      if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2]))
+      {
         logger.debug("setting sort on");
 
         this.session.setSFSessionProperty("sort", true);
-      } else {
+      }
+      else
+      {
         logger.debug("setting sort off");
         this.session.setSFSessionProperty("sort", false);
       }
     }
   }
 
-  protected SFSession getSession() {
+  protected SFSession getSession()
+  {
     return session;
   }
 
-  public void setHasUnsupportedStageBind(boolean hasUnsupportedStageBind) {
+  public void setHasUnsupportedStageBind(boolean hasUnsupportedStageBind)
+  {
     this.hasUnsupportedStageBind = hasUnsupportedStageBind;
   }
 
   // *NOTE* this new SQL format is incomplete. It should only be used under certain circumstances.
-  private void setUseNewSqlFormat(boolean useNewSqlFormat) throws SFException {
+  private void setUseNewSqlFormat(boolean useNewSqlFormat) throws SFException
+  {
     this.addProperty("NEW_SQL_FORMAT", useNewSqlFormat);
   }
 
-  public boolean getMoreResults() throws SQLException {
+  public boolean getMoreResults() throws SQLException
+  {
     return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
   }
 
   /**
    * Sets the result set to the next one, if available.
    *
-   * @param current What to do with the current result. One of Statement.CLOSE_CURRENT_RESULT,
-   *     Statement.CLOSE_ALL_RESULTS, or Statement.KEEP_CURRENT_RESULT
-   * @return true if there is a next result and it's a result set false if there are no more
-   *     results, or there is a next result and it's an update count
+   * @param current What to do with the current result.
+   *                One of Statement.CLOSE_CURRENT_RESULT,
+   *                Statement.CLOSE_ALL_RESULTS, or
+   *                Statement.KEEP_CURRENT_RESULT
+   * @return true if there is a next result and it's a result set
+   * false if there are no more results, or there is a next result
+   * and it's an update count
    * @throws SQLException if something fails while getting the next result
    */
-  public boolean getMoreResults(int current) throws SQLException {
+  public boolean getMoreResults(int current) throws SQLException
+  {
     // clean up current result, if exists
-    if (resultSet != null
-        && (current == Statement.CLOSE_CURRENT_RESULT || current == Statement.CLOSE_ALL_RESULTS)) {
+    if (resultSet != null &&
+        (current == Statement.CLOSE_CURRENT_RESULT ||
+         current == Statement.CLOSE_ALL_RESULTS))
+    {
       resultSet.close();
     }
     resultSet = null;
 
     // verify if more results exist
-    if (childResults == null || childResults.isEmpty()) {
+    if (childResults == null || childResults.isEmpty())
+    {
       return false;
     }
 
     // fetch next result using the query id
     SFChildResult nextResult = childResults.remove(0);
-    try {
-      JsonNode result = StmtUtil.getQueryResultJSON(nextResult.getId(), session);
+    try
+    {
+      JsonNode result = StmtUtil.getQueryResultJSON(
+          nextResult.getId(), session);
       Object sortProperty = session.getSFSessionProperty("sort");
       boolean sortResult = sortProperty != null && (Boolean) sortProperty;
       resultSet = SFResultSetFactory.getResultSet(result, this, sortResult);
@@ -928,16 +1079,20 @@ public class SFStatement {
       resultSet.setStatementType(nextResult.getType());
 
       return nextResult.getType().isGenerateResultSet();
-    } catch (SFException ex) {
+    }
+    catch (SFException ex)
+    {
       throw new SnowflakeSQLException(ex);
     }
   }
 
-  public SFBaseResultSet getResultSet() {
+  public SFBaseResultSet getResultSet()
+  {
     return resultSet;
   }
 
-  public boolean hasChildren() {
+  public boolean hasChildren()
+  {
     return !childResults.isEmpty();
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -3,13 +3,6 @@
  */
 package net.snowflake.client.jdbc;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.channels.ClosedByInterruptException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import net.snowflake.client.core.DataConversionContext;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.core.SFSession;
@@ -24,61 +17,77 @@ import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.util.TransferPair;
 
-public class ArrowResultChunk extends SnowflakeResultChunk {
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.ClosedByInterruptException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ArrowResultChunk extends SnowflakeResultChunk
+{
   /**
-   * A 2-D array of arrow ValueVectors, this list represents data in the whole chunk. Since each
-   * chunk is divided into record batchs and each record batch is composed of list of column
-   * vectors.
-   *
-   * <p>So the outer list is list of record batches, inner list represents list of columns
+   * A 2-D array of arrow ValueVectors, this list represents data in the whole
+   * chunk. Since each chunk is divided into record batchs and each record batch
+   * is composed of list of column vectors.
+   * <p>
+   * So the outer list is list of record batches, inner list represents list of
+   * columns
    */
   private final ArrayList<List<ValueVector>> batchOfVectors;
 
-  private static final SFLogger logger = SFLoggerFactory.getLogger(ArrowResultChunk.class);
+  private static final SFLogger logger =
+      SFLoggerFactory.getLogger(ArrowResultChunk.class);
 
-  /** arrow root allocator used by this resultSet */
+
+  /**
+   * arrow root allocator used by this resultSet
+   */
   private final RootAllocator rootAllocator;
-
   private boolean enableSortFirstResultChunk;
   private IntVector firstResultChunkSortedIndices;
   private VectorSchemaRoot root;
   private static SFSession session;
 
-  public ArrowResultChunk(
-      String url,
-      int rowCount,
-      int colCount,
-      int uncompressedSize,
-      RootAllocator rootAllocator,
-      SFSession session) {
+  public ArrowResultChunk(String url, int rowCount, int colCount,
+                          int uncompressedSize, RootAllocator rootAllocator, SFSession session)
+  {
     super(url, rowCount, colCount, uncompressedSize);
     this.batchOfVectors = new ArrayList<>();
     this.rootAllocator = rootAllocator;
     this.session = session;
   }
 
-  private void addBatchData(List<ValueVector> batch) {
+  private void addBatchData(List<ValueVector> batch)
+  {
     batchOfVectors.add(batch);
   }
 
   /**
-   * Read an inputStream of arrow data bytes and load them into java vectors of value. Note, there
-   * is no copy of data involved once data is loaded into memory. a.k.a ArrowStreamReader originally
-   * allocates the memory to hold vectors, but those memory ownership is transfer into
-   * ArrowResultChunk class and once ArrowStreamReader is garbage collected, memory will not be
-   * cleared up
+   * Read an inputStream of arrow data bytes and load them into java vectors
+   * of value.
+   * Note, there is no copy of data involved once data is loaded into memory.
+   * a.k.a ArrowStreamReader originally allocates the memory to hold vectors,
+   * but those memory ownership is transfer into ArrowResultChunk class and once
+   * ArrowStreamReader is garbage collected, memory will not be cleared up
    *
    * @param is inputStream which contains arrow data file in bytes
    * @throws IOException if failed to read data as arrow file
    */
-  public void readArrowStream(InputStream is) throws IOException {
+  public void readArrowStream(InputStream is)
+  throws IOException
+  {
     ArrayList<ValueVector> valueVectors = new ArrayList<>();
-    try (ArrowStreamReader reader = new ArrowStreamReader(is, rootAllocator)) {
+    try (ArrowStreamReader reader = new ArrowStreamReader(is, rootAllocator))
+    {
       root = reader.getVectorSchemaRoot();
-      while (reader.loadNextBatch()) {
+      while (reader.loadNextBatch())
+      {
         valueVectors = new ArrayList<>();
 
-        for (FieldVector f : root.getFieldVectors()) {
+        for (FieldVector f : root.getFieldVectors())
+        {
           // transfer will not copy data but transfer ownership of memory
           // from streamReader to resultChunk
           TransferPair t = f.getTransferPair(rootAllocator);
@@ -89,12 +98,16 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
         addBatchData(valueVectors);
         root.clear();
       }
-    } catch (ClosedByInterruptException cbie) {
+    }
+    catch (ClosedByInterruptException cbie)
+    {
       // happens when the statement is closed before finish parsing
       logger.debug("Interrupted when loading Arrow result", cbie);
       valueVectors.forEach(ValueVector::close);
       freeData();
-    } catch (Exception ex) {
+    }
+    catch (Exception ex)
+    {
       valueVectors.forEach(ValueVector::close);
       freeData();
       throw ex;
@@ -102,65 +115,80 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
   }
 
   @Override
-  public void reset() {
+  public void reset()
+  {
     freeData();
     this.batchOfVectors.clear();
   }
 
   @Override
-  public long computeNeededChunkMemory() {
+  public long computeNeededChunkMemory()
+  {
     return getUncompressedSize();
   }
 
   @Override
-  public void freeData() {
+  public void freeData()
+  {
     batchOfVectors.forEach(list -> list.forEach(ValueVector::close));
-    if (firstResultChunkSortedIndices != null) {
+    if (firstResultChunkSortedIndices != null)
+    {
       firstResultChunkSortedIndices.close();
     }
-    if (root != null) {
+    if (root != null)
+    {
       root.clear();
       root = null;
     }
   }
 
   /**
-   * Given a list of arrow vectors (all columns in a single record batch), return list of arrow
-   * vector converter. Note, converter is built on top of arrow vector, so that arrow data can be
-   * converted back to java data
-   *
+   * Given a list of arrow vectors (all columns in a single record batch),
+   * return list of arrow vector converter. Note, converter is built on top of
+   * arrow vector, so that arrow data can be converted back to java data
    * <p>
-   *
-   * <p>Arrow converter mappings for Snowflake fixed-point numbers
-   * ----------------------------------------------------------------------------------------- Max
-   * position & scale Converter
+   * <p>
+   * Arrow converter mappings for Snowflake fixed-point numbers
    * -----------------------------------------------------------------------------------------
-   * number(3,0) {@link TinyIntToFixedConverter} number(3,2) {@link TinyIntToScaledFixedConverter}
-   * number(5,0) {@link SmallIntToFixedConverter} number(5,4) {@link SmallIntToScaledFixedConverter}
-   * number(10,0) {@link IntToFixedConverter} number(10,9) {@link IntToScaledFixedConverter}
-   * number(19,0) {@link BigIntToFixedConverter} number(19,18) {@link BigIntToFixedConverter}
-   * number(38,37) {@link DecimalToScaledFixedConverter}
+   * Max position & scale                    Converter
+   * -----------------------------------------------------------------------------------------
+   * number(3,0)                             {@link TinyIntToFixedConverter}
+   * number(3,2)                             {@link TinyIntToScaledFixedConverter}
+   * number(5,0)                             {@link SmallIntToFixedConverter}
+   * number(5,4)                             {@link SmallIntToScaledFixedConverter}
+   * number(10,0)                            {@link IntToFixedConverter}
+   * number(10,9)                            {@link IntToScaledFixedConverter}
+   * number(19,0)                            {@link BigIntToFixedConverter}
+   * number(19,18)                           {@link BigIntToFixedConverter}
+   * number(38,37)                           {@link DecimalToScaledFixedConverter}
    * ------------------------------------------------------------------------------------------
    *
    * @param vectors list of arrow vectors
    * @return list of converters on top of each converters
    */
   private static List<ArrowVectorConverter> initConverters(
-      List<ValueVector> vectors, DataConversionContext context) throws SnowflakeSQLException {
+      List<ValueVector> vectors, DataConversionContext context) throws SnowflakeSQLException
+  {
     List<ArrowVectorConverter> converters = new ArrayList<>();
-    for (int i = 0; i < vectors.size(); i++) {
+    for (int i = 0; i < vectors.size(); i++)
+    {
       ValueVector vector = vectors.get(i);
       // arrow minor type
-      Types.MinorType type = Types.getMinorTypeForArrowType(vector.getField().getType());
+      Types.MinorType type = Types.getMinorTypeForArrowType(
+          vector.getField().getType());
 
       // each column's metadata
       Map<String, String> customMeta = vector.getField().getMetadata();
-      if (type == Types.MinorType.DECIMAL) {
+      if (type == Types.MinorType.DECIMAL)
+      {
         // Note: Decimal vector is different from others
         converters.add(new DecimalToScaledFixedConverter(vector, i, context));
-      } else if (!customMeta.isEmpty()) {
+      }
+      else if (!customMeta.isEmpty())
+      {
         SnowflakeType st = SnowflakeType.valueOf(customMeta.get("logicalType"));
-        switch (st) {
+        switch (st)
+        {
           case ANY:
           case ARRAY:
           case CHAR:
@@ -185,32 +213,45 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
           case FIXED:
             String scaleStr = vector.getField().getMetadata().get("scale");
             int sfScale = Integer.parseInt(scaleStr);
-            switch (type) {
+            switch (type)
+            {
               case TINYINT:
-                if (sfScale == 0) {
+                if (sfScale == 0)
+                {
                   converters.add(new TinyIntToFixedConverter(vector, i, context));
-                } else {
+                }
+                else
+                {
                   converters.add(new TinyIntToScaledFixedConverter(vector, i, context, sfScale));
                 }
                 break;
               case SMALLINT:
-                if (sfScale == 0) {
+                if (sfScale == 0)
+                {
                   converters.add(new SmallIntToFixedConverter(vector, i, context));
-                } else {
+                }
+                else
+                {
                   converters.add(new SmallIntToScaledFixedConverter(vector, i, context, sfScale));
                 }
                 break;
               case INT:
-                if (sfScale == 0) {
+                if (sfScale == 0)
+                {
                   converters.add(new IntToFixedConverter(vector, i, context));
-                } else {
+                }
+                else
+                {
                   converters.add(new IntToScaledFixedConverter(vector, i, context, sfScale));
                 }
                 break;
               case BIGINT:
-                if (sfScale == 0) {
+                if (sfScale == 0)
+                {
                   converters.add(new BigIntToFixedConverter(vector, i, context));
-                } else {
+                }
+                else
+                {
                   converters.add(new BigIntToScaledFixedConverter(vector, i, context, sfScale));
                 }
                 break;
@@ -222,7 +263,8 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
             break;
 
           case TIME:
-            switch (type) {
+            switch (type)
+            {
               case INT:
                 converters.add(new IntToTimeConverter(vector, i, context));
                 break;
@@ -232,61 +274,70 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
               default:
                 throw new SnowflakeSQLLoggedException(
                     SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                    session,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                     "Unexpected Arrow Field for ",
                     st.name());
             }
             break;
 
           case TIMESTAMP_LTZ:
-            if (vector.getField().getChildren().isEmpty()) {
+            if (vector.getField().getChildren().isEmpty())
+            {
               // case when the scale of the timestamp is equal or smaller than millisecs since epoch
               converters.add(new BigIntToTimestampLTZConverter(vector, i, context));
-            } else if (vector.getField().getChildren().size() == 2) {
-              // case when the scale of the timestamp is larger than millisecs since epoch, e.g.,
-              // nanosecs
+            }
+            else if (vector.getField().getChildren().size() == 2)
+            {
+              // case when the scale of the timestamp is larger than millisecs since epoch, e.g., nanosecs
               converters.add(new TwoFieldStructToTimestampLTZConverter(vector, i, context));
-            } else {
+            }
+            else
+            {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
             break;
 
           case TIMESTAMP_NTZ:
-            if (vector.getField().getChildren().isEmpty()) {
+            if (vector.getField().getChildren().isEmpty())
+            {
               // case when the scale of the timestamp is equal or smaller than 7
               converters.add(new BigIntToTimestampNTZConverter(vector, i, context));
-            } else if (vector.getField().getChildren().size() == 2) {
+            }
+            else if (vector.getField().getChildren().size() == 2)
+            {
               // when the timestamp is represent in two-field struct
               converters.add(new TwoFieldStructToTimestampNTZConverter(vector, i, context));
-            } else {
+            }
+            else
+            {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
             break;
 
           case TIMESTAMP_TZ:
-            if (vector.getField().getChildren().size() == 2) {
+            if (vector.getField().getChildren().size() == 2)
+            {
               // case when the scale of the timestamp is equal or smaller than millisecs since epoch
               converters.add(new TwoFieldStructToTimestampTZConverter(vector, i, context));
-            } else if (vector.getField().getChildren().size() == 3) {
-              // case when the scale of the timestamp is larger than millisecs since epoch, e.g.,
-              // nanosecs
+            }
+            else if (vector.getField().getChildren().size() == 3)
+            {
+              // case when the scale of the timestamp is larger than millisecs since epoch, e.g., nanosecs
               converters.add(new ThreeFieldStructToTimestampTZConverter(vector, i, context));
-            } else {
+            }
+            else
+            {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                   "Unexpected SnowflakeType ",
                   st.name());
             }
@@ -295,16 +346,16 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
           default:
             throw new SnowflakeSQLLoggedException(
                 SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
                 "Unexpected Arrow Field for ",
                 st.name());
         }
-      } else {
+      }
+      else
+      {
         throw new SnowflakeSQLLoggedException(
             SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            session,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
             "Unexpected Arrow Field for ",
             type.toString());
       }
@@ -312,46 +363,70 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
     return converters;
   }
 
-  /** @return an iterator to iterate over current chunk */
-  public ArrowChunkIterator getIterator(DataConversionContext dataConversionContext) {
+
+  /**
+   * @return an iterator to iterate over current chunk
+   */
+  public ArrowChunkIterator getIterator(DataConversionContext dataConversionContext)
+  {
     return new ArrowChunkIterator(this, dataConversionContext);
   }
 
-  public static ArrowChunkIterator getEmptyChunkIterator() {
+  public static ArrowChunkIterator getEmptyChunkIterator()
+  {
     return new ArrowChunkIterator(new EmptyArrowResultChunk());
   }
 
-  public void enableSortFirstResultChunk() {
+  public void enableSortFirstResultChunk()
+  {
     enableSortFirstResultChunk = true;
   }
 
-  /** Iterator class used to go through the arrow chunk row by row */
-  public static class ArrowChunkIterator {
-    /** chunk that iterator will iterate through */
+  /**
+   * Iterator class used to go through the arrow chunk row by row
+   */
+  public static class ArrowChunkIterator
+  {
+    /**
+     * chunk that iterator will iterate through
+     */
     private ArrowResultChunk resultChunk;
 
-    /** index of record batch that iterator currently points to */
+    /**
+     * index of record batch that iterator currently points to
+     */
     private int currentRecordBatchIndex;
 
-    /** total number of record batch */
+    /**
+     * total number of record batch
+     */
     private int totalRecordBatch;
 
-    /** index of row inside current record batch that iterator points to */
+    /**
+     * index of row inside current record batch that iterator points to
+     */
     private int currentRowInRecordBatch;
 
-    /** number of rows inside current record batch */
+    /**
+     * number of rows inside current record batch
+     */
     private int rowCountInCurrentRecordBatch;
 
     /**
-     * list of converters that attached to current record batch Note: this list is updated every
-     * time iterator points to a new record batch
+     * list of converters that attached to current record batch
+     * Note: this list is updated every time iterator points to a new record
+     * batch
      */
     private List<ArrowVectorConverter> currentConverters;
 
-    /** formatters to each data type */
+    /**
+     * formatters to each data type
+     */
     private DataConversionContext dataConversionContext;
 
-    ArrowChunkIterator(ArrowResultChunk resultChunk, DataConversionContext dataConversionContext) {
+    ArrowChunkIterator(ArrowResultChunk resultChunk,
+                       DataConversionContext dataConversionContext)
+    {
       this.resultChunk = resultChunk;
       this.currentRecordBatchIndex = -1;
       this.totalRecordBatch = resultChunk.batchOfVectors.size();
@@ -360,7 +435,8 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
       this.dataConversionContext = dataConversionContext;
     }
 
-    ArrowChunkIterator(EmptyArrowResultChunk emptyArrowResultChunk) {
+    ArrowChunkIterator(EmptyArrowResultChunk emptyArrowResultChunk)
+    {
       this.resultChunk = emptyArrowResultChunk;
       this.currentRecordBatchIndex = 0;
       this.totalRecordBatch = 0;
@@ -369,36 +445,48 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
       this.currentConverters = Collections.emptyList();
     }
 
-    /** advance to next row */
-    public boolean next() throws SnowflakeSQLException {
+    /**
+     * advance to next row
+     */
+    public boolean next() throws SnowflakeSQLException
+    {
       currentRowInRecordBatch++;
-      if (currentRowInRecordBatch < rowCountInCurrentRecordBatch) {
+      if (currentRowInRecordBatch < rowCountInCurrentRecordBatch)
+      {
         // still in current recordbatch
         return true;
-      } else {
+      }
+      else
+      {
         currentRecordBatchIndex++;
-        if (currentRecordBatchIndex < totalRecordBatch) {
+        if (currentRecordBatchIndex < totalRecordBatch)
+        {
           this.currentRowInRecordBatch = 0;
-          if (currentRecordBatchIndex == 0 && resultChunk.sortFirstResultChunkEnabled()) {
-            // perform client-side sorting for the first chunk (only used in Snowflake internal
-            // regression tests)
+          if (currentRecordBatchIndex == 0 && resultChunk.sortFirstResultChunkEnabled())
+          {
+            // perform client-side sorting for the first chunk (only used in Snowflake internal regression tests)
             // if first chunk has multiple record batches, merge them into one and sort it
-            if (resultChunk.batchOfVectors.size() > 1) {
+            if (resultChunk.batchOfVectors.size() > 1)
+            {
               resultChunk.mergeBatchesIntoOne();
               totalRecordBatch = 1;
             }
             this.rowCountInCurrentRecordBatch =
-                resultChunk.batchOfVectors.get(currentRecordBatchIndex).get(0).getValueCount();
-            currentConverters =
-                initConverters(
-                    resultChunk.batchOfVectors.get(currentRecordBatchIndex), dataConversionContext);
+                resultChunk.batchOfVectors.get(currentRecordBatchIndex)
+                    .get(0).getValueCount();
+            currentConverters = initConverters(
+                resultChunk.batchOfVectors.get(currentRecordBatchIndex),
+                dataConversionContext);
             resultChunk.sortFirstResultChunk(currentConverters);
-          } else {
+          }
+          else
+          {
             this.rowCountInCurrentRecordBatch =
-                resultChunk.batchOfVectors.get(currentRecordBatchIndex).get(0).getValueCount();
-            currentConverters =
-                initConverters(
-                    resultChunk.batchOfVectors.get(currentRecordBatchIndex), dataConversionContext);
+                resultChunk.batchOfVectors.get(currentRecordBatchIndex)
+                    .get(0).getValueCount();
+            currentConverters = initConverters(
+                resultChunk.batchOfVectors.get(currentRecordBatchIndex),
+                dataConversionContext);
           }
           return true;
         }
@@ -406,58 +494,73 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
       return false;
     }
 
-    public boolean isLast() {
+    public boolean isLast()
+    {
       return currentRecordBatchIndex + 1 == totalRecordBatch
-          && currentRowInRecordBatch + 1 == rowCountInCurrentRecordBatch;
+             && currentRowInRecordBatch + 1 == rowCountInCurrentRecordBatch;
     }
 
-    public boolean isAfterLast() {
+    public boolean isAfterLast()
+    {
       return currentRecordBatchIndex >= totalRecordBatch
-          && currentRowInRecordBatch >= rowCountInCurrentRecordBatch;
+             && currentRowInRecordBatch >= rowCountInCurrentRecordBatch;
     }
 
-    public ArrowResultChunk getChunk() {
+    public ArrowResultChunk getChunk()
+    {
       return resultChunk;
     }
 
-    public ArrowVectorConverter getCurrentConverter(int columnIdx) throws SFException {
-      if (columnIdx < 0 || columnIdx >= currentConverters.size()) {
+    public ArrowVectorConverter getCurrentConverter(int columnIdx) throws SFException
+    {
+      if (columnIdx < 0 || columnIdx >= currentConverters.size())
+      {
         throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIdx + 1);
       }
 
       return currentConverters.get(columnIdx);
     }
 
-    /** @return index of row in current record batch */
-    public int getCurrentRowInRecordBatch() {
-      if (resultChunk.sortFirstResultChunkEnabled() && currentRecordBatchIndex == 0) {
+    /**
+     * @return index of row in current record batch
+     */
+    public int getCurrentRowInRecordBatch()
+    {
+      if (resultChunk.sortFirstResultChunkEnabled() && currentRecordBatchIndex == 0)
+      {
         return resultChunk.firstResultChunkSortedIndices.get(currentRowInRecordBatch);
-      } else {
+      }
+      else
+      {
         return currentRowInRecordBatch;
       }
     }
   }
 
   /**
-   * merge arrow result chunk with more than one batches into one record batch (Only used for the
-   * first chunk when client side sorting is required)
+   * merge arrow result chunk with more than one batches into one record batch
+   * (Only used for the first chunk when client side sorting is required)
    */
-  private void mergeBatchesIntoOne() throws SnowflakeSQLException {
-    try {
+  private void mergeBatchesIntoOne() throws SnowflakeSQLException
+  {
+    try
+    {
       List<ValueVector> first = batchOfVectors.get(0);
-      for (int i = 1; i < batchOfVectors.size(); i++) {
+      for (int i = 1; i < batchOfVectors.size(); i++)
+      {
         List<ValueVector> batch = batchOfVectors.get(i);
         mergeBatch(first, batch);
         batch.forEach(ValueVector::close);
       }
       batchOfVectors.clear();
       batchOfVectors.add(first);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Failed to merge first result chunk: " + ex.getLocalizedMessage());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Failed to merge first result chunk: "
+                                            + ex.getLocalizedMessage());
     }
   }
 
@@ -467,8 +570,10 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
    * @param left
    * @param right
    */
-  private void mergeBatch(List<ValueVector> left, List<ValueVector> right) throws SFException {
-    for (int i = 0; i < left.size(); i++) {
+  private void mergeBatch(List<ValueVector> left, List<ValueVector> right) throws SFException
+  {
+    for (int i = 0; i < left.size(); i++)
+    {
       mergeVector(left.get(i), right.get(i));
     }
   }
@@ -479,10 +584,14 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
    * @param left
    * @param right
    */
-  private void mergeVector(ValueVector left, ValueVector right) throws SFException {
-    if (left instanceof StructVector) {
+  private void mergeVector(ValueVector left, ValueVector right) throws SFException
+  {
+    if (left instanceof StructVector)
+    {
       mergeStructVector((StructVector) left, (StructVector) right);
-    } else {
+    }
+    else
+    {
       mergeNonStructVector(left, right);
     }
   }
@@ -493,15 +602,19 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
    * @param left
    * @param right
    */
-  private void mergeStructVector(StructVector left, StructVector right) throws SFException {
+  private void mergeStructVector(StructVector left, StructVector right) throws SFException
+  {
     int numOfChildren = left.getChildrenFromFields().size();
-    for (int i = 0; i < numOfChildren; i++) {
-      mergeNonStructVector(
-          left.getChildrenFromFields().get(i), right.getChildrenFromFields().get(i));
+    for (int i = 0; i < numOfChildren; i++)
+    {
+      mergeNonStructVector(left.getChildrenFromFields().get(i),
+                           right.getChildrenFromFields().get(i));
     }
     int offset = left.getValueCount();
-    for (int i = 0; i < right.getValueCount(); i++) {
-      if (right.isNull(i)) {
+    for (int i = 0; i < right.getValueCount(); i++)
+    {
+      if (right.isNull(i))
+      {
         left.setNull(offset + i);
       }
     }
@@ -514,30 +627,46 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
    * @param left
    * @param right
    */
-  private void mergeNonStructVector(ValueVector left, ValueVector right) throws SFException {
-    if (left instanceof BigIntVector) {
+  private void mergeNonStructVector(ValueVector left, ValueVector right)
+  throws SFException
+  {
+    if (left instanceof BigIntVector)
+    {
       BigIntVector bigIntVectorLeft = (BigIntVector) left;
       BigIntVector bigIntVectorRight = (BigIntVector) right;
       int offset = bigIntVectorLeft.getValueCount();
-      for (int i = 0; i < bigIntVectorRight.getValueCount(); i++) {
-        if (bigIntVectorRight.isNull(i)) {
+      for (int i = 0; i < bigIntVectorRight.getValueCount(); i++)
+      {
+        if (bigIntVectorRight.isNull(i))
+        {
           bigIntVectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           bigIntVectorLeft.setSafe(offset + i, bigIntVectorRight.get(i));
         }
       }
       bigIntVectorLeft.setValueCount(offset + bigIntVectorRight.getValueCount());
-    } else if (left instanceof BitVector) {
+    }
+    else if (left instanceof BitVector)
+    {
       BitVector bitVectorLeft = (BitVector) left;
       BitVector bitVectorRight = (BitVector) right;
       int offset = bitVectorLeft.getValueCount();
-      for (int i = 0; i < bitVectorRight.getValueCount(); i++) {
-        if (bitVectorRight.isNull(i)) {
+      for (int i = 0; i < bitVectorRight.getValueCount(); i++)
+      {
+        if (bitVectorRight.isNull(i))
+        {
           bitVectorLeft.setNull(offset + i);
-        } else {
-          try {
+        }
+        else
+        {
+          try
+          {
             bitVectorLeft.setSafe(offset + i, bitVectorRight.get(i));
-          } catch (IndexOutOfBoundsException e) {
+          }
+          catch (IndexOutOfBoundsException e)
+          {
             // this can be a bug in arrow that doesn't safely set value for
             // BitVector so we have to reAlloc manually
             bitVectorLeft.reAlloc();
@@ -546,145 +675,201 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
         }
       }
       bitVectorLeft.setValueCount(offset + bitVectorRight.getValueCount());
-    } else if (left instanceof DateDayVector) {
+    }
+    else if (left instanceof DateDayVector)
+    {
       DateDayVector dateDayVectorLeft = (DateDayVector) left;
       DateDayVector dateDayVectorRight = (DateDayVector) right;
       int offset = dateDayVectorLeft.getValueCount();
-      for (int i = 0; i < dateDayVectorRight.getValueCount(); i++) {
-        if (dateDayVectorRight.isNull(i)) {
+      for (int i = 0; i < dateDayVectorRight.getValueCount(); i++)
+      {
+        if (dateDayVectorRight.isNull(i))
+        {
           dateDayVectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           dateDayVectorLeft.setSafe(offset + i, dateDayVectorRight.get(i));
         }
       }
       dateDayVectorLeft.setValueCount(offset + dateDayVectorRight.getValueCount());
-    } else if (left instanceof DecimalVector) {
+    }
+    else if (left instanceof DecimalVector)
+    {
       DecimalVector decimalVectorLeft = (DecimalVector) left;
       DecimalVector decimalVectorRight = (DecimalVector) right;
       int offset = decimalVectorLeft.getValueCount();
-      for (int i = 0; i < decimalVectorRight.getValueCount(); i++) {
-        if (decimalVectorRight.isNull(i)) {
+      for (int i = 0; i < decimalVectorRight.getValueCount(); i++)
+      {
+        if (decimalVectorRight.isNull(i))
+        {
           decimalVectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           decimalVectorLeft.setSafe(offset + i, decimalVectorRight.get(i));
         }
       }
       decimalVectorLeft.setValueCount(offset + decimalVectorRight.getValueCount());
-    } else if (left instanceof Float8Vector) {
+    }
+    else if (left instanceof Float8Vector)
+    {
       Float8Vector float8VectorLeft = (Float8Vector) left;
       Float8Vector float8VectorRight = (Float8Vector) right;
       int offset = float8VectorLeft.getValueCount();
-      for (int i = 0; i < float8VectorRight.getValueCount(); i++) {
-        if (float8VectorRight.isNull(i)) {
+      for (int i = 0; i < float8VectorRight.getValueCount(); i++)
+      {
+        if (float8VectorRight.isNull(i))
+        {
           float8VectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           float8VectorLeft.setSafe(offset + i, float8VectorRight.get(i));
         }
       }
       float8VectorLeft.setValueCount(offset + float8VectorRight.getValueCount());
-    } else if (left instanceof IntVector) {
+    }
+    else if (left instanceof IntVector)
+    {
       IntVector intVectorLeft = (IntVector) left;
       IntVector intVectorRight = (IntVector) right;
       int offset = intVectorLeft.getValueCount();
-      for (int i = 0; i < intVectorRight.getValueCount(); i++) {
-        if (intVectorRight.isNull(i)) {
+      for (int i = 0; i < intVectorRight.getValueCount(); i++)
+      {
+        if (intVectorRight.isNull(i))
+        {
           intVectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           intVectorLeft.setSafe(offset + i, intVectorRight.get(i));
         }
       }
       intVectorLeft.setValueCount(offset + intVectorRight.getValueCount());
-    } else if (left instanceof SmallIntVector) {
+    }
+    else if (left instanceof SmallIntVector)
+    {
       SmallIntVector smallIntVectorLeft = (SmallIntVector) left;
       SmallIntVector smallIntVectorRight = (SmallIntVector) right;
       int offset = smallIntVectorLeft.getValueCount();
-      for (int i = 0; i < smallIntVectorRight.getValueCount(); i++) {
-        if (smallIntVectorRight.isNull(i)) {
+      for (int i = 0; i < smallIntVectorRight.getValueCount(); i++)
+      {
+        if (smallIntVectorRight.isNull(i))
+        {
           smallIntVectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           smallIntVectorLeft.setSafe(offset + i, smallIntVectorRight.get(i));
         }
       }
       smallIntVectorLeft.setValueCount(offset + smallIntVectorRight.getValueCount());
-    } else if (left instanceof TinyIntVector) {
+    }
+    else if (left instanceof TinyIntVector)
+    {
       TinyIntVector tinyIntVectorLeft = (TinyIntVector) left;
       TinyIntVector tinyIntVectorRight = (TinyIntVector) right;
       int offset = tinyIntVectorLeft.getValueCount();
-      for (int i = 0; i < tinyIntVectorRight.getValueCount(); i++) {
-        if (tinyIntVectorRight.isNull(i)) {
+      for (int i = 0; i < tinyIntVectorRight.getValueCount(); i++)
+      {
+        if (tinyIntVectorRight.isNull(i))
+        {
           tinyIntVectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           tinyIntVectorLeft.setSafe(offset + i, tinyIntVectorRight.get(i));
         }
       }
       tinyIntVectorLeft.setValueCount(offset + tinyIntVectorRight.getValueCount());
-    } else if (left instanceof VarBinaryVector) {
+    }
+    else if (left instanceof VarBinaryVector)
+    {
       VarBinaryVector varBinaryVectorLeft = (VarBinaryVector) left;
       VarBinaryVector varBinaryVectorRight = (VarBinaryVector) right;
       int offset = varBinaryVectorLeft.getValueCount();
-      for (int i = 0; i < varBinaryVectorRight.getValueCount(); i++) {
-        if (varBinaryVectorRight.isNull(i)) {
+      for (int i = 0; i < varBinaryVectorRight.getValueCount(); i++)
+      {
+        if (varBinaryVectorRight.isNull(i))
+        {
           varBinaryVectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           varBinaryVectorLeft.setSafe(offset + i, varBinaryVectorRight.get(i));
         }
       }
       varBinaryVectorLeft.setValueCount(offset + varBinaryVectorRight.getValueCount());
-    } else if (left instanceof VarCharVector) {
+    }
+    else if (left instanceof VarCharVector)
+    {
       VarCharVector varCharVectorLeft = (VarCharVector) left;
       VarCharVector varCharVectorRight = (VarCharVector) right;
       int offset = varCharVectorLeft.getValueCount();
-      for (int i = 0; i < varCharVectorRight.getValueCount(); i++) {
-        if (varCharVectorRight.isNull(i)) {
+      for (int i = 0; i < varCharVectorRight.getValueCount(); i++)
+      {
+        if (varCharVectorRight.isNull(i))
+        {
           varCharVectorLeft.setNull(offset + i);
-        } else {
+        }
+        else
+        {
           varCharVectorLeft.setSafe(offset + i, varCharVectorRight.get(i));
         }
       }
       varCharVectorLeft.setValueCount(offset + varCharVectorRight.getValueCount());
-    } else {
-      throw new SFException(
-          ErrorCode.INTERNAL_ERROR, "Failed to merge vector due to unknown vector type");
+    }
+    else
+    {
+      throw new SFException(ErrorCode.INTERNAL_ERROR, "Failed to merge vector due to unknown vector type");
     }
   }
 
-  private void sortFirstResultChunk(List<ArrowVectorConverter> converters)
-      throws SnowflakeSQLException {
-    try {
+  private void sortFirstResultChunk(List<ArrowVectorConverter> converters) throws SnowflakeSQLException
+  {
+    try
+    {
       List<ValueVector> firstResultChunk = this.batchOfVectors.get(0);
-      ArrowResultChunkIndexSorter sorter =
-          new ArrowResultChunkIndexSorter(firstResultChunk, converters);
+      ArrowResultChunkIndexSorter sorter = new ArrowResultChunkIndexSorter(firstResultChunk, converters);
       firstResultChunkSortedIndices = sorter.sort();
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Failed to sort first result chunk: " + ex.getLocalizedMessage());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                                      "Failed to sort first result chunk: "
+                                      + ex.getLocalizedMessage());
     }
   }
 
-  private boolean sortFirstResultChunkEnabled() {
+  private boolean sortFirstResultChunkEnabled()
+  {
     return enableSortFirstResultChunk;
   }
 
   /**
-   * Empty arrow result chunk implementation. Used when rowset from server is null or empty or in
-   * testing
+   * Empty arrow result chunk implementation. Used when rowset from server is
+   * null or empty or in testing
    */
-  private static class EmptyArrowResultChunk extends ArrowResultChunk {
-    EmptyArrowResultChunk() {
+  private static class EmptyArrowResultChunk extends ArrowResultChunk
+  {
+    EmptyArrowResultChunk()
+    {
       super("", 0, 0, 0, null, null);
     }
 
     @Override
-    public final long computeNeededChunkMemory() {
+    public final long computeNeededChunkMemory()
+    {
       return 0;
     }
 
     @Override
-    public final void freeData() {
+    public final void freeData()
+    {
       // do nothing
     }
+
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -3,6 +3,13 @@
  */
 package net.snowflake.client.jdbc;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.ClosedByInterruptException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import net.snowflake.client.core.DataConversionContext;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.core.SFSession;
@@ -17,77 +24,61 @@ import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.util.TransferPair;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.channels.ClosedByInterruptException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-public class ArrowResultChunk extends SnowflakeResultChunk
-{
+public class ArrowResultChunk extends SnowflakeResultChunk {
   /**
-   * A 2-D array of arrow ValueVectors, this list represents data in the whole
-   * chunk. Since each chunk is divided into record batchs and each record batch
-   * is composed of list of column vectors.
-   * <p>
-   * So the outer list is list of record batches, inner list represents list of
-   * columns
+   * A 2-D array of arrow ValueVectors, this list represents data in the whole chunk. Since each
+   * chunk is divided into record batchs and each record batch is composed of list of column
+   * vectors.
+   *
+   * <p>So the outer list is list of record batches, inner list represents list of columns
    */
   private final ArrayList<List<ValueVector>> batchOfVectors;
 
-  private static final SFLogger logger =
-      SFLoggerFactory.getLogger(ArrowResultChunk.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(ArrowResultChunk.class);
 
-
-  /**
-   * arrow root allocator used by this resultSet
-   */
+  /** arrow root allocator used by this resultSet */
   private final RootAllocator rootAllocator;
+
   private boolean enableSortFirstResultChunk;
   private IntVector firstResultChunkSortedIndices;
   private VectorSchemaRoot root;
   private static SFSession session;
 
-  public ArrowResultChunk(String url, int rowCount, int colCount,
-                          int uncompressedSize, RootAllocator rootAllocator, SFSession session)
-  {
+  public ArrowResultChunk(
+      String url,
+      int rowCount,
+      int colCount,
+      int uncompressedSize,
+      RootAllocator rootAllocator,
+      SFSession session) {
     super(url, rowCount, colCount, uncompressedSize);
     this.batchOfVectors = new ArrayList<>();
     this.rootAllocator = rootAllocator;
     this.session = session;
   }
 
-  private void addBatchData(List<ValueVector> batch)
-  {
+  private void addBatchData(List<ValueVector> batch) {
     batchOfVectors.add(batch);
   }
 
   /**
-   * Read an inputStream of arrow data bytes and load them into java vectors
-   * of value.
-   * Note, there is no copy of data involved once data is loaded into memory.
-   * a.k.a ArrowStreamReader originally allocates the memory to hold vectors,
-   * but those memory ownership is transfer into ArrowResultChunk class and once
-   * ArrowStreamReader is garbage collected, memory will not be cleared up
+   * Read an inputStream of arrow data bytes and load them into java vectors of value. Note, there
+   * is no copy of data involved once data is loaded into memory. a.k.a ArrowStreamReader originally
+   * allocates the memory to hold vectors, but those memory ownership is transfer into
+   * ArrowResultChunk class and once ArrowStreamReader is garbage collected, memory will not be
+   * cleared up
    *
    * @param is inputStream which contains arrow data file in bytes
    * @throws IOException if failed to read data as arrow file
    */
-  public void readArrowStream(InputStream is)
-  throws IOException
-  {
+  public void readArrowStream(InputStream is) throws IOException {
     ArrayList<ValueVector> valueVectors = new ArrayList<>();
-    try (ArrowStreamReader reader = new ArrowStreamReader(is, rootAllocator))
-    {
+    try (ArrowStreamReader reader = new ArrowStreamReader(is, rootAllocator)) {
       root = reader.getVectorSchemaRoot();
-      while (reader.loadNextBatch())
-      {
+      while (reader.loadNextBatch()) {
         valueVectors = new ArrayList<>();
 
-        for (FieldVector f : root.getFieldVectors())
-        {
+        for (FieldVector f : root.getFieldVectors()) {
           // transfer will not copy data but transfer ownership of memory
           // from streamReader to resultChunk
           TransferPair t = f.getTransferPair(rootAllocator);
@@ -98,16 +89,12 @@ public class ArrowResultChunk extends SnowflakeResultChunk
         addBatchData(valueVectors);
         root.clear();
       }
-    }
-    catch (ClosedByInterruptException cbie)
-    {
+    } catch (ClosedByInterruptException cbie) {
       // happens when the statement is closed before finish parsing
       logger.debug("Interrupted when loading Arrow result", cbie);
       valueVectors.forEach(ValueVector::close);
       freeData();
-    }
-    catch (Exception ex)
-    {
+    } catch (Exception ex) {
       valueVectors.forEach(ValueVector::close);
       freeData();
       throw ex;
@@ -115,80 +102,65 @@ public class ArrowResultChunk extends SnowflakeResultChunk
   }
 
   @Override
-  public void reset()
-  {
+  public void reset() {
     freeData();
     this.batchOfVectors.clear();
   }
 
   @Override
-  public long computeNeededChunkMemory()
-  {
+  public long computeNeededChunkMemory() {
     return getUncompressedSize();
   }
 
   @Override
-  public void freeData()
-  {
+  public void freeData() {
     batchOfVectors.forEach(list -> list.forEach(ValueVector::close));
-    if (firstResultChunkSortedIndices != null)
-    {
+    if (firstResultChunkSortedIndices != null) {
       firstResultChunkSortedIndices.close();
     }
-    if (root != null)
-    {
+    if (root != null) {
       root.clear();
       root = null;
     }
   }
 
   /**
-   * Given a list of arrow vectors (all columns in a single record batch),
-   * return list of arrow vector converter. Note, converter is built on top of
-   * arrow vector, so that arrow data can be converted back to java data
+   * Given a list of arrow vectors (all columns in a single record batch), return list of arrow
+   * vector converter. Note, converter is built on top of arrow vector, so that arrow data can be
+   * converted back to java data
+   *
    * <p>
-   * <p>
-   * Arrow converter mappings for Snowflake fixed-point numbers
+   *
+   * <p>Arrow converter mappings for Snowflake fixed-point numbers
+   * ----------------------------------------------------------------------------------------- Max
+   * position & scale Converter
    * -----------------------------------------------------------------------------------------
-   * Max position & scale                    Converter
-   * -----------------------------------------------------------------------------------------
-   * number(3,0)                             {@link TinyIntToFixedConverter}
-   * number(3,2)                             {@link TinyIntToScaledFixedConverter}
-   * number(5,0)                             {@link SmallIntToFixedConverter}
-   * number(5,4)                             {@link SmallIntToScaledFixedConverter}
-   * number(10,0)                            {@link IntToFixedConverter}
-   * number(10,9)                            {@link IntToScaledFixedConverter}
-   * number(19,0)                            {@link BigIntToFixedConverter}
-   * number(19,18)                           {@link BigIntToFixedConverter}
-   * number(38,37)                           {@link DecimalToScaledFixedConverter}
+   * number(3,0) {@link TinyIntToFixedConverter} number(3,2) {@link TinyIntToScaledFixedConverter}
+   * number(5,0) {@link SmallIntToFixedConverter} number(5,4) {@link SmallIntToScaledFixedConverter}
+   * number(10,0) {@link IntToFixedConverter} number(10,9) {@link IntToScaledFixedConverter}
+   * number(19,0) {@link BigIntToFixedConverter} number(19,18) {@link BigIntToFixedConverter}
+   * number(38,37) {@link DecimalToScaledFixedConverter}
    * ------------------------------------------------------------------------------------------
    *
    * @param vectors list of arrow vectors
    * @return list of converters on top of each converters
    */
   private static List<ArrowVectorConverter> initConverters(
-      List<ValueVector> vectors, DataConversionContext context) throws SnowflakeSQLException
-  {
+      List<ValueVector> vectors, DataConversionContext context) throws SnowflakeSQLException {
     List<ArrowVectorConverter> converters = new ArrayList<>();
-    for (int i = 0; i < vectors.size(); i++)
-    {
+    for (int i = 0; i < vectors.size(); i++) {
       ValueVector vector = vectors.get(i);
       // arrow minor type
-      Types.MinorType type = Types.getMinorTypeForArrowType(
-          vector.getField().getType());
+      Types.MinorType type = Types.getMinorTypeForArrowType(vector.getField().getType());
 
       // each column's metadata
       Map<String, String> customMeta = vector.getField().getMetadata();
-      if (type == Types.MinorType.DECIMAL)
-      {
+      if (type == Types.MinorType.DECIMAL) {
         // Note: Decimal vector is different from others
         converters.add(new DecimalToScaledFixedConverter(vector, i, context));
-      }
-      else if (!customMeta.isEmpty())
-      {
+      } else if (!customMeta.isEmpty()) {
         SnowflakeType st = SnowflakeType.valueOf(customMeta.get("logicalType"));
-        switch (st)
-        {
+        switch (st) {
           case ANY:
           case ARRAY:
           case CHAR:
@@ -213,45 +185,32 @@ public class ArrowResultChunk extends SnowflakeResultChunk
           case FIXED:
             String scaleStr = vector.getField().getMetadata().get("scale");
             int sfScale = Integer.parseInt(scaleStr);
-            switch (type)
-            {
+            switch (type) {
               case TINYINT:
-                if (sfScale == 0)
-                {
+                if (sfScale == 0) {
                   converters.add(new TinyIntToFixedConverter(vector, i, context));
-                }
-                else
-                {
+                } else {
                   converters.add(new TinyIntToScaledFixedConverter(vector, i, context, sfScale));
                 }
                 break;
               case SMALLINT:
-                if (sfScale == 0)
-                {
+                if (sfScale == 0) {
                   converters.add(new SmallIntToFixedConverter(vector, i, context));
-                }
-                else
-                {
+                } else {
                   converters.add(new SmallIntToScaledFixedConverter(vector, i, context, sfScale));
                 }
                 break;
               case INT:
-                if (sfScale == 0)
-                {
+                if (sfScale == 0) {
                   converters.add(new IntToFixedConverter(vector, i, context));
-                }
-                else
-                {
+                } else {
                   converters.add(new IntToScaledFixedConverter(vector, i, context, sfScale));
                 }
                 break;
               case BIGINT:
-                if (sfScale == 0)
-                {
+                if (sfScale == 0) {
                   converters.add(new BigIntToFixedConverter(vector, i, context));
-                }
-                else
-                {
+                } else {
                   converters.add(new BigIntToScaledFixedConverter(vector, i, context, sfScale));
                 }
                 break;
@@ -263,8 +222,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
             break;
 
           case TIME:
-            switch (type)
-            {
+            switch (type) {
               case INT:
                 converters.add(new IntToTimeConverter(vector, i, context));
                 break;
@@ -274,70 +232,61 @@ public class ArrowResultChunk extends SnowflakeResultChunk
               default:
                 throw new SnowflakeSQLLoggedException(
                     SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    session,
                     "Unexpected Arrow Field for ",
                     st.name());
             }
             break;
 
           case TIMESTAMP_LTZ:
-            if (vector.getField().getChildren().isEmpty())
-            {
+            if (vector.getField().getChildren().isEmpty()) {
               // case when the scale of the timestamp is equal or smaller than millisecs since epoch
               converters.add(new BigIntToTimestampLTZConverter(vector, i, context));
-            }
-            else if (vector.getField().getChildren().size() == 2)
-            {
-              // case when the scale of the timestamp is larger than millisecs since epoch, e.g., nanosecs
+            } else if (vector.getField().getChildren().size() == 2) {
+              // case when the scale of the timestamp is larger than millisecs since epoch, e.g.,
+              // nanosecs
               converters.add(new TwoFieldStructToTimestampLTZConverter(vector, i, context));
-            }
-            else
-            {
+            } else {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  session,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
             break;
 
           case TIMESTAMP_NTZ:
-            if (vector.getField().getChildren().isEmpty())
-            {
+            if (vector.getField().getChildren().isEmpty()) {
               // case when the scale of the timestamp is equal or smaller than 7
               converters.add(new BigIntToTimestampNTZConverter(vector, i, context));
-            }
-            else if (vector.getField().getChildren().size() == 2)
-            {
+            } else if (vector.getField().getChildren().size() == 2) {
               // when the timestamp is represent in two-field struct
               converters.add(new TwoFieldStructToTimestampNTZConverter(vector, i, context));
-            }
-            else
-            {
+            } else {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  session,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
             break;
 
           case TIMESTAMP_TZ:
-            if (vector.getField().getChildren().size() == 2)
-            {
+            if (vector.getField().getChildren().size() == 2) {
               // case when the scale of the timestamp is equal or smaller than millisecs since epoch
               converters.add(new TwoFieldStructToTimestampTZConverter(vector, i, context));
-            }
-            else if (vector.getField().getChildren().size() == 3)
-            {
-              // case when the scale of the timestamp is larger than millisecs since epoch, e.g., nanosecs
+            } else if (vector.getField().getChildren().size() == 3) {
+              // case when the scale of the timestamp is larger than millisecs since epoch, e.g.,
+              // nanosecs
               converters.add(new ThreeFieldStructToTimestampTZConverter(vector, i, context));
-            }
-            else
-            {
+            } else {
               throw new SnowflakeSQLLoggedException(
                   SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  session,
                   "Unexpected SnowflakeType ",
                   st.name());
             }
@@ -346,16 +295,16 @@ public class ArrowResultChunk extends SnowflakeResultChunk
           default:
             throw new SnowflakeSQLLoggedException(
                 SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
                 "Unexpected Arrow Field for ",
                 st.name());
         }
-      }
-      else
-      {
+      } else {
         throw new SnowflakeSQLLoggedException(
             SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            session,
             "Unexpected Arrow Field for ",
             type.toString());
       }
@@ -363,70 +312,46 @@ public class ArrowResultChunk extends SnowflakeResultChunk
     return converters;
   }
 
-
-  /**
-   * @return an iterator to iterate over current chunk
-   */
-  public ArrowChunkIterator getIterator(DataConversionContext dataConversionContext)
-  {
+  /** @return an iterator to iterate over current chunk */
+  public ArrowChunkIterator getIterator(DataConversionContext dataConversionContext) {
     return new ArrowChunkIterator(this, dataConversionContext);
   }
 
-  public static ArrowChunkIterator getEmptyChunkIterator()
-  {
+  public static ArrowChunkIterator getEmptyChunkIterator() {
     return new ArrowChunkIterator(new EmptyArrowResultChunk());
   }
 
-  public void enableSortFirstResultChunk()
-  {
+  public void enableSortFirstResultChunk() {
     enableSortFirstResultChunk = true;
   }
 
-  /**
-   * Iterator class used to go through the arrow chunk row by row
-   */
-  public static class ArrowChunkIterator
-  {
-    /**
-     * chunk that iterator will iterate through
-     */
+  /** Iterator class used to go through the arrow chunk row by row */
+  public static class ArrowChunkIterator {
+    /** chunk that iterator will iterate through */
     private ArrowResultChunk resultChunk;
 
-    /**
-     * index of record batch that iterator currently points to
-     */
+    /** index of record batch that iterator currently points to */
     private int currentRecordBatchIndex;
 
-    /**
-     * total number of record batch
-     */
+    /** total number of record batch */
     private int totalRecordBatch;
 
-    /**
-     * index of row inside current record batch that iterator points to
-     */
+    /** index of row inside current record batch that iterator points to */
     private int currentRowInRecordBatch;
 
-    /**
-     * number of rows inside current record batch
-     */
+    /** number of rows inside current record batch */
     private int rowCountInCurrentRecordBatch;
 
     /**
-     * list of converters that attached to current record batch
-     * Note: this list is updated every time iterator points to a new record
-     * batch
+     * list of converters that attached to current record batch Note: this list is updated every
+     * time iterator points to a new record batch
      */
     private List<ArrowVectorConverter> currentConverters;
 
-    /**
-     * formatters to each data type
-     */
+    /** formatters to each data type */
     private DataConversionContext dataConversionContext;
 
-    ArrowChunkIterator(ArrowResultChunk resultChunk,
-                       DataConversionContext dataConversionContext)
-    {
+    ArrowChunkIterator(ArrowResultChunk resultChunk, DataConversionContext dataConversionContext) {
       this.resultChunk = resultChunk;
       this.currentRecordBatchIndex = -1;
       this.totalRecordBatch = resultChunk.batchOfVectors.size();
@@ -435,8 +360,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk
       this.dataConversionContext = dataConversionContext;
     }
 
-    ArrowChunkIterator(EmptyArrowResultChunk emptyArrowResultChunk)
-    {
+    ArrowChunkIterator(EmptyArrowResultChunk emptyArrowResultChunk) {
       this.resultChunk = emptyArrowResultChunk;
       this.currentRecordBatchIndex = 0;
       this.totalRecordBatch = 0;
@@ -445,48 +369,36 @@ public class ArrowResultChunk extends SnowflakeResultChunk
       this.currentConverters = Collections.emptyList();
     }
 
-    /**
-     * advance to next row
-     */
-    public boolean next() throws SnowflakeSQLException
-    {
+    /** advance to next row */
+    public boolean next() throws SnowflakeSQLException {
       currentRowInRecordBatch++;
-      if (currentRowInRecordBatch < rowCountInCurrentRecordBatch)
-      {
+      if (currentRowInRecordBatch < rowCountInCurrentRecordBatch) {
         // still in current recordbatch
         return true;
-      }
-      else
-      {
+      } else {
         currentRecordBatchIndex++;
-        if (currentRecordBatchIndex < totalRecordBatch)
-        {
+        if (currentRecordBatchIndex < totalRecordBatch) {
           this.currentRowInRecordBatch = 0;
-          if (currentRecordBatchIndex == 0 && resultChunk.sortFirstResultChunkEnabled())
-          {
-            // perform client-side sorting for the first chunk (only used in Snowflake internal regression tests)
+          if (currentRecordBatchIndex == 0 && resultChunk.sortFirstResultChunkEnabled()) {
+            // perform client-side sorting for the first chunk (only used in Snowflake internal
+            // regression tests)
             // if first chunk has multiple record batches, merge them into one and sort it
-            if (resultChunk.batchOfVectors.size() > 1)
-            {
+            if (resultChunk.batchOfVectors.size() > 1) {
               resultChunk.mergeBatchesIntoOne();
               totalRecordBatch = 1;
             }
             this.rowCountInCurrentRecordBatch =
-                resultChunk.batchOfVectors.get(currentRecordBatchIndex)
-                    .get(0).getValueCount();
-            currentConverters = initConverters(
-                resultChunk.batchOfVectors.get(currentRecordBatchIndex),
-                dataConversionContext);
+                resultChunk.batchOfVectors.get(currentRecordBatchIndex).get(0).getValueCount();
+            currentConverters =
+                initConverters(
+                    resultChunk.batchOfVectors.get(currentRecordBatchIndex), dataConversionContext);
             resultChunk.sortFirstResultChunk(currentConverters);
-          }
-          else
-          {
+          } else {
             this.rowCountInCurrentRecordBatch =
-                resultChunk.batchOfVectors.get(currentRecordBatchIndex)
-                    .get(0).getValueCount();
-            currentConverters = initConverters(
-                resultChunk.batchOfVectors.get(currentRecordBatchIndex),
-                dataConversionContext);
+                resultChunk.batchOfVectors.get(currentRecordBatchIndex).get(0).getValueCount();
+            currentConverters =
+                initConverters(
+                    resultChunk.batchOfVectors.get(currentRecordBatchIndex), dataConversionContext);
           }
           return true;
         }
@@ -494,73 +406,59 @@ public class ArrowResultChunk extends SnowflakeResultChunk
       return false;
     }
 
-    public boolean isLast()
-    {
+    public boolean isLast() {
       return currentRecordBatchIndex + 1 == totalRecordBatch
-             && currentRowInRecordBatch + 1 == rowCountInCurrentRecordBatch;
+          && currentRowInRecordBatch + 1 == rowCountInCurrentRecordBatch;
     }
 
-    public boolean isAfterLast()
-    {
+    public boolean isAfterLast() {
       return currentRecordBatchIndex >= totalRecordBatch
-             && currentRowInRecordBatch >= rowCountInCurrentRecordBatch;
+          && currentRowInRecordBatch >= rowCountInCurrentRecordBatch;
     }
 
-    public ArrowResultChunk getChunk()
-    {
+    public ArrowResultChunk getChunk() {
       return resultChunk;
     }
 
-    public ArrowVectorConverter getCurrentConverter(int columnIdx) throws SFException
-    {
-      if (columnIdx < 0 || columnIdx >= currentConverters.size())
-      {
+    public ArrowVectorConverter getCurrentConverter(int columnIdx) throws SFException {
+      if (columnIdx < 0 || columnIdx >= currentConverters.size()) {
         throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIdx + 1);
       }
 
       return currentConverters.get(columnIdx);
     }
 
-    /**
-     * @return index of row in current record batch
-     */
-    public int getCurrentRowInRecordBatch()
-    {
-      if (resultChunk.sortFirstResultChunkEnabled() && currentRecordBatchIndex == 0)
-      {
+    /** @return index of row in current record batch */
+    public int getCurrentRowInRecordBatch() {
+      if (resultChunk.sortFirstResultChunkEnabled() && currentRecordBatchIndex == 0) {
         return resultChunk.firstResultChunkSortedIndices.get(currentRowInRecordBatch);
-      }
-      else
-      {
+      } else {
         return currentRowInRecordBatch;
       }
     }
   }
 
   /**
-   * merge arrow result chunk with more than one batches into one record batch
-   * (Only used for the first chunk when client side sorting is required)
+   * merge arrow result chunk with more than one batches into one record batch (Only used for the
+   * first chunk when client side sorting is required)
    */
-  private void mergeBatchesIntoOne() throws SnowflakeSQLException
-  {
-    try
-    {
+  private void mergeBatchesIntoOne() throws SnowflakeSQLException {
+    try {
       List<ValueVector> first = batchOfVectors.get(0);
-      for (int i = 1; i < batchOfVectors.size(); i++)
-      {
+      for (int i = 1; i < batchOfVectors.size(); i++) {
         List<ValueVector> batch = batchOfVectors.get(i);
         mergeBatch(first, batch);
         batch.forEach(ValueVector::close);
       }
       batchOfVectors.clear();
       batchOfVectors.add(first);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "Failed to merge first result chunk: "
-                                            + ex.getLocalizedMessage());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "Failed to merge first result chunk: " + ex.getLocalizedMessage());
     }
   }
 
@@ -570,10 +468,8 @@ public class ArrowResultChunk extends SnowflakeResultChunk
    * @param left
    * @param right
    */
-  private void mergeBatch(List<ValueVector> left, List<ValueVector> right) throws SFException
-  {
-    for (int i = 0; i < left.size(); i++)
-    {
+  private void mergeBatch(List<ValueVector> left, List<ValueVector> right) throws SFException {
+    for (int i = 0; i < left.size(); i++) {
       mergeVector(left.get(i), right.get(i));
     }
   }
@@ -584,14 +480,10 @@ public class ArrowResultChunk extends SnowflakeResultChunk
    * @param left
    * @param right
    */
-  private void mergeVector(ValueVector left, ValueVector right) throws SFException
-  {
-    if (left instanceof StructVector)
-    {
+  private void mergeVector(ValueVector left, ValueVector right) throws SFException {
+    if (left instanceof StructVector) {
       mergeStructVector((StructVector) left, (StructVector) right);
-    }
-    else
-    {
+    } else {
       mergeNonStructVector(left, right);
     }
   }
@@ -602,19 +494,15 @@ public class ArrowResultChunk extends SnowflakeResultChunk
    * @param left
    * @param right
    */
-  private void mergeStructVector(StructVector left, StructVector right) throws SFException
-  {
+  private void mergeStructVector(StructVector left, StructVector right) throws SFException {
     int numOfChildren = left.getChildrenFromFields().size();
-    for (int i = 0; i < numOfChildren; i++)
-    {
-      mergeNonStructVector(left.getChildrenFromFields().get(i),
-                           right.getChildrenFromFields().get(i));
+    for (int i = 0; i < numOfChildren; i++) {
+      mergeNonStructVector(
+          left.getChildrenFromFields().get(i), right.getChildrenFromFields().get(i));
     }
     int offset = left.getValueCount();
-    for (int i = 0; i < right.getValueCount(); i++)
-    {
-      if (right.isNull(i))
-      {
+    for (int i = 0; i < right.getValueCount(); i++) {
+      if (right.isNull(i)) {
         left.setNull(offset + i);
       }
     }
@@ -627,46 +515,30 @@ public class ArrowResultChunk extends SnowflakeResultChunk
    * @param left
    * @param right
    */
-  private void mergeNonStructVector(ValueVector left, ValueVector right)
-  throws SFException
-  {
-    if (left instanceof BigIntVector)
-    {
+  private void mergeNonStructVector(ValueVector left, ValueVector right) throws SFException {
+    if (left instanceof BigIntVector) {
       BigIntVector bigIntVectorLeft = (BigIntVector) left;
       BigIntVector bigIntVectorRight = (BigIntVector) right;
       int offset = bigIntVectorLeft.getValueCount();
-      for (int i = 0; i < bigIntVectorRight.getValueCount(); i++)
-      {
-        if (bigIntVectorRight.isNull(i))
-        {
+      for (int i = 0; i < bigIntVectorRight.getValueCount(); i++) {
+        if (bigIntVectorRight.isNull(i)) {
           bigIntVectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           bigIntVectorLeft.setSafe(offset + i, bigIntVectorRight.get(i));
         }
       }
       bigIntVectorLeft.setValueCount(offset + bigIntVectorRight.getValueCount());
-    }
-    else if (left instanceof BitVector)
-    {
+    } else if (left instanceof BitVector) {
       BitVector bitVectorLeft = (BitVector) left;
       BitVector bitVectorRight = (BitVector) right;
       int offset = bitVectorLeft.getValueCount();
-      for (int i = 0; i < bitVectorRight.getValueCount(); i++)
-      {
-        if (bitVectorRight.isNull(i))
-        {
+      for (int i = 0; i < bitVectorRight.getValueCount(); i++) {
+        if (bitVectorRight.isNull(i)) {
           bitVectorLeft.setNull(offset + i);
-        }
-        else
-        {
-          try
-          {
+        } else {
+          try {
             bitVectorLeft.setSafe(offset + i, bitVectorRight.get(i));
-          }
-          catch (IndexOutOfBoundsException e)
-          {
+          } catch (IndexOutOfBoundsException e) {
             // this can be a bug in arrow that doesn't safely set value for
             // BitVector so we have to reAlloc manually
             bitVectorLeft.reAlloc();
@@ -675,201 +547,145 @@ public class ArrowResultChunk extends SnowflakeResultChunk
         }
       }
       bitVectorLeft.setValueCount(offset + bitVectorRight.getValueCount());
-    }
-    else if (left instanceof DateDayVector)
-    {
+    } else if (left instanceof DateDayVector) {
       DateDayVector dateDayVectorLeft = (DateDayVector) left;
       DateDayVector dateDayVectorRight = (DateDayVector) right;
       int offset = dateDayVectorLeft.getValueCount();
-      for (int i = 0; i < dateDayVectorRight.getValueCount(); i++)
-      {
-        if (dateDayVectorRight.isNull(i))
-        {
+      for (int i = 0; i < dateDayVectorRight.getValueCount(); i++) {
+        if (dateDayVectorRight.isNull(i)) {
           dateDayVectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           dateDayVectorLeft.setSafe(offset + i, dateDayVectorRight.get(i));
         }
       }
       dateDayVectorLeft.setValueCount(offset + dateDayVectorRight.getValueCount());
-    }
-    else if (left instanceof DecimalVector)
-    {
+    } else if (left instanceof DecimalVector) {
       DecimalVector decimalVectorLeft = (DecimalVector) left;
       DecimalVector decimalVectorRight = (DecimalVector) right;
       int offset = decimalVectorLeft.getValueCount();
-      for (int i = 0; i < decimalVectorRight.getValueCount(); i++)
-      {
-        if (decimalVectorRight.isNull(i))
-        {
+      for (int i = 0; i < decimalVectorRight.getValueCount(); i++) {
+        if (decimalVectorRight.isNull(i)) {
           decimalVectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           decimalVectorLeft.setSafe(offset + i, decimalVectorRight.get(i));
         }
       }
       decimalVectorLeft.setValueCount(offset + decimalVectorRight.getValueCount());
-    }
-    else if (left instanceof Float8Vector)
-    {
+    } else if (left instanceof Float8Vector) {
       Float8Vector float8VectorLeft = (Float8Vector) left;
       Float8Vector float8VectorRight = (Float8Vector) right;
       int offset = float8VectorLeft.getValueCount();
-      for (int i = 0; i < float8VectorRight.getValueCount(); i++)
-      {
-        if (float8VectorRight.isNull(i))
-        {
+      for (int i = 0; i < float8VectorRight.getValueCount(); i++) {
+        if (float8VectorRight.isNull(i)) {
           float8VectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           float8VectorLeft.setSafe(offset + i, float8VectorRight.get(i));
         }
       }
       float8VectorLeft.setValueCount(offset + float8VectorRight.getValueCount());
-    }
-    else if (left instanceof IntVector)
-    {
+    } else if (left instanceof IntVector) {
       IntVector intVectorLeft = (IntVector) left;
       IntVector intVectorRight = (IntVector) right;
       int offset = intVectorLeft.getValueCount();
-      for (int i = 0; i < intVectorRight.getValueCount(); i++)
-      {
-        if (intVectorRight.isNull(i))
-        {
+      for (int i = 0; i < intVectorRight.getValueCount(); i++) {
+        if (intVectorRight.isNull(i)) {
           intVectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           intVectorLeft.setSafe(offset + i, intVectorRight.get(i));
         }
       }
       intVectorLeft.setValueCount(offset + intVectorRight.getValueCount());
-    }
-    else if (left instanceof SmallIntVector)
-    {
+    } else if (left instanceof SmallIntVector) {
       SmallIntVector smallIntVectorLeft = (SmallIntVector) left;
       SmallIntVector smallIntVectorRight = (SmallIntVector) right;
       int offset = smallIntVectorLeft.getValueCount();
-      for (int i = 0; i < smallIntVectorRight.getValueCount(); i++)
-      {
-        if (smallIntVectorRight.isNull(i))
-        {
+      for (int i = 0; i < smallIntVectorRight.getValueCount(); i++) {
+        if (smallIntVectorRight.isNull(i)) {
           smallIntVectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           smallIntVectorLeft.setSafe(offset + i, smallIntVectorRight.get(i));
         }
       }
       smallIntVectorLeft.setValueCount(offset + smallIntVectorRight.getValueCount());
-    }
-    else if (left instanceof TinyIntVector)
-    {
+    } else if (left instanceof TinyIntVector) {
       TinyIntVector tinyIntVectorLeft = (TinyIntVector) left;
       TinyIntVector tinyIntVectorRight = (TinyIntVector) right;
       int offset = tinyIntVectorLeft.getValueCount();
-      for (int i = 0; i < tinyIntVectorRight.getValueCount(); i++)
-      {
-        if (tinyIntVectorRight.isNull(i))
-        {
+      for (int i = 0; i < tinyIntVectorRight.getValueCount(); i++) {
+        if (tinyIntVectorRight.isNull(i)) {
           tinyIntVectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           tinyIntVectorLeft.setSafe(offset + i, tinyIntVectorRight.get(i));
         }
       }
       tinyIntVectorLeft.setValueCount(offset + tinyIntVectorRight.getValueCount());
-    }
-    else if (left instanceof VarBinaryVector)
-    {
+    } else if (left instanceof VarBinaryVector) {
       VarBinaryVector varBinaryVectorLeft = (VarBinaryVector) left;
       VarBinaryVector varBinaryVectorRight = (VarBinaryVector) right;
       int offset = varBinaryVectorLeft.getValueCount();
-      for (int i = 0; i < varBinaryVectorRight.getValueCount(); i++)
-      {
-        if (varBinaryVectorRight.isNull(i))
-        {
+      for (int i = 0; i < varBinaryVectorRight.getValueCount(); i++) {
+        if (varBinaryVectorRight.isNull(i)) {
           varBinaryVectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           varBinaryVectorLeft.setSafe(offset + i, varBinaryVectorRight.get(i));
         }
       }
       varBinaryVectorLeft.setValueCount(offset + varBinaryVectorRight.getValueCount());
-    }
-    else if (left instanceof VarCharVector)
-    {
+    } else if (left instanceof VarCharVector) {
       VarCharVector varCharVectorLeft = (VarCharVector) left;
       VarCharVector varCharVectorRight = (VarCharVector) right;
       int offset = varCharVectorLeft.getValueCount();
-      for (int i = 0; i < varCharVectorRight.getValueCount(); i++)
-      {
-        if (varCharVectorRight.isNull(i))
-        {
+      for (int i = 0; i < varCharVectorRight.getValueCount(); i++) {
+        if (varCharVectorRight.isNull(i)) {
           varCharVectorLeft.setNull(offset + i);
-        }
-        else
-        {
+        } else {
           varCharVectorLeft.setSafe(offset + i, varCharVectorRight.get(i));
         }
       }
       varCharVectorLeft.setValueCount(offset + varCharVectorRight.getValueCount());
-    }
-    else
-    {
-      throw new SFException(ErrorCode.INTERNAL_ERROR, "Failed to merge vector due to unknown vector type");
+    } else {
+      throw new SFException(
+          ErrorCode.INTERNAL_ERROR, "Failed to merge vector due to unknown vector type");
     }
   }
 
-  private void sortFirstResultChunk(List<ArrowVectorConverter> converters) throws SnowflakeSQLException
-  {
-    try
-    {
+  private void sortFirstResultChunk(List<ArrowVectorConverter> converters)
+      throws SnowflakeSQLException {
+    try {
       List<ValueVector> firstResultChunk = this.batchOfVectors.get(0);
-      ArrowResultChunkIndexSorter sorter = new ArrowResultChunkIndexSorter(firstResultChunk, converters);
+      ArrowResultChunkIndexSorter sorter =
+          new ArrowResultChunkIndexSorter(firstResultChunk, converters);
       firstResultChunkSortedIndices = sorter.sort();
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                      "Failed to sort first result chunk: "
-                                      + ex.getLocalizedMessage());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Failed to sort first result chunk: " + ex.getLocalizedMessage());
     }
   }
 
-  private boolean sortFirstResultChunkEnabled()
-  {
+  private boolean sortFirstResultChunkEnabled() {
     return enableSortFirstResultChunk;
   }
 
   /**
-   * Empty arrow result chunk implementation. Used when rowset from server is
-   * null or empty or in testing
+   * Empty arrow result chunk implementation. Used when rowset from server is null or empty or in
+   * testing
    */
-  private static class EmptyArrowResultChunk extends ArrowResultChunk
-  {
-    EmptyArrowResultChunk()
-    {
+  private static class EmptyArrowResultChunk extends ArrowResultChunk {
+    EmptyArrowResultChunk() {
       super("", 0, 0, 0, null, null);
     }
 
     @Override
-    public final long computeNeededChunkMemory()
-    {
+    public final long computeNeededChunkMemory() {
       return 0;
     }
 
     @Override
-    public final void freeData()
-    {
+    public final void freeData() {
       // do nothing
     }
-
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -161,9 +161,9 @@ public class RestRequest {
       } catch (Exception ex) {
         // if exception is caused by illegal state, e.g shutdown of http client
         // because of closing of connection, stop retrying
-        if (ex instanceof IllegalStateException)
-        {
-          throw new SnowflakeSQLLoggedException(ex, ErrorCode.INVALID_STATE, /* session = */ null, ex.getMessage());
+        if (ex instanceof IllegalStateException) {
+          throw new SnowflakeSQLLoggedException(
+              ex, ErrorCode.INVALID_STATE, /* session = */ null, ex.getMessage());
         }
         savedEx = ex;
         // if the request took more than 5 min (socket timeout) log an error

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -161,11 +161,11 @@ public class RestRequest {
       } catch (Exception ex) {
         // if exception is caused by illegal state, e.g shutdown of http client
         // because of closing of connection, stop retrying
-        if (ex instanceof IllegalStateException) {
-          throw new SnowflakeSQLException(ex, ErrorCode.INVALID_STATE, ex.getMessage());
+        if (ex instanceof IllegalStateException)
+        {
+          throw new SnowflakeSQLLoggedException(ex, ErrorCode.INVALID_STATE, /* session = */ null, ex.getMessage());
         }
         savedEx = ex;
-
         // if the request took more than 5 min (socket timeout) log an error
         if ((System.currentTimeMillis() - startTimePerRequest) > 300000) {
           logger.error(

--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -4,6 +4,12 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.common.core.SqlState;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -28,14 +34,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
-import net.snowflake.client.core.QueryStatus;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.common.core.SqlState;
 
-/** SFAsyncResultSet implementation */
-class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet {
+/**
+ * SFAsyncResultSet implementation
+ */
+class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet
+{
   private final SFBaseResultSet sfBaseResultSet;
   private ResultSet resultSetForNext = new EmptyResultSet();
   private boolean resultSetForNextInitialized = false;
@@ -44,131 +48,161 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
   private Statement extraStatement;
 
   /**
-   * Constructor takes an inputstream from the API response that we get from executing a SQL
-   * statement.
-   *
-   * <p>The constructor will fetch the first row (if any) so that it can initialize the
-   * ResultSetMetaData.
+   * Constructor takes an inputstream from the API response that we get from
+   * executing a SQL statement.
+   * <p>
+   * The constructor will fetch the first row (if any) so that it can initialize
+   * the ResultSetMetaData.
+   * </p>
    *
    * @param sfBaseResultSet snowflake core base result rest object
-   * @param statement query statement that generates this result set
+   * @param statement       query statement that generates this result set
    * @throws SQLException if failed to construct snowflake result set metadata
    */
-  SFAsyncResultSet(SFBaseResultSet sfBaseResultSet, Statement statement) throws SQLException {
+  SFAsyncResultSet(
+      SFBaseResultSet sfBaseResultSet,
+      Statement statement)
+  throws SQLException
+  {
     super(statement);
     this.sfBaseResultSet = sfBaseResultSet;
     this.queryID = sfBaseResultSet.getQueryId();
     this.session = sfBaseResultSet.getSession();
     this.extraStatement = statement;
-    try {
-      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    try
+    {
+      this.resultSetMetaData =
+          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
       this.resultSetMetaData.setQueryIdForAsyncResults(this.queryID);
-      this.resultSetMetaData.setQueryType(SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+      this.resultSetMetaData.setQueryType(
+          SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(),
+                                            ex.getSqlState(), ex.getVendorCode(), this.session, ex.getParams());
     }
   }
 
   /**
-   * Constructor takes a result set serializable object to create a sessionless result set.
+   * Constructor takes a result set serializable object to create
+   * a sessionless result set.
    *
-   * @param sfBaseResultSet snowflake core base result rest object
-   * @param resultSetSerializable The result set serializable object which includes all metadata to
-   *     create the result set
+   * @param sfBaseResultSet       snowflake core base result rest object
+   * @param resultSetSerializable The result set serializable object which
+   *                              includes all metadata to create the result
+   *                              set
    * @throws SQLException if fails to create the result set object
    */
   public SFAsyncResultSet(
-      SFBaseResultSet sfBaseResultSet, SnowflakeResultSetSerializableV1 resultSetSerializable)
-      throws SQLException {
+      SFBaseResultSet sfBaseResultSet,
+      SnowflakeResultSetSerializableV1 resultSetSerializable)
+  throws SQLException
+  {
     super(resultSetSerializable);
     this.queryID = sfBaseResultSet.getQueryId();
     this.sfBaseResultSet = sfBaseResultSet;
 
-    try {
-      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    try
+    {
+      this.resultSetMetaData =
+          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
       this.resultSetMetaData.setQueryIdForAsyncResults(this.queryID);
-      this.resultSetMetaData.setQueryType(SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+      this.resultSetMetaData.setQueryType(
+          SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(),
+                                            ex.getSqlState(), ex.getVendorCode(), this.session, ex.getParams());
     }
   }
 
-  public SFAsyncResultSet(String queryID) throws SQLException {
+  public SFAsyncResultSet(String queryID) throws SQLException
+  {
     this.sfBaseResultSet = null;
     queryID.trim();
-    if (!Pattern.matches("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}", queryID)) {
-      throw new SQLException(
-          "The provided query ID " + queryID + " is invalid.", SqlState.INVALID_PARAMETER_VALUE);
+    if (!Pattern
+        .matches("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}", queryID))
+    {
+      throw new SQLException("The provided query ID " + queryID + " is invalid.",
+                             SqlState.INVALID_PARAMETER_VALUE);
     }
     this.queryID = queryID;
   }
 
   @Override
-  protected void raiseSQLExceptionIfResultSetIsClosed() throws SQLException {
-    if (isClosed()) {
+  protected void raiseSQLExceptionIfResultSetIsClosed() throws SQLException
+  {
+    if (isClosed())
+    {
       throw new SnowflakeSQLException(ErrorCode.RESULTSET_ALREADY_CLOSED);
     }
   }
 
   @Override
-  public QueryStatus getStatus() throws SQLException {
-    if (session == null) {
+  public QueryStatus getStatus() throws SQLException
+  {
+    if (session == null)
+    {
       throw new SQLException("Session not set");
     }
-    if (this.queryID == null) {
+    if (this.queryID == null)
+    {
       throw new SQLException("QueryID unknown");
     }
     return session.getQueryStatus(this.queryID);
   }
 
   /**
-   * helper function for next() and getMetaData(). Calls result_scan to get resultSet after
-   * asynchronous query call
+   * helper function for next() and getMetaData(). Calls result_scan
+   * to get resultSet after asynchronous query call
    *
    * @throws SQLException
    */
-  private void getRealResults() throws SQLException {
-    if (!resultSetForNextInitialized) {
+  private void getRealResults() throws SQLException
+  {
+    if (!resultSetForNextInitialized)
+    {
       QueryStatus qs = this.getStatus();
       int noDataRetry = 0;
       final int noDataMaxRetries = 30;
       final int[] retryPattern = {1, 1, 2, 3, 4, 8, 10};
       final int maxIndex = retryPattern.length - 1;
       int retry = 0;
-      while (qs != QueryStatus.SUCCESS) {
-        // if query is not running due to a failure (Aborted, failed with error, etc), generate
-        // exception
-        if (!QueryStatus.isStillRunning(qs) && qs.getValue() != QueryStatus.SUCCESS.getValue()) {
+      while (qs != QueryStatus.SUCCESS)
+      {
+        // if query is not running due to a failure (Aborted, failed with error, etc), generate exception
+        if (!QueryStatus.isStillRunning(qs) && qs.getValue() != QueryStatus.SUCCESS.getValue())
+        {
           throw new SQLException(
-              "Status of query associated with resultSet is "
-                  + qs.getDescription()
-                  + ". Results not generated.");
+              "Status of query associated with resultSet is " + qs.getDescription() + ". Results not generated.");
         }
         // if no data about the query is returned after about 2 minutes, give up
-        if (qs == QueryStatus.NO_DATA) {
+        if (qs == QueryStatus.NO_DATA)
+        {
           noDataRetry++;
-          if (noDataRetry >= noDataMaxRetries) {
-            throw new SQLException(
-                "Cannot retrieve data on the status of this query. No information returned from server for queryID={}.",
-                this.queryID);
+          if (noDataRetry >= noDataMaxRetries)
+          {
+            throw new SQLException("Cannot retrieve data on the status of this query. No information returned from server for queryID={}.", this.queryID);
           }
         }
-        try {
-          // Sleep for an amount before trying again. Exponential backoff up to 5 seconds
-          // implemented.
+        try
+        {
+          // Sleep for an amount before trying again. Exponential backoff up to 5 seconds implemented.
           Thread.sleep(500 * retryPattern[retry]);
-        } catch (InterruptedException e) {
+        }
+        catch (InterruptedException e)
+        {
           e.printStackTrace();
         }
-        if (retry < maxIndex) {
+        if (retry < maxIndex)
+        {
           retry++;
         }
         qs = this.getStatus();
       }
-      resultSetForNext =
-          extraStatement.executeQuery("select * from table(result_scan('" + this.queryID + "'))");
+      resultSetForNext = extraStatement.executeQuery("select * from table(result_scan('" + this.queryID + "'))");
       resultSetForNextInitialized = true;
     }
   }
@@ -180,173 +214,208 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
    * @throws SQLException if failed to move to the next row
    */
   @Override
-  public boolean next() throws SQLException {
+  public boolean next() throws SQLException
+  {
     getRealResults();
     return resultSetForNext.next();
   }
 
   @Override
-  public void close() throws SQLException {
+  public void close() throws SQLException
+  {
     close(true);
   }
 
-  public void close(boolean removeClosedResultSetFromStatement) throws SQLException {
+  public void close(boolean removeClosedResultSetFromStatement) throws SQLException
+  {
     // no SQLException is raised.
     resultSetForNext.close();
-    if (sfBaseResultSet != null) {
+    if (sfBaseResultSet != null)
+    {
       sfBaseResultSet.close();
     }
-    if (removeClosedResultSetFromStatement && statement.isWrapperFor(SnowflakeStatementV1.class)) {
+    if (removeClosedResultSetFromStatement && statement.isWrapperFor(SnowflakeStatementV1.class))
+    {
       statement.unwrap(SnowflakeStatementV1.class).removeClosedResultSet(this);
     }
   }
 
-  public String getQueryID() {
+  public String getQueryID()
+  {
     return this.queryID;
   }
 
-  public boolean wasNull() throws SQLException {
+  public boolean wasNull() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.wasNull();
   }
 
-  public String getString(int columnIndex) throws SQLException {
+  public String getString(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getString(columnIndex);
   }
 
-  public void setSession(SFSession session) {
+  public void setSession(SFSession session)
+  {
     this.session = session;
   }
 
-  public void setStatement(Statement statement) {
+  public void setStatement(Statement statement)
+  {
     this.extraStatement = statement;
   }
 
-  public boolean getBoolean(int columnIndex) throws SQLException {
+  public boolean getBoolean(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getBoolean(columnIndex);
   }
 
   @Override
-  public byte getByte(int columnIndex) throws SQLException {
+  public byte getByte(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getByte(columnIndex);
   }
 
-  public short getShort(int columnIndex) throws SQLException {
+  public short getShort(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getShort(columnIndex);
   }
 
-  public int getInt(int columnIndex) throws SQLException {
+  public int getInt(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getInt(columnIndex);
   }
 
-  public long getLong(int columnIndex) throws SQLException {
+  public long getLong(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getLong(columnIndex);
   }
 
-  public float getFloat(int columnIndex) throws SQLException {
+  public float getFloat(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getFloat(columnIndex);
+
   }
 
-  public double getDouble(int columnIndex) throws SQLException {
+  public double getDouble(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getDouble(columnIndex);
   }
 
-  public Date getDate(int columnIndex, TimeZone tz) throws SQLException {
+  public Date getDate(int columnIndex, TimeZone tz) throws SQLException
+  {
     // Note: currently we provide this API but it does not use TimeZone tz.
     // TODO: use the time zone passed from the arguments
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getDate(columnIndex);
   }
 
-  public Time getTime(int columnIndex) throws SQLException {
+  public Time getTime(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getTime(columnIndex);
   }
 
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SQLException {
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz)
+  throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.unwrap(SnowflakeResultSetV1.class).getTimestamp(columnIndex, tz);
   }
 
-  public ResultSetMetaData getMetaData() throws SQLException {
+  public ResultSetMetaData getMetaData() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     getRealResults();
     this.resultSetMetaData =
-        (SnowflakeResultSetMetaDataV1)
-            resultSetForNext.unwrap(SnowflakeResultSetV1.class).getMetaData();
+        (SnowflakeResultSetMetaDataV1) resultSetForNext.unwrap(SnowflakeResultSetV1.class).getMetaData();
     this.resultSetMetaData.setQueryIdForAsyncResults(this.queryID);
-    this.resultSetMetaData.setQueryType(SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
+    this.resultSetMetaData.setQueryType(
+        SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
     return resultSetMetaData;
   }
 
-  public Object getObject(int columnIndex) throws SQLException {
+  public Object getObject(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getObject(columnIndex);
   }
 
-  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+  public BigDecimal getBigDecimal(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getBigDecimal(columnIndex);
   }
 
   @Deprecated
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getBigDecimal(columnIndex, scale);
   }
 
-  public byte[] getBytes(int columnIndex) throws SQLException {
+  public byte[] getBytes(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getBytes(columnIndex);
   }
 
-  public int getRow() throws SQLException {
+  public int getRow() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
 
     return resultSetForNext.getRow();
   }
 
-  public boolean isFirst() throws SQLException {
+  public boolean isFirst() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.isFirst();
   }
 
-  public boolean isClosed() throws SQLException {
+  public boolean isClosed() throws SQLException
+  {
     // no exception is raised.
-    if (sfBaseResultSet != null) {
+    if (sfBaseResultSet != null)
+    {
       return (resultSetForNext.isClosed() && sfBaseResultSet.isClosed());
     }
     return resultSetForNext.isClosed();
   }
 
   @Override
-  public boolean isLast() throws SQLException {
+  public boolean isLast() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.isLast();
   }
 
   @Override
-  public boolean isAfterLast() throws SQLException {
+  public boolean isAfterLast() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.isAfterLast();
   }
 
   @Override
-  public boolean isBeforeFirst() throws SQLException {
+  public boolean isBeforeFirst() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.isBeforeFirst();
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException
+  {
     logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -354,12 +423,15 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
+  public <T> T unwrap(Class<T> iface) throws SQLException
+  {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this)) {
+    if (!iface.isInstance(this))
+    {
       throw new SQLException(
-          this.getClass().getName() + " not unwrappable from " + iface.getName());
+          this.getClass().getName() + " not unwrappable from " + iface
+              .getName());
     }
     return (T) this;
   }
@@ -367,1096 +439,1334 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
   /**
    * Get a list of ResultSetSerializables for the ResultSet in order to parallel processing
    *
-   * @param maxSizeInBytes The expected max data size wrapped in the ResultSetSerializables object.
-   *     NOTE: this parameter is intended to make the data size in each serializable object to be
-   *     less than it. But if user specifies a small value which may be smaller than the data size
-   *     of one result chunk. So the definition can't be guaranteed completely. For this special
-   *     case, one serializable object is used to wrap the data chunk.
+   * @param maxSizeInBytes The expected max data size wrapped in the
+   *                       ResultSetSerializables object.
+   *                       NOTE: this parameter is intended to make the data
+   *                       size in each serializable object to be less than it.
+   *                       But if user specifies a small value which may be
+   *                       smaller than the data size of one result chunk.
+   *                       So the definition can't be guaranteed completely.
+   *                       For this special case, one serializable object is
+   *                       used to wrap the data chunk.
    * @return a list of ResultSetSerializables
    * @throws if fails to get the ResultSetSerializable objects.
    */
   @Override
   public List<SnowflakeResultSetSerializable> getResultSetSerializables(long maxSizeInBytes)
-      throws SQLException {
+  throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.getResultSetSerializables(maxSizeInBytes);
   }
 
-  /** Empty result set */
-  static class EmptyResultSet implements ResultSet {
+  /**
+   * Empty result set
+   */
+  static class EmptyResultSet implements ResultSet
+  {
     private boolean isClosed;
 
-    EmptyResultSet() {
+    EmptyResultSet()
+    {
       isClosed = false;
     }
 
-    private void raiseSQLExceptionIfResultSetIsClosed() throws SQLException {
-      if (isClosed()) {
+    private void raiseSQLExceptionIfResultSetIsClosed() throws SQLException
+    {
+      if (isClosed())
+      {
         throw new SnowflakeSQLException(ErrorCode.RESULTSET_ALREADY_CLOSED);
       }
     }
 
     @Override
-    public boolean wasNull() throws SQLException {
+    public boolean wasNull() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean next() throws SQLException {
+    public boolean next() throws SQLException
+    {
       return false; // no exception
     }
 
     @Override
-    public void close() throws SQLException {
+    public void close() throws SQLException
+    {
       isClosed = true;
     }
 
     @Override
-    public boolean getBoolean(int columnIndex) throws SQLException {
+    public boolean getBoolean(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public int getInt(int columnIndex) throws SQLException {
+    public int getInt(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public long getLong(int columnIndex) throws SQLException {
+    public long getLong(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0L;
     }
 
     @Override
-    public float getFloat(int columnIndex) throws SQLException {
+    public float getFloat(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return (float) 0;
     }
 
     @Override
-    public double getDouble(int columnIndex) throws SQLException {
+    public double getDouble(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return (double) 0;
     }
 
     @Override
-    public short getShort(int columnIndex) throws SQLException {
+    public short getShort(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return (short) 0;
     }
 
     @Override
-    public byte getByte(int columnIndex) throws SQLException {
+    public byte getByte(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return (byte) 0;
     }
 
     @Override
-    public String getString(int columnIndex) throws SQLException {
+    public String getString(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return "";
     }
 
     @Override
-    public byte[] getBytes(int columnIndex) throws SQLException {
+    public byte[] getBytes(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return new byte[0];
     }
 
     @Override
-    public Date getDate(int columnIndex) throws SQLException {
+    public Date getDate(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(int columnIndex) throws SQLException {
+    public Time getTime(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex) throws SQLException {
+    public Timestamp getTimestamp(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getAsciiStream(int columnIndex) throws SQLException {
+    public InputStream getAsciiStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+    public InputStream getUnicodeStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getBinaryStream(int columnIndex) throws SQLException {
+    public InputStream getBinaryStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public String getString(String columnLabel) throws SQLException {
+    public String getString(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean getBoolean(String columnLabel) throws SQLException {
+    public boolean getBoolean(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public byte getByte(String columnLabel) throws SQLException {
+    public byte getByte(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public short getShort(String columnLabel) throws SQLException {
+    public short getShort(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getInt(String columnLabel) throws SQLException {
+    public int getInt(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public long getLong(String columnLabel) throws SQLException {
+    public long getLong(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public float getFloat(String columnLabel) throws SQLException {
+    public float getFloat(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public double getDouble(String columnLabel) throws SQLException {
+    public double getDouble(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Deprecated
     @Override
-    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public byte[] getBytes(String columnLabel) throws SQLException {
+    public byte[] getBytes(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return new byte[0];
     }
 
     @Override
-    public Date getDate(String columnLabel) throws SQLException {
+    public Date getDate(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(String columnLabel) throws SQLException {
+    public Time getTime(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel) throws SQLException {
+    public Timestamp getTimestamp(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+    public BigDecimal getBigDecimal(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean isBeforeFirst() throws SQLException {
+    public boolean isBeforeFirst() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isAfterLast() throws SQLException {
+    public boolean isAfterLast() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isFirst() throws SQLException {
+    public boolean isFirst() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isLast() throws SQLException {
+    public boolean isLast() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void beforeFirst() throws SQLException {
+    public void beforeFirst() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void afterLast() throws SQLException {
+    public void afterLast() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public boolean first() throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return false;
-    }
-
-    @Override
-    public boolean last() throws SQLException {
+    public boolean first() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public int getRow() throws SQLException {
+    public boolean last() throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return false;
+    }
+
+    @Override
+    public int getRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean absolute(int row) throws SQLException {
+    public boolean absolute(int row) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean relative(int rows) throws SQLException {
+    public boolean relative(int rows) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean previous() throws SQLException {
+    public boolean previous() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void setFetchDirection(int direction) throws SQLException {
+    public void setFetchDirection(int direction) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public int getFetchDirection() throws SQLException {
+    public int getFetchDirection() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public void setFetchSize(int rows) throws SQLException {
+    public void setFetchSize(int rows) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public int getFetchSize() throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return 0;
-    }
-
-    @Override
-    public int getType() throws SQLException {
+    public int getFetchSize() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getConcurrency() throws SQLException {
+    public int getType() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean rowUpdated() throws SQLException {
+    public int getConcurrency() throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return 0;
+    }
+
+    @Override
+    public boolean rowUpdated() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean rowInserted() throws SQLException {
+    public boolean rowInserted() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean rowDeleted() throws SQLException {
+    public boolean rowDeleted() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void updateNull(int columnIndex) throws SQLException {
+    public void updateNull(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBoolean(int columnIndex, boolean x) throws SQLException {
+    public void updateBoolean(int columnIndex, boolean x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateByte(int columnIndex, byte x) throws SQLException {
+    public void updateByte(int columnIndex, byte x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateShort(int columnIndex, short x) throws SQLException {
+    public void updateShort(int columnIndex, short x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateInt(int columnIndex, int x) throws SQLException {
+    public void updateInt(int columnIndex, int x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateLong(int columnIndex, long x) throws SQLException {
+    public void updateLong(int columnIndex, long x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateFloat(int columnIndex, float x) throws SQLException {
+    public void updateFloat(int columnIndex, float x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDouble(int columnIndex, double x) throws SQLException {
+    public void updateDouble(int columnIndex, double x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateString(int columnIndex, String x) throws SQLException {
+    public void updateString(int columnIndex, String x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+    public void updateBytes(int columnIndex, byte[] x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDate(int columnIndex, Date x) throws SQLException {
+    public void updateDate(int columnIndex, Date x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTime(int columnIndex, Time x) throws SQLException {
+    public void updateTime(int columnIndex, Time x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x) throws SQLException {
+    public void updateObject(int columnIndex, Object x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateNull(String columnLabel) throws SQLException {
+    public void updateNull(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBoolean(String columnLabel, boolean x) throws SQLException {
+    public void updateBoolean(String columnLabel, boolean x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateByte(String columnLabel, byte x) throws SQLException {
+    public void updateByte(String columnLabel, byte x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateShort(String columnLabel, short x) throws SQLException {
+    public void updateShort(String columnLabel, short x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateInt(String columnLabel, int x) throws SQLException {
+    public void updateInt(String columnLabel, int x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateLong(String columnLabel, long x) throws SQLException {
+    public void updateLong(String columnLabel, long x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateFloat(String columnLabel, float x) throws SQLException {
+    public void updateFloat(String columnLabel, float x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDouble(String columnLabel, double x) throws SQLException {
+    public void updateDouble(String columnLabel, double x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateString(String columnLabel, String x) throws SQLException {
+    public void updateString(String columnLabel, String x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+    public void updateBytes(String columnLabel, byte[] x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDate(String columnLabel, Date x) throws SQLException {
+    public void updateDate(String columnLabel, Date x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTime(String columnLabel, Time x) throws SQLException {
+    public void updateTime(String columnLabel, Time x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, int length)
-        throws SQLException {
+    public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, int length)
-        throws SQLException {
+    public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, int length)
-        throws SQLException {
+    public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x) throws SQLException {
+    public void updateObject(String columnLabel, Object x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void insertRow() throws SQLException {
+    public void insertRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateRow() throws SQLException {
+    public void updateRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void deleteRow() throws SQLException {
+    public void deleteRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void refreshRow() throws SQLException {
+    public void refreshRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void cancelRowUpdates() throws SQLException {
+    public void cancelRowUpdates() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void moveToInsertRow() throws SQLException {
+    public void moveToInsertRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void moveToCurrentRow() throws SQLException {
+    public void moveToCurrentRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public Statement getStatement() throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Ref getRef(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Blob getBlob(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Clob getClob(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Array getArray(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Ref getRef(String columnLabel) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Blob getBlob(String columnLabel) throws SQLException {
+    public Statement getStatement() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Clob getClob(String columnLabel) throws SQLException {
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Array getArray(String columnLabel) throws SQLException {
+    public Ref getRef(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    public Blob getBlob(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    public Clob getClob(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    public Array getArray(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    public Ref getRef(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    public Blob getBlob(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public URL getURL(int columnIndex) throws SQLException {
+    public Clob getClob(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public URL getURL(String columnLabel) throws SQLException {
+    public Array getArray(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateRef(int columnIndex, Ref x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateRef(String columnLabel, Ref x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(int columnIndex, Blob x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(String columnLabel, Blob x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(int columnIndex, Clob x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(String columnLabel, Clob x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateArray(int columnIndex, Array x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateArray(String columnLabel, Array x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public RowId getRowId(int columnIndex) throws SQLException {
+    public Date getDate(int columnIndex, Calendar cal) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public RowId getRowId(String columnLabel) throws SQLException {
+    public Date getDate(String columnLabel, Calendar cal) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateRowId(int columnIndex, RowId x) throws SQLException {
+    public Time getTime(int columnIndex, Calendar cal) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+      return null;
     }
 
     @Override
-    public void updateRowId(String columnLabel, RowId x) throws SQLException {
+    public Time getTime(String columnLabel, Calendar cal) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+      return null;
     }
 
     @Override
-    public int getHoldability() throws SQLException {
+    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public URL getURL(int columnIndex) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public URL getURL(String columnLabel) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public void updateRef(int columnIndex, Ref x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateRef(String columnLabel, Ref x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, Blob x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, Blob x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Clob x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Clob x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateArray(int columnIndex, Array x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateArray(String columnLabel, Array x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public RowId getRowId(int columnIndex) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public RowId getRowId(String columnLabel) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public void updateRowId(int columnIndex, RowId x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateRowId(String columnLabel, RowId x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public int getHoldability() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean isClosed() throws SQLException {
+    public boolean isClosed() throws SQLException
+    {
       return isClosed; // no exception
     }
 
     @Override
-    public void updateNString(int columnIndex, String nString) throws SQLException {
+    public void updateNString(int columnIndex, String nString) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public void updateNString(String columnLabel, String nString) throws SQLException {
+    public void updateNString(String columnLabel, String nString) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+    public void updateNClob(int columnIndex, NClob nClob) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+    public void updateNClob(String columnLabel, NClob nClob) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public NClob getNClob(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public NClob getNClob(String columnLabel) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public SQLXML getSQLXML(int columnIndex) throws SQLException {
+    public NClob getNClob(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLXML getSQLXML(String columnLabel) throws SQLException {
+    public NClob getNClob(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public String getNString(int columnIndex) throws SQLException {
+    public SQLXML getSQLXML(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public String getNString(String columnLabel) throws SQLException {
+    public SQLXML getSQLXML(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getNCharacterStream(int columnIndex) throws SQLException {
+    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public String getNString(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getNCharacterStream(String columnLabel) throws SQLException {
+    public String getNString(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(int columnIndex, InputStream inputStream, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(String columnLabel, InputStream inputStream, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(int columnIndex, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(String columnLabel, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNClob(int columnIndex, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNClob(String columnLabel, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+    public Reader getNCharacterStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+    public Reader getNCharacterStream(String columnLabel) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getAsciiStream(String columnIndex) throws SQLException {
+    public InputStream getAsciiStream(String columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+    public InputStream getUnicodeStream(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getBinaryStream(String columnLabel) throws SQLException {
+    public InputStream getBinaryStream(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException {
+    public SQLWarning getWarnings() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void clearWarnings() throws SQLException {
+    public void clearWarnings() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public String getCursorName() throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public String getCursorName() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(int columnIndex) throws SQLException {
+    public ResultSetMetaData getMetaData() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(String columnLabel) throws SQLException {
+    public Object getObject(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public int findColumn(String columnLabel) throws SQLException {
+    public Object getObject(String columnLabel) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public int findColumn(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public Reader getCharacterStream(int columnIndex) throws SQLException {
+    public Reader getCharacterStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getCharacterStream(String columnLabel) throws SQLException {
+    public Reader getCharacterStream(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public <T> T unwrap(Class<T> iface) throws SQLException {
+    public <T> T unwrap(Class<T> iface) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    public boolean isWrapperFor(Class<?> iface) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
   }
+
 }

--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -4,12 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.QueryStatus;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.common.core.SqlState;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -34,12 +28,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.common.core.SqlState;
 
-/**
- * SFAsyncResultSet implementation
- */
-class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet
-{
+/** SFAsyncResultSet implementation */
+class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet {
   private final SFBaseResultSet sfBaseResultSet;
   private ResultSet resultSetForNext = new EmptyResultSet();
   private boolean resultSetForNextInitialized = false;
@@ -48,161 +44,131 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
   private Statement extraStatement;
 
   /**
-   * Constructor takes an inputstream from the API response that we get from
-   * executing a SQL statement.
-   * <p>
-   * The constructor will fetch the first row (if any) so that it can initialize
-   * the ResultSetMetaData.
-   * </p>
+   * Constructor takes an inputstream from the API response that we get from executing a SQL
+   * statement.
+   *
+   * <p>The constructor will fetch the first row (if any) so that it can initialize the
+   * ResultSetMetaData.
    *
    * @param sfBaseResultSet snowflake core base result rest object
-   * @param statement       query statement that generates this result set
+   * @param statement query statement that generates this result set
    * @throws SQLException if failed to construct snowflake result set metadata
    */
-  SFAsyncResultSet(
-      SFBaseResultSet sfBaseResultSet,
-      Statement statement)
-  throws SQLException
-  {
+  SFAsyncResultSet(SFBaseResultSet sfBaseResultSet, Statement statement) throws SQLException {
     super(statement);
     this.sfBaseResultSet = sfBaseResultSet;
     this.queryID = sfBaseResultSet.getQueryId();
     this.session = sfBaseResultSet.getSession();
     this.extraStatement = statement;
-    try
-    {
-      this.resultSetMetaData =
-          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    try {
+      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
       this.resultSetMetaData.setQueryIdForAsyncResults(this.queryID);
-      this.resultSetMetaData.setQueryType(
-          SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(),
-                                            ex.getSqlState(), ex.getVendorCode(), this.session, ex.getParams());
+      this.resultSetMetaData.setQueryType(SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), this.session, ex.getParams());
     }
   }
 
   /**
-   * Constructor takes a result set serializable object to create
-   * a sessionless result set.
+   * Constructor takes a result set serializable object to create a sessionless result set.
    *
-   * @param sfBaseResultSet       snowflake core base result rest object
-   * @param resultSetSerializable The result set serializable object which
-   *                              includes all metadata to create the result
-   *                              set
+   * @param sfBaseResultSet snowflake core base result rest object
+   * @param resultSetSerializable The result set serializable object which includes all metadata to
+   *     create the result set
    * @throws SQLException if fails to create the result set object
    */
   public SFAsyncResultSet(
-      SFBaseResultSet sfBaseResultSet,
-      SnowflakeResultSetSerializableV1 resultSetSerializable)
-  throws SQLException
-  {
+      SFBaseResultSet sfBaseResultSet, SnowflakeResultSetSerializableV1 resultSetSerializable)
+      throws SQLException {
     super(resultSetSerializable);
     this.queryID = sfBaseResultSet.getQueryId();
     this.sfBaseResultSet = sfBaseResultSet;
 
-    try
-    {
-      this.resultSetMetaData =
-          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    try {
+      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
       this.resultSetMetaData.setQueryIdForAsyncResults(this.queryID);
-      this.resultSetMetaData.setQueryType(
-          SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(),
-                                            ex.getSqlState(), ex.getVendorCode(), this.session, ex.getParams());
+      this.resultSetMetaData.setQueryType(SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), this.session, ex.getParams());
     }
   }
 
-  public SFAsyncResultSet(String queryID) throws SQLException
-  {
+  public SFAsyncResultSet(String queryID) throws SQLException {
     this.sfBaseResultSet = null;
     queryID.trim();
-    if (!Pattern
-        .matches("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}", queryID))
-    {
-      throw new SQLException("The provided query ID " + queryID + " is invalid.",
-                             SqlState.INVALID_PARAMETER_VALUE);
+    if (!Pattern.matches("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}", queryID)) {
+      throw new SQLException(
+          "The provided query ID " + queryID + " is invalid.", SqlState.INVALID_PARAMETER_VALUE);
     }
     this.queryID = queryID;
   }
 
   @Override
-  protected void raiseSQLExceptionIfResultSetIsClosed() throws SQLException
-  {
-    if (isClosed())
-    {
+  protected void raiseSQLExceptionIfResultSetIsClosed() throws SQLException {
+    if (isClosed()) {
       throw new SnowflakeSQLException(ErrorCode.RESULTSET_ALREADY_CLOSED);
     }
   }
 
   @Override
-  public QueryStatus getStatus() throws SQLException
-  {
-    if (session == null)
-    {
+  public QueryStatus getStatus() throws SQLException {
+    if (session == null) {
       throw new SQLException("Session not set");
     }
-    if (this.queryID == null)
-    {
+    if (this.queryID == null) {
       throw new SQLException("QueryID unknown");
     }
     return session.getQueryStatus(this.queryID);
   }
 
   /**
-   * helper function for next() and getMetaData(). Calls result_scan
-   * to get resultSet after asynchronous query call
+   * helper function for next() and getMetaData(). Calls result_scan to get resultSet after
+   * asynchronous query call
    *
    * @throws SQLException
    */
-  private void getRealResults() throws SQLException
-  {
-    if (!resultSetForNextInitialized)
-    {
+  private void getRealResults() throws SQLException {
+    if (!resultSetForNextInitialized) {
       QueryStatus qs = this.getStatus();
       int noDataRetry = 0;
       final int noDataMaxRetries = 30;
       final int[] retryPattern = {1, 1, 2, 3, 4, 8, 10};
       final int maxIndex = retryPattern.length - 1;
       int retry = 0;
-      while (qs != QueryStatus.SUCCESS)
-      {
-        // if query is not running due to a failure (Aborted, failed with error, etc), generate exception
-        if (!QueryStatus.isStillRunning(qs) && qs.getValue() != QueryStatus.SUCCESS.getValue())
-        {
+      while (qs != QueryStatus.SUCCESS) {
+        // if query is not running due to a failure (Aborted, failed with error, etc), generate
+        // exception
+        if (!QueryStatus.isStillRunning(qs) && qs.getValue() != QueryStatus.SUCCESS.getValue()) {
           throw new SQLException(
-              "Status of query associated with resultSet is " + qs.getDescription() + ". Results not generated.");
+              "Status of query associated with resultSet is "
+                  + qs.getDescription()
+                  + ". Results not generated.");
         }
         // if no data about the query is returned after about 2 minutes, give up
-        if (qs == QueryStatus.NO_DATA)
-        {
+        if (qs == QueryStatus.NO_DATA) {
           noDataRetry++;
-          if (noDataRetry >= noDataMaxRetries)
-          {
-            throw new SQLException("Cannot retrieve data on the status of this query. No information returned from server for queryID={}.", this.queryID);
+          if (noDataRetry >= noDataMaxRetries) {
+            throw new SQLException(
+                "Cannot retrieve data on the status of this query. No information returned from server for queryID={}.",
+                this.queryID);
           }
         }
-        try
-        {
-          // Sleep for an amount before trying again. Exponential backoff up to 5 seconds implemented.
+        try {
+          // Sleep for an amount before trying again. Exponential backoff up to 5 seconds
+          // implemented.
           Thread.sleep(500 * retryPattern[retry]);
-        }
-        catch (InterruptedException e)
-        {
+        } catch (InterruptedException e) {
           e.printStackTrace();
         }
-        if (retry < maxIndex)
-        {
+        if (retry < maxIndex) {
           retry++;
         }
         qs = this.getStatus();
       }
-      resultSetForNext = extraStatement.executeQuery("select * from table(result_scan('" + this.queryID + "'))");
+      resultSetForNext =
+          extraStatement.executeQuery("select * from table(result_scan('" + this.queryID + "'))");
       resultSetForNextInitialized = true;
     }
   }
@@ -214,208 +180,173 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
    * @throws SQLException if failed to move to the next row
    */
   @Override
-  public boolean next() throws SQLException
-  {
+  public boolean next() throws SQLException {
     getRealResults();
     return resultSetForNext.next();
   }
 
   @Override
-  public void close() throws SQLException
-  {
+  public void close() throws SQLException {
     close(true);
   }
 
-  public void close(boolean removeClosedResultSetFromStatement) throws SQLException
-  {
+  public void close(boolean removeClosedResultSetFromStatement) throws SQLException {
     // no SQLException is raised.
     resultSetForNext.close();
-    if (sfBaseResultSet != null)
-    {
+    if (sfBaseResultSet != null) {
       sfBaseResultSet.close();
     }
-    if (removeClosedResultSetFromStatement && statement.isWrapperFor(SnowflakeStatementV1.class))
-    {
+    if (removeClosedResultSetFromStatement && statement.isWrapperFor(SnowflakeStatementV1.class)) {
       statement.unwrap(SnowflakeStatementV1.class).removeClosedResultSet(this);
     }
   }
 
-  public String getQueryID()
-  {
+  public String getQueryID() {
     return this.queryID;
   }
 
-  public boolean wasNull() throws SQLException
-  {
+  public boolean wasNull() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.wasNull();
   }
 
-  public String getString(int columnIndex) throws SQLException
-  {
+  public String getString(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getString(columnIndex);
   }
 
-  public void setSession(SFSession session)
-  {
+  public void setSession(SFSession session) {
     this.session = session;
   }
 
-  public void setStatement(Statement statement)
-  {
+  public void setStatement(Statement statement) {
     this.extraStatement = statement;
   }
 
-  public boolean getBoolean(int columnIndex) throws SQLException
-  {
+  public boolean getBoolean(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getBoolean(columnIndex);
   }
 
   @Override
-  public byte getByte(int columnIndex) throws SQLException
-  {
+  public byte getByte(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getByte(columnIndex);
   }
 
-  public short getShort(int columnIndex) throws SQLException
-  {
+  public short getShort(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getShort(columnIndex);
   }
 
-  public int getInt(int columnIndex) throws SQLException
-  {
+  public int getInt(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getInt(columnIndex);
   }
 
-  public long getLong(int columnIndex) throws SQLException
-  {
+  public long getLong(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getLong(columnIndex);
   }
 
-  public float getFloat(int columnIndex) throws SQLException
-  {
+  public float getFloat(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getFloat(columnIndex);
-
   }
 
-  public double getDouble(int columnIndex) throws SQLException
-  {
+  public double getDouble(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getDouble(columnIndex);
   }
 
-  public Date getDate(int columnIndex, TimeZone tz) throws SQLException
-  {
+  public Date getDate(int columnIndex, TimeZone tz) throws SQLException {
     // Note: currently we provide this API but it does not use TimeZone tz.
     // TODO: use the time zone passed from the arguments
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getDate(columnIndex);
   }
 
-  public Time getTime(int columnIndex) throws SQLException
-  {
+  public Time getTime(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getTime(columnIndex);
   }
 
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz)
-  throws SQLException
-  {
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.unwrap(SnowflakeResultSetV1.class).getTimestamp(columnIndex, tz);
   }
 
-  public ResultSetMetaData getMetaData() throws SQLException
-  {
+  public ResultSetMetaData getMetaData() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     getRealResults();
     this.resultSetMetaData =
-        (SnowflakeResultSetMetaDataV1) resultSetForNext.unwrap(SnowflakeResultSetV1.class).getMetaData();
+        (SnowflakeResultSetMetaDataV1)
+            resultSetForNext.unwrap(SnowflakeResultSetV1.class).getMetaData();
     this.resultSetMetaData.setQueryIdForAsyncResults(this.queryID);
-    this.resultSetMetaData.setQueryType(
-        SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
+    this.resultSetMetaData.setQueryType(SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
     return resultSetMetaData;
   }
 
-  public Object getObject(int columnIndex) throws SQLException
-  {
+  public Object getObject(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getObject(columnIndex);
   }
 
-  public BigDecimal getBigDecimal(int columnIndex) throws SQLException
-  {
+  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getBigDecimal(columnIndex);
   }
 
   @Deprecated
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
-  {
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getBigDecimal(columnIndex, scale);
   }
 
-  public byte[] getBytes(int columnIndex) throws SQLException
-  {
+  public byte[] getBytes(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.getBytes(columnIndex);
   }
 
-  public int getRow() throws SQLException
-  {
+  public int getRow() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
 
     return resultSetForNext.getRow();
   }
 
-  public boolean isFirst() throws SQLException
-  {
+  public boolean isFirst() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.isFirst();
   }
 
-  public boolean isClosed() throws SQLException
-  {
+  public boolean isClosed() throws SQLException {
     // no exception is raised.
-    if (sfBaseResultSet != null)
-    {
+    if (sfBaseResultSet != null) {
       return (resultSetForNext.isClosed() && sfBaseResultSet.isClosed());
     }
     return resultSetForNext.isClosed();
   }
 
   @Override
-  public boolean isLast() throws SQLException
-  {
+  public boolean isLast() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.isLast();
   }
 
   @Override
-  public boolean isAfterLast() throws SQLException
-  {
+  public boolean isAfterLast() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.isAfterLast();
   }
 
   @Override
-  public boolean isBeforeFirst() throws SQLException
-  {
+  public boolean isBeforeFirst() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return resultSetForNext.isBeforeFirst();
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException
-  {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
     logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -423,15 +354,12 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException
-  {
+  public <T> T unwrap(Class<T> iface) throws SQLException {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this))
-    {
+    if (!iface.isInstance(this)) {
       throw new SQLException(
-          this.getClass().getName() + " not unwrappable from " + iface
-              .getName());
+          this.getClass().getName() + " not unwrappable from " + iface.getName());
     }
     return (T) this;
   }
@@ -439,1334 +367,1096 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
   /**
    * Get a list of ResultSetSerializables for the ResultSet in order to parallel processing
    *
-   * @param maxSizeInBytes The expected max data size wrapped in the
-   *                       ResultSetSerializables object.
-   *                       NOTE: this parameter is intended to make the data
-   *                       size in each serializable object to be less than it.
-   *                       But if user specifies a small value which may be
-   *                       smaller than the data size of one result chunk.
-   *                       So the definition can't be guaranteed completely.
-   *                       For this special case, one serializable object is
-   *                       used to wrap the data chunk.
+   * @param maxSizeInBytes The expected max data size wrapped in the ResultSetSerializables object.
+   *     NOTE: this parameter is intended to make the data size in each serializable object to be
+   *     less than it. But if user specifies a small value which may be smaller than the data size
+   *     of one result chunk. So the definition can't be guaranteed completely. For this special
+   *     case, one serializable object is used to wrap the data chunk.
    * @return a list of ResultSetSerializables
    * @throws if fails to get the ResultSetSerializable objects.
    */
   @Override
   public List<SnowflakeResultSetSerializable> getResultSetSerializables(long maxSizeInBytes)
-  throws SQLException
-  {
+      throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.getResultSetSerializables(maxSizeInBytes);
   }
 
-  /**
-   * Empty result set
-   */
-  static class EmptyResultSet implements ResultSet
-  {
+  /** Empty result set */
+  static class EmptyResultSet implements ResultSet {
     private boolean isClosed;
 
-    EmptyResultSet()
-    {
+    EmptyResultSet() {
       isClosed = false;
     }
 
-    private void raiseSQLExceptionIfResultSetIsClosed() throws SQLException
-    {
-      if (isClosed())
-      {
+    private void raiseSQLExceptionIfResultSetIsClosed() throws SQLException {
+      if (isClosed()) {
         throw new SnowflakeSQLException(ErrorCode.RESULTSET_ALREADY_CLOSED);
       }
     }
 
     @Override
-    public boolean wasNull() throws SQLException
-    {
+    public boolean wasNull() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean next() throws SQLException
-    {
+    public boolean next() throws SQLException {
       return false; // no exception
     }
 
     @Override
-    public void close() throws SQLException
-    {
+    public void close() throws SQLException {
       isClosed = true;
     }
 
     @Override
-    public boolean getBoolean(int columnIndex) throws SQLException
-    {
+    public boolean getBoolean(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public int getInt(int columnIndex) throws SQLException
-    {
+    public int getInt(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public long getLong(int columnIndex) throws SQLException
-    {
+    public long getLong(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0L;
     }
 
     @Override
-    public float getFloat(int columnIndex) throws SQLException
-    {
+    public float getFloat(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return (float) 0;
     }
 
     @Override
-    public double getDouble(int columnIndex) throws SQLException
-    {
+    public double getDouble(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return (double) 0;
     }
 
     @Override
-    public short getShort(int columnIndex) throws SQLException
-    {
+    public short getShort(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return (short) 0;
     }
 
     @Override
-    public byte getByte(int columnIndex) throws SQLException
-    {
+    public byte getByte(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return (byte) 0;
     }
 
     @Override
-    public String getString(int columnIndex) throws SQLException
-    {
+    public String getString(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return "";
     }
 
     @Override
-    public byte[] getBytes(int columnIndex) throws SQLException
-    {
+    public byte[] getBytes(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return new byte[0];
     }
 
     @Override
-    public Date getDate(int columnIndex) throws SQLException
-    {
+    public Date getDate(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(int columnIndex) throws SQLException
-    {
+    public Time getTime(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex) throws SQLException
-    {
+    public Timestamp getTimestamp(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getAsciiStream(int columnIndex) throws SQLException
-    {
+    public InputStream getAsciiStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public InputStream getUnicodeStream(int columnIndex) throws SQLException
-    {
+    public InputStream getUnicodeStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getBinaryStream(int columnIndex) throws SQLException
-    {
+    public InputStream getBinaryStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public String getString(String columnLabel) throws SQLException
-    {
+    public String getString(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean getBoolean(String columnLabel) throws SQLException
-    {
+    public boolean getBoolean(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public byte getByte(String columnLabel) throws SQLException
-    {
+    public byte getByte(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public short getShort(String columnLabel) throws SQLException
-    {
+    public short getShort(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getInt(String columnLabel) throws SQLException
-    {
+    public int getInt(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public long getLong(String columnLabel) throws SQLException
-    {
+    public long getLong(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public float getFloat(String columnLabel) throws SQLException
-    {
+    public float getFloat(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public double getDouble(String columnLabel) throws SQLException
-    {
+    public double getDouble(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Deprecated
     @Override
-    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException
-    {
+    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public byte[] getBytes(String columnLabel) throws SQLException
-    {
+    public byte[] getBytes(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return new byte[0];
     }
 
     @Override
-    public Date getDate(String columnLabel) throws SQLException
-    {
+    public Date getDate(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(String columnLabel) throws SQLException
-    {
+    public Time getTime(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel) throws SQLException
-    {
+    public Timestamp getTimestamp(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public BigDecimal getBigDecimal(int columnIndex) throws SQLException
-    {
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public BigDecimal getBigDecimal(String columnLabel) throws SQLException
-    {
+    public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean isBeforeFirst() throws SQLException
-    {
+    public boolean isBeforeFirst() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isAfterLast() throws SQLException
-    {
+    public boolean isAfterLast() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isFirst() throws SQLException
-    {
+    public boolean isFirst() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isLast() throws SQLException
-    {
+    public boolean isLast() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void beforeFirst() throws SQLException
-    {
+    public void beforeFirst() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void afterLast() throws SQLException
-    {
+    public void afterLast() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public boolean first() throws SQLException
-    {
+    public boolean first() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean last() throws SQLException
-    {
+    public boolean last() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public int getRow() throws SQLException
-    {
+    public int getRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean absolute(int row) throws SQLException
-    {
+    public boolean absolute(int row) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean relative(int rows) throws SQLException
-    {
+    public boolean relative(int rows) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean previous() throws SQLException
-    {
+    public boolean previous() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void setFetchDirection(int direction) throws SQLException
-    {
+    public void setFetchDirection(int direction) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public int getFetchDirection() throws SQLException
-    {
+    public int getFetchDirection() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public void setFetchSize(int rows) throws SQLException
-    {
+    public void setFetchSize(int rows) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public int getFetchSize() throws SQLException
-    {
+    public int getFetchSize() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getType() throws SQLException
-    {
+    public int getType() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getConcurrency() throws SQLException
-    {
+    public int getConcurrency() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean rowUpdated() throws SQLException
-    {
+    public boolean rowUpdated() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean rowInserted() throws SQLException
-    {
+    public boolean rowInserted() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean rowDeleted() throws SQLException
-    {
+    public boolean rowDeleted() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void updateNull(int columnIndex) throws SQLException
-    {
+    public void updateNull(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBoolean(int columnIndex, boolean x) throws SQLException
-    {
+    public void updateBoolean(int columnIndex, boolean x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateByte(int columnIndex, byte x) throws SQLException
-    {
+    public void updateByte(int columnIndex, byte x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateShort(int columnIndex, short x) throws SQLException
-    {
+    public void updateShort(int columnIndex, short x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateInt(int columnIndex, int x) throws SQLException
-    {
+    public void updateInt(int columnIndex, int x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateLong(int columnIndex, long x) throws SQLException
-    {
+    public void updateLong(int columnIndex, long x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateFloat(int columnIndex, float x) throws SQLException
-    {
+    public void updateFloat(int columnIndex, float x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDouble(int columnIndex, double x) throws SQLException
-    {
+    public void updateDouble(int columnIndex, double x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException
-    {
+    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateString(int columnIndex, String x) throws SQLException
-    {
+    public void updateString(int columnIndex, String x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBytes(int columnIndex, byte[] x) throws SQLException
-    {
+    public void updateBytes(int columnIndex, byte[] x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDate(int columnIndex, Date x) throws SQLException
-    {
+    public void updateDate(int columnIndex, Date x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTime(int columnIndex, Time x) throws SQLException
-    {
+    public void updateTime(int columnIndex, Time x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException
-    {
+    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException
-    {
+    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException
-    {
+    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException
-    {
+    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException
-    {
+    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x) throws SQLException
-    {
+    public void updateObject(int columnIndex, Object x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateNull(String columnLabel) throws SQLException
-    {
+    public void updateNull(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBoolean(String columnLabel, boolean x) throws SQLException
-    {
+    public void updateBoolean(String columnLabel, boolean x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateByte(String columnLabel, byte x) throws SQLException
-    {
+    public void updateByte(String columnLabel, byte x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateShort(String columnLabel, short x) throws SQLException
-    {
+    public void updateShort(String columnLabel, short x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateInt(String columnLabel, int x) throws SQLException
-    {
+    public void updateInt(String columnLabel, int x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateLong(String columnLabel, long x) throws SQLException
-    {
+    public void updateLong(String columnLabel, long x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateFloat(String columnLabel, float x) throws SQLException
-    {
+    public void updateFloat(String columnLabel, float x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDouble(String columnLabel, double x) throws SQLException
-    {
+    public void updateDouble(String columnLabel, double x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException
-    {
+    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateString(String columnLabel, String x) throws SQLException
-    {
+    public void updateString(String columnLabel, String x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBytes(String columnLabel, byte[] x) throws SQLException
-    {
+    public void updateBytes(String columnLabel, byte[] x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDate(String columnLabel, Date x) throws SQLException
-    {
+    public void updateDate(String columnLabel, Date x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTime(String columnLabel, Time x) throws SQLException
-    {
+    public void updateTime(String columnLabel, Time x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException
-    {
+    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException
-    {
+    public void updateAsciiStream(String columnLabel, InputStream x, int length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException
-    {
+    public void updateBinaryStream(String columnLabel, InputStream x, int length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException
-    {
+    public void updateCharacterStream(String columnLabel, Reader reader, int length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException
-    {
+    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x) throws SQLException
-    {
+    public void updateObject(String columnLabel, Object x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void insertRow() throws SQLException
-    {
+    public void insertRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateRow() throws SQLException
-    {
+    public void updateRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void deleteRow() throws SQLException
-    {
+    public void deleteRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void refreshRow() throws SQLException
-    {
+    public void refreshRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void cancelRowUpdates() throws SQLException
-    {
+    public void cancelRowUpdates() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void moveToInsertRow() throws SQLException
-    {
+    public void moveToInsertRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void moveToCurrentRow() throws SQLException
-    {
+    public void moveToCurrentRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public Statement getStatement() throws SQLException
-    {
+    public Statement getStatement() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException
-    {
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Ref getRef(int columnIndex) throws SQLException
-    {
+    public Ref getRef(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Blob getBlob(int columnIndex) throws SQLException
-    {
+    public Blob getBlob(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Clob getClob(int columnIndex) throws SQLException
-    {
+    public Clob getClob(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Array getArray(int columnIndex) throws SQLException
-    {
+    public Array getArray(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException
-    {
+    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Ref getRef(String columnLabel) throws SQLException
-    {
+    public Ref getRef(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Blob getBlob(String columnLabel) throws SQLException
-    {
+    public Blob getBlob(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Clob getClob(String columnLabel) throws SQLException
-    {
+    public Clob getClob(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Array getArray(String columnLabel) throws SQLException
-    {
+    public Array getArray(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Date getDate(int columnIndex, Calendar cal) throws SQLException
-    {
+    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Date getDate(String columnLabel, Calendar cal) throws SQLException
-    {
+    public Date getDate(String columnLabel, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(int columnIndex, Calendar cal) throws SQLException
-    {
+    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(String columnLabel, Calendar cal) throws SQLException
-    {
+    public Time getTime(String columnLabel, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException
-    {
+    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException
-    {
+    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public URL getURL(int columnIndex) throws SQLException
-    {
+    public URL getURL(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public URL getURL(String columnLabel) throws SQLException
-    {
+    public URL getURL(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateRef(int columnIndex, Ref x) throws SQLException
-    {
+    public void updateRef(int columnIndex, Ref x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateRef(String columnLabel, Ref x) throws SQLException
-    {
+    public void updateRef(String columnLabel, Ref x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(int columnIndex, Blob x) throws SQLException
-    {
+    public void updateBlob(int columnIndex, Blob x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(String columnLabel, Blob x) throws SQLException
-    {
+    public void updateBlob(String columnLabel, Blob x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(int columnIndex, Clob x) throws SQLException
-    {
+    public void updateClob(int columnIndex, Clob x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(String columnLabel, Clob x) throws SQLException
-    {
+    public void updateClob(String columnLabel, Clob x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateArray(int columnIndex, Array x) throws SQLException
-    {
+    public void updateArray(int columnIndex, Array x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateArray(String columnLabel, Array x) throws SQLException
-    {
+    public void updateArray(String columnLabel, Array x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public RowId getRowId(int columnIndex) throws SQLException
-    {
+    public RowId getRowId(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public RowId getRowId(String columnLabel) throws SQLException
-    {
+    public RowId getRowId(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateRowId(int columnIndex, RowId x) throws SQLException
-    {
+    public void updateRowId(int columnIndex, RowId x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateRowId(String columnLabel, RowId x) throws SQLException
-    {
+    public void updateRowId(String columnLabel, RowId x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public int getHoldability() throws SQLException
-    {
+    public int getHoldability() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean isClosed() throws SQLException
-    {
+    public boolean isClosed() throws SQLException {
       return isClosed; // no exception
     }
 
     @Override
-    public void updateNString(int columnIndex, String nString) throws SQLException
-    {
+    public void updateNString(int columnIndex, String nString) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNString(String columnLabel, String nString) throws SQLException
-    {
+    public void updateNString(String columnLabel, String nString) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(int columnIndex, NClob nClob) throws SQLException
-    {
+    public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(String columnLabel, NClob nClob) throws SQLException
-    {
+    public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public NClob getNClob(int columnIndex) throws SQLException
-    {
+    public NClob getNClob(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public NClob getNClob(String columnLabel) throws SQLException
-    {
+    public NClob getNClob(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLXML getSQLXML(int columnIndex) throws SQLException
-    {
+    public SQLXML getSQLXML(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLXML getSQLXML(String columnLabel) throws SQLException
-    {
+    public SQLXML getSQLXML(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException
-    {
+    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException
-    {
+    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public String getNString(int columnIndex) throws SQLException
-    {
+    public String getNString(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public String getNString(String columnLabel) throws SQLException
-    {
+    public String getNString(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getNCharacterStream(int columnIndex) throws SQLException
-    {
+    public Reader getNCharacterStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getNCharacterStream(String columnLabel) throws SQLException
-    {
+    public Reader getNCharacterStream(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException
-    {
+    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
-    {
+    public void updateNCharacterStream(String columnLabel, Reader reader, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException
-    {
+    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException
-    {
+    public void updateBinaryStream(int columnIndex, InputStream x, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException
-    {
+    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException
-    {
+    public void updateAsciiStream(String columnLabel, InputStream x, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException
-    {
+    public void updateBinaryStream(String columnLabel, InputStream x, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
-    {
+    public void updateCharacterStream(String columnLabel, Reader reader, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException
-    {
+    public void updateBlob(int columnIndex, InputStream inputStream, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException
-    {
+    public void updateBlob(String columnLabel, InputStream inputStream, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException
-    {
+    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException
-    {
+    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException
-    {
+    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException
-    {
+    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException
-    {
+    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException
-    {
+    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException
-    {
+    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException
-    {
+    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException
-    {
+    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException
-    {
+    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException
-    {
+    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException
-    {
+    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException
-    {
+    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException
-    {
+    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(int columnIndex, Reader reader) throws SQLException
-    {
+    public void updateClob(int columnIndex, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(String columnLabel, Reader reader) throws SQLException
-    {
+    public void updateClob(String columnLabel, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(int columnIndex, Reader reader) throws SQLException
-    {
+    public void updateNClob(int columnIndex, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(String columnLabel, Reader reader) throws SQLException
-    {
+    public void updateNClob(String columnLabel, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException
-    {
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException
-    {
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
-    {
+    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getAsciiStream(String columnIndex) throws SQLException
-    {
+    public InputStream getAsciiStream(String columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public InputStream getUnicodeStream(String columnLabel) throws SQLException
-    {
+    public InputStream getUnicodeStream(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getBinaryStream(String columnLabel) throws SQLException
-    {
+    public InputStream getBinaryStream(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException
-    {
+    public SQLWarning getWarnings() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void clearWarnings() throws SQLException
-    {
+    public void clearWarnings() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public String getCursorName() throws SQLException
-    {
+    public String getCursorName() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException
-    {
+    public ResultSetMetaData getMetaData() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(int columnIndex) throws SQLException
-    {
+    public Object getObject(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(String columnLabel) throws SQLException
-    {
+    public Object getObject(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public int findColumn(String columnLabel) throws SQLException
-    {
+    public int findColumn(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public Reader getCharacterStream(int columnIndex) throws SQLException
-    {
+    public Reader getCharacterStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getCharacterStream(String columnLabel) throws SQLException
-    {
+    public Reader getCharacterStream(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public <T> T unwrap(Class<T> iface) throws SQLException
-    {
+    public <T> T unwrap(Class<T> iface) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean isWrapperFor(Class<?> iface) throws SQLException
-    {
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
   }
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -4,25 +4,11 @@
 
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.core.Constants.MB;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import net.snowflake.client.core.*;
-import net.snowflake.client.jdbc.SnowflakeResultChunk.DownloadState;
-import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
-import net.snowflake.client.log.ArgSupplier;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.util.SecretDetector;
-import net.snowflake.common.core.SqlState;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -46,37 +32,43 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPInputStream;
-
-import static net.snowflake.client.core.Constants.MB;
+import net.snowflake.client.core.*;
+import net.snowflake.client.jdbc.SnowflakeResultChunk.DownloadState;
+import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
+import net.snowflake.client.log.ArgSupplier;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.util.SecretDetector;
+import net.snowflake.common.core.SqlState;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 /**
  * Class for managing async download of offline result chunks
- * <p>
- * Created by jhuang on 11/12/14.
+ *
+ * <p>Created by jhuang on 11/12/14.
  */
-public class SnowflakeChunkDownloader implements ChunkDownloader
-{
+public class SnowflakeChunkDownloader implements ChunkDownloader {
   // SSE-C algorithm header
-  private static final String SSE_C_ALGORITHM =
-      "x-amz-server-side-encryption-customer-algorithm";
+  private static final String SSE_C_ALGORITHM = "x-amz-server-side-encryption-customer-algorithm";
 
   // SSE-C customer key header
-  private static final String SSE_C_KEY =
-      "x-amz-server-side-encryption-customer-key";
+  private static final String SSE_C_KEY = "x-amz-server-side-encryption-customer-key";
 
   // SSE-C algorithm value
   private static final String SSE_C_AES = "AES256";
 
   // object mapper for deserialize JSON
-  private static final ObjectMapper mapper =
-      ObjectMapperFactory.getObjectMapper();
-  /**
-   * a shared JSON parser factory.
-   */
+  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+  /** a shared JSON parser factory. */
   private static final JsonFactory jsonFactory = new MappingJsonFactory();
 
-  private static final SFLogger logger =
-      SFLoggerFactory.getLogger(SnowflakeChunkDownloader.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeChunkDownloader.class);
   private static final int STREAM_BUFFER_SIZE = MB;
   private static final long SHUTDOWN_TIME = 3;
   private final SnowflakeConnectString snowflakeConnectionString;
@@ -85,8 +77,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
   // Session object, used solely for throwing exceptions. CAUTION: MAY BE NULL!
   private SFSession session;
 
-  private JsonResultChunk.ResultChunkDataCache chunkDataCache
-      = new JsonResultChunk.ResultChunkDataCache();
+  private JsonResultChunk.ResultChunkDataCache chunkDataCache =
+      new JsonResultChunk.ResultChunkDataCache();
   private List<SnowflakeResultChunk> chunks;
 
   // index of next chunk to be consumed (it may not be ready yet)
@@ -128,20 +120,14 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
   // used to track the downloading threads
   private Map<Integer, Future> downloaderFutures = new ConcurrentHashMap<>();
 
-  /**
-   * query result format
-   */
+  /** query result format */
   private QueryResultFormat queryResultFormat;
 
-  /**
-   * Arrow memory allocator for the current resultSet
-   */
+  /** Arrow memory allocator for the current resultSet */
   private RootAllocator rootAllocator;
 
-  static long getCurrentMemoryUsage()
-  {
-    synchronized (currentMemoryUsage)
-    {
+  static long getCurrentMemoryUsage() {
+    synchronized (currentMemoryUsage) {
       return currentMemoryUsage.longValue();
     }
   }
@@ -154,16 +140,14 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
   private long MAX_WAITING_MS = 30 * 1000;
   // the default jitter ratio 10%
   private long WAITING_JITTER_RATIO = 10;
-  /**
-   * Timeout that the main thread waits for downloading the current chunk
-   */
-  private static final long downloadedConditionTimeoutInSeconds = HttpUtil.getDownloadedConditionTimeoutInSeconds();
+  /** Timeout that the main thread waits for downloading the current chunk */
+  private static final long downloadedConditionTimeoutInSeconds =
+      HttpUtil.getDownloadedConditionTimeoutInSeconds();
 
   private static final int MAX_NUM_OF_RETRY = 10;
   private static final int MAX_RETRY_JITTER = 1000; // milliseconds
 
-  public OCSPMode getOCSPMode()
-  {
+  public OCSPMode getOCSPMode() {
     return ocspMode;
   }
 
@@ -171,52 +155,43 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
    * Create a pool of downloader threads.
    *
    * @param threadNamePrefix name of threads in pool
-   * @param parallel         number of thread in pool
+   * @param parallel number of thread in pool
    * @return new thread pool
    */
   private static ThreadPoolExecutor createChunkDownloaderExecutorService(
-      final String threadNamePrefix, final int parallel)
-  {
-    ThreadFactory threadFactory = new ThreadFactory()
-    {
-      private int threadCount = 1;
+      final String threadNamePrefix, final int parallel) {
+    ThreadFactory threadFactory =
+        new ThreadFactory() {
+          private int threadCount = 1;
 
-      public Thread newThread(final Runnable r)
-      {
-        final Thread thread = new Thread(r);
-        thread.setName(threadNamePrefix + threadCount++);
+          public Thread newThread(final Runnable r) {
+            final Thread thread = new Thread(r);
+            thread.setName(threadNamePrefix + threadCount++);
 
-        thread.setUncaughtExceptionHandler(
-            new Thread.UncaughtExceptionHandler()
-            {
-              public void uncaughtException(Thread t, Throwable e)
-              {
-                logger.error(
-                    "uncaughtException in thread: " + t + " {}",
-                    e);
-              }
-            });
+            thread.setUncaughtExceptionHandler(
+                new Thread.UncaughtExceptionHandler() {
+                  public void uncaughtException(Thread t, Throwable e) {
+                    logger.error("uncaughtException in thread: " + t + " {}", e);
+                  }
+                });
 
-        thread.setDaemon(true);
+            thread.setDaemon(true);
 
-        return thread;
-      }
-    };
-    return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallel,
-                                                             threadFactory);
+            return thread;
+          }
+        };
+    return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallel, threadFactory);
   }
 
   /**
    * Constructor to initialize downloader
    *
-   * @param resultSetSerializable the result set serializable object which
-   *                              includes required metadata to start chunk downloader
+   * @param resultSetSerializable the result set serializable object which includes required
+   *     metadata to start chunk downloader
    */
   public SnowflakeChunkDownloader(SnowflakeResultSetSerializableV1 resultSetSerializable)
-  throws SnowflakeSQLException
-  {
-    this.snowflakeConnectionString =
-        resultSetSerializable.getSnowflakeConnectString();
+      throws SnowflakeSQLException {
+    this.snowflakeConnectionString = resultSetSerializable.getSnowflakeConnectString();
     this.ocspMode = resultSetSerializable.getOCSPMode();
     this.qrmk = resultSetSerializable.getQrmk();
     this.networkTimeoutInMilli = resultSetSerializable.getNetworkTimeoutInMilli();
@@ -226,111 +201,112 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
     logger.debug("qrmk = {}", this.qrmk);
     this.chunkHeadersMap = resultSetSerializable.getChunkHeadersMap();
     // session may be null. Its only use is for in-band telemetry in this class
-    this.session = (resultSetSerializable.getSession() != null) ?
-                   resultSetSerializable.getSession().orElse(null) : null;
-
+    this.session =
+        (resultSetSerializable.getSession() != null)
+            ? resultSetSerializable.getSession().orElse(null)
+            : null;
 
     // create the chunks array
     this.chunks = new ArrayList<>(resultSetSerializable.getChunkFileCount());
 
-    if (resultSetSerializable.getChunkFileCount() < 1)
-    {
-      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
-                                            "Incorrect chunk count: " +
-                                            resultSetSerializable.getChunkFileCount());
+    if (resultSetSerializable.getChunkFileCount() < 1) {
+      throw new SnowflakeSQLLoggedException(
+          ErrorCode.INTERNAL_ERROR,
+          this.session,
+          "Incorrect chunk count: " + resultSetSerializable.getChunkFileCount());
     }
 
     // initialize chunks with url and row count
     for (SnowflakeResultSetSerializableV1.ChunkFileMetadata chunkFileMetadata :
-        resultSetSerializable.getChunkFileMetadatas())
-    {
+        resultSetSerializable.getChunkFileMetadatas()) {
       SnowflakeResultChunk chunk;
-      switch (this.queryResultFormat)
-      {
+      switch (this.queryResultFormat) {
         case ARROW:
           this.rootAllocator = resultSetSerializable.getRootAllocator();
-          chunk = new ArrowResultChunk(chunkFileMetadata.getFileURL(),
-                                       chunkFileMetadata.getRowCount(),
-                                       resultSetSerializable.getColumnCount(),
-                                       chunkFileMetadata.getUncompressedByteSize(),
-                                       this.rootAllocator, this.session);
+          chunk =
+              new ArrowResultChunk(
+                  chunkFileMetadata.getFileURL(),
+                  chunkFileMetadata.getRowCount(),
+                  resultSetSerializable.getColumnCount(),
+                  chunkFileMetadata.getUncompressedByteSize(),
+                  this.rootAllocator,
+                  this.session);
           break;
 
         case JSON:
-          chunk = new JsonResultChunk(chunkFileMetadata.getFileURL(),
-                                      chunkFileMetadata.getRowCount(),
-                                      resultSetSerializable.getColumnCount(),
-                                      chunkFileMetadata.getUncompressedByteSize(), this.session);
+          chunk =
+              new JsonResultChunk(
+                  chunkFileMetadata.getFileURL(),
+                  chunkFileMetadata.getRowCount(),
+                  resultSetSerializable.getColumnCount(),
+                  chunkFileMetadata.getUncompressedByteSize(),
+                  this.session);
           break;
 
         default:
-          throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
-                                                "Invalid result format: " + queryResultFormat.name());
+          throw new SnowflakeSQLLoggedException(
+              ErrorCode.INTERNAL_ERROR,
+              this.session,
+              "Invalid result format: " + queryResultFormat.name());
       }
 
-      logger.debug("add chunk, url={} rowCount={} uncompressedSize={} " +
-                   "neededChunkMemory={}, chunkResultFormat={}",
-                   chunk.getScrubbedUrl(), chunk.getRowCount(),
-                   chunk.getUncompressedSize(),
-                   chunk.computeNeededChunkMemory(),
-                   queryResultFormat.name());
+      logger.debug(
+          "add chunk, url={} rowCount={} uncompressedSize={} "
+              + "neededChunkMemory={}, chunkResultFormat={}",
+          chunk.getScrubbedUrl(),
+          chunk.getRowCount(),
+          chunk.getUncompressedSize(),
+          chunk.computeNeededChunkMemory(),
+          queryResultFormat.name());
 
       chunks.add(chunk);
     }
     // prefetch threads and slots from parameter settings
-    int effectiveThreads = Math.min(resultSetSerializable.getResultPrefetchThreads(),
-                                    resultSetSerializable.getChunkFileCount());
+    int effectiveThreads =
+        Math.min(
+            resultSetSerializable.getResultPrefetchThreads(),
+            resultSetSerializable.getChunkFileCount());
 
     logger.debug(
         "#chunks: {} #threads:{} #slots:{} -> pool:{}",
         resultSetSerializable.getChunkFileCount(),
         resultSetSerializable.getResultPrefetchThreads(),
-        prefetchSlots, effectiveThreads);
+        prefetchSlots,
+        effectiveThreads);
 
     // create thread pool
-    executor =
-        createChunkDownloaderExecutorService("result-chunk-downloader-",
-                                             effectiveThreads);
+    executor = createChunkDownloaderExecutorService("result-chunk-downloader-", effectiveThreads);
 
-    try
-    {
+    try {
       startNextDownloaders();
-    }
-    catch (OutOfMemoryError outOfMemoryError)
-    {
+    } catch (OutOfMemoryError outOfMemoryError) {
       logOutOfMemoryError();
       StringWriter errors = new StringWriter();
       outOfMemoryError.printStackTrace(new PrintWriter(errors));
-      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
-                                            errors);
+      throw new SnowflakeSQLLoggedException(
+          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session, errors);
     }
   }
 
-  /**
-   * Submit download chunk tasks to executor.
-   * Number depends on thread and memory limit
-   */
-  private void startNextDownloaders() throws SnowflakeSQLException
-  {
+  /** Submit download chunk tasks to executor. Number depends on thread and memory limit */
+  private void startNextDownloaders() throws SnowflakeSQLException {
     long waitingTime = BASE_WAITING_MS;
 
     // submit the chunks to be downloaded up to the prefetch slot capacity
     // and limited by memory
-    while (nextChunkToDownload - nextChunkToConsume < prefetchSlots &&
-           nextChunkToDownload < chunks.size())
-    {
+    while (nextChunkToDownload - nextChunkToConsume < prefetchSlots
+        && nextChunkToDownload < chunks.size()) {
       // check if memory limit allows more prefetching
       final SnowflakeResultChunk nextChunk = chunks.get(nextChunkToDownload);
       final long neededChunkMemory = nextChunk.computeNeededChunkMemory();
 
       // make sure memoryLimit > neededChunkMemory; otherwise, the thread hangs
-      if (neededChunkMemory > memoryLimit)
-      {
-        logger.debug("Thread {}: reset memoryLimit from {} MB to current chunk size {} MB",
-                     (ArgSupplier) () -> Thread.currentThread().getId(),
-                     (ArgSupplier) () -> memoryLimit / 1024 / 1024,
-                     (ArgSupplier) () -> neededChunkMemory / 1024 / 1024);
+      if (neededChunkMemory > memoryLimit) {
+        logger.debug(
+            "Thread {}: reset memoryLimit from {} MB to current chunk size {} MB",
+            (ArgSupplier) () -> Thread.currentThread().getId(),
+            (ArgSupplier) () -> memoryLimit / 1024 / 1024,
+            (ArgSupplier) () -> neededChunkMemory / 1024 / 1024);
 
         memoryLimit = neededChunkMemory;
       }
@@ -338,38 +314,42 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
       // try to reserve the needed memory
       long curMem = currentMemoryUsage.addAndGet(neededChunkMemory);
       // no memory allocate when memory is not enough for prefetch
-      if (curMem > memoryLimit &&
-          nextChunkToDownload - nextChunkToConsume > 0)
-      {
+      if (curMem > memoryLimit && nextChunkToDownload - nextChunkToConsume > 0) {
         // cancel the reserved memory and this downloader too
         currentMemoryUsage.addAndGet(-neededChunkMemory);
         break;
       }
 
       // only allocate memory when the future usage is less than the limit
-      if (curMem <= memoryLimit)
-      {
-        if (queryResultFormat == QueryResultFormat.JSON)
-        {
+      if (curMem <= memoryLimit) {
+        if (queryResultFormat == QueryResultFormat.JSON) {
           ((JsonResultChunk) nextChunk).tryReuse(chunkDataCache);
         }
 
-        logger.debug("Thread {}: currentMemoryUsage in MB: {}, nextChunkToDownload: {}, " +
-                     "nextChunkToConsume: {}, newReservedMemory in B: {} ",
-                     (ArgSupplier) () -> Thread.currentThread().getId(),
-                     curMem / MB,
-                     nextChunkToDownload,
-                     nextChunkToConsume,
-                     neededChunkMemory);
+        logger.debug(
+            "Thread {}: currentMemoryUsage in MB: {}, nextChunkToDownload: {}, "
+                + "nextChunkToConsume: {}, newReservedMemory in B: {} ",
+            (ArgSupplier) () -> Thread.currentThread().getId(),
+            curMem / MB,
+            nextChunkToDownload,
+            nextChunkToConsume,
+            neededChunkMemory);
 
-        logger.debug("submit chunk #{} for downloading, url={}",
-                     this.nextChunkToDownload, nextChunk.getScrubbedUrl());
+        logger.debug(
+            "submit chunk #{} for downloading, url={}",
+            this.nextChunkToDownload,
+            nextChunk.getScrubbedUrl());
 
-        Future downloaderFuture = executor.submit(getDownloadChunkCallable(this,
-                                                                           nextChunk,
-                                                                           qrmk, nextChunkToDownload,
-                                                                           chunkHeadersMap,
-                                                                           networkTimeoutInMilli, this.session));
+        Future downloaderFuture =
+            executor.submit(
+                getDownloadChunkCallable(
+                    this,
+                    nextChunk,
+                    qrmk,
+                    nextChunkToDownload,
+                    chunkHeadersMap,
+                    networkTimeoutInMilli,
+                    this.session));
         downloaderFutures.put(nextChunkToDownload, downloaderFuture);
         // increment next chunk to download
         nextChunkToDownload++;
@@ -377,35 +357,30 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
         waitingTime = BASE_WAITING_MS;
         // go to next chunk
         continue;
-      }
-      else
-      {
+      } else {
         // cancel the reserved memory
         curMem = currentMemoryUsage.addAndGet(-neededChunkMemory);
       }
 
       // waiting when nextChunkToDownload is equal to nextChunkToConsume but reach memory limit
-      try
-      {
+      try {
         waitingTime *= WAITING_SECS_MULTIPLIER;
         waitingTime = waitingTime > MAX_WAITING_MS ? MAX_WAITING_MS : waitingTime;
         long jitter = ThreadLocalRandom.current().nextLong(0, waitingTime / WAITING_JITTER_RATIO);
         waitingTime += jitter;
-        if (logger.isDebugEnabled())
-        {
-          logger.debug("Thread {} waiting for {}s: currentMemoryUsage in MB: {}, neededChunkMemory in MB: {}, " +
-                       "nextChunkToDownload: {}, nextChunkToConsume: {} ",
-                       (ArgSupplier) () -> Thread.currentThread().getId(),
-                       waitingTime / 1000.0,
-                       curMem / MB,
-                       neededChunkMemory / MB,
-                       nextChunkToDownload,
-                       nextChunkToConsume);
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              "Thread {} waiting for {}s: currentMemoryUsage in MB: {}, neededChunkMemory in MB: {}, "
+                  + "nextChunkToDownload: {}, nextChunkToConsume: {} ",
+              (ArgSupplier) () -> Thread.currentThread().getId(),
+              waitingTime / 1000.0,
+              curMem / MB,
+              neededChunkMemory / MB,
+              nextChunkToDownload,
+              nextChunkToConsume);
         }
         Thread.sleep(waitingTime);
-      }
-      catch (InterruptedException ie)
-      {
+      } catch (InterruptedException ie) {
         throw new SnowflakeSQLException(
             SqlState.INTERNAL_ERROR,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
@@ -421,22 +396,20 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
   /**
    * release the memory usage from currentMemoryUsage
    *
-   * @param chunkId             chunk ID
+   * @param chunkId chunk ID
    * @param optionalReleaseSize if present, then release the specified size
    */
-  private void releaseCurrentMemoryUsage(int chunkId, Optional<Long> optionalReleaseSize)
-  {
-    long releaseSize = optionalReleaseSize.isPresent() ?
-                       optionalReleaseSize.get() : chunks.get(chunkId).computeNeededChunkMemory();
-    if (releaseSize > 0
-        && !chunks.get(chunkId).isReleased()
-    )
-    {
+  private void releaseCurrentMemoryUsage(int chunkId, Optional<Long> optionalReleaseSize) {
+    long releaseSize =
+        optionalReleaseSize.isPresent()
+            ? optionalReleaseSize.get()
+            : chunks.get(chunkId).computeNeededChunkMemory();
+    if (releaseSize > 0 && !chunks.get(chunkId).isReleased()) {
       // has to be before reusing the memory
       long curMem = currentMemoryUsage.addAndGet(-releaseSize);
       logger.debug(
-          "Thread {}: currentMemoryUsage in MB: {}, released in MB: {}, " +
-          "chunk: {}, optionalReleaseSize: {}, JVMFreeMem: {}",
+          "Thread {}: currentMemoryUsage in MB: {}, released in MB: {}, "
+              + "chunk: {}, optionalReleaseSize: {}, JVMFreeMem: {}",
           (ArgSupplier) () -> Thread.currentThread().getId(),
           (ArgSupplier) () -> curMem / MB,
           releaseSize,
@@ -447,60 +420,47 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
     }
   }
 
-  /**
-   * release all existing chunk memory usage before close
-   */
-  private void releaseAllChunkMemoryUsage()
-  {
-    if (chunks == null || chunks.size() == 0)
-    {
+  /** release all existing chunk memory usage before close */
+  private void releaseAllChunkMemoryUsage() {
+    if (chunks == null || chunks.size() == 0) {
       return;
     }
 
     // only release the chunks has been downloading or downloaded
-    for (int i = 0; i < nextChunkToDownload; i++)
-    {
+    for (int i = 0; i < nextChunkToDownload; i++) {
       releaseCurrentMemoryUsage(i, Optional.empty());
     }
   }
 
   /**
    * The method does the following:
-   * <p>
-   * 1. free the previous chunk data and submit a new chunk to be downloaded
-   * <p>
-   * 2. get next chunk to consume, if it is not ready for consumption,
-   * it waits until it is ready
+   *
+   * <p>1. free the previous chunk data and submit a new chunk to be downloaded
+   *
+   * <p>2. get next chunk to consume, if it is not ready for consumption, it waits until it is ready
    *
    * @return next SnowflakeResultChunk to be consumed
-   * @throws InterruptedException  if downloading thread was interrupted
+   * @throws InterruptedException if downloading thread was interrupted
    * @throws SnowflakeSQLException if downloader encountered an error
    */
-  public SnowflakeResultChunk getNextChunkToConsume() throws InterruptedException,
-                                                             SnowflakeSQLException
-  {
+  public SnowflakeResultChunk getNextChunkToConsume()
+      throws InterruptedException, SnowflakeSQLException {
     // free previous chunk data and submit a new chunk for downloading
-    if (this.nextChunkToConsume > 0)
-    {
+    if (this.nextChunkToConsume > 0) {
       int prevChunk = this.nextChunkToConsume - 1;
 
       // free the chunk data for previous chunk
-      logger.debug("free chunk data for chunk #{}",
-                   prevChunk);
+      logger.debug("free chunk data for chunk #{}", prevChunk);
 
       long chunkMemUsage = chunks.get(prevChunk).computeNeededChunkMemory();
 
       // reuse chunkcache if json result
-      if (this.queryResultFormat == QueryResultFormat.JSON)
-      {
-        if (this.nextChunkToDownload < this.chunks.size())
-        {
+      if (this.queryResultFormat == QueryResultFormat.JSON) {
+        if (this.nextChunkToDownload < this.chunks.size()) {
           // Reuse the set of object to avoid reallocation
           // It is important to do this BEFORE starting the next download
           chunkDataCache.add((JsonResultChunk) this.chunks.get(prevChunk));
-        }
-        else
-        {
+        } else {
           // clear the cache if we don't need it anymore
           chunkDataCache.clear();
         }
@@ -510,95 +470,79 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
       this.chunks.get(prevChunk).freeData();
 
       releaseCurrentMemoryUsage(prevChunk, Optional.of(chunkMemUsage));
-
     }
 
     // if no more chunks, return null
-    if (this.nextChunkToConsume >= this.chunks.size())
-    {
+    if (this.nextChunkToConsume >= this.chunks.size()) {
       logger.debug("no more chunk");
       return null;
     }
 
     // prefetch next chunks
-    try
-    {
+    try {
       startNextDownloaders();
-    }
-    catch (OutOfMemoryError outOfMemoryError)
-    {
+    } catch (OutOfMemoryError outOfMemoryError) {
       logOutOfMemoryError();
       StringWriter errors = new StringWriter();
       outOfMemoryError.printStackTrace(new PrintWriter(errors));
-      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
-                                            errors);
+      throw new SnowflakeSQLLoggedException(
+          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session, errors);
     }
 
     SnowflakeResultChunk currentChunk = this.chunks.get(nextChunkToConsume);
 
-    if (currentChunk.getDownloadState() == DownloadState.SUCCESS)
-    {
+    if (currentChunk.getDownloadState() == DownloadState.SUCCESS) {
       logger.debug("chunk #{} is ready to consume", nextChunkToConsume);
       nextChunkToConsume++;
-      if (nextChunkToConsume == this.chunks.size())
-      {
+      if (nextChunkToConsume == this.chunks.size()) {
         // make sure to release the last chunk
         releaseCurrentMemoryUsage(nextChunkToConsume - 1, Optional.empty());
       }
       return currentChunk;
-    }
-    else
-    {
+    } else {
       // the chunk we want to consume is not ready yet, wait for it
       currentChunk.getLock().lock();
-      try
-      {
-        logger.debug("#chunk{} is not ready to consume",
-                     nextChunkToConsume);
+      try {
+        logger.debug("#chunk{} is not ready to consume", nextChunkToConsume);
         logger.debug("consumer get lock to check chunk state");
 
         waitForChunkReady(currentChunk);
 
         // downloader thread encountered an error
-        if (currentChunk.getDownloadState() == DownloadState.FAILURE)
-        {
+        if (currentChunk.getDownloadState() == DownloadState.FAILURE) {
           releaseAllChunkMemoryUsage();
-          logger.error("downloader encountered error: {}",
-                       currentChunk.getDownloadError());
+          logger.error("downloader encountered error: {}", currentChunk.getDownloadError());
 
-          if (currentChunk.getDownloadError().contains("java.lang.OutOfMemoryError: Java heap space"))
-          {
+          if (currentChunk
+              .getDownloadError()
+              .contains("java.lang.OutOfMemoryError: Java heap space")) {
             logOutOfMemoryError();
           }
 
-          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
-                                                currentChunk.getDownloadError());
+          throw new SnowflakeSQLLoggedException(
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              this.session,
+              currentChunk.getDownloadError());
         }
 
-        logger.debug("#chunk{} is ready to consume",
-                     nextChunkToConsume);
+        logger.debug("#chunk{} is ready to consume", nextChunkToConsume);
 
         nextChunkToConsume++;
 
         // next chunk to consume is ready for consumption
         return currentChunk;
-      }
-      finally
-      {
+      } finally {
         logger.debug("consumer free lock");
 
         boolean terminateDownloader = (currentChunk.getDownloadState() == DownloadState.FAILURE);
         // release the unlock always
         currentChunk.getLock().unlock();
-        if (nextChunkToConsume == this.chunks.size())
-        {
+        if (nextChunkToConsume == this.chunks.size()) {
           // make sure to release the last chunk
           releaseCurrentMemoryUsage(nextChunkToConsume - 1, Optional.empty());
         }
-        if (terminateDownloader)
-        {
+        if (terminateDownloader) {
           logger.debug("Download result fail. Shut down the chunk downloader");
           terminate();
         }
@@ -607,123 +551,128 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
   }
 
   /**
-   * wait for the current chunk to be ready to consume
-   * if the downloader fails then let it retry for at most 10 times
-   * if the downloader is in progress for at most one hour or the downloader has already retried more than 10 times,
-   * then throw an exception.
+   * wait for the current chunk to be ready to consume if the downloader fails then let it retry for
+   * at most 10 times if the downloader is in progress for at most one hour or the downloader has
+   * already retried more than 10 times, then throw an exception.
    *
    * @param currentChunk
    * @throws InterruptedException
    */
-  private void waitForChunkReady(SnowflakeResultChunk currentChunk) throws InterruptedException
-  {
+  private void waitForChunkReady(SnowflakeResultChunk currentChunk) throws InterruptedException {
     int retry = 0;
     long startTime = System.currentTimeMillis();
-    while (currentChunk.getDownloadState() != DownloadState.SUCCESS &&
-           retry < MAX_NUM_OF_RETRY)
-    {
-      logger.debug("Thread {} is waiting for #chunk{} to be ready, current"
-                   + "chunk state is: {}, retry={}",
-                   Thread.currentThread().getId(),
-                   nextChunkToConsume, currentChunk.getDownloadState(), retry);
+    while (currentChunk.getDownloadState() != DownloadState.SUCCESS && retry < MAX_NUM_OF_RETRY) {
+      logger.debug(
+          "Thread {} is waiting for #chunk{} to be ready, current" + "chunk state is: {}, retry={}",
+          Thread.currentThread().getId(),
+          nextChunkToConsume,
+          currentChunk.getDownloadState(),
+          retry);
 
-      if (currentChunk.getDownloadState() != DownloadState.FAILURE)
-      {
+      if (currentChunk.getDownloadState() != DownloadState.FAILURE) {
         // if the state is not failure, we should keep waiting; otherwise, we skip waiting
-        if (!currentChunk.getDownloadCondition().await(downloadedConditionTimeoutInSeconds, TimeUnit.SECONDS))
-        {
+        if (!currentChunk
+            .getDownloadCondition()
+            .await(downloadedConditionTimeoutInSeconds, TimeUnit.SECONDS)) {
           // if the current chunk has not condition change over the timeout (which is rare)
-          logger.debug("Thread {} is timeout for waiting #chunk{} to be ready, current"
-                       + "chunk state is: {}, retry={}",
-                       Thread.currentThread().getId(),
-                       nextChunkToConsume, currentChunk.getDownloadState(), retry);
+          logger.debug(
+              "Thread {} is timeout for waiting #chunk{} to be ready, current"
+                  + "chunk state is: {}, retry={}",
+              Thread.currentThread().getId(),
+              nextChunkToConsume,
+              currentChunk.getDownloadState(),
+              retry);
 
           currentChunk.setDownloadState(DownloadState.FAILURE);
-          currentChunk.setDownloadError(String.format("Timeout waiting for the download of #chunk%d" +
-                                                      "(Total chunks: %d) retry=%d", nextChunkToConsume,
-                                                      this.chunks.size(), retry));
+          currentChunk.setDownloadError(
+              String.format(
+                  "Timeout waiting for the download of #chunk%d" + "(Total chunks: %d) retry=%d",
+                  nextChunkToConsume, this.chunks.size(), retry));
           break;
         }
       }
 
-      if (currentChunk.getDownloadState() != DownloadState.SUCCESS)
-      {
+      if (currentChunk.getDownloadState() != DownloadState.SUCCESS) {
         // timeout or failed
         retry++;
-        logger.debug("Since downloadState is {} Thread {} decides to retry {} time(s) for #chunk{}",
-                     currentChunk.getDownloadState(),
-                     Thread.currentThread().getId(),
-                     retry,
-                     nextChunkToConsume);
+        logger.debug(
+            "Since downloadState is {} Thread {} decides to retry {} time(s) for #chunk{}",
+            currentChunk.getDownloadState(),
+            Thread.currentThread().getId(),
+            retry,
+            nextChunkToConsume);
         Future downloaderFuture = downloaderFutures.get(nextChunkToConsume);
-        if (downloaderFuture != null)
-        {
+        if (downloaderFuture != null) {
           downloaderFuture.cancel(true);
         }
         HttpUtil.closeExpiredAndIdleConnections();
 
         chunks.get(nextChunkToConsume).getLock().lock();
-        try
-        {
+        try {
           chunks.get(nextChunkToConsume).setDownloadState(DownloadState.IN_PROGRESS);
           chunks.get(nextChunkToConsume).reset();
-        }
-        finally
-        {
+        } finally {
           chunks.get(nextChunkToConsume).getLock().unlock();
         }
 
         // random jitter before start next retry
         Thread.sleep(new Random().nextInt(MAX_RETRY_JITTER));
 
-        downloaderFuture = executor.submit(getDownloadChunkCallable(this,
-                                                                    chunks.get(nextChunkToConsume),
-                                                                    qrmk, nextChunkToConsume,
-                                                                    chunkHeadersMap,
-                                                                    networkTimeoutInMilli, session));
+        downloaderFuture =
+            executor.submit(
+                getDownloadChunkCallable(
+                    this,
+                    chunks.get(nextChunkToConsume),
+                    qrmk,
+                    nextChunkToConsume,
+                    chunkHeadersMap,
+                    networkTimeoutInMilli,
+                    session));
         downloaderFutures.put(nextChunkToDownload, downloaderFuture);
       }
     }
-    if (currentChunk.getDownloadState() == DownloadState.SUCCESS)
-    {
+    if (currentChunk.getDownloadState() == DownloadState.SUCCESS) {
       logger.debug("ready to consume #chunk{}, succeed retry={}", nextChunkToConsume, retry);
-    }
-    else if (retry >= MAX_NUM_OF_RETRY)
-    {
+    } else if (retry >= MAX_NUM_OF_RETRY) {
       // stop retrying and report failure
       currentChunk.setDownloadState(DownloadState.FAILURE);
       currentChunk.setDownloadError(
-          String.format("Max retry reached for the download of #chunk%d " +
-                        "(Total chunks: %d) retry=%d, error=%s",
-                        nextChunkToConsume, this.chunks.size(), retry,
-                        chunks.get(nextChunkToConsume).getDownloadError()));
+          String.format(
+              "Max retry reached for the download of #chunk%d "
+                  + "(Total chunks: %d) retry=%d, error=%s",
+              nextChunkToConsume,
+              this.chunks.size(),
+              retry,
+              chunks.get(nextChunkToConsume).getDownloadError()));
     }
-    this.numberMillisWaitingForChunks +=
-        (System.currentTimeMillis() - startTime);
+    this.numberMillisWaitingForChunks += (System.currentTimeMillis() - startTime);
   }
 
-  /**
-   * log out of memory error and provide the suggestion to avoid this error
-   */
-  private void logOutOfMemoryError()
-  {
-    logger.error("Dump some crucial information below:\n" +
-                 "Total milliseconds waiting for chunks: {},\n" +
-                 "Total memory used: {}, Max heap size: {}, total download time: {} millisec,\n" +
-                 "total parsing time: {} milliseconds, total chunks: {},\n" +
-                 "currentMemoryUsage in Byte: {}, currentMemoryLimit in Bytes: {} \n" +
-                 "nextChunkToDownload: {}, nextChunkToConsume: {}\n" +
-                 "Several suggestions to try to resolve the OOM issue:\n" +
-                 "1. increase the JVM heap size if you have more space; or \n" +
-                 "2. use CLIENT_MEMORY_LIMIT to reduce the memory usage by the JDBC driver " +
-                 "(https://docs.snowflake.net/manuals/sql-reference/parameters.html#client-memory-limit)" +
-                 "3. please make sure 2 * CLIENT_PREFETCH_THREADS * CLIENT_RESULT_CHUNK_SIZE < CLIENT_MEMORY_LIMIT. " +
-                 "If not, please reduce CLIENT_PREFETCH_THREADS and CLIENT_RESULT_CHUNK_SIZE too.",
-                 numberMillisWaitingForChunks,
-                 Runtime.getRuntime().totalMemory(), Runtime.getRuntime().maxMemory(),
-                 totalMillisDownloadingChunks.get(),
-                 totalMillisParsingChunks.get(), chunks.size(), currentMemoryUsage, memoryLimit,
-                 nextChunkToDownload, nextChunkToConsume);
+  /** log out of memory error and provide the suggestion to avoid this error */
+  private void logOutOfMemoryError() {
+    logger.error(
+        "Dump some crucial information below:\n"
+            + "Total milliseconds waiting for chunks: {},\n"
+            + "Total memory used: {}, Max heap size: {}, total download time: {} millisec,\n"
+            + "total parsing time: {} milliseconds, total chunks: {},\n"
+            + "currentMemoryUsage in Byte: {}, currentMemoryLimit in Bytes: {} \n"
+            + "nextChunkToDownload: {}, nextChunkToConsume: {}\n"
+            + "Several suggestions to try to resolve the OOM issue:\n"
+            + "1. increase the JVM heap size if you have more space; or \n"
+            + "2. use CLIENT_MEMORY_LIMIT to reduce the memory usage by the JDBC driver "
+            + "(https://docs.snowflake.net/manuals/sql-reference/parameters.html#client-memory-limit)"
+            + "3. please make sure 2 * CLIENT_PREFETCH_THREADS * CLIENT_RESULT_CHUNK_SIZE < CLIENT_MEMORY_LIMIT. "
+            + "If not, please reduce CLIENT_PREFETCH_THREADS and CLIENT_RESULT_CHUNK_SIZE too.",
+        numberMillisWaitingForChunks,
+        Runtime.getRuntime().totalMemory(),
+        Runtime.getRuntime().maxMemory(),
+        totalMillisDownloadingChunks.get(),
+        totalMillisParsingChunks.get(),
+        chunks.size(),
+        currentMemoryUsage,
+        memoryLimit,
+        nextChunkToDownload,
+        nextChunkToConsume);
   }
 
   /**
@@ -732,58 +681,54 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
    * @return chunk downloader metrics collected over instance lifetime
    */
   @Override
-  public DownloaderMetrics terminate() throws InterruptedException
-  {
-    if (!terminated.getAndSet(true))
-    {
-      if (executor != null)
-      {
-        if (!executor.isShutdown())
-        {
+  public DownloaderMetrics terminate() throws InterruptedException {
+    if (!terminated.getAndSet(true)) {
+      if (executor != null) {
+        if (!executor.isShutdown()) {
           // cancel running downloaders
           downloaderFutures.forEach((k, v) -> v.cancel(true));
           // shutdown executor
           executor.shutdown();
-          if (!executor.awaitTermination(SHUTDOWN_TIME, TimeUnit.SECONDS))
-          {
+          if (!executor.awaitTermination(SHUTDOWN_TIME, TimeUnit.SECONDS)) {
             logger.debug("Executor did not terminate in the specified time.");
 
-            List<Runnable> droppedTasks = executor.shutdownNow(); //optional **
+            List<Runnable> droppedTasks = executor.shutdownNow(); // optional **
             logger.debug(
-                "Executor was abruptly shut down. " + droppedTasks.size() +
-                " tasks will not be executed."); //optional **
+                "Executor was abruptly shut down. "
+                    + droppedTasks.size()
+                    + " tasks will not be executed."); // optional **
           }
         }
       }
-      for (SnowflakeResultChunk chunk : chunks)
-      {
+      for (SnowflakeResultChunk chunk : chunks) {
         // explicitly free each chunk since Arrow chunk may hold direct memory
         chunk.freeData();
       }
 
-      if (queryResultFormat == QueryResultFormat.ARROW)
-      {
+      if (queryResultFormat == QueryResultFormat.ARROW) {
         SFArrowResultSet.closeRootAllocator(rootAllocator);
-      }
-      else
-      {
+      } else {
         chunkDataCache.clear();
       }
 
       releaseAllChunkMemoryUsage();
 
-      logger.debug("Total milliseconds waiting for chunks: {}, " +
-                   "Total memory used: {}, total download time: {} millisec, " +
-                   "total parsing time: {} milliseconds, total chunks: {}",
-                   numberMillisWaitingForChunks,
-                   Runtime.getRuntime().totalMemory(), totalMillisDownloadingChunks.get(),
-                   totalMillisParsingChunks.get(), chunks.size());
+      logger.debug(
+          "Total milliseconds waiting for chunks: {}, "
+              + "Total memory used: {}, total download time: {} millisec, "
+              + "total parsing time: {} milliseconds, total chunks: {}",
+          numberMillisWaitingForChunks,
+          Runtime.getRuntime().totalMemory(),
+          totalMillisDownloadingChunks.get(),
+          totalMillisParsingChunks.get(),
+          chunks.size());
 
       chunks = null;
 
-      return new DownloaderMetrics(numberMillisWaitingForChunks,
-                                   totalMillisDownloadingChunks.get(),
-                                   totalMillisParsingChunks.get());
+      return new DownloaderMetrics(
+          numberMillisWaitingForChunks,
+          totalMillisDownloadingChunks.get(),
+          totalMillisParsingChunks.get());
     }
     return null;
   }
@@ -793,8 +738,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
    *
    * @param downloadTime Time for downloading a single chunk
    */
-  private void addDownloadTime(long downloadTime)
-  {
+  private void addDownloadTime(long downloadTime) {
     this.totalMillisDownloadingChunks.addAndGet(downloadTime);
   }
 
@@ -803,95 +747,84 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
    *
    * @param parsingTime Time for parsing a single chunk
    */
-  private void addParsingTime(long parsingTime)
-  {
+  private void addParsingTime(long parsingTime) {
     this.totalMillisParsingChunks.addAndGet(parsingTime);
   }
 
   /**
    * Create a download callable that will be run in download thread
    *
-   * @param downloader            object to download the chunk
-   * @param resultChunk           object contains information about the chunk will
-   *                              be downloaded
-   * @param qrmk                  Query Result Master Key
-   * @param chunkIndex            the index of the chunk which will be downloaded in array
-   *                              chunks. This is mainly for logging purpose
-   * @param chunkHeadersMap       contains headers needed to be added when downloading from s3
+   * @param downloader object to download the chunk
+   * @param resultChunk object contains information about the chunk will be downloaded
+   * @param qrmk Query Result Master Key
+   * @param chunkIndex the index of the chunk which will be downloaded in array chunks. This is
+   *     mainly for logging purpose
+   * @param chunkHeadersMap contains headers needed to be added when downloading from s3
    * @param networkTimeoutInMilli network timeout
    * @return A callable responsible for downloading chunk
    */
   private static Callable<Void> getDownloadChunkCallable(
       final SnowflakeChunkDownloader downloader,
       final SnowflakeResultChunk resultChunk,
-      final String qrmk, final int chunkIndex,
+      final String qrmk,
+      final int chunkIndex,
       final Map<String, String> chunkHeadersMap,
       final int networkTimeoutInMilli,
-      final SFSession session)
-  {
-    return new Callable<Void>()
-    {
+      final SFSession session) {
+    return new Callable<Void>() {
       /**
-       *  Step 1. use chunk url to get the input stream
+       * Step 1. use chunk url to get the input stream
+       *
        * @return
        * @throws SnowflakeSQLException
        */
-      private InputStream getInputStream() throws SnowflakeSQLException
-      {
+      private InputStream getInputStream() throws SnowflakeSQLException {
         HttpResponse response;
-        try
-        {
+        try {
           response = getResultChunk(resultChunk.getUrl());
-        }
-        catch (URISyntaxException | IOException ex)
-        {
-          throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
-                                                ErrorCode.NETWORK_ERROR
-                                                    .getMessageCode(), session,
-                                                "Error encountered when request a result chunk URL: "
-                                                + resultChunk.getUrl()
-                                                + " " + ex.getLocalizedMessage());
+        } catch (URISyntaxException | IOException ex) {
+          throw new SnowflakeSQLLoggedException(
+              SqlState.IO_ERROR,
+              ErrorCode.NETWORK_ERROR.getMessageCode(),
+              session,
+              "Error encountered when request a result chunk URL: "
+                  + resultChunk.getUrl()
+                  + " "
+                  + ex.getLocalizedMessage());
         }
 
         /*
          * return error if we don't get a response or the response code
          * means failure.
          */
-        if (response == null
-            || response.getStatusLine().getStatusCode() != 200)
-        {
-          logger.error("Error fetching chunk from: {}",
-                       resultChunk.getScrubbedUrl());
+        if (response == null || response.getStatusLine().getStatusCode() != 200) {
+          logger.error("Error fetching chunk from: {}", resultChunk.getScrubbedUrl());
 
           SnowflakeUtil.logResponseDetails(response, logger);
 
-          throw new SnowflakeSQLException(SqlState.IO_ERROR,
-                                          ErrorCode.NETWORK_ERROR
-                                              .getMessageCode(),
-                                          "Error encountered when downloading a result chunk: HTTP "
-                                          + "status="
-                                          + ((response != null)
-                                             ? response.getStatusLine().getStatusCode()
-                                             : "null response"));
+          throw new SnowflakeSQLException(
+              SqlState.IO_ERROR,
+              ErrorCode.NETWORK_ERROR.getMessageCode(),
+              "Error encountered when downloading a result chunk: HTTP "
+                  + "status="
+                  + ((response != null)
+                      ? response.getStatusLine().getStatusCode()
+                      : "null response"));
         }
 
         InputStream inputStream;
         final HttpEntity entity = response.getEntity();
-        try
-        {
+        try {
           // read the chunk data
           inputStream = detectContentEncodingAndGetInputStream(response, entity.getContent());
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
           logger.error("Failed to decompress data: {}", response);
 
-          throw
-              new SnowflakeSQLLoggedException(
-                  SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                  "Failed to decompress data: " +
-                  response.toString());
+          throw new SnowflakeSQLLoggedException(
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "Failed to decompress data: " + response.toString());
         }
 
         // trace the response if requested
@@ -900,61 +833,48 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
         return inputStream;
       }
 
-      private InputStream detectContentEncodingAndGetInputStream(HttpResponse response, InputStream is)
-      throws IOException, SnowflakeSQLException
-      {
-        InputStream inputStream = is;// Determine the format of the response, if it is not
+      private InputStream detectContentEncodingAndGetInputStream(
+          HttpResponse response, InputStream is) throws IOException, SnowflakeSQLException {
+        InputStream inputStream = is; // Determine the format of the response, if it is not
         // either plain text or gzip, raise an error.
         Header encoding = response.getFirstHeader("Content-Encoding");
-        if (encoding != null)
-        {
-          if ("gzip".equalsIgnoreCase(encoding.getValue()))
-          {
+        if (encoding != null) {
+          if ("gzip".equalsIgnoreCase(encoding.getValue())) {
             /* specify buffer size for GZIPInputStream */
             inputStream = new GZIPInputStream(is, STREAM_BUFFER_SIZE);
+          } else {
+            throw new SnowflakeSQLException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                "Exception: unexpected compression got " + encoding.getValue());
           }
-          else
-          {
-            throw
-                new SnowflakeSQLException(
-                    SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                    "Exception: unexpected compression got " +
-                    encoding.getValue());
-          }
-        }
-        else
-        {
+        } else {
           inputStream = detectGzipAndGetStream(is);
         }
 
         return inputStream;
       }
 
-      private InputStream detectGzipAndGetStream(InputStream is) throws IOException
-      {
+      private InputStream detectGzipAndGetStream(InputStream is) throws IOException {
         PushbackInputStream pb = new PushbackInputStream(is, 2);
         byte[] signature = new byte[2];
         int len = pb.read(signature);
         pb.unread(signature, 0, len);
         // https://tools.ietf.org/html/rfc1952
-        if (signature[0] == (byte) 0x1f && signature[1] == (byte) 0x8b)
-        {
+        if (signature[0] == (byte) 0x1f && signature[1] == (byte) 0x8b) {
           return new GZIPInputStream(pb);
-        }
-        else
-        {
+        } else {
           return pb;
         }
       }
 
       /**
        * Read the input stream and parse chunk data into memory
+       *
        * @param inputStream
        * @throws SnowflakeSQLException
        */
-      private void downloadAndParseChunk(InputStream inputStream) throws SnowflakeSQLException
-      {
+      private void downloadAndParseChunk(InputStream inputStream) throws SnowflakeSQLException {
         // remember the download time
         resultChunk.setDownloadTime(System.currentTimeMillis() - startTime);
         downloader.addDownloadTime(resultChunk.getDownloadTime());
@@ -962,45 +882,40 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
         startTime = System.currentTimeMillis();
 
         // parse the result json
-        try
-        {
-          if (downloader.queryResultFormat == QueryResultFormat.ARROW)
-          {
+        try {
+          if (downloader.queryResultFormat == QueryResultFormat.ARROW) {
             ((ArrowResultChunk) resultChunk).readArrowStream(inputStream);
-          }
-          else
-          {
+          } else {
             parseJsonToChunkV2(inputStream, resultChunk);
           }
-        }
-        catch (Exception ex)
-        {
-          logger.debug("Thread {} Exception when parsing result #chunk{}: {}",
-                       Thread.currentThread().getId(), chunkIndex, ex.getLocalizedMessage());
+        } catch (Exception ex) {
+          logger.debug(
+              "Thread {} Exception when parsing result #chunk{}: {}",
+              Thread.currentThread().getId(),
+              chunkIndex,
+              ex.getLocalizedMessage());
 
-          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR
-                                                    .getMessageCode(), session,
-                                                "Exception: " +
-                                                ex.getLocalizedMessage());
-        }
-        finally
-        {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "Exception: " + ex.getLocalizedMessage());
+        } finally {
           // close the buffer reader will close underlying stream
-          logger.debug("Thread {} close input stream for #chunk{}",
-                       Thread.currentThread().getId(),
-                       chunkIndex);
-          try
-          {
+          logger.debug(
+              "Thread {} close input stream for #chunk{}",
+              Thread.currentThread().getId(),
+              chunkIndex);
+          try {
             inputStream.close();
-          }
-          catch (IOException ex)
-          {
-            throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR
-                                                      .getMessageCode(), session,
-                                                  "Exception: " +
-                                                  ex.getLocalizedMessage());
+          } catch (IOException ex) {
+            throw new SnowflakeSQLLoggedException(
+                ex,
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
+                "Exception: " + ex.getLocalizedMessage());
           }
         }
 
@@ -1011,85 +926,68 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
 
       private long startTime;
 
-      public Void call()
-      {
+      public Void call() {
         resultChunk.getLock().lock();
-        try
-        {
+        try {
           resultChunk.setDownloadState(DownloadState.IN_PROGRESS);
-        }
-        finally
-        {
+        } finally {
           resultChunk.getLock().unlock();
         }
 
-        logger.debug("Downloading #chunk{}, url={}, Thread {}",
-                     chunkIndex, resultChunk.getUrl(), Thread.currentThread().getId());
+        logger.debug(
+            "Downloading #chunk{}, url={}, Thread {}",
+            chunkIndex,
+            resultChunk.getUrl(),
+            Thread.currentThread().getId());
 
         startTime = System.currentTimeMillis();
 
-        // initialize the telemetry service for this downloader thread using the main telemetry service
+        // initialize the telemetry service for this downloader thread using the main telemetry
+        // service
         TelemetryService.getInstance().updateContext(downloader.snowflakeConnectionString);
 
-        try
-        {
+        try {
           InputStream is = getInputStream();
-          logger.debug("Thread {} start downloading #chunk{}",
-                       Thread.currentThread().getId(),
-                       chunkIndex);
+          logger.debug(
+              "Thread {} start downloading #chunk{}", Thread.currentThread().getId(), chunkIndex);
           downloadAndParseChunk(is);
-          logger.debug("Thread {} finish downloading #chunk{}",
-                       Thread.currentThread().getId(),
-                       chunkIndex);
+          logger.debug(
+              "Thread {} finish downloading #chunk{}", Thread.currentThread().getId(), chunkIndex);
           downloader.downloaderFutures.remove(chunkIndex);
           logger.debug(
-              "Finished preparing chunk data for {}, " +
-              "total download time={}ms, total parse time={}ms",
+              "Finished preparing chunk data for {}, "
+                  + "total download time={}ms, total parse time={}ms",
               resultChunk.getScrubbedUrl(),
               resultChunk.getDownloadTime(),
               resultChunk.getParseTime());
 
           resultChunk.getLock().lock();
-          try
-          {
-            logger.debug(
-                "get lock to change the chunk to be ready to consume");
+          try {
+            logger.debug("get lock to change the chunk to be ready to consume");
 
-            logger.debug(
-                "wake up consumer if it is waiting for a chunk to be "
-                + "ready");
+            logger.debug("wake up consumer if it is waiting for a chunk to be " + "ready");
 
             resultChunk.setDownloadState(DownloadState.SUCCESS);
             resultChunk.getDownloadCondition().signal();
-          }
-          finally
-          {
-            logger.debug(
-                "Downloaded #chunk{}, free lock", chunkIndex);
+          } finally {
+            logger.debug("Downloaded #chunk{}, free lock", chunkIndex);
 
             resultChunk.getLock().unlock();
           }
-        }
-        catch (SnowflakeSQLException ex)
-        {
+        } catch (SnowflakeSQLException ex) {
           resultChunk.getLock().lock();
-          try
-          {
+          try {
             logger.debug("get lock to set chunk download error");
             resultChunk.setDownloadState(DownloadState.FAILURE);
             StringWriter errors = new StringWriter();
             ex.printStackTrace(new PrintWriter(errors));
             resultChunk.setDownloadError(errors.toString());
 
-            logger.debug(
-                "wake up consumer if it is waiting for a chunk to be ready");
+            logger.debug("wake up consumer if it is waiting for a chunk to be ready");
 
             resultChunk.getDownloadCondition().signal();
-          }
-          finally
-          {
-            logger.debug("Failed to download #chunk{}, free lock",
-                         chunkIndex);
+          } finally {
+            logger.debug("Failed to download #chunk{}, free lock", chunkIndex);
             resultChunk.getLock().unlock();
           }
 
@@ -1106,10 +1004,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
         return null;
       }
 
-      private void parseJsonToChunkV2(InputStream jsonInputStream,
-                                      SnowflakeResultChunk resultChunk)
-      throws IOException, SnowflakeSQLException
-      {
+      private void parseJsonToChunkV2(InputStream jsonInputStream, SnowflakeResultChunk resultChunk)
+          throws IOException, SnowflakeSQLException {
         /*
          * This is a hand-written binary parser that
          * handle.
@@ -1126,88 +1022,83 @@ public class SnowflakeChunkDownloader implements ChunkDownloader
 
         byte[] buf = new byte[STREAM_BUFFER_SIZE];
         int len;
-        logger.debug("Thread {} start to read inputstream for #chunk{}",
-                     Thread.currentThread().getId(), chunkIndex);
-        while ((len = jsonInputStream.read(buf)) != -1)
-        {
+        logger.debug(
+            "Thread {} start to read inputstream for #chunk{}",
+            Thread.currentThread().getId(),
+            chunkIndex);
+        while ((len = jsonInputStream.read(buf)) != -1) {
           jp.continueParsing(ByteBuffer.wrap(buf, 0, len), session);
         }
-        logger.debug("Thread {} finish reading inputstream for #chunk{}",
-                     Thread.currentThread().getId(), chunkIndex);
+        logger.debug(
+            "Thread {} finish reading inputstream for #chunk{}",
+            Thread.currentThread().getId(),
+            chunkIndex);
         jp.endParsing(session);
       }
 
       private HttpResponse getResultChunk(String chunkUrl)
-      throws URISyntaxException, IOException, SnowflakeSQLException
-      {
+          throws URISyntaxException, IOException, SnowflakeSQLException {
         URIBuilder uriBuilder = new URIBuilder(chunkUrl);
 
         HttpGet httpRequest = new HttpGet(uriBuilder.build());
 
-        if (chunkHeadersMap != null && chunkHeadersMap.size() != 0)
-        {
-          for (Map.Entry<String, String> entry : chunkHeadersMap.entrySet())
-          {
-            logger.debug("Adding header key={}, value={}",
-                         entry.getKey(), entry.getValue());
+        if (chunkHeadersMap != null && chunkHeadersMap.size() != 0) {
+          for (Map.Entry<String, String> entry : chunkHeadersMap.entrySet()) {
+            logger.debug("Adding header key={}, value={}", entry.getKey(), entry.getValue());
             httpRequest.addHeader(entry.getKey(), entry.getValue());
           }
         }
         // Add SSE-C headers
-        else if (qrmk != null)
-        {
+        else if (qrmk != null) {
           httpRequest.addHeader(SSE_C_ALGORITHM, SSE_C_AES);
           httpRequest.addHeader(SSE_C_KEY, qrmk);
           logger.debug("Adding SSE-C headers");
         }
 
-        logger.debug("Thread {} Fetching result #chunk{}: {}",
-                     Thread.currentThread().getId(),
-                     chunkIndex,
-                     resultChunk.getScrubbedUrl());
+        logger.debug(
+            "Thread {} Fetching result #chunk{}: {}",
+            Thread.currentThread().getId(),
+            chunkIndex,
+            resultChunk.getScrubbedUrl());
 
-        //TODO move this s3 request to HttpUtil class. In theory, upper layer
-        //TODO does not need to know about http client
+        // TODO move this s3 request to HttpUtil class. In theory, upper layer
+        // TODO does not need to know about http client
         CloseableHttpClient httpClient = HttpUtil.getHttpClient(downloader.getOCSPMode());
 
         // fetch the result chunk
         HttpResponse response =
-            RestRequest.execute(httpClient,
-                                httpRequest,
-                                networkTimeoutInMilli / 1000, // retry timeout
-                                0, // no socketime injection
-                                null, // no canceling
-                                false, // no cookie
-                                false, // no retry
-                                false, // no request_guid
-                                true // retry on HTTP403 for AWS S3
-            );
+            RestRequest.execute(
+                httpClient,
+                httpRequest,
+                networkTimeoutInMilli / 1000, // retry timeout
+                0, // no socketime injection
+                null, // no canceling
+                false, // no cookie
+                false, // no retry
+                false, // no request_guid
+                true // retry on HTTP403 for AWS S3
+                );
 
-        logger.debug("Thread {} Call #chunk{} returned for URL: {}, response={}",
-                     Thread.currentThread().getId(),
-                     chunkIndex,
-                     (ArgSupplier) () -> SecretDetector.maskSASToken(chunkUrl),
-                     response);
+        logger.debug(
+            "Thread {} Call #chunk{} returned for URL: {}, response={}",
+            Thread.currentThread().getId(),
+            chunkIndex,
+            (ArgSupplier) () -> SecretDetector.maskSASToken(chunkUrl),
+            response);
         return response;
       }
     };
   }
 
-  /**
-   * This is a No Operation chunk downloader to avoid potential null pointer exception
-   */
-  public static class NoOpChunkDownloader implements ChunkDownloader
-  {
+  /** This is a No Operation chunk downloader to avoid potential null pointer exception */
+  public static class NoOpChunkDownloader implements ChunkDownloader {
     @Override
-    public SnowflakeResultChunk getNextChunkToConsume()
-    throws SnowflakeSQLException
-    {
+    public SnowflakeResultChunk getNextChunkToConsume() throws SnowflakeSQLException {
       return null;
     }
 
     @Override
-    public DownloaderMetrics terminate()
-    {
+    public DownloaderMetrics terminate() {
       return null;
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -4,11 +4,25 @@
 
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.core.Constants.MB;
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import net.snowflake.client.core.*;
+import net.snowflake.client.jdbc.SnowflakeResultChunk.DownloadState;
+import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
+import net.snowflake.client.log.ArgSupplier;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.util.SecretDetector;
+import net.snowflake.common.core.SqlState;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -32,43 +46,37 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPInputStream;
-import net.snowflake.client.core.*;
-import net.snowflake.client.jdbc.SnowflakeResultChunk.DownloadState;
-import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
-import net.snowflake.client.log.ArgSupplier;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.util.SecretDetector;
-import net.snowflake.common.core.SqlState;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
+
+import static net.snowflake.client.core.Constants.MB;
 
 /**
  * Class for managing async download of offline result chunks
- *
- * <p>Created by jhuang on 11/12/14.
+ * <p>
+ * Created by jhuang on 11/12/14.
  */
-public class SnowflakeChunkDownloader implements ChunkDownloader {
+public class SnowflakeChunkDownloader implements ChunkDownloader
+{
   // SSE-C algorithm header
-  private static final String SSE_C_ALGORITHM = "x-amz-server-side-encryption-customer-algorithm";
+  private static final String SSE_C_ALGORITHM =
+      "x-amz-server-side-encryption-customer-algorithm";
 
   // SSE-C customer key header
-  private static final String SSE_C_KEY = "x-amz-server-side-encryption-customer-key";
+  private static final String SSE_C_KEY =
+      "x-amz-server-side-encryption-customer-key";
 
   // SSE-C algorithm value
   private static final String SSE_C_AES = "AES256";
 
   // object mapper for deserialize JSON
-  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
-  /** a shared JSON parser factory. */
+  private static final ObjectMapper mapper =
+      ObjectMapperFactory.getObjectMapper();
+  /**
+   * a shared JSON parser factory.
+   */
   private static final JsonFactory jsonFactory = new MappingJsonFactory();
 
-  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeChunkDownloader.class);
+  private static final SFLogger logger =
+      SFLoggerFactory.getLogger(SnowflakeChunkDownloader.class);
   private static final int STREAM_BUFFER_SIZE = MB;
   private static final long SHUTDOWN_TIME = 3;
   private final SnowflakeConnectString snowflakeConnectionString;
@@ -77,8 +85,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
   // Session object, used solely for throwing exceptions. CAUTION: MAY BE NULL!
   private SFSession session;
 
-  private JsonResultChunk.ResultChunkDataCache chunkDataCache =
-      new JsonResultChunk.ResultChunkDataCache();
+  private JsonResultChunk.ResultChunkDataCache chunkDataCache
+      = new JsonResultChunk.ResultChunkDataCache();
   private List<SnowflakeResultChunk> chunks;
 
   // index of next chunk to be consumed (it may not be ready yet)
@@ -120,14 +128,20 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
   // used to track the downloading threads
   private Map<Integer, Future> downloaderFutures = new ConcurrentHashMap<>();
 
-  /** query result format */
+  /**
+   * query result format
+   */
   private QueryResultFormat queryResultFormat;
 
-  /** Arrow memory allocator for the current resultSet */
+  /**
+   * Arrow memory allocator for the current resultSet
+   */
   private RootAllocator rootAllocator;
 
-  static long getCurrentMemoryUsage() {
-    synchronized (currentMemoryUsage) {
+  static long getCurrentMemoryUsage()
+  {
+    synchronized (currentMemoryUsage)
+    {
       return currentMemoryUsage.longValue();
     }
   }
@@ -140,14 +154,16 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
   private long MAX_WAITING_MS = 30 * 1000;
   // the default jitter ratio 10%
   private long WAITING_JITTER_RATIO = 10;
-  /** Timeout that the main thread waits for downloading the current chunk */
-  private static final long downloadedConditionTimeoutInSeconds =
-      HttpUtil.getDownloadedConditionTimeoutInSeconds();
+  /**
+   * Timeout that the main thread waits for downloading the current chunk
+   */
+  private static final long downloadedConditionTimeoutInSeconds = HttpUtil.getDownloadedConditionTimeoutInSeconds();
 
   private static final int MAX_NUM_OF_RETRY = 10;
   private static final int MAX_RETRY_JITTER = 1000; // milliseconds
 
-  public OCSPMode getOCSPMode() {
+  public OCSPMode getOCSPMode()
+  {
     return ocspMode;
   }
 
@@ -155,43 +171,52 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
    * Create a pool of downloader threads.
    *
    * @param threadNamePrefix name of threads in pool
-   * @param parallel number of thread in pool
+   * @param parallel         number of thread in pool
    * @return new thread pool
    */
   private static ThreadPoolExecutor createChunkDownloaderExecutorService(
-      final String threadNamePrefix, final int parallel) {
-    ThreadFactory threadFactory =
-        new ThreadFactory() {
-          private int threadCount = 1;
+      final String threadNamePrefix, final int parallel)
+  {
+    ThreadFactory threadFactory = new ThreadFactory()
+    {
+      private int threadCount = 1;
 
-          public Thread newThread(final Runnable r) {
-            final Thread thread = new Thread(r);
-            thread.setName(threadNamePrefix + threadCount++);
+      public Thread newThread(final Runnable r)
+      {
+        final Thread thread = new Thread(r);
+        thread.setName(threadNamePrefix + threadCount++);
 
-            thread.setUncaughtExceptionHandler(
-                new Thread.UncaughtExceptionHandler() {
-                  public void uncaughtException(Thread t, Throwable e) {
-                    logger.error("uncaughtException in thread: " + t + " {}", e);
-                  }
-                });
+        thread.setUncaughtExceptionHandler(
+            new Thread.UncaughtExceptionHandler()
+            {
+              public void uncaughtException(Thread t, Throwable e)
+              {
+                logger.error(
+                    "uncaughtException in thread: " + t + " {}",
+                    e);
+              }
+            });
 
-            thread.setDaemon(true);
+        thread.setDaemon(true);
 
-            return thread;
-          }
-        };
-    return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallel, threadFactory);
+        return thread;
+      }
+    };
+    return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallel,
+                                                             threadFactory);
   }
 
   /**
    * Constructor to initialize downloader
    *
-   * @param resultSetSerializable the result set serializable object which includes required
-   *     metadata to start chunk downloader
+   * @param resultSetSerializable the result set serializable object which
+   *                              includes required metadata to start chunk downloader
    */
   public SnowflakeChunkDownloader(SnowflakeResultSetSerializableV1 resultSetSerializable)
-      throws SnowflakeSQLException {
-    this.snowflakeConnectionString = resultSetSerializable.getSnowflakeConnectString();
+  throws SnowflakeSQLException
+  {
+    this.snowflakeConnectionString =
+        resultSetSerializable.getSnowflakeConnectString();
     this.ocspMode = resultSetSerializable.getOCSPMode();
     this.qrmk = resultSetSerializable.getQrmk();
     this.networkTimeoutInMilli = resultSetSerializable.getNetworkTimeoutInMilli();
@@ -201,112 +226,111 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
     logger.debug("qrmk = {}", this.qrmk);
     this.chunkHeadersMap = resultSetSerializable.getChunkHeadersMap();
     // session may be null. Its only use is for in-band telemetry in this class
-    this.session =
-        (resultSetSerializable.getSession() != null)
-            ? resultSetSerializable.getSession().orElse(null)
-            : null;
+    this.session = (resultSetSerializable.getSession() != null) ?
+                   resultSetSerializable.getSession().orElse(null) : null;
+
 
     // create the chunks array
     this.chunks = new ArrayList<>(resultSetSerializable.getChunkFileCount());
 
-    if (resultSetSerializable.getChunkFileCount() < 1) {
-      throw new SnowflakeSQLLoggedException(
-          ErrorCode.INTERNAL_ERROR,
-          this.session,
-          "Incorrect chunk count: " + resultSetSerializable.getChunkFileCount());
+    if (resultSetSerializable.getChunkFileCount() < 1)
+    {
+      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
+                                            "Incorrect chunk count: " +
+                                            resultSetSerializable.getChunkFileCount());
     }
 
     // initialize chunks with url and row count
     for (SnowflakeResultSetSerializableV1.ChunkFileMetadata chunkFileMetadata :
-        resultSetSerializable.getChunkFileMetadatas()) {
+        resultSetSerializable.getChunkFileMetadatas())
+    {
       SnowflakeResultChunk chunk;
-      switch (this.queryResultFormat) {
+      switch (this.queryResultFormat)
+      {
         case ARROW:
           this.rootAllocator = resultSetSerializable.getRootAllocator();
-          chunk =
-              new ArrowResultChunk(
-                  chunkFileMetadata.getFileURL(),
-                  chunkFileMetadata.getRowCount(),
-                  resultSetSerializable.getColumnCount(),
-                  chunkFileMetadata.getUncompressedByteSize(),
-                  this.rootAllocator,
-                  this.session);
+          chunk = new ArrowResultChunk(chunkFileMetadata.getFileURL(),
+                                       chunkFileMetadata.getRowCount(),
+                                       resultSetSerializable.getColumnCount(),
+                                       chunkFileMetadata.getUncompressedByteSize(),
+                                       this.rootAllocator, this.session);
           break;
 
         case JSON:
-          chunk =
-              new JsonResultChunk(
-                  chunkFileMetadata.getFileURL(),
-                  chunkFileMetadata.getRowCount(),
-                  resultSetSerializable.getColumnCount(),
-                  chunkFileMetadata.getUncompressedByteSize(),
-                  this.session);
+          chunk = new JsonResultChunk(chunkFileMetadata.getFileURL(),
+                                      chunkFileMetadata.getRowCount(),
+                                      resultSetSerializable.getColumnCount(),
+                                      chunkFileMetadata.getUncompressedByteSize(), this.session);
           break;
 
         default:
-          throw new SnowflakeSQLLoggedException(
-              ErrorCode.INTERNAL_ERROR,
-              this.session,
-              "Invalid result format: " + queryResultFormat.name());
+          throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, this.session,
+                                                "Invalid result format: " + queryResultFormat.name());
       }
 
-      logger.debug(
-          "add chunk, url={} rowCount={} uncompressedSize={} "
-              + "neededChunkMemory={}, chunkResultFormat={}",
-          chunk.getScrubbedUrl(),
-          chunk.getRowCount(),
-          chunk.getUncompressedSize(),
-          chunk.computeNeededChunkMemory(),
-          queryResultFormat.name());
+      logger.debug("add chunk, url={} rowCount={} uncompressedSize={} " +
+                   "neededChunkMemory={}, chunkResultFormat={}",
+                   chunk.getScrubbedUrl(), chunk.getRowCount(),
+                   chunk.getUncompressedSize(),
+                   chunk.computeNeededChunkMemory(),
+                   queryResultFormat.name());
 
       chunks.add(chunk);
     }
     // prefetch threads and slots from parameter settings
-    int effectiveThreads =
-        Math.min(
-            resultSetSerializable.getResultPrefetchThreads(),
-            resultSetSerializable.getChunkFileCount());
+    int effectiveThreads = Math.min(resultSetSerializable.getResultPrefetchThreads(),
+                                    resultSetSerializable.getChunkFileCount());
 
     logger.debug(
         "#chunks: {} #threads:{} #slots:{} -> pool:{}",
         resultSetSerializable.getChunkFileCount(),
         resultSetSerializable.getResultPrefetchThreads(),
-        prefetchSlots,
-        effectiveThreads);
+        prefetchSlots, effectiveThreads);
 
     // create thread pool
-    executor = createChunkDownloaderExecutorService("result-chunk-downloader-", effectiveThreads);
+    executor =
+        createChunkDownloaderExecutorService("result-chunk-downloader-",
+                                             effectiveThreads);
 
-    try {
+    try
+    {
       startNextDownloaders();
-    } catch (OutOfMemoryError outOfMemoryError) {
+    }
+    catch (OutOfMemoryError outOfMemoryError)
+    {
       logOutOfMemoryError();
       StringWriter errors = new StringWriter();
       outOfMemoryError.printStackTrace(new PrintWriter(errors));
-      throw new SnowflakeSQLException(
-          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), errors);
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
+                                            errors);
     }
   }
 
-  /** Submit download chunk tasks to executor. Number depends on thread and memory limit */
-  private void startNextDownloaders() throws SnowflakeSQLException {
+  /**
+   * Submit download chunk tasks to executor.
+   * Number depends on thread and memory limit
+   */
+  private void startNextDownloaders() throws SnowflakeSQLException
+  {
     long waitingTime = BASE_WAITING_MS;
 
     // submit the chunks to be downloaded up to the prefetch slot capacity
     // and limited by memory
-    while (nextChunkToDownload - nextChunkToConsume < prefetchSlots
-        && nextChunkToDownload < chunks.size()) {
+    while (nextChunkToDownload - nextChunkToConsume < prefetchSlots &&
+           nextChunkToDownload < chunks.size())
+    {
       // check if memory limit allows more prefetching
       final SnowflakeResultChunk nextChunk = chunks.get(nextChunkToDownload);
       final long neededChunkMemory = nextChunk.computeNeededChunkMemory();
 
       // make sure memoryLimit > neededChunkMemory; otherwise, the thread hangs
-      if (neededChunkMemory > memoryLimit) {
-        logger.debug(
-            "Thread {}: reset memoryLimit from {} MB to current chunk size {} MB",
-            (ArgSupplier) () -> Thread.currentThread().getId(),
-            (ArgSupplier) () -> memoryLimit / 1024 / 1024,
-            (ArgSupplier) () -> neededChunkMemory / 1024 / 1024);
+      if (neededChunkMemory > memoryLimit)
+      {
+        logger.debug("Thread {}: reset memoryLimit from {} MB to current chunk size {} MB",
+                     (ArgSupplier) () -> Thread.currentThread().getId(),
+                     (ArgSupplier) () -> memoryLimit / 1024 / 1024,
+                     (ArgSupplier) () -> neededChunkMemory / 1024 / 1024);
 
         memoryLimit = neededChunkMemory;
       }
@@ -314,42 +338,38 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
       // try to reserve the needed memory
       long curMem = currentMemoryUsage.addAndGet(neededChunkMemory);
       // no memory allocate when memory is not enough for prefetch
-      if (curMem > memoryLimit && nextChunkToDownload - nextChunkToConsume > 0) {
+      if (curMem > memoryLimit &&
+          nextChunkToDownload - nextChunkToConsume > 0)
+      {
         // cancel the reserved memory and this downloader too
         currentMemoryUsage.addAndGet(-neededChunkMemory);
         break;
       }
 
       // only allocate memory when the future usage is less than the limit
-      if (curMem <= memoryLimit) {
-        if (queryResultFormat == QueryResultFormat.JSON) {
+      if (curMem <= memoryLimit)
+      {
+        if (queryResultFormat == QueryResultFormat.JSON)
+        {
           ((JsonResultChunk) nextChunk).tryReuse(chunkDataCache);
         }
 
-        logger.debug(
-            "Thread {}: currentMemoryUsage in MB: {}, nextChunkToDownload: {}, "
-                + "nextChunkToConsume: {}, newReservedMemory in B: {} ",
-            (ArgSupplier) () -> Thread.currentThread().getId(),
-            curMem / MB,
-            nextChunkToDownload,
-            nextChunkToConsume,
-            neededChunkMemory);
+        logger.debug("Thread {}: currentMemoryUsage in MB: {}, nextChunkToDownload: {}, " +
+                     "nextChunkToConsume: {}, newReservedMemory in B: {} ",
+                     (ArgSupplier) () -> Thread.currentThread().getId(),
+                     curMem / MB,
+                     nextChunkToDownload,
+                     nextChunkToConsume,
+                     neededChunkMemory);
 
-        logger.debug(
-            "submit chunk #{} for downloading, url={}",
-            this.nextChunkToDownload,
-            nextChunk.getScrubbedUrl());
+        logger.debug("submit chunk #{} for downloading, url={}",
+                     this.nextChunkToDownload, nextChunk.getScrubbedUrl());
 
-        Future downloaderFuture =
-            executor.submit(
-                getDownloadChunkCallable(
-                    this,
-                    nextChunk,
-                    qrmk,
-                    nextChunkToDownload,
-                    chunkHeadersMap,
-                    networkTimeoutInMilli,
-                    this.session));
+        Future downloaderFuture = executor.submit(getDownloadChunkCallable(this,
+                                                                           nextChunk,
+                                                                           qrmk, nextChunkToDownload,
+                                                                           chunkHeadersMap,
+                                                                           networkTimeoutInMilli, this.session));
         downloaderFutures.put(nextChunkToDownload, downloaderFuture);
         // increment next chunk to download
         nextChunkToDownload++;
@@ -357,30 +377,35 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         waitingTime = BASE_WAITING_MS;
         // go to next chunk
         continue;
-      } else {
+      }
+      else
+      {
         // cancel the reserved memory
         curMem = currentMemoryUsage.addAndGet(-neededChunkMemory);
       }
 
       // waiting when nextChunkToDownload is equal to nextChunkToConsume but reach memory limit
-      try {
+      try
+      {
         waitingTime *= WAITING_SECS_MULTIPLIER;
         waitingTime = waitingTime > MAX_WAITING_MS ? MAX_WAITING_MS : waitingTime;
         long jitter = ThreadLocalRandom.current().nextLong(0, waitingTime / WAITING_JITTER_RATIO);
         waitingTime += jitter;
-        if (logger.isDebugEnabled()) {
-          logger.debug(
-              "Thread {} waiting for {}s: currentMemoryUsage in MB: {}, neededChunkMemory in MB: {}, "
-                  + "nextChunkToDownload: {}, nextChunkToConsume: {} ",
-              (ArgSupplier) () -> Thread.currentThread().getId(),
-              waitingTime / 1000.0,
-              curMem / MB,
-              neededChunkMemory / MB,
-              nextChunkToDownload,
-              nextChunkToConsume);
+        if (logger.isDebugEnabled())
+        {
+          logger.debug("Thread {} waiting for {}s: currentMemoryUsage in MB: {}, neededChunkMemory in MB: {}, " +
+                       "nextChunkToDownload: {}, nextChunkToConsume: {} ",
+                       (ArgSupplier) () -> Thread.currentThread().getId(),
+                       waitingTime / 1000.0,
+                       curMem / MB,
+                       neededChunkMemory / MB,
+                       nextChunkToDownload,
+                       nextChunkToConsume);
         }
         Thread.sleep(waitingTime);
-      } catch (InterruptedException ie) {
+      }
+      catch (InterruptedException ie)
+      {
         throw new SnowflakeSQLException(
             SqlState.INTERNAL_ERROR,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
@@ -396,20 +421,22 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
   /**
    * release the memory usage from currentMemoryUsage
    *
-   * @param chunkId chunk ID
+   * @param chunkId             chunk ID
    * @param optionalReleaseSize if present, then release the specified size
    */
-  private void releaseCurrentMemoryUsage(int chunkId, Optional<Long> optionalReleaseSize) {
-    long releaseSize =
-        optionalReleaseSize.isPresent()
-            ? optionalReleaseSize.get()
-            : chunks.get(chunkId).computeNeededChunkMemory();
-    if (releaseSize > 0 && !chunks.get(chunkId).isReleased()) {
+  private void releaseCurrentMemoryUsage(int chunkId, Optional<Long> optionalReleaseSize)
+  {
+    long releaseSize = optionalReleaseSize.isPresent() ?
+                       optionalReleaseSize.get() : chunks.get(chunkId).computeNeededChunkMemory();
+    if (releaseSize > 0
+        && !chunks.get(chunkId).isReleased()
+    )
+    {
       // has to be before reusing the memory
       long curMem = currentMemoryUsage.addAndGet(-releaseSize);
       logger.debug(
-          "Thread {}: currentMemoryUsage in MB: {}, released in MB: {}, "
-              + "chunk: {}, optionalReleaseSize: {}, JVMFreeMem: {}",
+          "Thread {}: currentMemoryUsage in MB: {}, released in MB: {}, " +
+          "chunk: {}, optionalReleaseSize: {}, JVMFreeMem: {}",
           (ArgSupplier) () -> Thread.currentThread().getId(),
           (ArgSupplier) () -> curMem / MB,
           releaseSize,
@@ -420,47 +447,60 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
     }
   }
 
-  /** release all existing chunk memory usage before close */
-  private void releaseAllChunkMemoryUsage() {
-    if (chunks == null || chunks.size() == 0) {
+  /**
+   * release all existing chunk memory usage before close
+   */
+  private void releaseAllChunkMemoryUsage()
+  {
+    if (chunks == null || chunks.size() == 0)
+    {
       return;
     }
 
     // only release the chunks has been downloading or downloaded
-    for (int i = 0; i < nextChunkToDownload; i++) {
+    for (int i = 0; i < nextChunkToDownload; i++)
+    {
       releaseCurrentMemoryUsage(i, Optional.empty());
     }
   }
 
   /**
    * The method does the following:
-   *
-   * <p>1. free the previous chunk data and submit a new chunk to be downloaded
-   *
-   * <p>2. get next chunk to consume, if it is not ready for consumption, it waits until it is ready
+   * <p>
+   * 1. free the previous chunk data and submit a new chunk to be downloaded
+   * <p>
+   * 2. get next chunk to consume, if it is not ready for consumption,
+   * it waits until it is ready
    *
    * @return next SnowflakeResultChunk to be consumed
-   * @throws InterruptedException if downloading thread was interrupted
+   * @throws InterruptedException  if downloading thread was interrupted
    * @throws SnowflakeSQLException if downloader encountered an error
    */
-  public SnowflakeResultChunk getNextChunkToConsume()
-      throws InterruptedException, SnowflakeSQLException {
+  public SnowflakeResultChunk getNextChunkToConsume() throws InterruptedException,
+                                                             SnowflakeSQLException
+  {
     // free previous chunk data and submit a new chunk for downloading
-    if (this.nextChunkToConsume > 0) {
+    if (this.nextChunkToConsume > 0)
+    {
       int prevChunk = this.nextChunkToConsume - 1;
 
       // free the chunk data for previous chunk
-      logger.debug("free chunk data for chunk #{}", prevChunk);
+      logger.debug("free chunk data for chunk #{}",
+                   prevChunk);
 
       long chunkMemUsage = chunks.get(prevChunk).computeNeededChunkMemory();
 
       // reuse chunkcache if json result
-      if (this.queryResultFormat == QueryResultFormat.JSON) {
-        if (this.nextChunkToDownload < this.chunks.size()) {
+      if (this.queryResultFormat == QueryResultFormat.JSON)
+      {
+        if (this.nextChunkToDownload < this.chunks.size())
+        {
           // Reuse the set of object to avoid reallocation
           // It is important to do this BEFORE starting the next download
           chunkDataCache.add((JsonResultChunk) this.chunks.get(prevChunk));
-        } else {
+        }
+        else
+        {
           // clear the cache if we don't need it anymore
           chunkDataCache.clear();
         }
@@ -470,79 +510,95 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
       this.chunks.get(prevChunk).freeData();
 
       releaseCurrentMemoryUsage(prevChunk, Optional.of(chunkMemUsage));
+
     }
 
     // if no more chunks, return null
-    if (this.nextChunkToConsume >= this.chunks.size()) {
+    if (this.nextChunkToConsume >= this.chunks.size())
+    {
       logger.debug("no more chunk");
       return null;
     }
 
     // prefetch next chunks
-    try {
+    try
+    {
       startNextDownloaders();
-    } catch (OutOfMemoryError outOfMemoryError) {
+    }
+    catch (OutOfMemoryError outOfMemoryError)
+    {
       logOutOfMemoryError();
       StringWriter errors = new StringWriter();
       outOfMemoryError.printStackTrace(new PrintWriter(errors));
-      throw new SnowflakeSQLException(
-          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), errors);
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
+                                            errors);
     }
 
     SnowflakeResultChunk currentChunk = this.chunks.get(nextChunkToConsume);
 
-    if (currentChunk.getDownloadState() == DownloadState.SUCCESS) {
+    if (currentChunk.getDownloadState() == DownloadState.SUCCESS)
+    {
       logger.debug("chunk #{} is ready to consume", nextChunkToConsume);
       nextChunkToConsume++;
-      if (nextChunkToConsume == this.chunks.size()) {
+      if (nextChunkToConsume == this.chunks.size())
+      {
         // make sure to release the last chunk
         releaseCurrentMemoryUsage(nextChunkToConsume - 1, Optional.empty());
       }
       return currentChunk;
-    } else {
+    }
+    else
+    {
       // the chunk we want to consume is not ready yet, wait for it
       currentChunk.getLock().lock();
-      try {
-        logger.debug("#chunk{} is not ready to consume", nextChunkToConsume);
+      try
+      {
+        logger.debug("#chunk{} is not ready to consume",
+                     nextChunkToConsume);
         logger.debug("consumer get lock to check chunk state");
 
         waitForChunkReady(currentChunk);
 
         // downloader thread encountered an error
-        if (currentChunk.getDownloadState() == DownloadState.FAILURE) {
+        if (currentChunk.getDownloadState() == DownloadState.FAILURE)
+        {
           releaseAllChunkMemoryUsage();
-          logger.error("downloader encountered error: {}", currentChunk.getDownloadError());
+          logger.error("downloader encountered error: {}",
+                       currentChunk.getDownloadError());
 
-          if (currentChunk
-              .getDownloadError()
-              .contains("java.lang.OutOfMemoryError: Java heap space")) {
+          if (currentChunk.getDownloadError().contains("java.lang.OutOfMemoryError: Java heap space"))
+          {
             logOutOfMemoryError();
           }
 
-          throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              this.session,
-              currentChunk.getDownloadError());
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session,
+                                                currentChunk.getDownloadError());
         }
 
-        logger.debug("#chunk{} is ready to consume", nextChunkToConsume);
+        logger.debug("#chunk{} is ready to consume",
+                     nextChunkToConsume);
 
         nextChunkToConsume++;
 
         // next chunk to consume is ready for consumption
         return currentChunk;
-      } finally {
+      }
+      finally
+      {
         logger.debug("consumer free lock");
 
         boolean terminateDownloader = (currentChunk.getDownloadState() == DownloadState.FAILURE);
         // release the unlock always
         currentChunk.getLock().unlock();
-        if (nextChunkToConsume == this.chunks.size()) {
+        if (nextChunkToConsume == this.chunks.size())
+        {
           // make sure to release the last chunk
           releaseCurrentMemoryUsage(nextChunkToConsume - 1, Optional.empty());
         }
-        if (terminateDownloader) {
+        if (terminateDownloader)
+        {
           logger.debug("Download result fail. Shut down the chunk downloader");
           terminate();
         }
@@ -551,128 +607,123 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
   }
 
   /**
-   * wait for the current chunk to be ready to consume if the downloader fails then let it retry for
-   * at most 10 times if the downloader is in progress for at most one hour or the downloader has
-   * already retried more than 10 times, then throw an exception.
+   * wait for the current chunk to be ready to consume
+   * if the downloader fails then let it retry for at most 10 times
+   * if the downloader is in progress for at most one hour or the downloader has already retried more than 10 times,
+   * then throw an exception.
    *
    * @param currentChunk
    * @throws InterruptedException
    */
-  private void waitForChunkReady(SnowflakeResultChunk currentChunk) throws InterruptedException {
+  private void waitForChunkReady(SnowflakeResultChunk currentChunk) throws InterruptedException
+  {
     int retry = 0;
     long startTime = System.currentTimeMillis();
-    while (currentChunk.getDownloadState() != DownloadState.SUCCESS && retry < MAX_NUM_OF_RETRY) {
-      logger.debug(
-          "Thread {} is waiting for #chunk{} to be ready, current" + "chunk state is: {}, retry={}",
-          Thread.currentThread().getId(),
-          nextChunkToConsume,
-          currentChunk.getDownloadState(),
-          retry);
+    while (currentChunk.getDownloadState() != DownloadState.SUCCESS &&
+           retry < MAX_NUM_OF_RETRY)
+    {
+      logger.debug("Thread {} is waiting for #chunk{} to be ready, current"
+                   + "chunk state is: {}, retry={}",
+                   Thread.currentThread().getId(),
+                   nextChunkToConsume, currentChunk.getDownloadState(), retry);
 
-      if (currentChunk.getDownloadState() != DownloadState.FAILURE) {
+      if (currentChunk.getDownloadState() != DownloadState.FAILURE)
+      {
         // if the state is not failure, we should keep waiting; otherwise, we skip waiting
-        if (!currentChunk
-            .getDownloadCondition()
-            .await(downloadedConditionTimeoutInSeconds, TimeUnit.SECONDS)) {
+        if (!currentChunk.getDownloadCondition().await(downloadedConditionTimeoutInSeconds, TimeUnit.SECONDS))
+        {
           // if the current chunk has not condition change over the timeout (which is rare)
-          logger.debug(
-              "Thread {} is timeout for waiting #chunk{} to be ready, current"
-                  + "chunk state is: {}, retry={}",
-              Thread.currentThread().getId(),
-              nextChunkToConsume,
-              currentChunk.getDownloadState(),
-              retry);
+          logger.debug("Thread {} is timeout for waiting #chunk{} to be ready, current"
+                       + "chunk state is: {}, retry={}",
+                       Thread.currentThread().getId(),
+                       nextChunkToConsume, currentChunk.getDownloadState(), retry);
 
           currentChunk.setDownloadState(DownloadState.FAILURE);
-          currentChunk.setDownloadError(
-              String.format(
-                  "Timeout waiting for the download of #chunk%d" + "(Total chunks: %d) retry=%d",
-                  nextChunkToConsume, this.chunks.size(), retry));
+          currentChunk.setDownloadError(String.format("Timeout waiting for the download of #chunk%d" +
+                                                      "(Total chunks: %d) retry=%d", nextChunkToConsume,
+                                                      this.chunks.size(), retry));
           break;
         }
       }
 
-      if (currentChunk.getDownloadState() != DownloadState.SUCCESS) {
+      if (currentChunk.getDownloadState() != DownloadState.SUCCESS)
+      {
         // timeout or failed
         retry++;
-        logger.debug(
-            "Since downloadState is {} Thread {} decides to retry {} time(s) for #chunk{}",
-            currentChunk.getDownloadState(),
-            Thread.currentThread().getId(),
-            retry,
-            nextChunkToConsume);
+        logger.debug("Since downloadState is {} Thread {} decides to retry {} time(s) for #chunk{}",
+                     currentChunk.getDownloadState(),
+                     Thread.currentThread().getId(),
+                     retry,
+                     nextChunkToConsume);
         Future downloaderFuture = downloaderFutures.get(nextChunkToConsume);
-        if (downloaderFuture != null) {
+        if (downloaderFuture != null)
+        {
           downloaderFuture.cancel(true);
         }
         HttpUtil.closeExpiredAndIdleConnections();
 
         chunks.get(nextChunkToConsume).getLock().lock();
-        try {
+        try
+        {
           chunks.get(nextChunkToConsume).setDownloadState(DownloadState.IN_PROGRESS);
           chunks.get(nextChunkToConsume).reset();
-        } finally {
+        }
+        finally
+        {
           chunks.get(nextChunkToConsume).getLock().unlock();
         }
 
         // random jitter before start next retry
         Thread.sleep(new Random().nextInt(MAX_RETRY_JITTER));
 
-        downloaderFuture =
-            executor.submit(
-                getDownloadChunkCallable(
-                    this,
-                    chunks.get(nextChunkToConsume),
-                    qrmk,
-                    nextChunkToConsume,
-                    chunkHeadersMap,
-                    networkTimeoutInMilli,
-                    session));
+        downloaderFuture = executor.submit(getDownloadChunkCallable(this,
+                                                                    chunks.get(nextChunkToConsume),
+                                                                    qrmk, nextChunkToConsume,
+                                                                    chunkHeadersMap,
+                                                                    networkTimeoutInMilli, session));
         downloaderFutures.put(nextChunkToDownload, downloaderFuture);
       }
     }
-    if (currentChunk.getDownloadState() == DownloadState.SUCCESS) {
+    if (currentChunk.getDownloadState() == DownloadState.SUCCESS)
+    {
       logger.debug("ready to consume #chunk{}, succeed retry={}", nextChunkToConsume, retry);
-    } else if (retry >= MAX_NUM_OF_RETRY) {
+    }
+    else if (retry >= MAX_NUM_OF_RETRY)
+    {
       // stop retrying and report failure
       currentChunk.setDownloadState(DownloadState.FAILURE);
       currentChunk.setDownloadError(
-          String.format(
-              "Max retry reached for the download of #chunk%d "
-                  + "(Total chunks: %d) retry=%d, error=%s",
-              nextChunkToConsume,
-              this.chunks.size(),
-              retry,
-              chunks.get(nextChunkToConsume).getDownloadError()));
+          String.format("Max retry reached for the download of #chunk%d " +
+                        "(Total chunks: %d) retry=%d, error=%s",
+                        nextChunkToConsume, this.chunks.size(), retry,
+                        chunks.get(nextChunkToConsume).getDownloadError()));
     }
-    this.numberMillisWaitingForChunks += (System.currentTimeMillis() - startTime);
+    this.numberMillisWaitingForChunks +=
+        (System.currentTimeMillis() - startTime);
   }
 
-  /** log out of memory error and provide the suggestion to avoid this error */
-  private void logOutOfMemoryError() {
-    logger.error(
-        "Dump some crucial information below:\n"
-            + "Total milliseconds waiting for chunks: {},\n"
-            + "Total memory used: {}, Max heap size: {}, total download time: {} millisec,\n"
-            + "total parsing time: {} milliseconds, total chunks: {},\n"
-            + "currentMemoryUsage in Byte: {}, currentMemoryLimit in Bytes: {} \n"
-            + "nextChunkToDownload: {}, nextChunkToConsume: {}\n"
-            + "Several suggestions to try to resolve the OOM issue:\n"
-            + "1. increase the JVM heap size if you have more space; or \n"
-            + "2. use CLIENT_MEMORY_LIMIT to reduce the memory usage by the JDBC driver "
-            + "(https://docs.snowflake.net/manuals/sql-reference/parameters.html#client-memory-limit)"
-            + "3. please make sure 2 * CLIENT_PREFETCH_THREADS * CLIENT_RESULT_CHUNK_SIZE < CLIENT_MEMORY_LIMIT. "
-            + "If not, please reduce CLIENT_PREFETCH_THREADS and CLIENT_RESULT_CHUNK_SIZE too.",
-        numberMillisWaitingForChunks,
-        Runtime.getRuntime().totalMemory(),
-        Runtime.getRuntime().maxMemory(),
-        totalMillisDownloadingChunks.get(),
-        totalMillisParsingChunks.get(),
-        chunks.size(),
-        currentMemoryUsage,
-        memoryLimit,
-        nextChunkToDownload,
-        nextChunkToConsume);
+  /**
+   * log out of memory error and provide the suggestion to avoid this error
+   */
+  private void logOutOfMemoryError()
+  {
+    logger.error("Dump some crucial information below:\n" +
+                 "Total milliseconds waiting for chunks: {},\n" +
+                 "Total memory used: {}, Max heap size: {}, total download time: {} millisec,\n" +
+                 "total parsing time: {} milliseconds, total chunks: {},\n" +
+                 "currentMemoryUsage in Byte: {}, currentMemoryLimit in Bytes: {} \n" +
+                 "nextChunkToDownload: {}, nextChunkToConsume: {}\n" +
+                 "Several suggestions to try to resolve the OOM issue:\n" +
+                 "1. increase the JVM heap size if you have more space; or \n" +
+                 "2. use CLIENT_MEMORY_LIMIT to reduce the memory usage by the JDBC driver " +
+                 "(https://docs.snowflake.net/manuals/sql-reference/parameters.html#client-memory-limit)" +
+                 "3. please make sure 2 * CLIENT_PREFETCH_THREADS * CLIENT_RESULT_CHUNK_SIZE < CLIENT_MEMORY_LIMIT. " +
+                 "If not, please reduce CLIENT_PREFETCH_THREADS and CLIENT_RESULT_CHUNK_SIZE too.",
+                 numberMillisWaitingForChunks,
+                 Runtime.getRuntime().totalMemory(), Runtime.getRuntime().maxMemory(),
+                 totalMillisDownloadingChunks.get(),
+                 totalMillisParsingChunks.get(), chunks.size(), currentMemoryUsage, memoryLimit,
+                 nextChunkToDownload, nextChunkToConsume);
   }
 
   /**
@@ -681,54 +732,58 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
    * @return chunk downloader metrics collected over instance lifetime
    */
   @Override
-  public DownloaderMetrics terminate() throws InterruptedException {
-    if (!terminated.getAndSet(true)) {
-      if (executor != null) {
-        if (!executor.isShutdown()) {
+  public DownloaderMetrics terminate() throws InterruptedException
+  {
+    if (!terminated.getAndSet(true))
+    {
+      if (executor != null)
+      {
+        if (!executor.isShutdown())
+        {
           // cancel running downloaders
           downloaderFutures.forEach((k, v) -> v.cancel(true));
           // shutdown executor
           executor.shutdown();
-          if (!executor.awaitTermination(SHUTDOWN_TIME, TimeUnit.SECONDS)) {
+          if (!executor.awaitTermination(SHUTDOWN_TIME, TimeUnit.SECONDS))
+          {
             logger.debug("Executor did not terminate in the specified time.");
 
-            List<Runnable> droppedTasks = executor.shutdownNow(); // optional **
+            List<Runnable> droppedTasks = executor.shutdownNow(); //optional **
             logger.debug(
-                "Executor was abruptly shut down. "
-                    + droppedTasks.size()
-                    + " tasks will not be executed."); // optional **
+                "Executor was abruptly shut down. " + droppedTasks.size() +
+                " tasks will not be executed."); //optional **
           }
         }
       }
-      for (SnowflakeResultChunk chunk : chunks) {
+      for (SnowflakeResultChunk chunk : chunks)
+      {
         // explicitly free each chunk since Arrow chunk may hold direct memory
         chunk.freeData();
       }
 
-      if (queryResultFormat == QueryResultFormat.ARROW) {
+      if (queryResultFormat == QueryResultFormat.ARROW)
+      {
         SFArrowResultSet.closeRootAllocator(rootAllocator);
-      } else {
+      }
+      else
+      {
         chunkDataCache.clear();
       }
 
       releaseAllChunkMemoryUsage();
 
-      logger.debug(
-          "Total milliseconds waiting for chunks: {}, "
-              + "Total memory used: {}, total download time: {} millisec, "
-              + "total parsing time: {} milliseconds, total chunks: {}",
-          numberMillisWaitingForChunks,
-          Runtime.getRuntime().totalMemory(),
-          totalMillisDownloadingChunks.get(),
-          totalMillisParsingChunks.get(),
-          chunks.size());
+      logger.debug("Total milliseconds waiting for chunks: {}, " +
+                   "Total memory used: {}, total download time: {} millisec, " +
+                   "total parsing time: {} milliseconds, total chunks: {}",
+                   numberMillisWaitingForChunks,
+                   Runtime.getRuntime().totalMemory(), totalMillisDownloadingChunks.get(),
+                   totalMillisParsingChunks.get(), chunks.size());
 
       chunks = null;
 
-      return new DownloaderMetrics(
-          numberMillisWaitingForChunks,
-          totalMillisDownloadingChunks.get(),
-          totalMillisParsingChunks.get());
+      return new DownloaderMetrics(numberMillisWaitingForChunks,
+                                   totalMillisDownloadingChunks.get(),
+                                   totalMillisParsingChunks.get());
     }
     return null;
   }
@@ -738,7 +793,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
    *
    * @param downloadTime Time for downloading a single chunk
    */
-  private void addDownloadTime(long downloadTime) {
+  private void addDownloadTime(long downloadTime)
+  {
     this.totalMillisDownloadingChunks.addAndGet(downloadTime);
   }
 
@@ -747,82 +803,95 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
    *
    * @param parsingTime Time for parsing a single chunk
    */
-  private void addParsingTime(long parsingTime) {
+  private void addParsingTime(long parsingTime)
+  {
     this.totalMillisParsingChunks.addAndGet(parsingTime);
   }
 
   /**
    * Create a download callable that will be run in download thread
    *
-   * @param downloader object to download the chunk
-   * @param resultChunk object contains information about the chunk will be downloaded
-   * @param qrmk Query Result Master Key
-   * @param chunkIndex the index of the chunk which will be downloaded in array chunks. This is
-   *     mainly for logging purpose
-   * @param chunkHeadersMap contains headers needed to be added when downloading from s3
+   * @param downloader            object to download the chunk
+   * @param resultChunk           object contains information about the chunk will
+   *                              be downloaded
+   * @param qrmk                  Query Result Master Key
+   * @param chunkIndex            the index of the chunk which will be downloaded in array
+   *                              chunks. This is mainly for logging purpose
+   * @param chunkHeadersMap       contains headers needed to be added when downloading from s3
    * @param networkTimeoutInMilli network timeout
    * @return A callable responsible for downloading chunk
    */
   private static Callable<Void> getDownloadChunkCallable(
       final SnowflakeChunkDownloader downloader,
       final SnowflakeResultChunk resultChunk,
-      final String qrmk,
-      final int chunkIndex,
+      final String qrmk, final int chunkIndex,
       final Map<String, String> chunkHeadersMap,
       final int networkTimeoutInMilli,
-      final SFSession session) {
-    return new Callable<Void>() {
+      final SFSession session)
+  {
+    return new Callable<Void>()
+    {
       /**
-       * Step 1. use chunk url to get the input stream
-       *
+       *  Step 1. use chunk url to get the input stream
        * @return
        * @throws SnowflakeSQLException
        */
-      private InputStream getInputStream() throws SnowflakeSQLException {
+      private InputStream getInputStream() throws SnowflakeSQLException
+      {
         HttpResponse response;
-        try {
+        try
+        {
           response = getResultChunk(resultChunk.getUrl());
-        } catch (URISyntaxException | IOException ex) {
-          throw new SnowflakeSQLException(
-              SqlState.IO_ERROR,
-              ErrorCode.NETWORK_ERROR.getMessageCode(),
-              "Error encountered when request a result chunk URL: "
-                  + resultChunk.getUrl()
-                  + " "
-                  + ex.getLocalizedMessage());
+        }
+        catch (URISyntaxException | IOException ex)
+        {
+          throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
+                                                ErrorCode.NETWORK_ERROR
+                                                    .getMessageCode(), session,
+                                                "Error encountered when request a result chunk URL: "
+                                                + resultChunk.getUrl()
+                                                + " " + ex.getLocalizedMessage());
         }
 
         /*
          * return error if we don't get a response or the response code
          * means failure.
          */
-        if (response == null || response.getStatusLine().getStatusCode() != 200) {
-          logger.error("Error fetching chunk from: {}", resultChunk.getScrubbedUrl());
+        if (response == null
+            || response.getStatusLine().getStatusCode() != 200)
+        {
+          logger.error("Error fetching chunk from: {}",
+                       resultChunk.getScrubbedUrl());
 
           SnowflakeUtil.logResponseDetails(response, logger);
 
-          throw new SnowflakeSQLException(
-              SqlState.IO_ERROR,
-              ErrorCode.NETWORK_ERROR.getMessageCode(),
-              "Error encountered when downloading a result chunk: HTTP "
-                  + "status="
-                  + ((response != null)
-                      ? response.getStatusLine().getStatusCode()
-                      : "null response"));
+          throw new SnowflakeSQLException(SqlState.IO_ERROR,
+                                          ErrorCode.NETWORK_ERROR
+                                              .getMessageCode(),
+                                          "Error encountered when downloading a result chunk: HTTP "
+                                          + "status="
+                                          + ((response != null)
+                                             ? response.getStatusLine().getStatusCode()
+                                             : "null response"));
         }
 
         InputStream inputStream;
         final HttpEntity entity = response.getEntity();
-        try {
+        try
+        {
           // read the chunk data
           inputStream = detectContentEncodingAndGetInputStream(response, entity.getContent());
-        } catch (Exception ex) {
+        }
+        catch (Exception ex)
+        {
           logger.error("Failed to decompress data: {}", response);
 
-          throw new SnowflakeSQLException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Failed to decompress data: " + response.toString());
+          throw
+              new SnowflakeSQLLoggedException(
+                  SqlState.INTERNAL_ERROR,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                  "Failed to decompress data: " +
+                  response.toString());
         }
 
         // trace the response if requested
@@ -831,48 +900,61 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         return inputStream;
       }
 
-      private InputStream detectContentEncodingAndGetInputStream(
-          HttpResponse response, InputStream is) throws IOException, SnowflakeSQLException {
-        InputStream inputStream = is; // Determine the format of the response, if it is not
+      private InputStream detectContentEncodingAndGetInputStream(HttpResponse response, InputStream is)
+      throws IOException, SnowflakeSQLException
+      {
+        InputStream inputStream = is;// Determine the format of the response, if it is not
         // either plain text or gzip, raise an error.
         Header encoding = response.getFirstHeader("Content-Encoding");
-        if (encoding != null) {
-          if ("gzip".equalsIgnoreCase(encoding.getValue())) {
+        if (encoding != null)
+        {
+          if ("gzip".equalsIgnoreCase(encoding.getValue()))
+          {
             /* specify buffer size for GZIPInputStream */
             inputStream = new GZIPInputStream(is, STREAM_BUFFER_SIZE);
-          } else {
-            throw new SnowflakeSQLException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                "Exception: unexpected compression got " + encoding.getValue());
           }
-        } else {
+          else
+          {
+            throw
+                new SnowflakeSQLException(
+                    SqlState.INTERNAL_ERROR,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    "Exception: unexpected compression got " +
+                    encoding.getValue());
+          }
+        }
+        else
+        {
           inputStream = detectGzipAndGetStream(is);
         }
 
         return inputStream;
       }
 
-      private InputStream detectGzipAndGetStream(InputStream is) throws IOException {
+      private InputStream detectGzipAndGetStream(InputStream is) throws IOException
+      {
         PushbackInputStream pb = new PushbackInputStream(is, 2);
         byte[] signature = new byte[2];
         int len = pb.read(signature);
         pb.unread(signature, 0, len);
         // https://tools.ietf.org/html/rfc1952
-        if (signature[0] == (byte) 0x1f && signature[1] == (byte) 0x8b) {
+        if (signature[0] == (byte) 0x1f && signature[1] == (byte) 0x8b)
+        {
           return new GZIPInputStream(pb);
-        } else {
+        }
+        else
+        {
           return pb;
         }
       }
 
       /**
        * Read the input stream and parse chunk data into memory
-       *
        * @param inputStream
        * @throws SnowflakeSQLException
        */
-      private void downloadAndParseChunk(InputStream inputStream) throws SnowflakeSQLException {
+      private void downloadAndParseChunk(InputStream inputStream) throws SnowflakeSQLException
+      {
         // remember the download time
         resultChunk.setDownloadTime(System.currentTimeMillis() - startTime);
         downloader.addDownloadTime(resultChunk.getDownloadTime());
@@ -880,38 +962,45 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         startTime = System.currentTimeMillis();
 
         // parse the result json
-        try {
-          if (downloader.queryResultFormat == QueryResultFormat.ARROW) {
+        try
+        {
+          if (downloader.queryResultFormat == QueryResultFormat.ARROW)
+          {
             ((ArrowResultChunk) resultChunk).readArrowStream(inputStream);
-          } else {
+          }
+          else
+          {
             parseJsonToChunkV2(inputStream, resultChunk);
           }
-        } catch (Exception ex) {
-          logger.debug(
-              "Thread {} Exception when parsing result #chunk{}: {}",
-              Thread.currentThread().getId(),
-              chunkIndex,
-              ex.getLocalizedMessage());
+        }
+        catch (Exception ex)
+        {
+          logger.debug("Thread {} Exception when parsing result #chunk{}: {}",
+                       Thread.currentThread().getId(), chunkIndex, ex.getLocalizedMessage());
 
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Exception: " + ex.getLocalizedMessage());
-        } finally {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR
+                                                    .getMessageCode(), session,
+                                                "Exception: " +
+                                                ex.getLocalizedMessage());
+        }
+        finally
+        {
           // close the buffer reader will close underlying stream
-          logger.debug(
-              "Thread {} close input stream for #chunk{}",
-              Thread.currentThread().getId(),
-              chunkIndex);
-          try {
+          logger.debug("Thread {} close input stream for #chunk{}",
+                       Thread.currentThread().getId(),
+                       chunkIndex);
+          try
+          {
             inputStream.close();
-          } catch (IOException ex) {
-            throw new SnowflakeSQLException(
-                ex,
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                "Exception: " + ex.getLocalizedMessage());
+          }
+          catch (IOException ex)
+          {
+            throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR
+                                                      .getMessageCode(), session,
+                                                  "Exception: " +
+                                                  ex.getLocalizedMessage());
           }
         }
 
@@ -922,68 +1011,85 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
 
       private long startTime;
 
-      public Void call() {
+      public Void call()
+      {
         resultChunk.getLock().lock();
-        try {
+        try
+        {
           resultChunk.setDownloadState(DownloadState.IN_PROGRESS);
-        } finally {
+        }
+        finally
+        {
           resultChunk.getLock().unlock();
         }
 
-        logger.debug(
-            "Downloading #chunk{}, url={}, Thread {}",
-            chunkIndex,
-            resultChunk.getUrl(),
-            Thread.currentThread().getId());
+        logger.debug("Downloading #chunk{}, url={}, Thread {}",
+                     chunkIndex, resultChunk.getUrl(), Thread.currentThread().getId());
 
         startTime = System.currentTimeMillis();
 
-        // initialize the telemetry service for this downloader thread using the main telemetry
-        // service
+        // initialize the telemetry service for this downloader thread using the main telemetry service
         TelemetryService.getInstance().updateContext(downloader.snowflakeConnectionString);
 
-        try {
+        try
+        {
           InputStream is = getInputStream();
-          logger.debug(
-              "Thread {} start downloading #chunk{}", Thread.currentThread().getId(), chunkIndex);
+          logger.debug("Thread {} start downloading #chunk{}",
+                       Thread.currentThread().getId(),
+                       chunkIndex);
           downloadAndParseChunk(is);
-          logger.debug(
-              "Thread {} finish downloading #chunk{}", Thread.currentThread().getId(), chunkIndex);
+          logger.debug("Thread {} finish downloading #chunk{}",
+                       Thread.currentThread().getId(),
+                       chunkIndex);
           downloader.downloaderFutures.remove(chunkIndex);
           logger.debug(
-              "Finished preparing chunk data for {}, "
-                  + "total download time={}ms, total parse time={}ms",
+              "Finished preparing chunk data for {}, " +
+              "total download time={}ms, total parse time={}ms",
               resultChunk.getScrubbedUrl(),
               resultChunk.getDownloadTime(),
               resultChunk.getParseTime());
 
           resultChunk.getLock().lock();
-          try {
-            logger.debug("get lock to change the chunk to be ready to consume");
+          try
+          {
+            logger.debug(
+                "get lock to change the chunk to be ready to consume");
 
-            logger.debug("wake up consumer if it is waiting for a chunk to be " + "ready");
+            logger.debug(
+                "wake up consumer if it is waiting for a chunk to be "
+                + "ready");
 
             resultChunk.setDownloadState(DownloadState.SUCCESS);
             resultChunk.getDownloadCondition().signal();
-          } finally {
-            logger.debug("Downloaded #chunk{}, free lock", chunkIndex);
+          }
+          finally
+          {
+            logger.debug(
+                "Downloaded #chunk{}, free lock", chunkIndex);
 
             resultChunk.getLock().unlock();
           }
-        } catch (SnowflakeSQLException ex) {
+        }
+        catch (SnowflakeSQLException ex)
+        {
           resultChunk.getLock().lock();
-          try {
+          try
+          {
             logger.debug("get lock to set chunk download error");
             resultChunk.setDownloadState(DownloadState.FAILURE);
             StringWriter errors = new StringWriter();
             ex.printStackTrace(new PrintWriter(errors));
             resultChunk.setDownloadError(errors.toString());
 
-            logger.debug("wake up consumer if it is waiting for a chunk to be ready");
+            logger.debug(
+                "wake up consumer if it is waiting for a chunk to be ready");
 
             resultChunk.getDownloadCondition().signal();
-          } finally {
-            logger.debug("Failed to download #chunk{}, free lock", chunkIndex);
+          }
+          finally
+          {
+            logger.debug("Failed to download #chunk{}, free lock",
+                         chunkIndex);
             resultChunk.getLock().unlock();
           }
 
@@ -1000,8 +1106,10 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         return null;
       }
 
-      private void parseJsonToChunkV2(InputStream jsonInputStream, SnowflakeResultChunk resultChunk)
-          throws IOException, SnowflakeSQLException {
+      private void parseJsonToChunkV2(InputStream jsonInputStream,
+                                      SnowflakeResultChunk resultChunk)
+      throws IOException, SnowflakeSQLException
+      {
         /*
          * This is a hand-written binary parser that
          * handle.
@@ -1018,83 +1126,88 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
 
         byte[] buf = new byte[STREAM_BUFFER_SIZE];
         int len;
-        logger.debug(
-            "Thread {} start to read inputstream for #chunk{}",
-            Thread.currentThread().getId(),
-            chunkIndex);
-        while ((len = jsonInputStream.read(buf)) != -1) {
+        logger.debug("Thread {} start to read inputstream for #chunk{}",
+                     Thread.currentThread().getId(), chunkIndex);
+        while ((len = jsonInputStream.read(buf)) != -1)
+        {
           jp.continueParsing(ByteBuffer.wrap(buf, 0, len), session);
         }
-        logger.debug(
-            "Thread {} finish reading inputstream for #chunk{}",
-            Thread.currentThread().getId(),
-            chunkIndex);
+        logger.debug("Thread {} finish reading inputstream for #chunk{}",
+                     Thread.currentThread().getId(), chunkIndex);
         jp.endParsing(session);
       }
 
       private HttpResponse getResultChunk(String chunkUrl)
-          throws URISyntaxException, IOException, SnowflakeSQLException {
+      throws URISyntaxException, IOException, SnowflakeSQLException
+      {
         URIBuilder uriBuilder = new URIBuilder(chunkUrl);
 
         HttpGet httpRequest = new HttpGet(uriBuilder.build());
 
-        if (chunkHeadersMap != null && chunkHeadersMap.size() != 0) {
-          for (Map.Entry<String, String> entry : chunkHeadersMap.entrySet()) {
-            logger.debug("Adding header key={}, value={}", entry.getKey(), entry.getValue());
+        if (chunkHeadersMap != null && chunkHeadersMap.size() != 0)
+        {
+          for (Map.Entry<String, String> entry : chunkHeadersMap.entrySet())
+          {
+            logger.debug("Adding header key={}, value={}",
+                         entry.getKey(), entry.getValue());
             httpRequest.addHeader(entry.getKey(), entry.getValue());
           }
         }
         // Add SSE-C headers
-        else if (qrmk != null) {
+        else if (qrmk != null)
+        {
           httpRequest.addHeader(SSE_C_ALGORITHM, SSE_C_AES);
           httpRequest.addHeader(SSE_C_KEY, qrmk);
           logger.debug("Adding SSE-C headers");
         }
 
-        logger.debug(
-            "Thread {} Fetching result #chunk{}: {}",
-            Thread.currentThread().getId(),
-            chunkIndex,
-            resultChunk.getScrubbedUrl());
+        logger.debug("Thread {} Fetching result #chunk{}: {}",
+                     Thread.currentThread().getId(),
+                     chunkIndex,
+                     resultChunk.getScrubbedUrl());
 
-        // TODO move this s3 request to HttpUtil class. In theory, upper layer
-        // TODO does not need to know about http client
+        //TODO move this s3 request to HttpUtil class. In theory, upper layer
+        //TODO does not need to know about http client
         CloseableHttpClient httpClient = HttpUtil.getHttpClient(downloader.getOCSPMode());
 
         // fetch the result chunk
         HttpResponse response =
-            RestRequest.execute(
-                httpClient,
-                httpRequest,
-                networkTimeoutInMilli / 1000, // retry timeout
-                0, // no socketime injection
-                null, // no canceling
-                false, // no cookie
-                false, // no retry
-                false, // no request_guid
-                true // retry on HTTP403 for AWS S3
-                );
+            RestRequest.execute(httpClient,
+                                httpRequest,
+                                networkTimeoutInMilli / 1000, // retry timeout
+                                0, // no socketime injection
+                                null, // no canceling
+                                false, // no cookie
+                                false, // no retry
+                                false, // no request_guid
+                                true // retry on HTTP403 for AWS S3
+            );
 
-        logger.debug(
-            "Thread {} Call #chunk{} returned for URL: {}, response={}",
-            Thread.currentThread().getId(),
-            chunkIndex,
-            (ArgSupplier) () -> SecretDetector.maskSASToken(chunkUrl),
-            response);
+        logger.debug("Thread {} Call #chunk{} returned for URL: {}, response={}",
+                     Thread.currentThread().getId(),
+                     chunkIndex,
+                     (ArgSupplier) () -> SecretDetector.maskSASToken(chunkUrl),
+                     response);
         return response;
       }
     };
   }
 
-  /** This is a No Operation chunk downloader to avoid potential null pointer exception */
-  public static class NoOpChunkDownloader implements ChunkDownloader {
+  /**
+   * This is a No Operation chunk downloader to avoid potential null pointer exception
+   */
+  public static class NoOpChunkDownloader implements ChunkDownloader
+  {
     @Override
-    public SnowflakeResultChunk getNextChunkToConsume() throws SnowflakeSQLException {
+    public SnowflakeResultChunk getNextChunkToConsume()
+    throws SnowflakeSQLException
+    {
       return null;
     }
 
     @Override
-    public DownloaderMetrics terminate() {
+    public DownloaderMetrics terminate()
+    {
       return null;
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -4,13 +4,17 @@
 
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.core.SessionUtil.CLIENT_SFSQL;
-import static net.snowflake.client.core.SessionUtil.JVM_PARAMS_TO_PARAMS;
-import static net.snowflake.client.jdbc.ErrorCode.FEATURE_UNSUPPORTED;
-import static net.snowflake.client.jdbc.ErrorCode.INVALID_CONNECT_STRING;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 import com.google.common.base.Strings;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.log.SFLoggerUtil;
+import net.snowflake.common.core.LoginInfoDTO;
+import net.snowflake.common.core.SqlState;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Array;
@@ -43,23 +47,25 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPInputStream;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.core.SFSessionProperty;
-import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.log.SFLoggerUtil;
-import net.snowflake.common.core.LoginInfoDTO;
-import net.snowflake.common.core.SqlState;
 
-/** Snowflake connection implementation */
-public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
-  static {
+import static net.snowflake.client.core.SessionUtil.CLIENT_SFSQL;
+import static net.snowflake.client.core.SessionUtil.JVM_PARAMS_TO_PARAMS;
+import static net.snowflake.client.jdbc.ErrorCode.FEATURE_UNSUPPORTED;
+import static net.snowflake.client.jdbc.ErrorCode.INVALID_CONNECT_STRING;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
+/**
+ * Snowflake connection implementation
+ */
+public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
+{
+  static
+  {
     SFLoggerUtil.initializeSnowflakeLogger();
   }
 
-  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionV1.class);
+  static private final
+  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionV1.class);
 
   private boolean isClosed;
 
@@ -76,12 +82,13 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   private boolean showStatementParameters;
 
   /**
-   * Amount of milliseconds a user is willing to tolerate for network related issues (e.g. HTTP
-   * 503/504) or database transient issues (e.g. GS not responding)
-   *
-   * <p>A value of 0 means no timeout
-   *
-   * <p>Default: 300 seconds
+   * Amount of milliseconds a user is willing to tolerate for network related
+   * issues (e.g. HTTP 503/504) or database transient issues (e.g. GS
+   * not responding)
+   * <p>
+   * A value of 0 means no timeout
+   * <p>
+   * Default: 300 seconds
    */
   private int networkTimeoutInMilli = 0; // in milliseconds
 
@@ -93,59 +100,72 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
   private SFSession sfSession;
 
-  /** Refer to all created and open statements from this connection */
+  /**
+   * Refer to all created and open statements from this connection
+   */
   private final Set<Statement> openStatements = ConcurrentHashMap.newKeySet();
 
   /**
    * A connection will establish a session token from snowflake
    *
-   * @param url server url used to create snowflake connection
+   * @param url  server url used to create snowflake connection
    * @param info properties about the snowflake connection
-   * @throws SQLException if failed to create a snowflake connection i.e. username or password not
-   *     specified
+   * @throws SQLException if failed to create a snowflake connection
+   *                      i.e. username or password not specified
    */
-  public SnowflakeConnectionV1(String url, Properties info) throws SQLException {
+  public SnowflakeConnectionV1(String url, Properties info)
+  throws SQLException
+  {
     SnowflakeConnectString conStr = SnowflakeConnectString.parse(url, info);
-    if (!conStr.isValid()) {
+    if (!conStr.isValid())
+    {
       throw new SnowflakeSQLException(INVALID_CONNECT_STRING, url);
     }
     initialize(conStr);
   }
 
   public SnowflakeConnectionV1(String url, Properties info, boolean fakeConnection)
-      throws SQLException {
+  throws SQLException
+  {
     SnowflakeConnectString conStr = SnowflakeConnectString.parse(url, info);
-    if (!conStr.isValid()) {
-      throw new SnowflakeSQLException(
-          SqlState.CONNECTION_EXCEPTION, INVALID_CONNECT_STRING.getMessageCode(), url);
+    if (!conStr.isValid())
+    {
+      throw new SnowflakeSQLException(SqlState.CONNECTION_EXCEPTION, INVALID_CONNECT_STRING.getMessageCode(), url);
     }
     sfSession = new SFSession();
     sfSession.setSnowflakeConnectionString(conStr);
-    try {
+    try
+    {
       initSessionProperties(conStr);
       missingProperties = sfSession.checkProperties();
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(),
-          ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(), ex.getSqlState(),
+                                            ex.getVendorCode(), sfSession, ex.getParams());
     }
 
     isClosed = false;
   }
 
-  public List<DriverPropertyInfo> returnMissingProperties() {
+
+  public List<DriverPropertyInfo> returnMissingProperties()
+  {
     return missingProperties;
   }
 
-  private void initialize(SnowflakeConnectString conStr) throws SQLException {
-    logger.debug(
-        "Trying to establish session, JDBC driver version: {}", SnowflakeDriver.implementVersion);
+  private void initialize(SnowflakeConnectString conStr)
+  throws SQLException
+  {
+    logger.debug("Trying to establish session, JDBC driver version: {}",
+                 SnowflakeDriver.implementVersion);
     TelemetryService.getInstance().updateContext(conStr);
     // open connection to GS
     sfSession = new SFSession();
     sfSession.setSnowflakeConnectionString(conStr);
 
-    try {
+    try
+    {
       // pass the parameters to sfSession
       initSessionProperties(conStr);
 
@@ -156,10 +176,11 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
       databaseMajorVersion = sfSession.getDatabaseMajorVersion();
       databaseMinorVersion = sfSession.getDatabaseMinorVersion();
       showStatementParameters = sfSession.getPreparedStatementLogging();
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(),
-          ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(), ex.getSqlState(),
+                                            ex.getVendorCode(), sfSession, ex.getParams());
     }
 
     appendWarnings(sfSession.getSqlWarnings());
@@ -167,57 +188,71 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
     isClosed = false;
   }
 
-  private void raiseSQLExceptionIfConnectionIsClosed() throws SQLException {
-    if (isClosed) {
+  private void raiseSQLExceptionIfConnectionIsClosed() throws SQLException
+  {
+    if (isClosed)
+    {
       throw new SnowflakeSQLException(ErrorCode.CONNECTION_CLOSED);
     }
   }
 
   /**
-   * Processes parameters given in the connection string. This extracts accountName, databaseName,
-   * schemaName from the URL if it is specified there, where the URL is of the form:
-   *
-   * <p>jdbc:snowflake://host:port/?user=v&password=v&account=v&
+   * Processes parameters given in the connection string. This extracts
+   * accountName, databaseName, schemaName from
+   * the URL if it is specified there, where the URL is of the form:
+   * <p>
+   * jdbc:snowflake://host:port/?user=v&password=v&account=v&
    * db=v&schema=v&ssl=v&[passcode=v|passcodeInPassword=on]
    *
    * @param conStr Connection string object
    */
-  static Map<String, Object> mergeProperties(SnowflakeConnectString conStr) {
+  static Map<String, Object> mergeProperties(SnowflakeConnectString conStr)
+  {
     conStr.getParameters().remove("SSL");
-    conStr
-        .getParameters()
-        .put(
-            "SERVERURL",
-            conStr.getScheme() + "://" + conStr.getHost() + ":" + conStr.getPort() + "/");
+    conStr.getParameters().put("SERVERURL",
+                               conStr.getScheme() + "://" + conStr.getHost() + ":" + conStr.getPort() + "/");
     return conStr.getParameters();
   }
 
-  private void initSessionProperties(SnowflakeConnectString conStr) throws SFException {
+  private void initSessionProperties(SnowflakeConnectString conStr) throws SFException
+  {
     Map<String, Object> properties = mergeProperties(conStr);
 
-    for (Map.Entry<String, Object> property : properties.entrySet()) {
-      if ("CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY".equals(property.getKey())) {
-        try {
+    for (Map.Entry<String, Object> property : properties.entrySet())
+    {
+      if ("CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY".equals(property.getKey()))
+      {
+        try
+        {
           Object v0 = property.getValue();
           int intV;
-          if (v0 instanceof Integer) {
+          if (v0 instanceof Integer)
+          {
             intV = (Integer) v0;
-          } else {
+          }
+          else
+          {
             intV = Integer.parseInt((String) v0);
           }
-          if (intV > 3600) {
+          if (intV > 3600)
+          {
             properties.replace(property.getKey(), "3600");
           }
-          if (intV < 900) {
+          if (intV < 900)
+          {
             properties.replace(property.getKey(), "900");
           }
-        } catch (NumberFormatException ex) {
+        }
+        catch (NumberFormatException ex)
+        {
           logger.info(
               "Invalid data type for CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY: {}",
               property.getValue());
           continue;
         }
-      } else if (CLIENT_SFSQL.equals(property.getKey())) {
+      }
+      else if (CLIENT_SFSQL.equals(property.getKey()))
+      {
         Object v0 = property.getValue();
         boolean booleanV = v0 instanceof Boolean ? (Boolean) v0 : Boolean.parseBoolean((String) v0);
         sfSession.setSfSQLMode(booleanV);
@@ -227,27 +262,32 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
     // populate app id and version
     sfSession.addProperty(SFSessionProperty.APP_ID, LoginInfoDTO.SF_JDBC_APP_ID);
-    sfSession.addProperty(SFSessionProperty.APP_VERSION, SnowflakeDriver.implementVersion);
+    sfSession.addProperty(SFSessionProperty.APP_VERSION,
+                          SnowflakeDriver.implementVersion);
 
     // Set the corresponding session parameters to the JVM properties
-    for (Map.Entry<String, String> entry : JVM_PARAMS_TO_PARAMS.entrySet()) {
+    for (Map.Entry<String, String> entry : JVM_PARAMS_TO_PARAMS.entrySet())
+    {
       String value = systemGetProperty(entry.getKey());
-      if (value != null && !sfSession.containProperty(entry.getValue())) {
+      if (value != null && !sfSession.containProperty(entry.getValue()))
+      {
         sfSession.addProperty(entry.getValue(), value);
       }
     }
   }
 
   /**
-   * Execute a statement where the result isn't needed, and the statement is closed before this
-   * method returns
+   * Execute a statement where the result isn't needed, and the statement is
+   * closed before this method returns
    *
    * @param stmtText text of the statement
    * @throws SQLException exception thrown it the statement fails to execute
    */
-  private void executeImmediate(String stmtText) throws SQLException {
+  private void executeImmediate(String stmtText) throws SQLException
+  {
     // execute the statement and auto-close it as well
-    try (final Statement statement = this.createStatement()) {
+    try (final Statement statement = this.createStatement())
+    {
       statement.execute(stmtText);
     }
   }
@@ -259,9 +299,12 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
    * @throws SQLException if failed to create a snowflake statement
    */
   @Override
-  public Statement createStatement() throws SQLException {
+  public Statement createStatement() throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
-    Statement stmt = createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+    Statement stmt = createStatement(
+        ResultSet.TYPE_FORWARD_ONLY,
+        ResultSet.CONCUR_READ_ONLY);
     openStatements.add(stmt);
     return stmt;
   }
@@ -273,7 +316,8 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
    * @return
    * @throws SQLException
    */
-  public ResultSet createResultSet(String queryID) throws SQLException {
+  public ResultSet createResultSet(String queryID) throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
     SFAsyncResultSet rs = new SFAsyncResultSet(queryID);
     rs.setSession(sfSession);
@@ -281,53 +325,68 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
     return rs;
   }
 
+
   /**
    * Close the connection
    *
    * @throws SQLException failed to close the connection
    */
   @Override
-  public void close() throws SQLException {
+  public void close() throws SQLException
+  {
     logger.debug(" public void close()");
 
-    if (isClosed) {
+    if (isClosed)
+    {
       // No exception is raised even if the connection is closed.
       return;
     }
 
     isClosed = true;
-    try {
-      if (sfSession != null && sfSession.isSafeToClose()) {
+    try
+    {
+      if (sfSession != null && sfSession.isSafeToClose())
+      {
         sfSession.close();
         sfSession = null;
       }
       // make sure to close all created statements
-      for (Statement stmt : openStatements) {
-        if (stmt != null && !stmt.isClosed()) {
-          if (stmt.isWrapperFor(SnowflakeStatementV1.class)) {
+      for (Statement stmt : openStatements)
+      {
+        if (stmt != null && !stmt.isClosed())
+        {
+          if (stmt.isWrapperFor(SnowflakeStatementV1.class))
+          {
             stmt.unwrap(SnowflakeStatementV1.class).close(false);
-          } else {
+          }
+          else
+          {
             stmt.close();
           }
         }
       }
       openStatements.clear();
 
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), sfSession, ex.getParams());
     }
   }
 
-  public String getSessionID() throws SQLException {
-    if (isClosed) {
+  public String getSessionID() throws SQLException
+  {
+    if (isClosed)
+    {
       raiseSQLExceptionIfConnectionIsClosed();
     }
     return sfSession.getSessionId();
   }
 
   @Override
-  public boolean isClosed() throws SQLException {
+  public boolean isClosed() throws SQLException
+  {
     logger.debug(" public boolean isClosed()");
 
     return isClosed;
@@ -340,131 +399,149 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
    * @throws SQLException if any database error occurs
    */
   @Override
-  public DatabaseMetaData getMetaData() throws SQLException {
-    logger.debug(" public DatabaseMetaData getMetaData()");
+  public DatabaseMetaData getMetaData() throws SQLException
+  {
+    logger.debug(
+        " public DatabaseMetaData getMetaData()");
     raiseSQLExceptionIfConnectionIsClosed();
     return new SnowflakeDatabaseMetaData(this);
   }
 
   @Override
-  public CallableStatement prepareCall(String sql) throws SQLException {
-    logger.debug(" public CallableStatement prepareCall(String sql)");
+  public CallableStatement prepareCall(String sql) throws SQLException
+  {
+    logger.debug(
+        " public CallableStatement prepareCall(String sql)");
     raiseSQLExceptionIfConnectionIsClosed();
     CallableStatement stmt = prepareCall(sql, false);
     openStatements.add(stmt);
     return stmt;
   }
 
-  public CallableStatement prepareCall(String sql, boolean skipParsing) throws SQLException {
-    logger.debug(" public CallableStatement prepareCall(String sql, boolean skipParsing)");
-    raiseSQLExceptionIfConnectionIsClosed();
-    CallableStatement stmt =
-        new SnowflakeCallableStatementV1(
-            this,
-            sql,
-            skipParsing,
-            ResultSet.TYPE_FORWARD_ONLY,
-            ResultSet.CONCUR_READ_ONLY,
-            ResultSet.CLOSE_CURSORS_AT_COMMIT);
-    openStatements.add(stmt);
-    return stmt;
-  }
-
-  @Override
-  public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
-      throws SQLException {
+  public CallableStatement prepareCall(String sql, boolean skipParsing) throws SQLException
+  {
     logger.debug(
-        " public CallableStatement prepareCall(String sql,"
-            + " int resultSetType,int resultSetConcurrency");
-    CallableStatement stmt =
-        prepareCall(sql, resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
+        " public CallableStatement prepareCall(String sql, boolean skipParsing)");
+    raiseSQLExceptionIfConnectionIsClosed();
+    CallableStatement stmt = new SnowflakeCallableStatementV1(
+        this, sql, skipParsing, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
+        ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public CallableStatement prepareCall(
-      String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
-      throws SQLException {
-    logger.debug(" public CallableStatement prepareCall(String sql, int " + "resultSetType,");
-    CallableStatement stmt =
-        new SnowflakeCallableStatementV1(
-            this, sql, false, resultSetType, resultSetConcurrency, resultSetHoldability);
+  public CallableStatement prepareCall(String sql, int resultSetType,
+                                       int resultSetConcurrency) throws SQLException
+  {
+    logger.debug(
+        " public CallableStatement prepareCall(String sql," +
+        " int resultSetType,int resultSetConcurrency");
+    CallableStatement stmt = prepareCall(sql, resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public String nativeSQL(String sql) throws SQLException {
+  public CallableStatement prepareCall(String sql, int resultSetType,
+                                       int resultSetConcurrency,
+                                       int resultSetHoldability) throws SQLException
+  {
+    logger.debug(
+        " public CallableStatement prepareCall(String sql, int "
+        + "resultSetType,");
+    CallableStatement stmt = new SnowflakeCallableStatementV1(this, sql, false, resultSetType,
+                                                              resultSetConcurrency, resultSetHoldability);
+    openStatements.add(stmt);
+    return stmt;
+  }
+
+  @Override
+  public String nativeSQL(String sql) throws SQLException
+  {
     logger.debug("public String nativeSQL(String sql)");
     raiseSQLExceptionIfConnectionIsClosed();
     return sql;
   }
 
   @Override
-  public void setAutoCommit(boolean isAutoCommit) throws SQLException {
+  public void setAutoCommit(boolean isAutoCommit) throws SQLException
+  {
     logger.debug("void setAutoCommit(boolean isAutoCommit)");
     boolean currentAutoCommit = this.getAutoCommit();
-    if (isAutoCommit != currentAutoCommit) {
+    if (isAutoCommit != currentAutoCommit)
+    {
       sfSession.setAutoCommit(isAutoCommit);
       this.executeImmediate(
-          "alter session /* JDBC:SnowflakeConnectionV1.setAutoCommit*/ set autocommit="
-              + isAutoCommit);
+          "alter session /* JDBC:SnowflakeConnectionV1.setAutoCommit*/ set autocommit=" +
+          isAutoCommit);
     }
   }
 
   @Override
-  public boolean getAutoCommit() throws SQLException {
+  public boolean getAutoCommit() throws SQLException
+  {
     logger.debug("boolean getAutoCommit()");
     raiseSQLExceptionIfConnectionIsClosed();
     return sfSession.getAutoCommit();
   }
 
   @Override
-  public void commit() throws SQLException {
+  public void commit() throws SQLException
+  {
     logger.debug("void commit()");
     this.executeImmediate("commit");
   }
 
   @Override
-  public void rollback() throws SQLException {
+  public void rollback() throws SQLException
+  {
     logger.debug("void rollback()");
     this.executeImmediate("rollback");
   }
 
   @Override
-  public void rollback(Savepoint savepoint) throws SQLException {
-    logger.debug("void rollback(Savepoint savepoint)");
+  public void rollback(Savepoint savepoint) throws SQLException
+  {
+    logger.debug(
+        "void rollback(Savepoint savepoint)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setReadOnly(boolean readOnly) throws SQLException {
-    logger.debug("void setReadOnly(boolean readOnly)");
+  public void setReadOnly(boolean readOnly) throws SQLException
+  {
+    logger.debug(
+        "void setReadOnly(boolean readOnly)");
     raiseSQLExceptionIfConnectionIsClosed();
-    if (readOnly) {
+    if (readOnly)
+    {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public boolean isReadOnly() throws SQLException {
+  public boolean isReadOnly() throws SQLException
+  {
     logger.debug("boolean isReadOnly()");
     raiseSQLExceptionIfConnectionIsClosed();
     return false;
   }
 
   @Override
-  public void setCatalog(String catalog) throws SQLException {
-    logger.debug("void setCatalog(String catalog)");
+  public void setCatalog(String catalog) throws SQLException
+  {
+    logger.debug(
+        "void setCatalog(String catalog)");
 
     // switch db by running "use db"
     this.executeImmediate("use database \"" + catalog + "\"");
   }
 
   @Override
-  public String getCatalog() throws SQLException {
+  public String getCatalog() throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
     return sfSession.getDatabase();
   }
@@ -476,12 +553,18 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
    * @throws SQLException if any SQL error occurs
    */
   @Override
-  public void setTransactionIsolation(int level) throws SQLException {
-    logger.debug("void setTransactionIsolation(int level), level = {}", level);
+  public void setTransactionIsolation(int level) throws SQLException
+  {
+    logger.debug(
+        "void setTransactionIsolation(int level), level = {}", level);
     raiseSQLExceptionIfConnectionIsClosed();
-    if (level == Connection.TRANSACTION_NONE || level == Connection.TRANSACTION_READ_COMMITTED) {
+    if (level == Connection.TRANSACTION_NONE
+        || level == Connection.TRANSACTION_READ_COMMITTED)
+    {
       this.transactionIsolation = level;
-    } else {
+    }
+    else
+    {
       throw new SQLFeatureNotSupportedException(
           "Transaction Isolation " + level + " not supported.",
           FEATURE_UNSUPPORTED.getSqlState(),
@@ -490,21 +573,24 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   }
 
   @Override
-  public int getTransactionIsolation() throws SQLException {
+  public int getTransactionIsolation() throws SQLException
+  {
     logger.debug("int getTransactionIsolation()");
     raiseSQLExceptionIfConnectionIsClosed();
     return this.transactionIsolation;
   }
 
   @Override
-  public SQLWarning getWarnings() throws SQLException {
+  public SQLWarning getWarnings() throws SQLException
+  {
     logger.debug("SQLWarning getWarnings()");
     raiseSQLExceptionIfConnectionIsClosed();
     return sqlWarnings;
   }
 
   @Override
-  public void clearWarnings() throws SQLException {
+  public void clearWarnings() throws SQLException
+  {
     logger.debug("void clearWarnings()");
     raiseSQLExceptionIfConnectionIsClosed();
     sfSession.clearSqlWarnings();
@@ -513,30 +599,36 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
   @Override
   public Statement createStatement(int resultSetType, int resultSetConcurrency)
-      throws SQLException {
-    logger.debug("Statement createStatement(int resultSetType, " + "int resultSetConcurrency)");
-
-    Statement stmt =
-        createStatement(resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
-    openStatements.add(stmt);
-    return stmt;
-  }
-
-  @Override
-  public Statement createStatement(
-      int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+  throws SQLException
+  {
     logger.debug(
         "Statement createStatement(int resultSetType, "
-            + "int resultSetConcurrency, int resultSetHoldability");
+        + "int resultSetConcurrency)");
 
-    Statement stmt =
-        new SnowflakeStatementV1(this, resultSetType, resultSetConcurrency, resultSetHoldability);
+    Statement stmt = createStatement(
+        resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql) throws SQLException {
+  public Statement createStatement(int resultSetType, int resultSetConcurrency,
+                                   int resultSetHoldability)
+  throws SQLException
+  {
+    logger.debug(
+        "Statement createStatement(int resultSetType, "
+        + "int resultSetConcurrency, int resultSetHoldability");
+
+    Statement stmt = new SnowflakeStatementV1(
+        this, resultSetType, resultSetConcurrency, resultSetHoldability);
+    openStatements.add(stmt);
+    return stmt;
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql) throws SQLException
+  {
     logger.debug("PreparedStatement prepareStatement(String sql)");
     raiseSQLExceptionIfConnectionIsClosed();
     PreparedStatement stmt = prepareStatement(sql, false);
@@ -545,10 +637,15 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
-    logger.debug("PreparedStatement prepareStatement(String sql, " + "int autoGeneratedKeys)");
+  public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
+  throws SQLException
+  {
+    logger.debug(
+        "PreparedStatement prepareStatement(String sql, "
+        + "int autoGeneratedKeys)");
 
-    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
+    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS)
+    {
       return prepareStatement(sql);
     }
 
@@ -556,131 +653,171 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
-    logger.debug("PreparedStatement prepareStatement(String sql, " + "int[] columnIndexes)");
+  public PreparedStatement prepareStatement(String sql, int[] columnIndexes)
+  throws SQLException
+  {
+    logger.debug(
+        "PreparedStatement prepareStatement(String sql, "
+        + "int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
-    logger.debug("PreparedStatement prepareStatement(String sql, " + "String[] columnNames)");
+  public PreparedStatement prepareStatement(String sql, String[] columnNames)
+  throws SQLException
+  {
+    logger.debug(
+        "PreparedStatement prepareStatement(String sql, "
+        + "String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency)
-      throws SQLException {
-    logger.debug("PreparedStatement prepareStatement(String sql, " + "int resultSetType,");
+  public PreparedStatement prepareStatement(
+      String sql,
+      int resultSetType,
+      int resultSetConcurrency)
+  throws SQLException
+  {
+    logger.debug(
+        "PreparedStatement prepareStatement(String sql, "
+        + "int resultSetType,");
 
-    PreparedStatement stmt =
-        prepareStatement(
-            sql, resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    PreparedStatement stmt = prepareStatement(sql, resultSetType, resultSetConcurrency,
+                                              ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
   public PreparedStatement prepareStatement(
-      String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
-      throws SQLException {
-    logger.debug("PreparedStatement prepareStatement(String sql, " + "int resultSetType,");
+      String sql,
+      int resultSetType,
+      int resultSetConcurrency,
+      int resultSetHoldability)
+  throws SQLException
+  {
+    logger.debug(
+        "PreparedStatement prepareStatement(String sql, "
+        + "int resultSetType,");
 
-    PreparedStatement stmt =
-        new SnowflakePreparedStatementV1(
-            this, sql, false, resultSetType, resultSetConcurrency, resultSetHoldability);
+    PreparedStatement stmt = new SnowflakePreparedStatementV1(
+        this, sql,
+        false,
+        resultSetType,
+        resultSetConcurrency,
+        resultSetHoldability);
     openStatements.add(stmt);
     return stmt;
   }
 
-  public PreparedStatement prepareStatement(String sql, boolean skipParsing) throws SQLException {
-    logger.debug("PreparedStatement prepareStatement(String sql, boolean skipParsing)");
+  public PreparedStatement prepareStatement(String sql, boolean skipParsing)
+  throws SQLException
+  {
+    logger.debug(
+        "PreparedStatement prepareStatement(String sql, boolean skipParsing)");
     raiseSQLExceptionIfConnectionIsClosed();
-    PreparedStatement stmt =
-        new SnowflakePreparedStatementV1(
-            this,
-            sql,
-            skipParsing,
-            ResultSet.TYPE_FORWARD_ONLY,
-            ResultSet.CONCUR_READ_ONLY,
-            ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    PreparedStatement stmt = new SnowflakePreparedStatementV1(
+        this,
+        sql,
+        skipParsing,
+        ResultSet.TYPE_FORWARD_ONLY,
+        ResultSet.CONCUR_READ_ONLY,
+        ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public Map<String, Class<?>> getTypeMap() throws SQLException {
+  public Map<String, Class<?>> getTypeMap() throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
     return Collections.emptyMap(); // nop
   }
 
   @Override
-  public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+  public void setTypeMap(Map<String, Class<?>> map) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setHoldability(int holdability) throws SQLException {
+  public void setHoldability(int holdability) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getHoldability() throws SQLException {
+  public int getHoldability() throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
     return ResultSet.CLOSE_CURSORS_AT_COMMIT; // nop
   }
 
   @Override
-  public Savepoint setSavepoint() throws SQLException {
+  public Savepoint setSavepoint() throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Savepoint setSavepoint(String name) throws SQLException {
+  public Savepoint setSavepoint(String name) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+  public void releaseSavepoint(Savepoint savepoint) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Blob createBlob() throws SQLException {
+  public Blob createBlob() throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Clob createClob() throws SQLException {
+  public Clob createClob() throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
     return new SnowflakeClob();
   }
 
   @Override
-  public NClob createNClob() throws SQLException {
+  public NClob createNClob() throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public SQLXML createSQLXML() throws SQLException {
+  public SQLXML createSQLXML() throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isValid(int timeout) throws SQLException {
+  public boolean isValid(int timeout) throws SQLException
+  {
     // TODO: run query here or ping
-    if (timeout < 0) {
+    if (timeout < 0)
+    {
       throw new SQLException("timeout is less than 0");
     }
     return !isClosed; // no exception is raised
   }
 
   @Override
-  public void setClientInfo(Properties properties) throws SQLClientInfoException {
+  public void setClientInfo(Properties properties)
+  throws SQLClientInfoException
+  {
     Map<String, ClientInfoStatus> failedProps = new HashMap<>();
     Enumeration<?> propList = properties.propertyNames();
-    while (propList.hasMoreElements()) {
+    while (propList.hasMoreElements())
+    {
       String name = (String) propList.nextElement();
       failedProps.put(name, ClientInfoStatus.REASON_UNKNOWN_PROPERTY);
     }
@@ -688,31 +825,33 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   }
 
   @Override
-  public void setClientInfo(String name, String value) throws SQLClientInfoException {
+  public void setClientInfo(String name, String value)
+  throws SQLClientInfoException
+  {
     Map<String, ClientInfoStatus> failedProps = new HashMap<>();
     failedProps.put(name, ClientInfoStatus.REASON_UNKNOWN_PROPERTY);
     raiseSetClientInfoException(failedProps);
   }
 
-  private void raiseSetClientInfoException(Map<String, ClientInfoStatus> failedProps)
-      throws SQLClientInfoException {
-    if (isClosed) {
+  private void raiseSetClientInfoException(Map<String, ClientInfoStatus> failedProps) throws SQLClientInfoException
+  {
+    if (isClosed)
+    {
       throw new SQLClientInfoException(
           "The connection is not opened.",
           ErrorCode.CONNECTION_CLOSED.getSqlState(),
-          ErrorCode.CONNECTION_CLOSED.getMessageCode(),
-          failedProps);
+          ErrorCode.CONNECTION_CLOSED.getMessageCode(), failedProps);
     }
 
     throw new SQLClientInfoException(
         "The client property cannot be set by setClientInfo.",
         ErrorCode.INVALID_PARAMETER_VALUE.getSqlState(),
-        ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode(),
-        failedProps);
+        ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode(), failedProps);
   }
 
   @Override
-  public Properties getClientInfo() throws SQLException {
+  public Properties getClientInfo() throws SQLException
+  {
     logger.debug("Properties getClientInfo()");
     raiseSQLExceptionIfConnectionIsClosed();
     // sfSession must not be null if the connection is not closed.
@@ -720,7 +859,8 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   }
 
   @Override
-  public String getClientInfo(String name) throws SQLException {
+  public String getClientInfo(String name) throws SQLException
+  {
     logger.debug("String getClientInfo(String name)");
 
     raiseSQLExceptionIfConnectionIsClosed();
@@ -729,63 +869,86 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   }
 
   @Override
-  public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
-    logger.debug("Array createArrayOf(String typeName, Object[] " + "elements)");
+  public Array createArrayOf(String typeName, Object[] elements)
+  throws SQLException
+  {
+    logger.debug(
+        "Array createArrayOf(String typeName, Object[] "
+        + "elements)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
-    logger.debug("Struct createStruct(String typeName, Object[] " + "attributes)");
+  public Struct createStruct(String typeName, Object[] attributes)
+  throws SQLException
+  {
+    logger.debug(
+        "Struct createStruct(String typeName, Object[] "
+        + "attributes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setSchema(String schema) throws SQLException {
-    logger.debug("void setSchema(String schema)");
+  public void setSchema(String schema) throws SQLException
+  {
+    logger.debug(
+        "void setSchema(String schema)");
 
     String databaseName = getCatalog();
 
     // switch schema by running "use db.schema"
-    if (databaseName == null) {
+    if (databaseName == null)
+    {
       this.executeImmediate("use schema \"" + schema + "\"");
-    } else {
+    }
+    else
+    {
       this.executeImmediate("use schema \"" + databaseName + "\".\"" + schema + "\"");
     }
   }
 
   @Override
-  public String getSchema() throws SQLException {
+  public String getSchema() throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
     return sfSession.getSchema();
   }
 
   @Override
-  public void abort(Executor executor) throws SQLException {
-    logger.debug("void abort(Executor executor)");
+  public void abort(Executor executor) throws SQLException
+  {
+    logger.debug(
+        "void abort(Executor executor)");
 
     close();
   }
 
   @Override
-  public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
-    logger.debug("void setNetworkTimeout(Executor executor, int " + "milliseconds)");
+  public void setNetworkTimeout(Executor executor, int milliseconds)
+  throws SQLException
+  {
+    logger.debug(
+        "void setNetworkTimeout(Executor executor, int "
+        + "milliseconds)");
     raiseSQLExceptionIfConnectionIsClosed();
 
     networkTimeoutInMilli = milliseconds;
   }
 
   @Override
-  public int getNetworkTimeout() throws SQLException {
-    logger.debug("int getNetworkTimeout()");
+  public int getNetworkTimeout() throws SQLException
+  {
+    logger.debug(
+        "int getNetworkTimeout()");
     raiseSQLExceptionIfConnectionIsClosed();
     return networkTimeoutInMilli;
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException
+  {
     logger.debug("boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -793,146 +956,157 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
+  public <T> T unwrap(Class<T> iface) throws SQLException
+  {
     logger.debug("<T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this)) {
+    if (!iface.isInstance(this))
+    {
       throw new SQLException(
           this.getClass().getName() + " not unwrappable from " + iface.getName());
     }
     return (T) this;
   }
 
-  int getDatabaseMajorVersion() {
+  int getDatabaseMajorVersion()
+  {
     return databaseMajorVersion;
   }
 
-  int getDatabaseMinorVersion() {
+  int getDatabaseMinorVersion()
+  {
     return databaseMinorVersion;
   }
 
-  String getDatabaseVersion() {
+  String getDatabaseVersion()
+  {
     return databaseVersion;
   }
 
   /**
-   * Method to put data from a stream at a stage location. The data will be uploaded as one file. No
-   * splitting is done in this method.
+   * Method to put data from a stream at a stage location. The data will be
+   * uploaded as one file. No splitting is done in this method.
+   * <p>
+   * Stream size must match the total size of data in the input stream unless
+   * compressData parameter is set to true.
+   * <p>
+   * caller is responsible for passing the correct size for the data in the
+   * stream and releasing the inputStream after the method is called.
+   * <p>
+   * Note this method is deprecated since streamSize is not required now. Keep
+   * the function signature for backward compatibility
    *
-   * <p>Stream size must match the total size of data in the input stream unless compressData
-   * parameter is set to true.
-   *
-   * <p>caller is responsible for passing the correct size for the data in the stream and releasing
-   * the inputStream after the method is called.
-   *
-   * <p>Note this method is deprecated since streamSize is not required now. Keep the function
-   * signature for backward compatibility
-   *
-   * @param stageName stage name: e.g. ~ or table name or stage name
-   * @param destPrefix path prefix under which the data should be uploaded on the stage
-   * @param inputStream input stream from which the data will be uploaded
+   * @param stageName    stage name: e.g. ~ or table name or stage name
+   * @param destPrefix   path prefix under which the data should be uploaded on the stage
+   * @param inputStream  input stream from which the data will be uploaded
    * @param destFileName destination file name to use
-   * @param streamSize data size in the stream
+   * @param streamSize   data size in the stream
    * @throws SQLException failed to put data from a stream at stage
    */
   @Deprecated
-  public void uploadStream(
-      String stageName,
-      String destPrefix,
-      InputStream inputStream,
-      String destFileName,
-      long streamSize)
-      throws SQLException {
-    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, false);
+  public void uploadStream(String stageName,
+                           String destPrefix,
+                           InputStream inputStream,
+                           String destFileName,
+                           long streamSize)
+  throws SQLException
+  {
+    uploadStreamInternal(stageName, destPrefix, inputStream,
+                         destFileName, false);
   }
 
   /**
-   * Method to compress data from a stream and upload it at a stage location. The data will be
-   * uploaded as one file. No splitting is done in this method.
+   * Method to compress data from a stream and upload it at a stage location.
+   * The data will be uploaded as one file. No splitting is done in this method.
+   * <p>
+   * caller is responsible for releasing the inputStream after the method is
+   * called.
    *
-   * <p>caller is responsible for releasing the inputStream after the method is called.
-   *
-   * @param stageName stage name: e.g. ~ or table name or stage name
-   * @param destPrefix path prefix under which the data should be uploaded on the stage
-   * @param inputStream input stream from which the data will be uploaded
+   * @param stageName    stage name: e.g. ~ or table name or stage name
+   * @param destPrefix   path prefix under which the data should be uploaded on the stage
+   * @param inputStream  input stream from which the data will be uploaded
    * @param destFileName destination file name to use
    * @param compressData compress data or not before uploading stream
    * @throws SQLException failed to compress and put data from a stream at stage
    */
-  public void uploadStream(
-      String stageName,
-      String destPrefix,
-      InputStream inputStream,
-      String destFileName,
-      boolean compressData)
-      throws SQLException {
-    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, compressData);
+  public void uploadStream(String stageName,
+                           String destPrefix,
+                           InputStream inputStream,
+                           String destFileName,
+                           boolean compressData)
+  throws SQLException
+  {
+    uploadStreamInternal(stageName, destPrefix, inputStream,
+                         destFileName, compressData);
   }
 
   /**
-   * Method to compress data from a stream and upload it at a stage location. The data will be
-   * uploaded as one file. No splitting is done in this method.
+   * Method to compress data from a stream and upload it at a stage location.
+   * The data will be uploaded as one file. No splitting is done in this method.
+   * <p>
+   * caller is responsible for releasing the inputStream after the method is
+   * called.
+   * <p>
+   * This method is deprecated
    *
-   * <p>caller is responsible for releasing the inputStream after the method is called.
-   *
-   * <p>This method is deprecated
-   *
-   * @param stageName stage name: e.g. ~ or table name or stage name
-   * @param destPrefix path prefix under which the data should be uploaded on the stage
-   * @param inputStream input stream from which the data will be uploaded
+   * @param stageName    stage name: e.g. ~ or table name or stage name
+   * @param destPrefix   path prefix under which the data should be uploaded on the stage
+   * @param inputStream  input stream from which the data will be uploaded
    * @param destFileName destination file name to use
    * @throws SQLException failed to compress and put data from a stream at stage
    */
   @Deprecated
-  public void compressAndUploadStream(
-      String stageName, String destPrefix, InputStream inputStream, String destFileName)
-      throws SQLException {
-    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, true);
+  public void compressAndUploadStream(String stageName,
+                                      String destPrefix,
+                                      InputStream inputStream,
+                                      String destFileName)
+  throws SQLException
+  {
+    uploadStreamInternal(stageName, destPrefix, inputStream,
+                         destFileName, true);
   }
 
   /**
-   * Method to put data from a stream at a stage location. The data will be uploaded as one file. No
-   * splitting is done in this method.
+   * Method to put data from a stream at a stage location. The data will be
+   * uploaded as one file. No splitting is done in this method.
+   * <p>
+   * Stream size must match the total size of data in the input stream unless
+   * compressData parameter is set to true.
+   * <p>
+   * caller is responsible for passing the correct size for the data in the
+   * stream and releasing the inputStream after the method is called.
    *
-   * <p>Stream size must match the total size of data in the input stream unless compressData
-   * parameter is set to true.
-   *
-   * <p>caller is responsible for passing the correct size for the data in the stream and releasing
-   * the inputStream after the method is called.
-   *
-   * @param stageName stage name: e.g. ~ or table name or stage name
-   * @param destPrefix path prefix under which the data should be uploaded on the stage
-   * @param inputStream input stream from which the data will be uploaded
+   * @param stageName    stage name: e.g. ~ or table name or stage name
+   * @param destPrefix   path prefix under which the data should be uploaded on the stage
+   * @param inputStream  input stream from which the data will be uploaded
    * @param destFileName destination file name to use
    * @param compressData whether compression is requested fore uploading data
    * @throws SQLException raises if any error occurs
    */
-  private void uploadStreamInternal(
-      String stageName,
-      String destPrefix,
-      InputStream inputStream,
-      String destFileName,
-      boolean compressData)
-      throws SQLException {
-    logger.debug(
-        "upload data from stream: stageName={}" + ", destPrefix={}, destFileName={}",
-        stageName,
-        destPrefix,
-        destFileName);
+  private void uploadStreamInternal(String stageName,
+                                    String destPrefix,
+                                    InputStream inputStream,
+                                    String destFileName,
+                                    boolean compressData)
+  throws SQLException
+  {
+    logger.debug("upload data from stream: stageName={}" +
+                 ", destPrefix={}, destFileName={}",
+                 stageName, destPrefix, destFileName);
 
-    if (stageName == null) {
+    if (stageName == null)
+    {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
           "stage name is null");
     }
 
-    if (destFileName == null) {
+    if (destFileName == null)
+    {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
           "stage name is null");
     }
 
@@ -944,14 +1118,17 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
     putCommand.append("put file:///tmp/placeholder ");
 
     // add stage name
-    if (!(stageName.startsWith("@") || stageName.startsWith("'@") || stageName.startsWith("$$@"))) {
+    if (!(stageName.startsWith("@") || stageName.startsWith("'@") || stageName.startsWith("$$@")))
+    {
       putCommand.append("@");
     }
     putCommand.append(stageName);
 
     // add dest prefix
-    if (destPrefix != null) {
-      if (!destPrefix.startsWith("/")) {
+    if (destPrefix != null)
+    {
+      if (!destPrefix.startsWith("/"))
+      {
         putCommand.append("/");
       }
       putCommand.append(destPrefix);
@@ -960,8 +1137,8 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
     putCommand.append(" overwrite=true");
 
     SnowflakeFileTransferAgent transferAgent;
-    transferAgent =
-        new SnowflakeFileTransferAgent(putCommand.toString(), sfSession, stmt.getSfStatement());
+    transferAgent = new SnowflakeFileTransferAgent(putCommand.toString(),
+                                                   sfSession, stmt.getSfStatement());
 
     transferAgent.setSourceStream(inputStream);
     transferAgent.setDestFileNameForStreamSource(destFileName);
@@ -974,46 +1151,48 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   /**
    * Download file from the given stage and return an input stream
    *
-   * @param stageName stage name
+   * @param stageName      stage name
    * @param sourceFileName file path in stage
-   * @param decompress true if file compressed
+   * @param decompress     true if file compressed
    * @return an input stream
    * @throws SnowflakeSQLException if any SQL error occurs.
    */
-  public InputStream downloadStream(String stageName, String sourceFileName, boolean decompress)
-      throws SQLException {
+  public InputStream downloadStream(String stageName, String sourceFileName,
+                                    boolean decompress) throws SQLException
 
-    logger.debug(
-        "download data to stream: stageName={}" + ", sourceFileName={}", stageName, sourceFileName);
+  {
+    logger.debug("download data to stream: stageName={}" +
+                 ", sourceFileName={}",
+                 stageName, sourceFileName);
 
-    if (Strings.isNullOrEmpty(stageName)) {
+    if (Strings.isNullOrEmpty(stageName))
+    {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
           "stage name is null or empty");
     }
 
-    if (Strings.isNullOrEmpty(sourceFileName)) {
+    if (Strings.isNullOrEmpty(sourceFileName))
+    {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
           "source file name is null or empty");
     }
 
-    SnowflakeStatementV1 stmt =
-        new SnowflakeStatementV1(
-            this,
-            ResultSet.TYPE_FORWARD_ONLY,
-            ResultSet.CONCUR_READ_ONLY,
-            ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    SnowflakeStatementV1 stmt = new SnowflakeStatementV1(
+        this,
+        ResultSet.TYPE_FORWARD_ONLY,
+        ResultSet.CONCUR_READ_ONLY,
+        ResultSet.CLOSE_CURSORS_AT_COMMIT);
 
     StringBuilder getCommand = new StringBuilder();
 
     getCommand.append("get ");
 
-    if (!stageName.startsWith("@")) {
+    if (!stageName.startsWith("@"))
+    {
       getCommand.append("@");
     }
 
@@ -1021,82 +1200,111 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
     getCommand.append("/");
 
-    if (sourceFileName.startsWith("/")) {
+    if (sourceFileName.startsWith("/"))
+    {
       sourceFileName = sourceFileName.substring(1);
     }
 
     getCommand.append(sourceFileName);
 
-    // this is a fake path, used to form Get query and retrieve stage info,
-    // no file will be downloaded to this location
+    //this is a fake path, used to form Get query and retrieve stage info,
+    //no file will be downloaded to this location
     getCommand.append(" file:///tmp/ /*jdbc download stream*/");
 
+
     SnowflakeFileTransferAgent transferAgent =
-        new SnowflakeFileTransferAgent(getCommand.toString(), sfSession, stmt.getSfStatement());
+        new SnowflakeFileTransferAgent(getCommand.toString(), sfSession,
+                                       stmt.getSfStatement());
 
     InputStream stream = transferAgent.downloadStream(sourceFileName);
 
-    if (decompress) {
-      try {
+    if (decompress)
+    {
+      try
+      {
         return new GZIPInputStream(stream);
-      } catch (IOException ex) {
-        throw new SnowflakeSQLException(
-            SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), ex.getMessage());
       }
-    } else {
+      catch (IOException ex)
+      {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
+            ex.getMessage());
+      }
+    }
+    else
+    {
       return stream;
     }
   }
 
-  public void setInjectedDelay(int delay) throws SQLException {
+  public void setInjectedDelay(int delay) throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
     sfSession.setInjectedDelay(delay);
   }
 
-  void injectedDelay() throws SQLException {
+  void injectedDelay() throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
 
     int d = _injectedDelay.get();
 
-    if (d != 0) {
+    if (d != 0)
+    {
       _injectedDelay.set(0);
-      try {
+      try
+      {
         logger.trace("delayed for {}", d);
 
         Thread.sleep(d);
-      } catch (InterruptedException ex) {
+      }
+      catch (InterruptedException ex)
+      {
       }
     }
   }
 
-  public void setInjectFileUploadFailure(String fileToFail) throws SQLException {
+  public void setInjectFileUploadFailure(String fileToFail) throws SQLException
+  {
     raiseSQLExceptionIfConnectionIsClosed();
     sfSession.setInjectFileUploadFailure(fileToFail);
   }
 
-  public SFSession getSfSession() {
+  public SFSession getSfSession()
+  {
     return sfSession;
   }
 
-  private void appendWarning(SQLWarning w) {
-    if (sqlWarnings == null) {
+  private void appendWarning(SQLWarning w)
+  {
+    if (sqlWarnings == null)
+    {
       sqlWarnings = w;
-    } else {
+    }
+    else
+    {
       sqlWarnings.setNextWarning(w);
     }
   }
 
-  private void appendWarnings(List<SFException> warnings) {
-    for (SFException e : warnings) {
-      appendWarning(new SQLWarning(e.getMessage(), e.getSqlState(), e.getVendorCode()));
+  private void appendWarnings(List<SFException> warnings)
+  {
+    for (SFException e : warnings)
+    {
+      appendWarning(new SQLWarning(e.getMessage(),
+                                   e.getSqlState(),
+                                   e.getVendorCode()));
     }
   }
 
-  public boolean getShowStatementParameters() {
+  public boolean getShowStatementParameters()
+  {
     return showStatementParameters;
   }
 
-  void removeClosedStatement(Statement stmt) {
+  void removeClosedStatement(Statement stmt)
+  {
     openStatements.remove(stmt);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -4,17 +4,13 @@
 
 package net.snowflake.client.jdbc;
 
-import com.google.common.base.Strings;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.core.SFSessionProperty;
-import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.log.SFLoggerUtil;
-import net.snowflake.common.core.LoginInfoDTO;
-import net.snowflake.common.core.SqlState;
+import static net.snowflake.client.core.SessionUtil.CLIENT_SFSQL;
+import static net.snowflake.client.core.SessionUtil.JVM_PARAMS_TO_PARAMS;
+import static net.snowflake.client.jdbc.ErrorCode.FEATURE_UNSUPPORTED;
+import static net.snowflake.client.jdbc.ErrorCode.INVALID_CONNECT_STRING;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Array;
@@ -47,25 +43,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPInputStream;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.log.SFLoggerUtil;
+import net.snowflake.common.core.LoginInfoDTO;
+import net.snowflake.common.core.SqlState;
 
-import static net.snowflake.client.core.SessionUtil.CLIENT_SFSQL;
-import static net.snowflake.client.core.SessionUtil.JVM_PARAMS_TO_PARAMS;
-import static net.snowflake.client.jdbc.ErrorCode.FEATURE_UNSUPPORTED;
-import static net.snowflake.client.jdbc.ErrorCode.INVALID_CONNECT_STRING;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
-/**
- * Snowflake connection implementation
- */
-public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
-{
-  static
-  {
+/** Snowflake connection implementation */
+public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
+  static {
     SFLoggerUtil.initializeSnowflakeLogger();
   }
 
-  static private final
-  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionV1.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionV1.class);
 
   private boolean isClosed;
 
@@ -82,13 +76,12 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
   private boolean showStatementParameters;
 
   /**
-   * Amount of milliseconds a user is willing to tolerate for network related
-   * issues (e.g. HTTP 503/504) or database transient issues (e.g. GS
-   * not responding)
-   * <p>
-   * A value of 0 means no timeout
-   * <p>
-   * Default: 300 seconds
+   * Amount of milliseconds a user is willing to tolerate for network related issues (e.g. HTTP
+   * 503/504) or database transient issues (e.g. GS not responding)
+   *
+   * <p>A value of 0 means no timeout
+   *
+   * <p>Default: 300 seconds
    */
   private int networkTimeoutInMilli = 0; // in milliseconds
 
@@ -100,72 +93,58 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
 
   private SFSession sfSession;
 
-  /**
-   * Refer to all created and open statements from this connection
-   */
+  /** Refer to all created and open statements from this connection */
   private final Set<Statement> openStatements = ConcurrentHashMap.newKeySet();
 
   /**
    * A connection will establish a session token from snowflake
    *
-   * @param url  server url used to create snowflake connection
+   * @param url server url used to create snowflake connection
    * @param info properties about the snowflake connection
-   * @throws SQLException if failed to create a snowflake connection
-   *                      i.e. username or password not specified
+   * @throws SQLException if failed to create a snowflake connection i.e. username or password not
+   *     specified
    */
-  public SnowflakeConnectionV1(String url, Properties info)
-  throws SQLException
-  {
+  public SnowflakeConnectionV1(String url, Properties info) throws SQLException {
     SnowflakeConnectString conStr = SnowflakeConnectString.parse(url, info);
-    if (!conStr.isValid())
-    {
+    if (!conStr.isValid()) {
       throw new SnowflakeSQLException(INVALID_CONNECT_STRING, url);
     }
     initialize(conStr);
   }
 
   public SnowflakeConnectionV1(String url, Properties info, boolean fakeConnection)
-  throws SQLException
-  {
+      throws SQLException {
     SnowflakeConnectString conStr = SnowflakeConnectString.parse(url, info);
-    if (!conStr.isValid())
-    {
-      throw new SnowflakeSQLException(SqlState.CONNECTION_EXCEPTION, INVALID_CONNECT_STRING.getMessageCode(), url);
+    if (!conStr.isValid()) {
+      throw new SnowflakeSQLException(
+          SqlState.CONNECTION_EXCEPTION, INVALID_CONNECT_STRING.getMessageCode(), url);
     }
     sfSession = new SFSession();
     sfSession.setSnowflakeConnectionString(conStr);
-    try
-    {
+    try {
       initSessionProperties(conStr);
       missingProperties = sfSession.checkProperties();
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(), ex.getSqlState(),
-                                            ex.getVendorCode(), sfSession, ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), sfSession, ex.getParams());
     }
 
     isClosed = false;
   }
 
-
-  public List<DriverPropertyInfo> returnMissingProperties()
-  {
+  public List<DriverPropertyInfo> returnMissingProperties() {
     return missingProperties;
   }
 
-  private void initialize(SnowflakeConnectString conStr)
-  throws SQLException
-  {
-    logger.debug("Trying to establish session, JDBC driver version: {}",
-                 SnowflakeDriver.implementVersion);
+  private void initialize(SnowflakeConnectString conStr) throws SQLException {
+    logger.debug(
+        "Trying to establish session, JDBC driver version: {}", SnowflakeDriver.implementVersion);
     TelemetryService.getInstance().updateContext(conStr);
     // open connection to GS
     sfSession = new SFSession();
     sfSession.setSnowflakeConnectionString(conStr);
 
-    try
-    {
+    try {
       // pass the parameters to sfSession
       initSessionProperties(conStr);
 
@@ -176,11 +155,9 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
       databaseMajorVersion = sfSession.getDatabaseMajorVersion();
       databaseMinorVersion = sfSession.getDatabaseMinorVersion();
       showStatementParameters = sfSession.getPreparedStatementLogging();
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(), ex.getSqlState(),
-                                            ex.getVendorCode(), sfSession, ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), sfSession, ex.getParams());
     }
 
     appendWarnings(sfSession.getSqlWarnings());
@@ -188,71 +165,57 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
     isClosed = false;
   }
 
-  private void raiseSQLExceptionIfConnectionIsClosed() throws SQLException
-  {
-    if (isClosed)
-    {
+  private void raiseSQLExceptionIfConnectionIsClosed() throws SQLException {
+    if (isClosed) {
       throw new SnowflakeSQLException(ErrorCode.CONNECTION_CLOSED);
     }
   }
 
   /**
-   * Processes parameters given in the connection string. This extracts
-   * accountName, databaseName, schemaName from
-   * the URL if it is specified there, where the URL is of the form:
-   * <p>
-   * jdbc:snowflake://host:port/?user=v&password=v&account=v&
+   * Processes parameters given in the connection string. This extracts accountName, databaseName,
+   * schemaName from the URL if it is specified there, where the URL is of the form:
+   *
+   * <p>jdbc:snowflake://host:port/?user=v&password=v&account=v&
    * db=v&schema=v&ssl=v&[passcode=v|passcodeInPassword=on]
    *
    * @param conStr Connection string object
    */
-  static Map<String, Object> mergeProperties(SnowflakeConnectString conStr)
-  {
+  static Map<String, Object> mergeProperties(SnowflakeConnectString conStr) {
     conStr.getParameters().remove("SSL");
-    conStr.getParameters().put("SERVERURL",
-                               conStr.getScheme() + "://" + conStr.getHost() + ":" + conStr.getPort() + "/");
+    conStr
+        .getParameters()
+        .put(
+            "SERVERURL",
+            conStr.getScheme() + "://" + conStr.getHost() + ":" + conStr.getPort() + "/");
     return conStr.getParameters();
   }
 
-  private void initSessionProperties(SnowflakeConnectString conStr) throws SFException
-  {
+  private void initSessionProperties(SnowflakeConnectString conStr) throws SFException {
     Map<String, Object> properties = mergeProperties(conStr);
 
-    for (Map.Entry<String, Object> property : properties.entrySet())
-    {
-      if ("CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY".equals(property.getKey()))
-      {
-        try
-        {
+    for (Map.Entry<String, Object> property : properties.entrySet()) {
+      if ("CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY".equals(property.getKey())) {
+        try {
           Object v0 = property.getValue();
           int intV;
-          if (v0 instanceof Integer)
-          {
+          if (v0 instanceof Integer) {
             intV = (Integer) v0;
-          }
-          else
-          {
+          } else {
             intV = Integer.parseInt((String) v0);
           }
-          if (intV > 3600)
-          {
+          if (intV > 3600) {
             properties.replace(property.getKey(), "3600");
           }
-          if (intV < 900)
-          {
+          if (intV < 900) {
             properties.replace(property.getKey(), "900");
           }
-        }
-        catch (NumberFormatException ex)
-        {
+        } catch (NumberFormatException ex) {
           logger.info(
               "Invalid data type for CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY: {}",
               property.getValue());
           continue;
         }
-      }
-      else if (CLIENT_SFSQL.equals(property.getKey()))
-      {
+      } else if (CLIENT_SFSQL.equals(property.getKey())) {
         Object v0 = property.getValue();
         boolean booleanV = v0 instanceof Boolean ? (Boolean) v0 : Boolean.parseBoolean((String) v0);
         sfSession.setSfSQLMode(booleanV);
@@ -262,32 +225,27 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
 
     // populate app id and version
     sfSession.addProperty(SFSessionProperty.APP_ID, LoginInfoDTO.SF_JDBC_APP_ID);
-    sfSession.addProperty(SFSessionProperty.APP_VERSION,
-                          SnowflakeDriver.implementVersion);
+    sfSession.addProperty(SFSessionProperty.APP_VERSION, SnowflakeDriver.implementVersion);
 
     // Set the corresponding session parameters to the JVM properties
-    for (Map.Entry<String, String> entry : JVM_PARAMS_TO_PARAMS.entrySet())
-    {
+    for (Map.Entry<String, String> entry : JVM_PARAMS_TO_PARAMS.entrySet()) {
       String value = systemGetProperty(entry.getKey());
-      if (value != null && !sfSession.containProperty(entry.getValue()))
-      {
+      if (value != null && !sfSession.containProperty(entry.getValue())) {
         sfSession.addProperty(entry.getValue(), value);
       }
     }
   }
 
   /**
-   * Execute a statement where the result isn't needed, and the statement is
-   * closed before this method returns
+   * Execute a statement where the result isn't needed, and the statement is closed before this
+   * method returns
    *
    * @param stmtText text of the statement
    * @throws SQLException exception thrown it the statement fails to execute
    */
-  private void executeImmediate(String stmtText) throws SQLException
-  {
+  private void executeImmediate(String stmtText) throws SQLException {
     // execute the statement and auto-close it as well
-    try (final Statement statement = this.createStatement())
-    {
+    try (final Statement statement = this.createStatement()) {
       statement.execute(stmtText);
     }
   }
@@ -299,12 +257,9 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
    * @throws SQLException if failed to create a snowflake statement
    */
   @Override
-  public Statement createStatement() throws SQLException
-  {
+  public Statement createStatement() throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
-    Statement stmt = createStatement(
-        ResultSet.TYPE_FORWARD_ONLY,
-        ResultSet.CONCUR_READ_ONLY);
+    Statement stmt = createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
     openStatements.add(stmt);
     return stmt;
   }
@@ -316,8 +271,7 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
    * @return
    * @throws SQLException
    */
-  public ResultSet createResultSet(String queryID) throws SQLException
-  {
+  public ResultSet createResultSet(String queryID) throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
     SFAsyncResultSet rs = new SFAsyncResultSet(queryID);
     rs.setSession(sfSession);
@@ -325,68 +279,53 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
     return rs;
   }
 
-
   /**
    * Close the connection
    *
    * @throws SQLException failed to close the connection
    */
   @Override
-  public void close() throws SQLException
-  {
+  public void close() throws SQLException {
     logger.debug(" public void close()");
 
-    if (isClosed)
-    {
+    if (isClosed) {
       // No exception is raised even if the connection is closed.
       return;
     }
 
     isClosed = true;
-    try
-    {
-      if (sfSession != null && sfSession.isSafeToClose())
-      {
+    try {
+      if (sfSession != null && sfSession.isSafeToClose()) {
         sfSession.close();
         sfSession = null;
       }
       // make sure to close all created statements
-      for (Statement stmt : openStatements)
-      {
-        if (stmt != null && !stmt.isClosed())
-        {
-          if (stmt.isWrapperFor(SnowflakeStatementV1.class))
-          {
+      for (Statement stmt : openStatements) {
+        if (stmt != null && !stmt.isClosed()) {
+          if (stmt.isWrapperFor(SnowflakeStatementV1.class)) {
             stmt.unwrap(SnowflakeStatementV1.class).close(false);
-          }
-          else
-          {
+          } else {
             stmt.close();
           }
         }
       }
       openStatements.clear();
 
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), sfSession, ex.getParams());
     }
   }
 
-  public String getSessionID() throws SQLException
-  {
-    if (isClosed)
-    {
+  public String getSessionID() throws SQLException {
+    if (isClosed) {
       raiseSQLExceptionIfConnectionIsClosed();
     }
     return sfSession.getSessionId();
   }
 
   @Override
-  public boolean isClosed() throws SQLException
-  {
+  public boolean isClosed() throws SQLException {
     logger.debug(" public boolean isClosed()");
 
     return isClosed;
@@ -399,149 +338,131 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
    * @throws SQLException if any database error occurs
    */
   @Override
-  public DatabaseMetaData getMetaData() throws SQLException
-  {
-    logger.debug(
-        " public DatabaseMetaData getMetaData()");
+  public DatabaseMetaData getMetaData() throws SQLException {
+    logger.debug(" public DatabaseMetaData getMetaData()");
     raiseSQLExceptionIfConnectionIsClosed();
     return new SnowflakeDatabaseMetaData(this);
   }
 
   @Override
-  public CallableStatement prepareCall(String sql) throws SQLException
-  {
-    logger.debug(
-        " public CallableStatement prepareCall(String sql)");
+  public CallableStatement prepareCall(String sql) throws SQLException {
+    logger.debug(" public CallableStatement prepareCall(String sql)");
     raiseSQLExceptionIfConnectionIsClosed();
     CallableStatement stmt = prepareCall(sql, false);
     openStatements.add(stmt);
     return stmt;
   }
 
-  public CallableStatement prepareCall(String sql, boolean skipParsing) throws SQLException
-  {
-    logger.debug(
-        " public CallableStatement prepareCall(String sql, boolean skipParsing)");
+  public CallableStatement prepareCall(String sql, boolean skipParsing) throws SQLException {
+    logger.debug(" public CallableStatement prepareCall(String sql, boolean skipParsing)");
     raiseSQLExceptionIfConnectionIsClosed();
-    CallableStatement stmt = new SnowflakeCallableStatementV1(
-        this, sql, skipParsing, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
-        ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    CallableStatement stmt =
+        new SnowflakeCallableStatementV1(
+            this,
+            sql,
+            skipParsing,
+            ResultSet.TYPE_FORWARD_ONLY,
+            ResultSet.CONCUR_READ_ONLY,
+            ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public CallableStatement prepareCall(String sql, int resultSetType,
-                                       int resultSetConcurrency) throws SQLException
-  {
+  public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
+      throws SQLException {
     logger.debug(
-        " public CallableStatement prepareCall(String sql," +
-        " int resultSetType,int resultSetConcurrency");
-    CallableStatement stmt = prepareCall(sql, resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
+        " public CallableStatement prepareCall(String sql,"
+            + " int resultSetType,int resultSetConcurrency");
+    CallableStatement stmt =
+        prepareCall(sql, resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public CallableStatement prepareCall(String sql, int resultSetType,
-                                       int resultSetConcurrency,
-                                       int resultSetHoldability) throws SQLException
-  {
-    logger.debug(
-        " public CallableStatement prepareCall(String sql, int "
-        + "resultSetType,");
-    CallableStatement stmt = new SnowflakeCallableStatementV1(this, sql, false, resultSetType,
-                                                              resultSetConcurrency, resultSetHoldability);
+  public CallableStatement prepareCall(
+      String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+      throws SQLException {
+    logger.debug(" public CallableStatement prepareCall(String sql, int " + "resultSetType,");
+    CallableStatement stmt =
+        new SnowflakeCallableStatementV1(
+            this, sql, false, resultSetType, resultSetConcurrency, resultSetHoldability);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public String nativeSQL(String sql) throws SQLException
-  {
+  public String nativeSQL(String sql) throws SQLException {
     logger.debug("public String nativeSQL(String sql)");
     raiseSQLExceptionIfConnectionIsClosed();
     return sql;
   }
 
   @Override
-  public void setAutoCommit(boolean isAutoCommit) throws SQLException
-  {
+  public void setAutoCommit(boolean isAutoCommit) throws SQLException {
     logger.debug("void setAutoCommit(boolean isAutoCommit)");
     boolean currentAutoCommit = this.getAutoCommit();
-    if (isAutoCommit != currentAutoCommit)
-    {
+    if (isAutoCommit != currentAutoCommit) {
       sfSession.setAutoCommit(isAutoCommit);
       this.executeImmediate(
-          "alter session /* JDBC:SnowflakeConnectionV1.setAutoCommit*/ set autocommit=" +
-          isAutoCommit);
+          "alter session /* JDBC:SnowflakeConnectionV1.setAutoCommit*/ set autocommit="
+              + isAutoCommit);
     }
   }
 
   @Override
-  public boolean getAutoCommit() throws SQLException
-  {
+  public boolean getAutoCommit() throws SQLException {
     logger.debug("boolean getAutoCommit()");
     raiseSQLExceptionIfConnectionIsClosed();
     return sfSession.getAutoCommit();
   }
 
   @Override
-  public void commit() throws SQLException
-  {
+  public void commit() throws SQLException {
     logger.debug("void commit()");
     this.executeImmediate("commit");
   }
 
   @Override
-  public void rollback() throws SQLException
-  {
+  public void rollback() throws SQLException {
     logger.debug("void rollback()");
     this.executeImmediate("rollback");
   }
 
   @Override
-  public void rollback(Savepoint savepoint) throws SQLException
-  {
-    logger.debug(
-        "void rollback(Savepoint savepoint)");
+  public void rollback(Savepoint savepoint) throws SQLException {
+    logger.debug("void rollback(Savepoint savepoint)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setReadOnly(boolean readOnly) throws SQLException
-  {
-    logger.debug(
-        "void setReadOnly(boolean readOnly)");
+  public void setReadOnly(boolean readOnly) throws SQLException {
+    logger.debug("void setReadOnly(boolean readOnly)");
     raiseSQLExceptionIfConnectionIsClosed();
-    if (readOnly)
-    {
+    if (readOnly) {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public boolean isReadOnly() throws SQLException
-  {
+  public boolean isReadOnly() throws SQLException {
     logger.debug("boolean isReadOnly()");
     raiseSQLExceptionIfConnectionIsClosed();
     return false;
   }
 
   @Override
-  public void setCatalog(String catalog) throws SQLException
-  {
-    logger.debug(
-        "void setCatalog(String catalog)");
+  public void setCatalog(String catalog) throws SQLException {
+    logger.debug("void setCatalog(String catalog)");
 
     // switch db by running "use db"
     this.executeImmediate("use database \"" + catalog + "\"");
   }
 
   @Override
-  public String getCatalog() throws SQLException
-  {
+  public String getCatalog() throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
     return sfSession.getDatabase();
   }
@@ -553,18 +474,12 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
    * @throws SQLException if any SQL error occurs
    */
   @Override
-  public void setTransactionIsolation(int level) throws SQLException
-  {
-    logger.debug(
-        "void setTransactionIsolation(int level), level = {}", level);
+  public void setTransactionIsolation(int level) throws SQLException {
+    logger.debug("void setTransactionIsolation(int level), level = {}", level);
     raiseSQLExceptionIfConnectionIsClosed();
-    if (level == Connection.TRANSACTION_NONE
-        || level == Connection.TRANSACTION_READ_COMMITTED)
-    {
+    if (level == Connection.TRANSACTION_NONE || level == Connection.TRANSACTION_READ_COMMITTED) {
       this.transactionIsolation = level;
-    }
-    else
-    {
+    } else {
       throw new SQLFeatureNotSupportedException(
           "Transaction Isolation " + level + " not supported.",
           FEATURE_UNSUPPORTED.getSqlState(),
@@ -573,24 +488,21 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
   }
 
   @Override
-  public int getTransactionIsolation() throws SQLException
-  {
+  public int getTransactionIsolation() throws SQLException {
     logger.debug("int getTransactionIsolation()");
     raiseSQLExceptionIfConnectionIsClosed();
     return this.transactionIsolation;
   }
 
   @Override
-  public SQLWarning getWarnings() throws SQLException
-  {
+  public SQLWarning getWarnings() throws SQLException {
     logger.debug("SQLWarning getWarnings()");
     raiseSQLExceptionIfConnectionIsClosed();
     return sqlWarnings;
   }
 
   @Override
-  public void clearWarnings() throws SQLException
-  {
+  public void clearWarnings() throws SQLException {
     logger.debug("void clearWarnings()");
     raiseSQLExceptionIfConnectionIsClosed();
     sfSession.clearSqlWarnings();
@@ -599,36 +511,30 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
 
   @Override
   public Statement createStatement(int resultSetType, int resultSetConcurrency)
-  throws SQLException
-  {
-    logger.debug(
-        "Statement createStatement(int resultSetType, "
-        + "int resultSetConcurrency)");
+      throws SQLException {
+    logger.debug("Statement createStatement(int resultSetType, " + "int resultSetConcurrency)");
 
-    Statement stmt = createStatement(
-        resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    Statement stmt =
+        createStatement(resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public Statement createStatement(int resultSetType, int resultSetConcurrency,
-                                   int resultSetHoldability)
-  throws SQLException
-  {
+  public Statement createStatement(
+      int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
     logger.debug(
         "Statement createStatement(int resultSetType, "
-        + "int resultSetConcurrency, int resultSetHoldability");
+            + "int resultSetConcurrency, int resultSetHoldability");
 
-    Statement stmt = new SnowflakeStatementV1(
-        this, resultSetType, resultSetConcurrency, resultSetHoldability);
+    Statement stmt =
+        new SnowflakeStatementV1(this, resultSetType, resultSetConcurrency, resultSetHoldability);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql) throws SQLException
-  {
+  public PreparedStatement prepareStatement(String sql) throws SQLException {
     logger.debug("PreparedStatement prepareStatement(String sql)");
     raiseSQLExceptionIfConnectionIsClosed();
     PreparedStatement stmt = prepareStatement(sql, false);
@@ -637,15 +543,10 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
-  throws SQLException
-  {
-    logger.debug(
-        "PreparedStatement prepareStatement(String sql, "
-        + "int autoGeneratedKeys)");
+  public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+    logger.debug("PreparedStatement prepareStatement(String sql, " + "int autoGeneratedKeys)");
 
-    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS)
-    {
+    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
       return prepareStatement(sql);
     }
 
@@ -653,171 +554,131 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int[] columnIndexes)
-  throws SQLException
-  {
-    logger.debug(
-        "PreparedStatement prepareStatement(String sql, "
-        + "int[] columnIndexes)");
+  public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+    logger.debug("PreparedStatement prepareStatement(String sql, " + "int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, String[] columnNames)
-  throws SQLException
-  {
-    logger.debug(
-        "PreparedStatement prepareStatement(String sql, "
-        + "String[] columnNames)");
+  public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+    logger.debug("PreparedStatement prepareStatement(String sql, " + "String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public PreparedStatement prepareStatement(
-      String sql,
-      int resultSetType,
-      int resultSetConcurrency)
-  throws SQLException
-  {
-    logger.debug(
-        "PreparedStatement prepareStatement(String sql, "
-        + "int resultSetType,");
+  public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency)
+      throws SQLException {
+    logger.debug("PreparedStatement prepareStatement(String sql, " + "int resultSetType,");
 
-    PreparedStatement stmt = prepareStatement(sql, resultSetType, resultSetConcurrency,
-                                              ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    PreparedStatement stmt =
+        prepareStatement(
+            sql, resultSetType, resultSetConcurrency, ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
   public PreparedStatement prepareStatement(
-      String sql,
-      int resultSetType,
-      int resultSetConcurrency,
-      int resultSetHoldability)
-  throws SQLException
-  {
-    logger.debug(
-        "PreparedStatement prepareStatement(String sql, "
-        + "int resultSetType,");
+      String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+      throws SQLException {
+    logger.debug("PreparedStatement prepareStatement(String sql, " + "int resultSetType,");
 
-    PreparedStatement stmt = new SnowflakePreparedStatementV1(
-        this, sql,
-        false,
-        resultSetType,
-        resultSetConcurrency,
-        resultSetHoldability);
+    PreparedStatement stmt =
+        new SnowflakePreparedStatementV1(
+            this, sql, false, resultSetType, resultSetConcurrency, resultSetHoldability);
     openStatements.add(stmt);
     return stmt;
   }
 
-  public PreparedStatement prepareStatement(String sql, boolean skipParsing)
-  throws SQLException
-  {
-    logger.debug(
-        "PreparedStatement prepareStatement(String sql, boolean skipParsing)");
+  public PreparedStatement prepareStatement(String sql, boolean skipParsing) throws SQLException {
+    logger.debug("PreparedStatement prepareStatement(String sql, boolean skipParsing)");
     raiseSQLExceptionIfConnectionIsClosed();
-    PreparedStatement stmt = new SnowflakePreparedStatementV1(
-        this,
-        sql,
-        skipParsing,
-        ResultSet.TYPE_FORWARD_ONLY,
-        ResultSet.CONCUR_READ_ONLY,
-        ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    PreparedStatement stmt =
+        new SnowflakePreparedStatementV1(
+            this,
+            sql,
+            skipParsing,
+            ResultSet.TYPE_FORWARD_ONLY,
+            ResultSet.CONCUR_READ_ONLY,
+            ResultSet.CLOSE_CURSORS_AT_COMMIT);
     openStatements.add(stmt);
     return stmt;
   }
 
   @Override
-  public Map<String, Class<?>> getTypeMap() throws SQLException
-  {
+  public Map<String, Class<?>> getTypeMap() throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
     return Collections.emptyMap(); // nop
   }
 
   @Override
-  public void setTypeMap(Map<String, Class<?>> map) throws SQLException
-  {
+  public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setHoldability(int holdability) throws SQLException
-  {
+  public void setHoldability(int holdability) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int getHoldability() throws SQLException
-  {
+  public int getHoldability() throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
     return ResultSet.CLOSE_CURSORS_AT_COMMIT; // nop
   }
 
   @Override
-  public Savepoint setSavepoint() throws SQLException
-  {
+  public Savepoint setSavepoint() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Savepoint setSavepoint(String name) throws SQLException
-  {
+  public Savepoint setSavepoint(String name) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void releaseSavepoint(Savepoint savepoint) throws SQLException
-  {
+  public void releaseSavepoint(Savepoint savepoint) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Blob createBlob() throws SQLException
-  {
+  public Blob createBlob() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Clob createClob() throws SQLException
-  {
+  public Clob createClob() throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
     return new SnowflakeClob();
   }
 
   @Override
-  public NClob createNClob() throws SQLException
-  {
+  public NClob createNClob() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public SQLXML createSQLXML() throws SQLException
-  {
+  public SQLXML createSQLXML() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isValid(int timeout) throws SQLException
-  {
+  public boolean isValid(int timeout) throws SQLException {
     // TODO: run query here or ping
-    if (timeout < 0)
-    {
+    if (timeout < 0) {
       throw new SQLException("timeout is less than 0");
     }
     return !isClosed; // no exception is raised
   }
 
   @Override
-  public void setClientInfo(Properties properties)
-  throws SQLClientInfoException
-  {
+  public void setClientInfo(Properties properties) throws SQLClientInfoException {
     Map<String, ClientInfoStatus> failedProps = new HashMap<>();
     Enumeration<?> propList = properties.propertyNames();
-    while (propList.hasMoreElements())
-    {
+    while (propList.hasMoreElements()) {
       String name = (String) propList.nextElement();
       failedProps.put(name, ClientInfoStatus.REASON_UNKNOWN_PROPERTY);
     }
@@ -825,33 +686,31 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
   }
 
   @Override
-  public void setClientInfo(String name, String value)
-  throws SQLClientInfoException
-  {
+  public void setClientInfo(String name, String value) throws SQLClientInfoException {
     Map<String, ClientInfoStatus> failedProps = new HashMap<>();
     failedProps.put(name, ClientInfoStatus.REASON_UNKNOWN_PROPERTY);
     raiseSetClientInfoException(failedProps);
   }
 
-  private void raiseSetClientInfoException(Map<String, ClientInfoStatus> failedProps) throws SQLClientInfoException
-  {
-    if (isClosed)
-    {
+  private void raiseSetClientInfoException(Map<String, ClientInfoStatus> failedProps)
+      throws SQLClientInfoException {
+    if (isClosed) {
       throw new SQLClientInfoException(
           "The connection is not opened.",
           ErrorCode.CONNECTION_CLOSED.getSqlState(),
-          ErrorCode.CONNECTION_CLOSED.getMessageCode(), failedProps);
+          ErrorCode.CONNECTION_CLOSED.getMessageCode(),
+          failedProps);
     }
 
     throw new SQLClientInfoException(
         "The client property cannot be set by setClientInfo.",
         ErrorCode.INVALID_PARAMETER_VALUE.getSqlState(),
-        ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode(), failedProps);
+        ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode(),
+        failedProps);
   }
 
   @Override
-  public Properties getClientInfo() throws SQLException
-  {
+  public Properties getClientInfo() throws SQLException {
     logger.debug("Properties getClientInfo()");
     raiseSQLExceptionIfConnectionIsClosed();
     // sfSession must not be null if the connection is not closed.
@@ -859,8 +718,7 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
   }
 
   @Override
-  public String getClientInfo(String name) throws SQLException
-  {
+  public String getClientInfo(String name) throws SQLException {
     logger.debug("String getClientInfo(String name)");
 
     raiseSQLExceptionIfConnectionIsClosed();
@@ -869,86 +727,63 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
   }
 
   @Override
-  public Array createArrayOf(String typeName, Object[] elements)
-  throws SQLException
-  {
-    logger.debug(
-        "Array createArrayOf(String typeName, Object[] "
-        + "elements)");
+  public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+    logger.debug("Array createArrayOf(String typeName, Object[] " + "elements)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Struct createStruct(String typeName, Object[] attributes)
-  throws SQLException
-  {
-    logger.debug(
-        "Struct createStruct(String typeName, Object[] "
-        + "attributes)");
+  public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+    logger.debug("Struct createStruct(String typeName, Object[] " + "attributes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setSchema(String schema) throws SQLException
-  {
-    logger.debug(
-        "void setSchema(String schema)");
+  public void setSchema(String schema) throws SQLException {
+    logger.debug("void setSchema(String schema)");
 
     String databaseName = getCatalog();
 
     // switch schema by running "use db.schema"
-    if (databaseName == null)
-    {
+    if (databaseName == null) {
       this.executeImmediate("use schema \"" + schema + "\"");
-    }
-    else
-    {
+    } else {
       this.executeImmediate("use schema \"" + databaseName + "\".\"" + schema + "\"");
     }
   }
 
   @Override
-  public String getSchema() throws SQLException
-  {
+  public String getSchema() throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
     return sfSession.getSchema();
   }
 
   @Override
-  public void abort(Executor executor) throws SQLException
-  {
-    logger.debug(
-        "void abort(Executor executor)");
+  public void abort(Executor executor) throws SQLException {
+    logger.debug("void abort(Executor executor)");
 
     close();
   }
 
   @Override
-  public void setNetworkTimeout(Executor executor, int milliseconds)
-  throws SQLException
-  {
-    logger.debug(
-        "void setNetworkTimeout(Executor executor, int "
-        + "milliseconds)");
+  public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+    logger.debug("void setNetworkTimeout(Executor executor, int " + "milliseconds)");
     raiseSQLExceptionIfConnectionIsClosed();
 
     networkTimeoutInMilli = milliseconds;
   }
 
   @Override
-  public int getNetworkTimeout() throws SQLException
-  {
-    logger.debug(
-        "int getNetworkTimeout()");
+  public int getNetworkTimeout() throws SQLException {
+    logger.debug("int getNetworkTimeout()");
     raiseSQLExceptionIfConnectionIsClosed();
     return networkTimeoutInMilli;
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException
-  {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
     logger.debug("boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -956,157 +791,146 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException
-  {
+  public <T> T unwrap(Class<T> iface) throws SQLException {
     logger.debug("<T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this))
-    {
+    if (!iface.isInstance(this)) {
       throw new SQLException(
           this.getClass().getName() + " not unwrappable from " + iface.getName());
     }
     return (T) this;
   }
 
-  int getDatabaseMajorVersion()
-  {
+  int getDatabaseMajorVersion() {
     return databaseMajorVersion;
   }
 
-  int getDatabaseMinorVersion()
-  {
+  int getDatabaseMinorVersion() {
     return databaseMinorVersion;
   }
 
-  String getDatabaseVersion()
-  {
+  String getDatabaseVersion() {
     return databaseVersion;
   }
 
   /**
-   * Method to put data from a stream at a stage location. The data will be
-   * uploaded as one file. No splitting is done in this method.
-   * <p>
-   * Stream size must match the total size of data in the input stream unless
-   * compressData parameter is set to true.
-   * <p>
-   * caller is responsible for passing the correct size for the data in the
-   * stream and releasing the inputStream after the method is called.
-   * <p>
-   * Note this method is deprecated since streamSize is not required now. Keep
-   * the function signature for backward compatibility
+   * Method to put data from a stream at a stage location. The data will be uploaded as one file. No
+   * splitting is done in this method.
    *
-   * @param stageName    stage name: e.g. ~ or table name or stage name
-   * @param destPrefix   path prefix under which the data should be uploaded on the stage
-   * @param inputStream  input stream from which the data will be uploaded
+   * <p>Stream size must match the total size of data in the input stream unless compressData
+   * parameter is set to true.
+   *
+   * <p>caller is responsible for passing the correct size for the data in the stream and releasing
+   * the inputStream after the method is called.
+   *
+   * <p>Note this method is deprecated since streamSize is not required now. Keep the function
+   * signature for backward compatibility
+   *
+   * @param stageName stage name: e.g. ~ or table name or stage name
+   * @param destPrefix path prefix under which the data should be uploaded on the stage
+   * @param inputStream input stream from which the data will be uploaded
    * @param destFileName destination file name to use
-   * @param streamSize   data size in the stream
+   * @param streamSize data size in the stream
    * @throws SQLException failed to put data from a stream at stage
    */
   @Deprecated
-  public void uploadStream(String stageName,
-                           String destPrefix,
-                           InputStream inputStream,
-                           String destFileName,
-                           long streamSize)
-  throws SQLException
-  {
-    uploadStreamInternal(stageName, destPrefix, inputStream,
-                         destFileName, false);
+  public void uploadStream(
+      String stageName,
+      String destPrefix,
+      InputStream inputStream,
+      String destFileName,
+      long streamSize)
+      throws SQLException {
+    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, false);
   }
 
   /**
-   * Method to compress data from a stream and upload it at a stage location.
-   * The data will be uploaded as one file. No splitting is done in this method.
-   * <p>
-   * caller is responsible for releasing the inputStream after the method is
-   * called.
+   * Method to compress data from a stream and upload it at a stage location. The data will be
+   * uploaded as one file. No splitting is done in this method.
    *
-   * @param stageName    stage name: e.g. ~ or table name or stage name
-   * @param destPrefix   path prefix under which the data should be uploaded on the stage
-   * @param inputStream  input stream from which the data will be uploaded
+   * <p>caller is responsible for releasing the inputStream after the method is called.
+   *
+   * @param stageName stage name: e.g. ~ or table name or stage name
+   * @param destPrefix path prefix under which the data should be uploaded on the stage
+   * @param inputStream input stream from which the data will be uploaded
    * @param destFileName destination file name to use
    * @param compressData compress data or not before uploading stream
    * @throws SQLException failed to compress and put data from a stream at stage
    */
-  public void uploadStream(String stageName,
-                           String destPrefix,
-                           InputStream inputStream,
-                           String destFileName,
-                           boolean compressData)
-  throws SQLException
-  {
-    uploadStreamInternal(stageName, destPrefix, inputStream,
-                         destFileName, compressData);
+  public void uploadStream(
+      String stageName,
+      String destPrefix,
+      InputStream inputStream,
+      String destFileName,
+      boolean compressData)
+      throws SQLException {
+    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, compressData);
   }
 
   /**
-   * Method to compress data from a stream and upload it at a stage location.
-   * The data will be uploaded as one file. No splitting is done in this method.
-   * <p>
-   * caller is responsible for releasing the inputStream after the method is
-   * called.
-   * <p>
-   * This method is deprecated
+   * Method to compress data from a stream and upload it at a stage location. The data will be
+   * uploaded as one file. No splitting is done in this method.
    *
-   * @param stageName    stage name: e.g. ~ or table name or stage name
-   * @param destPrefix   path prefix under which the data should be uploaded on the stage
-   * @param inputStream  input stream from which the data will be uploaded
+   * <p>caller is responsible for releasing the inputStream after the method is called.
+   *
+   * <p>This method is deprecated
+   *
+   * @param stageName stage name: e.g. ~ or table name or stage name
+   * @param destPrefix path prefix under which the data should be uploaded on the stage
+   * @param inputStream input stream from which the data will be uploaded
    * @param destFileName destination file name to use
    * @throws SQLException failed to compress and put data from a stream at stage
    */
   @Deprecated
-  public void compressAndUploadStream(String stageName,
-                                      String destPrefix,
-                                      InputStream inputStream,
-                                      String destFileName)
-  throws SQLException
-  {
-    uploadStreamInternal(stageName, destPrefix, inputStream,
-                         destFileName, true);
+  public void compressAndUploadStream(
+      String stageName, String destPrefix, InputStream inputStream, String destFileName)
+      throws SQLException {
+    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, true);
   }
 
   /**
-   * Method to put data from a stream at a stage location. The data will be
-   * uploaded as one file. No splitting is done in this method.
-   * <p>
-   * Stream size must match the total size of data in the input stream unless
-   * compressData parameter is set to true.
-   * <p>
-   * caller is responsible for passing the correct size for the data in the
-   * stream and releasing the inputStream after the method is called.
+   * Method to put data from a stream at a stage location. The data will be uploaded as one file. No
+   * splitting is done in this method.
    *
-   * @param stageName    stage name: e.g. ~ or table name or stage name
-   * @param destPrefix   path prefix under which the data should be uploaded on the stage
-   * @param inputStream  input stream from which the data will be uploaded
+   * <p>Stream size must match the total size of data in the input stream unless compressData
+   * parameter is set to true.
+   *
+   * <p>caller is responsible for passing the correct size for the data in the stream and releasing
+   * the inputStream after the method is called.
+   *
+   * @param stageName stage name: e.g. ~ or table name or stage name
+   * @param destPrefix path prefix under which the data should be uploaded on the stage
+   * @param inputStream input stream from which the data will be uploaded
    * @param destFileName destination file name to use
    * @param compressData whether compression is requested fore uploading data
    * @throws SQLException raises if any error occurs
    */
-  private void uploadStreamInternal(String stageName,
-                                    String destPrefix,
-                                    InputStream inputStream,
-                                    String destFileName,
-                                    boolean compressData)
-  throws SQLException
-  {
-    logger.debug("upload data from stream: stageName={}" +
-                 ", destPrefix={}, destFileName={}",
-                 stageName, destPrefix, destFileName);
+  private void uploadStreamInternal(
+      String stageName,
+      String destPrefix,
+      InputStream inputStream,
+      String destFileName,
+      boolean compressData)
+      throws SQLException {
+    logger.debug(
+        "upload data from stream: stageName={}" + ", destPrefix={}, destFileName={}",
+        stageName,
+        destPrefix,
+        destFileName);
 
-    if (stageName == null)
-    {
+    if (stageName == null) {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          sfSession,
           "stage name is null");
     }
 
-    if (destFileName == null)
-    {
+    if (destFileName == null) {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          sfSession,
           "stage name is null");
     }
 
@@ -1118,17 +942,14 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
     putCommand.append("put file:///tmp/placeholder ");
 
     // add stage name
-    if (!(stageName.startsWith("@") || stageName.startsWith("'@") || stageName.startsWith("$$@")))
-    {
+    if (!(stageName.startsWith("@") || stageName.startsWith("'@") || stageName.startsWith("$$@"))) {
       putCommand.append("@");
     }
     putCommand.append(stageName);
 
     // add dest prefix
-    if (destPrefix != null)
-    {
-      if (!destPrefix.startsWith("/"))
-      {
+    if (destPrefix != null) {
+      if (!destPrefix.startsWith("/")) {
         putCommand.append("/");
       }
       putCommand.append(destPrefix);
@@ -1137,8 +958,8 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
     putCommand.append(" overwrite=true");
 
     SnowflakeFileTransferAgent transferAgent;
-    transferAgent = new SnowflakeFileTransferAgent(putCommand.toString(),
-                                                   sfSession, stmt.getSfStatement());
+    transferAgent =
+        new SnowflakeFileTransferAgent(putCommand.toString(), sfSession, stmt.getSfStatement());
 
     transferAgent.setSourceStream(inputStream);
     transferAgent.setDestFileNameForStreamSource(destFileName);
@@ -1151,48 +972,46 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
   /**
    * Download file from the given stage and return an input stream
    *
-   * @param stageName      stage name
+   * @param stageName stage name
    * @param sourceFileName file path in stage
-   * @param decompress     true if file compressed
+   * @param decompress true if file compressed
    * @return an input stream
    * @throws SnowflakeSQLException if any SQL error occurs.
    */
-  public InputStream downloadStream(String stageName, String sourceFileName,
-                                    boolean decompress) throws SQLException
+  public InputStream downloadStream(String stageName, String sourceFileName, boolean decompress)
+      throws SQLException {
 
-  {
-    logger.debug("download data to stream: stageName={}" +
-                 ", sourceFileName={}",
-                 stageName, sourceFileName);
+    logger.debug(
+        "download data to stream: stageName={}" + ", sourceFileName={}", stageName, sourceFileName);
 
-    if (Strings.isNullOrEmpty(stageName))
-    {
+    if (Strings.isNullOrEmpty(stageName)) {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          sfSession,
           "stage name is null or empty");
     }
 
-    if (Strings.isNullOrEmpty(sourceFileName))
-    {
+    if (Strings.isNullOrEmpty(sourceFileName)) {
       throw new SnowflakeSQLLoggedException(
           SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          sfSession,
           "source file name is null or empty");
     }
 
-    SnowflakeStatementV1 stmt = new SnowflakeStatementV1(
-        this,
-        ResultSet.TYPE_FORWARD_ONLY,
-        ResultSet.CONCUR_READ_ONLY,
-        ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    SnowflakeStatementV1 stmt =
+        new SnowflakeStatementV1(
+            this,
+            ResultSet.TYPE_FORWARD_ONLY,
+            ResultSet.CONCUR_READ_ONLY,
+            ResultSet.CLOSE_CURSORS_AT_COMMIT);
 
     StringBuilder getCommand = new StringBuilder();
 
     getCommand.append("get ");
 
-    if (!stageName.startsWith("@"))
-    {
+    if (!stageName.startsWith("@")) {
       getCommand.append("@");
     }
 
@@ -1200,111 +1019,85 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection
 
     getCommand.append("/");
 
-    if (sourceFileName.startsWith("/"))
-    {
+    if (sourceFileName.startsWith("/")) {
       sourceFileName = sourceFileName.substring(1);
     }
 
     getCommand.append(sourceFileName);
 
-    //this is a fake path, used to form Get query and retrieve stage info,
-    //no file will be downloaded to this location
+    // this is a fake path, used to form Get query and retrieve stage info,
+    // no file will be downloaded to this location
     getCommand.append(" file:///tmp/ /*jdbc download stream*/");
 
-
     SnowflakeFileTransferAgent transferAgent =
-        new SnowflakeFileTransferAgent(getCommand.toString(), sfSession,
-                                       stmt.getSfStatement());
+        new SnowflakeFileTransferAgent(getCommand.toString(), sfSession, stmt.getSfStatement());
 
     InputStream stream = transferAgent.downloadStream(sourceFileName);
 
-    if (decompress)
-    {
-      try
-      {
+    if (decompress) {
+      try {
         return new GZIPInputStream(stream);
-      }
-      catch (IOException ex)
-      {
+      } catch (IOException ex) {
         throw new SnowflakeSQLLoggedException(
             SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(), sfSession,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            sfSession,
             ex.getMessage());
       }
-    }
-    else
-    {
+    } else {
       return stream;
     }
   }
 
-  public void setInjectedDelay(int delay) throws SQLException
-  {
+  public void setInjectedDelay(int delay) throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
     sfSession.setInjectedDelay(delay);
   }
 
-  void injectedDelay() throws SQLException
-  {
+  void injectedDelay() throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
 
     int d = _injectedDelay.get();
 
-    if (d != 0)
-    {
+    if (d != 0) {
       _injectedDelay.set(0);
-      try
-      {
+      try {
         logger.trace("delayed for {}", d);
 
         Thread.sleep(d);
-      }
-      catch (InterruptedException ex)
-      {
+      } catch (InterruptedException ex) {
       }
     }
   }
 
-  public void setInjectFileUploadFailure(String fileToFail) throws SQLException
-  {
+  public void setInjectFileUploadFailure(String fileToFail) throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
     sfSession.setInjectFileUploadFailure(fileToFail);
   }
 
-  public SFSession getSfSession()
-  {
+  public SFSession getSfSession() {
     return sfSession;
   }
 
-  private void appendWarning(SQLWarning w)
-  {
-    if (sqlWarnings == null)
-    {
+  private void appendWarning(SQLWarning w) {
+    if (sqlWarnings == null) {
       sqlWarnings = w;
-    }
-    else
-    {
+    } else {
       sqlWarnings.setNextWarning(w);
     }
   }
 
-  private void appendWarnings(List<SFException> warnings)
-  {
-    for (SFException e : warnings)
-    {
-      appendWarning(new SQLWarning(e.getMessage(),
-                                   e.getSqlState(),
-                                   e.getVendorCode()));
+  private void appendWarnings(List<SFException> warnings) {
+    for (SFException e : warnings) {
+      appendWarning(new SQLWarning(e.getMessage(), e.getSqlState(), e.getVendorCode()));
     }
   }
 
-  public boolean getShowStatementParameters()
-  {
+  public boolean getShowStatementParameters() {
     return showStatementParameters;
   }
 
-  void removeClosedStatement(Statement stmt)
-  {
+  void removeClosedStatement(Statement stmt) {
     openStatements.remove(stmt);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,6 +14,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
 import net.snowflake.client.core.*;
 import net.snowflake.client.jdbc.cloud.storage.*;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
@@ -29,46 +43,27 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.DigestOutputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.GZIPOutputStream;
-
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 /**
  * Class for uploading/downloading files
  *
  * @author jhuang
  */
-public class SnowflakeFileTransferAgent implements SnowflakeFixedView
-{
-  final static SFLogger logger =
-      SFLoggerFactory.getLogger(SnowflakeFileTransferAgent.class);
+public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeFileTransferAgent.class);
 
-  final static StorageClientFactory storageFactory = StorageClientFactory.getFactory();
+  static final StorageClientFactory storageFactory = StorageClientFactory.getFactory();
 
-  private static final ObjectMapper mapper =
-      ObjectMapperFactory.getObjectMapper();
+  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
 
   // We will allow buffering of upto 128M data before spilling to disk during
   // compression and digest computation
-  final static int MAX_BUFFER_SIZE = 1 << 27;
+  static final int MAX_BUFFER_SIZE = 1 << 27;
   public static final String SRC_FILE_NAME_FOR_STREAM = "stream";
 
   private static final String FILE_PROTOCOL = "file://";
 
-  static private String localFSFileSep = systemGetProperty("file.separator");
-  static private int DEFAULT_PARALLEL = 10;
+  private static String localFSFileSep = systemGetProperty("file.separator");
+  private static int DEFAULT_PARALLEL = 10;
 
   private String command;
 
@@ -84,7 +79,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
   // with 4 threads by default
   private Set<String> smallSourceFiles;
 
-  static final private int BIG_FILE_THRESHOLD = 64 * 1024 * 1024;
+  private static final int BIG_FILE_THRESHOLD = 64 * 1024 * 1024;
 
   private Map<String, FileMetadata> fileMetadataMap;
 
@@ -108,8 +103,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
   private String destFileNameForStreamSource;
 
-  public StageInfo getStageInfo()
-  {
+  public StageInfo getStageInfo() {
     return this.stageInfo;
   }
 
@@ -125,78 +119,63 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
   // Index: Source file to presigned URL
   HashMap<String, String> srcFileToPresignedUrl;
 
-  public Map<?, ?> getStageCredentials()
-  {
+  public Map<?, ?> getStageCredentials() {
     return new HashMap<>(stageInfo.getCredentials());
   }
 
-  public List<RemoteStoreFileEncryptionMaterial> getEncryptionMaterial()
-  {
+  public List<RemoteStoreFileEncryptionMaterial> getEncryptionMaterial() {
     return new ArrayList<>(encryptionMaterial);
   }
 
-  public Map<String, RemoteStoreFileEncryptionMaterial> getSrcToMaterialsMap()
-  {
+  public Map<String, RemoteStoreFileEncryptionMaterial> getSrcToMaterialsMap() {
     return new HashMap<>(srcFileToEncMat);
   }
 
-  public Map<String, String> getSrcToPresignedUrlMap()
-  {
+  public Map<String, String> getSrcToPresignedUrlMap() {
     return new HashMap<>(srcFileToPresignedUrl);
   }
 
-  public String getStageLocation()
-  {
+  public String getStageLocation() {
     return stageInfo.getLocation();
   }
 
   private void initEncryptionMaterial(CommandType commandType, JsonNode jsonNode)
-  throws SnowflakeSQLException, JsonProcessingException
-  {
+      throws SnowflakeSQLException, JsonProcessingException {
     encryptionMaterial = new ArrayList<>();
     JsonNode rootNode = jsonNode.path("data").path("encryptionMaterial");
-    if (commandType == CommandType.UPLOAD)
-    {
+    if (commandType == CommandType.UPLOAD) {
       logger.debug("initEncryptionMaterial: UPLOAD");
 
       RemoteStoreFileEncryptionMaterial encMat = null;
-      if (!rootNode.isMissingNode() && !rootNode.isNull())
-      {
+      if (!rootNode.isMissingNode() && !rootNode.isNull()) {
         encMat = mapper.treeToValue(rootNode, RemoteStoreFileEncryptionMaterial.class);
       }
       encryptionMaterial.add(encMat);
 
-    }
-    else
-    {
+    } else {
       logger.debug("initEncryptionMaterial: DOWNLOAD");
 
-      if (!rootNode.isMissingNode() && !rootNode.isNull())
-      {
-        encryptionMaterial = Arrays.asList(
-            mapper.treeToValue(rootNode, RemoteStoreFileEncryptionMaterial[].class));
+      if (!rootNode.isMissingNode() && !rootNode.isNull()) {
+        encryptionMaterial =
+            Arrays.asList(mapper.treeToValue(rootNode, RemoteStoreFileEncryptionMaterial[].class));
       }
     }
   }
 
   private void initPresignedUrls(CommandType commandType, JsonNode jsonNode)
-  throws SnowflakeSQLException, JsonProcessingException, IOException
-  {
+      throws SnowflakeSQLException, JsonProcessingException, IOException {
     presignedUrls = new ArrayList<>();
     JsonNode rootNode = jsonNode.path("data").path("presignedUrls");
-    if (commandType == CommandType.DOWNLOAD)
-    {
+    if (commandType == CommandType.DOWNLOAD) {
       logger.debug("initEncryptionMaterial: DOWNLOAD");
 
-      if (!rootNode.isMissingNode() && !rootNode.isNull())
-      {
+      if (!rootNode.isMissingNode() && !rootNode.isNull()) {
         presignedUrls = Arrays.asList(mapper.readValue(rootNode.toString(), String[].class));
       }
     }
   }
 
-  public enum CommandType
-  {
+  public enum CommandType {
     UPLOAD,
     DOWNLOAD
   }
@@ -219,11 +198,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
   private ExecutorService threadExecutor = null;
   private Boolean canceled = false;
 
-  /**
-   * Result status enum
-   */
-  public enum ResultStatus
-  {
+  /** Result status enum */
+  public enum ResultStatus {
     UNKNOWN("Unknown status"),
     UPLOADED("File uploaded"),
     UNSUPPORTED("File type not supported"),
@@ -236,39 +212,28 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
     private String desc;
 
-    public String getDesc()
-    {
+    public String getDesc() {
       return desc;
     }
 
-    private ResultStatus(String desc)
-    {
+    private ResultStatus(String desc) {
       this.desc = desc;
     }
   }
 
-  /**
-   * Remote object location
-   * location: "bucket" for S3, "container" for Azure BLOB
-   */
-  private static class remoteLocation
-  {
+  /** Remote object location location: "bucket" for S3, "container" for Azure BLOB */
+  private static class remoteLocation {
     String location;
     String path;
 
-    public remoteLocation(String remoteStorageLocation, String remotePath)
-    {
+    public remoteLocation(String remoteStorageLocation, String remotePath) {
       location = remoteStorageLocation;
       path = remotePath;
     }
   }
 
-  /**
-   * A class for encapsulating the columns to return for the upload command
-   */
-  public enum UploadColumns
-  {
-
+  /** A class for encapsulating the columns to return for the upload command */
+  public enum UploadColumns {
     source,
     target,
     source_size,
@@ -278,13 +243,9 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     status,
     encryption,
     message
+  };
 
-  }
-
-  ;
-
-  public class UploadCommandFacade
-  {
+  public class UploadCommandFacade {
 
     @FixedViewColumn(name = "source", ordinal = 10)
     private String srcFile;
@@ -310,13 +271,15 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     @FixedViewColumn(name = "message", ordinal = 80)
     private String errorDetails;
 
-    public UploadCommandFacade(String srcFile, String destFile,
-                               String resultStatus,
-                               String errorDetails,
-                               long srcSize, long destSize,
-                               String srcCompressionType,
-                               String destCompressionType)
-    {
+    public UploadCommandFacade(
+        String srcFile,
+        String destFile,
+        String resultStatus,
+        String errorDetails,
+        long srcSize,
+        long destSize,
+        String srcCompressionType,
+        String destCompressionType) {
       this.srcFile = srcFile;
       this.destFile = destFile;
       this.resultStatus = resultStatus;
@@ -328,30 +291,35 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     }
   }
 
-  public class UploadCommandEncryptionFacade extends UploadCommandFacade
-  {
+  public class UploadCommandEncryptionFacade extends UploadCommandFacade {
     @FixedViewColumn(name = "encryption", ordinal = 75)
     private String encryption;
 
-    public UploadCommandEncryptionFacade(String srcFile, String destFile,
-                                         String resultStatus,
-                                         String errorDetails,
-                                         long srcSize, long destSize,
-                                         String srcCompressionType,
-                                         String destCompressionType,
-                                         boolean isEncrypted)
-    {
-      super(srcFile, destFile, resultStatus, errorDetails, srcSize, destSize,
-            srcCompressionType, destCompressionType);
+    public UploadCommandEncryptionFacade(
+        String srcFile,
+        String destFile,
+        String resultStatus,
+        String errorDetails,
+        long srcSize,
+        long destSize,
+        String srcCompressionType,
+        String destCompressionType,
+        boolean isEncrypted) {
+      super(
+          srcFile,
+          destFile,
+          resultStatus,
+          errorDetails,
+          srcSize,
+          destSize,
+          srcCompressionType,
+          destCompressionType);
       this.encryption = isEncrypted ? "ENCRYPTED" : "";
     }
   }
 
-  /**
-   * A class for encapsulating the columns to return for the download command
-   */
-  public class DownloadCommandFacade
-  {
+  /** A class for encapsulating the columns to return for the download command */
+  public class DownloadCommandFacade {
     @FixedViewColumn(name = "file", ordinal = 10)
     private String file;
 
@@ -364,11 +332,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     @FixedViewColumn(name = "message", ordinal = 40)
     private String errorDetails;
 
-    public DownloadCommandFacade(String file,
-                                 String resultStatus,
-                                 String errorDetails,
-                                 long size)
-    {
+    public DownloadCommandFacade(String file, String resultStatus, String errorDetails, long size) {
       this.file = file;
       this.resultStatus = resultStatus;
       this.errorDetails = errorDetails;
@@ -376,28 +340,22 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     }
   }
 
-  public class DownloadCommandEncryptionFacade extends DownloadCommandFacade
-  {
+  public class DownloadCommandEncryptionFacade extends DownloadCommandFacade {
     @FixedViewColumn(name = "encryption", ordinal = 35)
     private String encryption;
 
-    public DownloadCommandEncryptionFacade(String file,
-                                           String resultStatus,
-                                           String errorDetails,
-                                           long size,
-                                           boolean isEncrypted)
-    {
+    public DownloadCommandEncryptionFacade(
+        String file, String resultStatus, String errorDetails, long size, boolean isEncrypted) {
       super(file, resultStatus, errorDetails, size);
       this.encryption = isEncrypted ? "DECRYPTED" : "";
     }
   }
 
   /**
-   * File metadata with everything we care so we don't need to repeat
-   * same processing to get these info.
+   * File metadata with everything we care so we don't need to repeat same processing to get these
+   * info.
    */
-  private class FileMetadata
-  {
+  private class FileMetadata {
     public String srcFileName;
     public long srcFileSize;
     public String destFileName;
@@ -410,8 +368,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     public boolean isEncrypted = false;
   }
 
-  static class InputStreamWithMetadata
-  {
+  static class InputStreamWithMetadata {
     long size;
     String digest;
 
@@ -419,9 +376,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     // the input stream has been consumed entirely
     FileBackedOutputStream fileBackedOutputStream;
 
-    InputStreamWithMetadata(long size, String digest,
-                            FileBackedOutputStream fileBackedOutputStream)
-    {
+    InputStreamWithMetadata(
+        long size, String digest, FileBackedOutputStream fileBackedOutputStream) {
       this.size = size;
       this.digest = digest;
       this.fileBackedOutputStream = fileBackedOutputStream;
@@ -429,28 +385,23 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
   }
 
   /**
-   * Compress an input stream with GZIP and return the result size, digest and
-   * compressed stream.
+   * Compress an input stream with GZIP and return the result size, digest and compressed stream.
    *
    * @param inputStream data input
-   * @param session     the session
+   * @param session the session
    * @return result size, digest and compressed stream
    * @throws SnowflakeSQLException if encountered exception when compressing
    */
   private static InputStreamWithMetadata compressStreamWithGZIP(
-      InputStream inputStream, SFSession session) throws SnowflakeSQLException
-  {
-    FileBackedOutputStream tempStream =
-        new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+      InputStream inputStream, SFSession session) throws SnowflakeSQLException {
+    FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
 
-    try
-    {
+    try {
 
-      DigestOutputStream digestStream = new DigestOutputStream(tempStream,
-                                                               MessageDigest.getInstance("SHA-256"));
+      DigestOutputStream digestStream =
+          new DigestOutputStream(tempStream, MessageDigest.getInstance("SHA-256"));
 
-      CountingOutputStream countingStream =
-          new CountingOutputStream(digestStream);
+      CountingOutputStream countingStream = new CountingOutputStream(digestStream);
 
       // construct a gzip stream with sync_flush mode
       GZIPOutputStream gzipStream;
@@ -466,43 +417,38 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
       countingStream.flush();
 
-      return new InputStreamWithMetadata(countingStream.getCount(),
-                                         Base64.encodeAsString(digestStream.getMessageDigest().digest()),
-                                         tempStream);
+      return new InputStreamWithMetadata(
+          countingStream.getCount(),
+          Base64.encodeAsString(digestStream.getMessageDigest().digest()),
+          tempStream);
 
-    }
-    catch (IOException | NoSuchAlgorithmException ex)
-    {
+    } catch (IOException | NoSuchAlgorithmException ex) {
       logger.error("Exception compressing input stream", ex);
 
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "error encountered for compression");
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "error encountered for compression");
     }
-
   }
 
   /**
-   * Compress an input stream with GZIP and return the result size, digest and
-   * compressed stream.
+   * Compress an input stream with GZIP and return the result size, digest and compressed stream.
    *
    * @param inputStream The input stream to compress
    * @return the compressed stream
-   * @throws SnowflakeSQLException Will be thrown if there is a problem with
-   *                               compression
+   * @throws SnowflakeSQLException Will be thrown if there is a problem with compression
    * @deprecated Can be removed when all accounts are encrypted
    */
   @Deprecated
   private static InputStreamWithMetadata compressStreamWithGZIPNoDigest(
-      InputStream inputStream, SFSession session) throws SnowflakeSQLException
-  {
-    try
-    {
-      FileBackedOutputStream tempStream =
-          new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+      InputStream inputStream, SFSession session) throws SnowflakeSQLException {
+    try {
+      FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
 
-      CountingOutputStream countingStream =
-          new CountingOutputStream(tempStream);
+      CountingOutputStream countingStream = new CountingOutputStream(tempStream);
 
       // construct a gzip stream with sync_flush mode
       GZIPOutputStream gzipStream;
@@ -518,73 +464,65 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
       countingStream.flush();
 
-      return new InputStreamWithMetadata(countingStream.getCount(),
-                                         null, tempStream);
+      return new InputStreamWithMetadata(countingStream.getCount(), null, tempStream);
 
-    }
-    catch (IOException ex)
-    {
+    } catch (IOException ex) {
       logger.error("Exception compressing input stream", ex);
 
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "error encountered for compression");
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "error encountered for compression");
     }
-
   }
 
-  private static InputStreamWithMetadata computeDigest(InputStream is,
-                                                       boolean resetStream)
-  throws NoSuchAlgorithmException, IOException
-  {
+  private static InputStreamWithMetadata computeDigest(InputStream is, boolean resetStream)
+      throws NoSuchAlgorithmException, IOException {
     MessageDigest md = MessageDigest.getInstance("SHA-256");
-    if (resetStream)
-    {
-      FileBackedOutputStream tempStream =
-          new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+    if (resetStream) {
+      FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
 
-      CountingOutputStream countingOutputStream =
-          new CountingOutputStream(tempStream);
+      CountingOutputStream countingOutputStream = new CountingOutputStream(tempStream);
 
       DigestOutputStream digestStream = new DigestOutputStream(countingOutputStream, md);
 
       IOUtils.copy(is, digestStream);
 
-      return new InputStreamWithMetadata(countingOutputStream.getCount(),
-                                         Base64.encodeAsString(digestStream.getMessageDigest().digest()),
-                                         tempStream);
-    }
-    else
-    {
+      return new InputStreamWithMetadata(
+          countingOutputStream.getCount(),
+          Base64.encodeAsString(digestStream.getMessageDigest().digest()),
+          tempStream);
+    } else {
       CountingOutputStream countingOutputStream =
           new CountingOutputStream(ByteStreams.nullOutputStream());
 
-      DigestOutputStream digestStream = new DigestOutputStream(
-          countingOutputStream,
-          md);
+      DigestOutputStream digestStream = new DigestOutputStream(countingOutputStream, md);
       IOUtils.copy(is, digestStream);
-      return new InputStreamWithMetadata(countingOutputStream.getCount(),
-                                         Base64.encodeAsString(digestStream.getMessageDigest().digest()), null);
+      return new InputStreamWithMetadata(
+          countingOutputStream.getCount(),
+          Base64.encodeAsString(digestStream.getMessageDigest().digest()),
+          null);
     }
   }
 
   /**
    * A callable that can be executed in a separate thread using exeuctor service.
-   * <p>
-   * The callable does compression if needed and upload the result to the
-   * table's staging area.
    *
-   * @param stage            information about the stage
-   * @param srcFilePath      source file path
-   * @param metadata         file metadata
-   * @param client           client object used to communicate with c3
-   * @param session          session object
-   * @param command          command string
-   * @param inputStream      null if upload source is file
+   * <p>The callable does compression if needed and upload the result to the table's staging area.
+   *
+   * @param stage information about the stage
+   * @param srcFilePath source file path
+   * @param metadata file metadata
+   * @param client client object used to communicate with c3
+   * @param session session object
+   * @param command command string
+   * @param inputStream null if upload source is file
    * @param sourceFromStream whether upload source is file or stream
-   * @param parallel         number of threads for parallel uploading
-   * @param srcFile          source file name
-   * @param encMat           not null if encryption is required
+   * @param parallel number of threads for parallel uploading
+   * @param srcFile source file name
+   * @param encMat not null if encryption is required
    * @return a callable that uploading file to the remote store
    */
   public static Callable<Void> getUploadFileCallable(
@@ -598,12 +536,9 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       final boolean sourceFromStream,
       final int parallel,
       final File srcFile,
-      final RemoteStoreFileEncryptionMaterial encMat)
-  {
-    return new Callable<Void>()
-    {
-      public Void call() throws Exception
-      {
+      final RemoteStoreFileEncryptionMaterial encMat) {
+    return new Callable<Void>() {
+      public Void call() throws Exception {
 
         logger.debug("Entering getUploadFileCallable...");
 
@@ -614,14 +549,10 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
         File fileToUpload = null;
 
-        if (uploadStream == null)
-        {
-          try
-          {
+        if (uploadStream == null) {
+          try {
             uploadStream = new FileInputStream(srcFilePath);
-          }
-          catch (FileNotFoundException ex)
-          {
+          } catch (FileNotFoundException ex) {
             metadata.resultStatus = ResultStatus.ERROR;
             metadata.errorDetails = ex.getMessage();
             throw ex;
@@ -629,11 +560,12 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         }
 
         // this shouldn't happen
-        if (metadata == null)
-        {
-          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "missing file metadata for: " + srcFilePath);
+        if (metadata == null) {
+          throw new SnowflakeSQLLoggedException(
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "missing file metadata for: " + srcFilePath);
         }
 
         String destFileName = metadata.destFileName;
@@ -649,52 +581,40 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
         // SNOW-16082: we should catpure exception if we fail to compress or
         // calcuate digest.
-        try
-        {
-          if (metadata.requireCompress)
-          {
-            InputStreamWithMetadata compressedSizeAndStream = (encMat == null ?
-                                                               compressStreamWithGZIPNoDigest(uploadStream, session) :
-                                                               compressStreamWithGZIP(uploadStream, session));
+        try {
+          if (metadata.requireCompress) {
+            InputStreamWithMetadata compressedSizeAndStream =
+                (encMat == null
+                    ? compressStreamWithGZIPNoDigest(uploadStream, session)
+                    : compressStreamWithGZIP(uploadStream, session));
 
-            fileBackedOutputStream =
-                compressedSizeAndStream.fileBackedOutputStream;
+            fileBackedOutputStream = compressedSizeAndStream.fileBackedOutputStream;
 
             // update the size
             uploadSize = compressedSizeAndStream.size;
             digest = compressedSizeAndStream.digest;
 
-            if (compressedSizeAndStream.fileBackedOutputStream.getFile() != null)
-            {
-              fileToUpload =
-                  compressedSizeAndStream.fileBackedOutputStream.getFile();
+            if (compressedSizeAndStream.fileBackedOutputStream.getFile() != null) {
+              fileToUpload = compressedSizeAndStream.fileBackedOutputStream.getFile();
             }
 
             logger.debug("New size after compression: {}", uploadSize);
-          }
-          else if (stage.getStageType() != StageInfo.StageType.LOCAL_FS)
-          {
+          } else if (stage.getStageType() != StageInfo.StageType.LOCAL_FS) {
             // If it's not local_fs, we store our digest in the metadata
-            // In local_fs, we don't need digest, and if we turn it on, we will consume whole uploadStream, which local_fs uses.
-            InputStreamWithMetadata result = computeDigest(uploadStream,
-                                                           sourceFromStream);
+            // In local_fs, we don't need digest, and if we turn it on, we will consume whole
+            // uploadStream, which local_fs uses.
+            InputStreamWithMetadata result = computeDigest(uploadStream, sourceFromStream);
             digest = result.digest;
             fileBackedOutputStream = result.fileBackedOutputStream;
             uploadSize = result.size;
 
-            if (!sourceFromStream)
-            {
+            if (!sourceFromStream) {
               fileToUpload = srcFile;
-            }
-            else if (result.fileBackedOutputStream.getFile() != null)
-            {
+            } else if (result.fileBackedOutputStream.getFile() != null) {
               fileToUpload = result.fileBackedOutputStream.getFile();
             }
-          }
-          else
-          {
-            if (!sourceFromStream && (srcFile != null))
-            {
+          } else {
+            if (!sourceFromStream && (srcFile != null)) {
               fileToUpload = srcFile;
             }
 
@@ -704,77 +624,79 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
             uploadSize = sourceFromStream ? 0 : srcFile.length();
           }
 
-          logger.debug("Started copying file from: {} to {}:{} destName: {} " +
-                       "auto compressed? {} size={}", srcFilePath, stage.getStageType().name(), stage.getLocation(),
-                       destFileName, (metadata.requireCompress ? "yes" : "no"),
-                       uploadSize);
+          logger.debug(
+              "Started copying file from: {} to {}:{} destName: {} "
+                  + "auto compressed? {} size={}",
+              srcFilePath,
+              stage.getStageType().name(),
+              stage.getLocation(),
+              destFileName,
+              (metadata.requireCompress ? "yes" : "no"),
+              uploadSize);
 
           // Simulated failure code.
-          if (session.getInjectFileUploadFailure()
-              != null && srcFilePath.endsWith(
-              (session).getInjectFileUploadFailure()))
-          {
+          if (session.getInjectFileUploadFailure() != null
+              && srcFilePath.endsWith((session).getInjectFileUploadFailure())) {
             throw new SnowflakeSimulatedUploadFailure(
                 srcFile != null ? srcFile.getName() : "Unknown");
           }
 
           // upload it
-          switch (stage.getStageType())
-          {
+          switch (stage.getStageType()) {
             case LOCAL_FS:
-              pushFileToLocal(stage.getLocation(),
-                              srcFilePath, destFileName, uploadStream,
-                              fileBackedOutputStream, session);
+              pushFileToLocal(
+                  stage.getLocation(),
+                  srcFilePath,
+                  destFileName,
+                  uploadStream,
+                  fileBackedOutputStream,
+                  session);
               break;
 
             case S3:
             case AZURE:
             case GCS:
-              pushFileToRemoteStore(stage,
-                                    destFileName,
-                                    uploadStream, fileBackedOutputStream, uploadSize,
-                                    digest, metadata.destCompressionType,
-                                    client, session, command, parallel, fileToUpload,
-                                    (fileToUpload == null), encMat);
+              pushFileToRemoteStore(
+                  stage,
+                  destFileName,
+                  uploadStream,
+                  fileBackedOutputStream,
+                  uploadSize,
+                  digest,
+                  metadata.destCompressionType,
+                  client,
+                  session,
+                  command,
+                  parallel,
+                  fileToUpload,
+                  (fileToUpload == null),
+                  encMat);
               metadata.isEncrypted = encMat != null;
               break;
           }
-        }
-        catch (SnowflakeSimulatedUploadFailure ex)
-        {
+        } catch (SnowflakeSimulatedUploadFailure ex) {
           // This code path is used for Simulated failure code in tests.
           // Never happen in production
           metadata.resultStatus = ResultStatus.ERROR;
           metadata.errorDetails = ex.getMessage();
           throw ex;
-        }
-        catch (Throwable ex)
-        {
-          logger.error(
-              "Exception encountered during file upload", ex);
+        } catch (Throwable ex) {
+          logger.error("Exception encountered during file upload", ex);
           metadata.resultStatus = ResultStatus.ERROR;
           metadata.errorDetails = ex.getMessage();
           throw ex;
-        }
-        finally
-        {
-          if (fileBackedOutputStream != null)
-          {
-            try
-            {
+        } finally {
+          if (fileBackedOutputStream != null) {
+            try {
               fileBackedOutputStream.reset();
-            }
-            catch (IOException ex)
-            {
+            } catch (IOException ex) {
               logger.debug("failed to clean up temp file: {}", ex);
             }
           }
-          if (inputStream == null)
-          {
+          if (inputStream == null) {
             IOUtils.closeQuietly(uploadStream);
           }
         }
-
 
         logger.debug("filePath: {}", srcFilePath);
 
@@ -791,19 +713,19 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
   /**
    * A callable that can be executed in a separate thread using executor service.
-   * <p>
-   * The callable download files from a stage location to a local location
    *
-   * @param stage           stage information
-   * @param srcFilePath     path that stores the downloaded file
-   * @param localLocation   local location
+   * <p>The callable download files from a stage location to a local location
+   *
+   * @param stage stage information
+   * @param srcFilePath path that stores the downloaded file
+   * @param localLocation local location
    * @param fileMetadataMap file metadata map
-   * @param client          remote store client
-   * @param session         session object
-   * @param command         command string
-   * @param encMat          remote store encryption material
-   * @param parallel        number of parallel threads for downloading
-   * @param presignedUrl    Presigned URL for file download
+   * @param client remote store client
+   * @param session session object
+   * @param command command string
+   * @param encMat remote store encryption material
+   * @param parallel number of parallel threads for downloading
+   * @param presignedUrl Presigned URL for file download
    * @return a callable responsible for downloading files
    */
   public static Callable<Void> getDownloadFileCallable(
@@ -816,12 +738,9 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       final String command,
       final int parallel,
       final RemoteStoreFileEncryptionMaterial encMat,
-      final String presignedUrl)
-  {
-    return new Callable<Void>()
-    {
-      public Void call() throws Exception
-      {
+      final String presignedUrl) {
+    return new Callable<Void>() {
+      public Void call() throws Exception {
 
         logger.debug("Entering getDownloadFileCallable...");
 
@@ -831,49 +750,49 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         FileMetadata metadata = fileMetadataMap.get(srcFilePath);
 
         // this shouldn't happen
-        if (metadata == null)
-        {
-          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "missing file metadata for: " + srcFilePath);
+        if (metadata == null) {
+          throw new SnowflakeSQLLoggedException(
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "missing file metadata for: " + srcFilePath);
         }
 
         String destFileName = metadata.destFileName;
-        logger.debug("Started copying file from: {}:{} file path:{} to {} destName:{}",
-                     stage.getStageType().name(), stage.getLocation(), srcFilePath, localLocation, destFileName);
+        logger.debug(
+            "Started copying file from: {}:{} file path:{} to {} destName:{}",
+            stage.getStageType().name(),
+            stage.getLocation(),
+            srcFilePath,
+            localLocation,
+            destFileName);
 
-        try
-        {
-          switch (stage.getStageType())
-          {
+        try {
+          switch (stage.getStageType()) {
             case LOCAL_FS:
-              pullFileFromLocal(stage.getLocation(),
-                                srcFilePath,
-                                localLocation,
-                                destFileName, session);
+              pullFileFromLocal(
+                  stage.getLocation(), srcFilePath, localLocation, destFileName, session);
               break;
 
             case AZURE:
             case S3:
             case GCS:
-              pullFileFromRemoteStore(stage,
-                                      srcFilePath,
-                                      destFileName,
-                                      localLocation,
-                                      client,
-                                      session,
-                                      command,
-                                      parallel,
-                                      encMat,
-                                      presignedUrl);
+              pullFileFromRemoteStore(
+                  stage,
+                  srcFilePath,
+                  destFileName,
+                  localLocation,
+                  client,
+                  session,
+                  command,
+                  parallel,
+                  encMat,
+                  presignedUrl);
               metadata.isEncrypted = encMat != null;
               break;
           }
-        }
-        catch (Throwable ex)
-        {
-          logger.error(
-              "Exception encountered during file download", ex);
+        } catch (Throwable ex) {
+          logger.error("Exception encountered during file download", ex);
 
           metadata.resultStatus = ResultStatus.ERROR;
           metadata.errorDetails = ex.getMessage();
@@ -896,11 +815,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     };
   }
 
-  public SnowflakeFileTransferAgent(String command,
-                                    SFSession session,
-                                    SFStatement statement)
-  throws SnowflakeSQLException
-  {
+  public SnowflakeFileTransferAgent(String command, SFSession session, SFStatement statement)
+      throws SnowflakeSQLException {
     this.command = command;
     this.session = session;
     this.statement = statement;
@@ -911,26 +827,24 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
     parseCommand();
 
-    if (stageInfo.getStageType() != StageInfo.StageType.LOCAL_FS)
-    {
+    if (stageInfo.getStageType() != StageInfo.StageType.LOCAL_FS) {
       storageClient = storageFactory.createClient(stageInfo, parallel, null, session);
     }
   }
 
   /**
    * Parse the put/get command.
-   * <p>
-   * We send the command to the GS to do the parsing. In the future, we
-   * will delegate more work to GS such as copying files from HTTP to the remote store.
+   *
+   * <p>We send the command to the GS to do the parsing. In the future, we will delegate more work
+   * to GS such as copying files from HTTP to the remote store.
    *
    * @throws SnowflakeSQLException failure to parse the PUT/GET command
    */
-  private void parseCommand() throws SnowflakeSQLException
-  {
+  private void parseCommand() throws SnowflakeSQLException {
     // For AWS and Azure, this command returns enough info for us to get creds
     // we can use for each of the GETs/PUTs. For GCS, we need to issue a separate
     // call to GS to get creds (in the form of a presigned URL) for each file
-    // we're uploading or downloading. This call gets our src_location and 
+    // we're uploading or downloading. This call gets our src_location and
     // encryption material, which we'll use for all the subsequent calls to GS
     // for creds for each file. Those calls are made from pushFileToRemoteStore
     // and pullFileFromRemoteStore if the storage slient requires a presigned
@@ -938,10 +852,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     JsonNode jsonNode = parseCommandInGS(statement, command);
 
     // get command type
-    if (!jsonNode.path("data").path("command").isMissingNode())
-    {
-      commandType = CommandType.valueOf(
-          jsonNode.path("data").path("command").asText());
+    if (!jsonNode.path("data").path("command").isMissingNode()) {
+      commandType = CommandType.valueOf(jsonNode.path("data").path("command").asText());
     }
 
     // get source file locations as array (apply to both upload and download)
@@ -951,68 +863,53 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
     String[] src_locations;
 
-    try
-    {
+    try {
       src_locations = mapper.readValue(locationsNode.toString(), String[].class);
       initEncryptionMaterial(commandType, jsonNode);
       initPresignedUrls(commandType, jsonNode);
-    }
-    catch (Exception ex)
-    {
-      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                      "Failed to parse the locations due to: " + ex.getMessage());
+    } catch (Exception ex) {
+      throw new SnowflakeSQLException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Failed to parse the locations due to: " + ex.getMessage());
     }
 
-    showEncryptionParameter = jsonNode.path("data")
-        .path("clientShowEncryptionParameter")
-        .asBoolean();
+    showEncryptionParameter =
+        jsonNode.path("data").path("clientShowEncryptionParameter").asBoolean();
 
     String localFilePathFromGS = null;
 
     // do upload command specific parsing
-    if (commandType == CommandType.UPLOAD)
-    {
-      if (src_locations.length > 0)
-      {
+    if (commandType == CommandType.UPLOAD) {
+      if (src_locations.length > 0) {
         localFilePathFromGS = src_locations[0];
       }
 
       sourceFiles = expandFileNames(src_locations);
 
-      autoCompress =
-          jsonNode.path("data").path("autoCompress").asBoolean(true);
+      autoCompress = jsonNode.path("data").path("autoCompress").asBoolean(true);
 
-      if (!jsonNode.path("data").path("sourceCompression").isMissingNode())
-      {
-        sourceCompression =
-            jsonNode.path("data").path("sourceCompression").asText();
+      if (!jsonNode.path("data").path("sourceCompression").isMissingNode()) {
+        sourceCompression = jsonNode.path("data").path("sourceCompression").asText();
       }
 
-    }
-    else
-    {
+    } else {
       // do download command specific parsing
       srcFileToEncMat = new HashMap<>();
 
       // create mapping from source file to encryption materials
-      if (src_locations.length == encryptionMaterial.size())
-      {
-        for (int srcFileIdx = 0; srcFileIdx < src_locations.length; srcFileIdx++)
-        {
-          srcFileToEncMat.put(src_locations[srcFileIdx],
-                              encryptionMaterial.get(srcFileIdx));
+      if (src_locations.length == encryptionMaterial.size()) {
+        for (int srcFileIdx = 0; srcFileIdx < src_locations.length; srcFileIdx++) {
+          srcFileToEncMat.put(src_locations[srcFileIdx], encryptionMaterial.get(srcFileIdx));
         }
       }
 
       // create mapping from source file to presigned URLs
       srcFileToPresignedUrl = new HashMap<>();
-      if (src_locations.length == presignedUrls.size())
-      {
-        for (int srcFileIdx = 0; srcFileIdx < src_locations.length; srcFileIdx++)
-        {
-          srcFileToPresignedUrl.put(src_locations[srcFileIdx],
-                                    presignedUrls.get(srcFileIdx));
+      if (src_locations.length == presignedUrls.size()) {
+        for (int srcFileIdx = 0; srcFileIdx < src_locations.length; srcFileIdx++) {
+          srcFileToPresignedUrl.put(src_locations[srcFileIdx], presignedUrls.get(srcFileIdx));
         }
       }
 
@@ -1022,19 +919,18 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
       localFilePathFromGS = localLocation;
 
-      if (localLocation.startsWith("~"))
-      {
+      if (localLocation.startsWith("~")) {
         // replace ~ with user home
-        localLocation = systemGetProperty("user.home") +
-                        localLocation.substring(1);
+        localLocation = systemGetProperty("user.home") + localLocation.substring(1);
       }
 
       // it should not contain any ~ after the above replacement
-      if (localLocation.contains("~"))
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
-                                              ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), session,
-                                              localLocation);
+      if (localLocation.contains("~")) {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.IO_ERROR,
+            ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(),
+            session,
+            localLocation);
       }
 
       // todo: replace ~userid with the home directory of a given userid
@@ -1043,8 +939,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
       // user may also specify files relative to current directory
       // add the current path if that is the case
-      if (!(new File(localLocation)).isAbsolute())
-      {
+      if (!(new File(localLocation)).isAbsolute()) {
         String cwd = systemGetProperty("user.dir");
 
         logger.debug("Adding current working dir to relative file path.");
@@ -1053,10 +948,12 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       }
 
       // local location should be a directory
-      if ((new File(localLocation)).isFile())
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
-                                              ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), session, localLocation);
+      if ((new File(localLocation)).isFile()) {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.IO_ERROR,
+            ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(),
+            session,
+            localLocation);
       }
     }
 
@@ -1064,29 +961,25 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     verifyLocalFilePath(localFilePathFromGS);
 
     // more parameters common to upload/download
-    String stageLocation = jsonNode.path("data").path("stageInfo").
-        path("location").asText();
+    String stageLocation = jsonNode.path("data").path("stageInfo").path("location").asText();
 
     parallel = jsonNode.path("data").path("parallel").asInt();
 
     overwrite = jsonNode.path("data").path("overwrite").asBoolean(false);
 
-    String stageLocationType = jsonNode.path("data").path("stageInfo").
-        path("locationType").asText();
+    String stageLocationType =
+        jsonNode.path("data").path("stageInfo").path("locationType").asText();
 
     String stageRegion = null;
-    if (!jsonNode.path("data").path("stageInfo").path("region").isMissingNode())
-    {
-      stageRegion = jsonNode.path("data").path("stageInfo")
-          .path("region").asText();
+    if (!jsonNode.path("data").path("stageInfo").path("region").isMissingNode()) {
+      stageRegion = jsonNode.path("data").path("stageInfo").path("region").asText();
     }
 
-    // endPoint and storageAccount are only available in Azure stages. Value 
+    // endPoint and storageAccount are only available in Azure stages. Value
     // will be present but null in other platforms.
     String endPoint = null;
     String stgAcct = null;
-    if ("AZURE".equalsIgnoreCase(stageLocationType))
-    {
+    if ("AZURE".equalsIgnoreCase(stageLocationType)) {
       // Jackson is doing some very strange things trying to pull the value of
       // the storageAccount node after adding the GCP library dependencies.
       // If we try to pull the value by name, we get back null, but clearly the
@@ -1097,57 +990,47 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       // "sto", this should work fine.
       endPoint = jsonNode.path("data").path("stageInfo").findValue("endPoint").asText();
       Iterator<Entry<String, JsonNode>> fields = jsonNode.path("data").path("stageInfo").fields();
-      while (fields.hasNext())
-      {
+      while (fields.hasNext()) {
         Entry<String, JsonNode> jsonField = fields.next();
-        if (jsonField.getKey().startsWith("sto"))
-        {
-          stgAcct = jsonField.getValue()
-              .toString()
-              .trim()
-              .substring(1, jsonField.getValue().toString().trim().lastIndexOf("\""));
+        if (jsonField.getKey().startsWith("sto")) {
+          stgAcct =
+              jsonField
+                  .getValue()
+                  .toString()
+                  .trim()
+                  .substring(1, jsonField.getValue().toString().trim().lastIndexOf("\""));
         }
       }
     }
 
-    if ("LOCAL_FS".equalsIgnoreCase(stageLocationType))
-    {
-      if (stageLocation.startsWith("~"))
-      {
+    if ("LOCAL_FS".equalsIgnoreCase(stageLocationType)) {
+      if (stageLocation.startsWith("~")) {
         // replace ~ with user home
-        stageLocation = systemGetProperty("user.home") +
-                        stageLocation.substring(1);
+        stageLocation = systemGetProperty("user.home") + stageLocation.substring(1);
       }
 
-      if (!(new File(stageLocation)).isAbsolute())
-      {
+      if (!(new File(stageLocation)).isAbsolute()) {
         String cwd = systemGetProperty("user.dir");
 
         logger.debug("Adding current working dir to stage file path.");
 
         stageLocation = cwd + localFSFileSep + stageLocation;
       }
-
     }
 
-    if (logger.isDebugEnabled())
-    {
+    if (logger.isDebugEnabled()) {
       logger.debug("Command type: {}", commandType);
 
-      if (commandType == CommandType.UPLOAD)
-      {
+      if (commandType == CommandType.UPLOAD) {
         logger.debug("autoCompress: {}", autoCompress);
 
         logger.debug("source compression: {}", sourceCompression);
-      }
-      else
-      {
+      } else {
         logger.debug("local download location: {}", localLocation);
       }
 
       logger.debug("Source files:");
-      for (String srcFile : sourceFiles)
-      {
+      for (String srcFile : sourceFiles) {
         logger.debug("file: {}", srcFile);
       }
 
@@ -1168,19 +1051,16 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
     Map<?, ?> stageCredentials = extractStageCreds(jsonNode);
 
-    stageInfo = StageInfo.createStageInfo(stageLocationType, stageLocation,
-                                          stageCredentials, stageRegion, endPoint, stgAcct);
+    stageInfo =
+        StageInfo.createStageInfo(
+            stageLocationType, stageLocation, stageCredentials, stageRegion, endPoint, stgAcct);
 
     // Setup pre-signed URL into stage info if pre-signed URL is returned.
-    if (stageInfo.getStageType() == StageInfo.StageType.GCS)
-    {
-      JsonNode presignedUrlNode =
-          jsonNode.path("data").path("stageInfo").path("presignedUrl");
-      if (!presignedUrlNode.isMissingNode())
-      {
+    if (stageInfo.getStageType() == StageInfo.StageType.GCS) {
+      JsonNode presignedUrlNode = jsonNode.path("data").path("stageInfo").path("presignedUrl");
+      if (!presignedUrlNode.isMissingNode()) {
         String presignedUrl = presignedUrlNode.asText();
-        if (!Strings.isNullOrEmpty(presignedUrl))
-        {
+        if (!Strings.isNullOrEmpty(presignedUrl)) {
           stageInfo.setPresignedUrl(presignedUrl);
         }
       }
@@ -1188,110 +1068,86 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
   }
 
   /**
-   * A helper method to verify if the local file path from GS matches
-   * what's parsed locally. This is for security purpose as documented in
-   * SNOW-15153.
+   * A helper method to verify if the local file path from GS matches what's parsed locally. This is
+   * for security purpose as documented in SNOW-15153.
    *
    * @param localFilePathFromGS the local file path to verify
-   * @throws SnowflakeSQLException Will be thrown if the log path if empty or
-   *                               if it doesn't match what comes back from GS
+   * @throws SnowflakeSQLException Will be thrown if the log path if empty or if it doesn't match
+   *     what comes back from GS
    */
-  private void verifyLocalFilePath(String localFilePathFromGS)
-  throws SnowflakeSQLException
-  {
+  private void verifyLocalFilePath(String localFilePathFromGS) throws SnowflakeSQLException {
     String localFilePath = getLocalFilePathFromCommand(command, true);
 
-    if (!localFilePath.isEmpty() && !localFilePath.equals(localFilePathFromGS))
-    {
-      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "Unexpected local file path from GS. From GS: " +
-                                            localFilePathFromGS + ", expected: " + localFilePath);
-    }
-    else if (localFilePath.isEmpty())
-    {
-      logger.debug(
-          "fail to parse local file path from command: {}", command);
-    }
-    else
-    {
-      logger.trace(
-          "local file path from GS matches local parsing: {}", localFilePath);
+    if (!localFilePath.isEmpty() && !localFilePath.equals(localFilePathFromGS)) {
+      throw new SnowflakeSQLLoggedException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "Unexpected local file path from GS. From GS: "
+              + localFilePathFromGS
+              + ", expected: "
+              + localFilePath);
+    } else if (localFilePath.isEmpty()) {
+      logger.debug("fail to parse local file path from command: {}", command);
+    } else {
+      logger.trace("local file path from GS matches local parsing: {}", localFilePath);
     }
   }
 
   /**
-   * Parses out the local file path from the command. We need this to get the
-   * file paths to expand wildcards and make sure the paths GS returns are
-   * correct
+   * Parses out the local file path from the command. We need this to get the file paths to expand
+   * wildcards and make sure the paths GS returns are correct
    *
-   * @param command  The GET/PUT command we send to GS
+   * @param command The GET/PUT command we send to GS
    * @param unescape True to unescape backslashes coming from GS
    * @return Path to the local file
    */
-  private static String getLocalFilePathFromCommand(String command, boolean unescape)
-  {
-    if (command == null)
-    {
+  private static String getLocalFilePathFromCommand(String command, boolean unescape) {
+    if (command == null) {
       logger.error("null command");
       return null;
     }
 
-    if (command.indexOf(FILE_PROTOCOL) < 0)
-    {
-      logger.error(
-          "file:// prefix not found in command: {}", command);
+    if (command.indexOf(FILE_PROTOCOL) < 0) {
+      logger.error("file:// prefix not found in command: {}", command);
       return null;
     }
 
-    int localFilePathBeginIdx = command.indexOf(FILE_PROTOCOL) +
-                                FILE_PROTOCOL.length();
+    int localFilePathBeginIdx = command.indexOf(FILE_PROTOCOL) + FILE_PROTOCOL.length();
     boolean isLocalFilePathQuoted =
-        (localFilePathBeginIdx > FILE_PROTOCOL.length()) &&
-        (command.charAt(localFilePathBeginIdx - 1 - FILE_PROTOCOL.length()) == '\'');
+        (localFilePathBeginIdx > FILE_PROTOCOL.length())
+            && (command.charAt(localFilePathBeginIdx - 1 - FILE_PROTOCOL.length()) == '\'');
 
     // the ending index is exclusive
     int localFilePathEndIdx = 0;
     String localFilePath = "";
 
-    if (isLocalFilePathQuoted)
-    {
+    if (isLocalFilePathQuoted) {
       // look for the matching quote
       localFilePathEndIdx = command.indexOf("'", localFilePathBeginIdx);
-      if (localFilePathEndIdx > localFilePathBeginIdx)
-      {
-        localFilePath = command.substring(localFilePathBeginIdx,
-                                          localFilePathEndIdx);
+      if (localFilePathEndIdx > localFilePathBeginIdx) {
+        localFilePath = command.substring(localFilePathBeginIdx, localFilePathEndIdx);
       }
       // unescape backslashes to match the file name from GS
-      if (unescape)
-      {
+      if (unescape) {
         localFilePath = localFilePath.replaceAll("\\\\\\\\", "\\\\");
       }
-    }
-    else
-    {
+    } else {
       // look for the first space or new line or semi colon
       List<Integer> indexList = new ArrayList<>();
       char[] delimiterChars = {' ', '\n', ';'};
-      for (int i = 0; i < delimiterChars.length; i++)
-      {
+      for (int i = 0; i < delimiterChars.length; i++) {
         int charIndex = command.indexOf(delimiterChars[i], localFilePathBeginIdx);
-        if (charIndex != -1)
-        {
+        if (charIndex != -1) {
           indexList.add(charIndex);
         }
       }
 
       localFilePathEndIdx = indexList.isEmpty() ? -1 : Collections.min(indexList);
 
-      if (localFilePathEndIdx > localFilePathBeginIdx)
-      {
-        localFilePath = command.substring(localFilePathBeginIdx,
-                                          localFilePathEndIdx);
-      }
-      else if (localFilePathEndIdx == -1)
-      {
+      if (localFilePathEndIdx > localFilePathBeginIdx) {
+        localFilePath = command.substring(localFilePathBeginIdx, localFilePathEndIdx);
+      } else if (localFilePathEndIdx == -1) {
         localFilePath = command.substring(localFilePathBeginIdx);
       }
     }
@@ -1301,29 +1157,24 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
   /**
    * @return JSON doc containing the command options returned by GS
-   * @throws SnowflakeSQLException Will be thrown if parsing the command by
-   *                               GS fails
+   * @throws SnowflakeSQLException Will be thrown if parsing the command by GS fails
    */
-  private static JsonNode parseCommandInGS(SFStatement statement,
-                                           String command)
-  throws SnowflakeSQLException
-  {
+  private static JsonNode parseCommandInGS(SFStatement statement, String command)
+      throws SnowflakeSQLException {
     Object result = null;
     // send the command to GS
-    try
-    {
-      result = statement.executeHelper(command,
-                                       "application/json",
-                                       null, // bindValues
-                                       false, // describeOnly
-                                       false, // internal
-                                       false // async
-      );
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex, ex.getSqlState(),
-                                      ex.getVendorCode(), ex.getParams());
+    try {
+      result =
+          statement.executeHelper(
+              command,
+              "application/json",
+              null, // bindValues
+              false, // describeOnly
+              false, // internal
+              false // async
+              );
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(ex, ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
 
     JsonNode jsonNode = (JsonNode) result;
@@ -1335,31 +1186,26 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
   /**
    * @param rootNode JSON doc returned by GS
-   * @throws SnowflakeSQLException Will be thrown if we fail to parse the
-   *                               stage credentials
+   * @throws SnowflakeSQLException Will be thrown if we fail to parse the stage credentials
    */
-  private static Map<?, ?> extractStageCreds(JsonNode rootNode)
-  throws SnowflakeSQLException
-  {
+  private static Map<?, ?> extractStageCreds(JsonNode rootNode) throws SnowflakeSQLException {
     JsonNode credsNode = rootNode.path("data").path("stageInfo").path("creds");
     Map<?, ?> stageCredentials = null;
 
-    try
-    {
-      TypeReference<HashMap<String, String>> typeRef
-          = new TypeReference<HashMap<String, String>>()
-      {
-      };
+    try {
+      TypeReference<HashMap<String, String>> typeRef =
+          new TypeReference<HashMap<String, String>>() {};
       stageCredentials = mapper.readValue(credsNode.toString(), typeRef);
 
-    }
-    catch (Exception ex)
-    {
-      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                      "Failed to parse the credentials (" +
-                                      (credsNode != null ? credsNode.toString() : "null") +
-                                      ") due to exception: " + ex.getMessage());
+    } catch (Exception ex) {
+      throw new SnowflakeSQLException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Failed to parse the credentials ("
+              + (credsNode != null ? credsNode.toString() : "null")
+              + ") due to exception: "
+              + ex.getMessage());
     }
 
     return stageCredentials;
@@ -1367,51 +1213,49 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
   /**
    * This is API function to retrieve the File Transfer Metadatas.
-   * <p>
-   * NOTE: It only supports PUT on GCP when it is created.
+   *
+   * <p>NOTE: It only supports PUT on GCP when it is created.
    *
    * @return The file transfer metadatas for to-be-transferred files.
    * @throws SnowflakeSQLException if any error occurs
    */
   public List<SnowflakeFileTransferMetadata> getFileTransferMetadatas()
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     List<SnowflakeFileTransferMetadata> result = new ArrayList<>();
-    if (stageInfo.getStageType() != StageInfo.StageType.GCS)
-    {
-      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "This API only supports GCS");
+    if (stageInfo.getStageType() != StageInfo.StageType.GCS) {
+      throw new SnowflakeSQLLoggedException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "This API only supports GCS");
     }
 
-    if (commandType != CommandType.UPLOAD)
-    {
-      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "This API only supports PUT command");
+    if (commandType != CommandType.UPLOAD) {
+      throw new SnowflakeSQLLoggedException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "This API only supports PUT command");
     }
 
-    for (String sourceFilePath : sourceFiles)
-    {
-      String sourceFileName =
-          sourceFilePath.substring(sourceFilePath.lastIndexOf("/") + 1);
-      result.add(new SnowflakeFileTransferMetadataV1(
-          stageInfo.getPresignedUrl(),
-          sourceFileName,
-          encryptionMaterial.get(0).getQueryStageMasterKey(),
-          encryptionMaterial.get(0).getQueryId(),
-          encryptionMaterial.get(0).getSmkId(),
-          commandType,
-          stageInfo));
+    for (String sourceFilePath : sourceFiles) {
+      String sourceFileName = sourceFilePath.substring(sourceFilePath.lastIndexOf("/") + 1);
+      result.add(
+          new SnowflakeFileTransferMetadataV1(
+              stageInfo.getPresignedUrl(),
+              sourceFileName,
+              encryptionMaterial.get(0).getQueryStageMasterKey(),
+              encryptionMaterial.get(0).getQueryId(),
+              encryptionMaterial.get(0).getSmkId(),
+              commandType,
+              stageInfo));
     }
 
     return result;
   }
 
-  public boolean execute() throws SQLException
-  {
-    try
-    {
+  public boolean execute() throws SQLException {
+    try {
       logger.debug("Start init metadata");
 
       // initialize file metadata map
@@ -1420,25 +1264,21 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       logger.debug("Start checking file types");
 
       // check file compression type
-      if (commandType == CommandType.UPLOAD)
-      {
+      if (commandType == CommandType.UPLOAD) {
         processFileCompressionTypes();
       }
 
       // Filter out files that are already existing in the destination.
       // GCS doesn't have permission to list in the presigned url, so we'll
       // always overwrite.
-      if (!overwrite && stageInfo.getStageType() != StageInfo.StageType.GCS)
-      {
+      if (!overwrite && stageInfo.getStageType() != StageInfo.StageType.GCS) {
         logger.debug("Start filtering");
 
         filterExistingFiles();
       }
 
-      synchronized (canceled)
-      {
-        if (canceled)
-        {
+      synchronized (canceled) {
+        if (canceled) {
           logger.debug("File transfer canceled by user");
           threadExecutor = null;
           return false;
@@ -1446,45 +1286,34 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       }
 
       // create target directory for download command
-      if (commandType == CommandType.DOWNLOAD)
-      {
+      if (commandType == CommandType.DOWNLOAD) {
         File dir = new File(localLocation);
-        if (!dir.exists())
-        {
+        if (!dir.exists()) {
           boolean created = dir.mkdirs();
 
-          if (created)
-          {
+          if (created) {
             logger.debug("directory created: {}", localLocation);
-          }
-          else
-          {
+          } else {
             logger.debug("directory not created {}", localLocation);
           }
         }
 
         downloadFiles();
-      }
-      else if (sourceFromStream)
-      {
+      } else if (sourceFromStream) {
         uploadStream();
-      }
-      else
-      {
+      } else {
         // separate files to big files list and small files list
         // big files will be uploaded in serial, while small files will be
         // uploaded concurrently.
         segregateFilesBySize();
 
-        if (bigSourceFiles != null)
-        {
+        if (bigSourceFiles != null) {
           logger.debug("start uploading big files");
           uploadFiles(bigSourceFiles, 1);
           logger.debug("end uploading big files");
         }
 
-        if (smallSourceFiles != null)
-        {
+        if (smallSourceFiles != null) {
           logger.debug("start uploading small files");
           uploadFiles(smallSourceFiles, parallel);
           logger.debug("end uploading small files");
@@ -1495,36 +1324,28 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       populateStatusRows();
 
       return true;
-    }
-    finally
-    {
-      if (storageClient != null)
-      {
+    } finally {
+      if (storageClient != null) {
         storageClient.shutdown();
       }
     }
   }
 
-  /**
-   * Helper to upload data from a stream
-   */
-  private void uploadStream() throws SnowflakeSQLException
-  {
-    try
-    {
-      threadExecutor = SnowflakeUtil.createDefaultExecutorService(
-          "sf-stream-upload-worker-", 1);
+  /** Helper to upload data from a stream */
+  private void uploadStream() throws SnowflakeSQLException {
+    try {
+      threadExecutor = SnowflakeUtil.createDefaultExecutorService("sf-stream-upload-worker-", 1);
 
       RemoteStoreFileEncryptionMaterial encMat = encryptionMaterial.get(0);
-      if (commandType == CommandType.UPLOAD)
-      {
+      if (commandType == CommandType.UPLOAD) {
         threadExecutor.submit(
             getUploadFileCallable(
                 stageInfo,
                 SRC_FILE_NAME_FOR_STREAM,
                 fileMetadataMap.get(SRC_FILE_NAME_FOR_STREAM),
-                (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
-                null : storageFactory.createClient(stageInfo, parallel, encMat, session),
+                (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
+                    ? null
+                    : storageFactory.createClient(stageInfo, parallel, encMat, session),
                 session,
                 command,
                 sourceStream,
@@ -1532,129 +1353,115 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
                 parallel,
                 null,
                 encMat));
-      }
-      else if (commandType == CommandType.DOWNLOAD)
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session);
+      } else if (commandType == CommandType.DOWNLOAD) {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), session);
       }
 
       threadExecutor.shutdown();
 
-      try
-      {
+      try {
         // wait for all threads to complete without timeout
         threadExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-      }
-      catch (InterruptedException ex)
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
+      } catch (InterruptedException ex) {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
       logger.debug("Done with uploading from a stream");
-    }
-    finally
-    {
-      if (threadExecutor != null)
-      {
+    } finally {
+      if (threadExecutor != null) {
         threadExecutor.shutdownNow();
         threadExecutor = null;
       }
     }
   }
 
-  /**
-   * Download a file from remote, and return an input stream
-   */
-  InputStream downloadStream(String fileName) throws SnowflakeSQLException
-  {
-    if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
-    {
+  /** Download a file from remote, and return an input stream */
+  InputStream downloadStream(String fileName) throws SnowflakeSQLException {
+    if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) {
       logger.error("downloadStream function doesn't support local file system");
 
-      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                      "downloadStream function only supported in remote stages");
+      throw new SnowflakeSQLException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "downloadStream function only supported in remote stages");
     }
 
-    remoteLocation remoteLocation =
-        extractLocationAndPath(stageInfo.getLocation());
+    remoteLocation remoteLocation = extractLocationAndPath(stageInfo.getLocation());
 
     String stageFilePath = fileName;
 
-    if (!remoteLocation.path.isEmpty())
-    {
-      stageFilePath = SnowflakeUtil.concatFilePathNames(remoteLocation.path,
-                                                        fileName, "/");
+    if (!remoteLocation.path.isEmpty()) {
+      stageFilePath = SnowflakeUtil.concatFilePathNames(remoteLocation.path, fileName, "/");
     }
 
     RemoteStoreFileEncryptionMaterial encMat = srcFileToEncMat.get(fileName);
     String presignedUrl = srcFileToPresignedUrl.get(fileName);
 
-    return storageFactory.createClient(stageInfo, parallel, encMat, session)
-        .downloadToStream(session, command, parallel, remoteLocation.location,
-                          stageFilePath, stageInfo.getRegion(), presignedUrl);
+    return storageFactory
+        .createClient(stageInfo, parallel, encMat, session)
+        .downloadToStream(
+            session,
+            command,
+            parallel,
+            remoteLocation.location,
+            stageFilePath,
+            stageInfo.getRegion(),
+            presignedUrl);
   }
 
-  /**
-   * Helper to download files from remote
-   */
-  private void downloadFiles() throws SnowflakeSQLException
-  {
-    try
-    {
-      threadExecutor = SnowflakeUtil.createDefaultExecutorService(
-          "sf-file-download-worker-", 1);
+  /** Helper to download files from remote */
+  private void downloadFiles() throws SnowflakeSQLException {
+    try {
+      threadExecutor = SnowflakeUtil.createDefaultExecutorService("sf-file-download-worker-", 1);
 
-      for (String srcFile : sourceFiles)
-      {
+      for (String srcFile : sourceFiles) {
         FileMetadata fileMetadata = fileMetadataMap.get(srcFile);
 
         // Check if the result status is already set so that we don't need to
         // upload it
-        if (fileMetadata.resultStatus != ResultStatus.UNKNOWN)
-        {
-          logger.debug("Skipping {}, status: {}, details: {}",
-                       srcFile, fileMetadata.resultStatus, fileMetadata.errorDetails);
+        if (fileMetadata.resultStatus != ResultStatus.UNKNOWN) {
+          logger.debug(
+              "Skipping {}, status: {}, details: {}",
+              srcFile,
+              fileMetadata.resultStatus,
+              fileMetadata.errorDetails);
           continue;
         }
 
         RemoteStoreFileEncryptionMaterial encMat = srcFileToEncMat.get(srcFile);
         String presignedUrl = srcFileToPresignedUrl.get(srcFile);
-        threadExecutor.submit(getDownloadFileCallable(
-            stageInfo,
-            srcFile,
-            localLocation,
-            fileMetadataMap,
-            (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
-            null : storageFactory.createClient(stageInfo, parallel, encMat, session),
-            session,
-            command,
-            parallel,
-            encMat,
-            presignedUrl));
+        threadExecutor.submit(
+            getDownloadFileCallable(
+                stageInfo,
+                srcFile,
+                localLocation,
+                fileMetadataMap,
+                (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
+                    ? null
+                    : storageFactory.createClient(stageInfo, parallel, encMat, session),
+                session,
+                command,
+                parallel,
+                encMat,
+                presignedUrl));
 
         logger.debug("submitted download job for: {}", srcFile);
       }
 
       threadExecutor.shutdown();
 
-      try
-      {
+      try {
         // wait for all threads to complete without timeout
         threadExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-      }
-      catch (InterruptedException ex)
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
+      } catch (InterruptedException ex) {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
       logger.debug("Done with downloading");
-    }
-    finally
-    {
-      if (threadExecutor != null)
-      {
+    } finally {
+      if (threadExecutor != null) {
         threadExecutor.shutdownNow();
         threadExecutor = null;
       }
@@ -1662,52 +1469,46 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
   }
 
   /**
-   * This method is used in uploadFiles to delay the file upload for the given time, which is set as a session
-   * parameter called "inject_wait_in_put." Normally this value is 0, but it is used in testing.
+   * This method is used in uploadFiles to delay the file upload for the given time, which is set as
+   * a session parameter called "inject_wait_in_put." Normally this value is 0, but it is used in
+   * testing.
    *
    * @param delayTime the number of seconds to sleep before uploading the file
    */
-  private void setUploadDelay(int delayTime)
-  {
-    if (delayTime > 0)
-    {
-      try
-      {
+  private void setUploadDelay(int delayTime) {
+    if (delayTime > 0) {
+      try {
         TimeUnit.SECONDS.sleep(delayTime);
-      }
-      catch (InterruptedException ie)
-      {
+      } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
       }
     }
   }
 
   /**
-   * This method create a thread pool based on requested number of threads
-   * and upload the files using the thread pool.
+   * This method create a thread pool based on requested number of threads and upload the files
+   * using the thread pool.
    *
    * @param fileList The set of files to upload
    * @param parallel degree of parallelism for the upload
    * @throws SnowflakeSQLException Will be thrown if uploading the files fails
    */
-  private void uploadFiles(Set<String> fileList,
-                           int parallel) throws SnowflakeSQLException
-  {
-    try
-    {
-      threadExecutor = SnowflakeUtil.createDefaultExecutorService(
-          "sf-file-upload-worker-", parallel);
+  private void uploadFiles(Set<String> fileList, int parallel) throws SnowflakeSQLException {
+    try {
+      threadExecutor =
+          SnowflakeUtil.createDefaultExecutorService("sf-file-upload-worker-", parallel);
 
-      for (String srcFile : fileList)
-      {
+      for (String srcFile : fileList) {
         FileMetadata fileMetadata = fileMetadataMap.get(srcFile);
 
         // Check if the result status is already set so that we don't need to
         // upload it
-        if (fileMetadata.resultStatus != ResultStatus.UNKNOWN)
-        {
-          logger.debug("Skipping {}, status: {}, details: {}",
-                       srcFile, fileMetadata.resultStatus, fileMetadata.errorDetails);
+        if (fileMetadata.resultStatus != ResultStatus.UNKNOWN) {
+          logger.debug(
+              "Skipping {}, status: {}, details: {}",
+              srcFile,
+              fileMetadata.resultStatus,
+              fileMetadata.errorDetails);
 
           continue;
         }
@@ -1724,15 +1525,22 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         int delay = session.getInjectWaitInPut();
         setUploadDelay(delay);
 
-        threadExecutor.submit(getUploadFileCallable(
-            stageInfo,
-            srcFile,
-            fileMetadata,
-            (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
-            null : storageFactory.createClient(stageInfo, parallel, encryptionMaterial.get(0), session),
-            session, command,
-            null, false,
-            (parallel > 1 ? 1 : this.parallel), srcFileObj, encryptionMaterial.get(0)));
+        threadExecutor.submit(
+            getUploadFileCallable(
+                stageInfo,
+                srcFile,
+                fileMetadata,
+                (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
+                    ? null
+                    : storageFactory.createClient(
+                        stageInfo, parallel, encryptionMaterial.get(0), session),
+                session,
+                command,
+                null,
+                false,
+                (parallel > 1 ? 1 : this.parallel),
+                srcFileObj,
+                encryptionMaterial.get(0)));
 
         logger.debug("submitted copy job for: {}", srcFile);
       }
@@ -1740,47 +1548,34 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       // shut down the thread executor
       threadExecutor.shutdown();
 
-      try
-      {
+      try {
         // wait for all threads to complete without timeout
         threadExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-      }
-      catch (InterruptedException ex)
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
-                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
+      } catch (InterruptedException ex) {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
       logger.debug("Done with uploading");
 
-    }
-    finally
-    {
+    } finally {
       // shut down the thread pool in any case
-      if (threadExecutor != null)
-      {
+      if (threadExecutor != null) {
         threadExecutor.shutdownNow();
         threadExecutor = null;
       }
     }
   }
 
-  private void segregateFilesBySize()
-  {
-    for (String srcFile : sourceFiles)
-    {
-      if ((new File(srcFile)).length() > BIG_FILE_THRESHOLD)
-      {
-        if (bigSourceFiles == null)
-        {
+  private void segregateFilesBySize() {
+    for (String srcFile : sourceFiles) {
+      if ((new File(srcFile)).length() > BIG_FILE_THRESHOLD) {
+        if (bigSourceFiles == null) {
           bigSourceFiles = new HashSet<String>(sourceFiles.size());
         }
 
         bigSourceFiles.add(srcFile);
-      }
-      else
-      {
-        if (smallSourceFiles == null)
-        {
+      } else {
+        if (smallSourceFiles == null) {
           smallSourceFiles = new HashSet<String>(sourceFiles.size());
         }
 
@@ -1789,32 +1584,25 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     }
   }
 
-  public void cancel()
-  {
-    synchronized (canceled)
-    {
-      if (threadExecutor != null)
-      {
+  public void cancel() {
+    synchronized (canceled) {
+      if (threadExecutor != null) {
         threadExecutor.shutdownNow();
         threadExecutor = null;
       }
       canceled = true;
-
     }
   }
 
   /**
-   * process a list of file paths separated by "," and expand the wildcards
-   * if any to generate the list of paths for all files matched by the
-   * wildcards
+   * process a list of file paths separated by "," and expand the wildcards if any to generate the
+   * list of paths for all files matched by the wildcards
    *
    * @param filePathList file path list
    * @return a set of file names that is matched
    * @throws SnowflakeSQLException if cannot find the file
    */
-  static Set<String> expandFileNames(String[] filePathList)
-  throws SnowflakeSQLException
-  {
+  static Set<String> expandFileNames(String[] filePathList) throws SnowflakeSQLException {
     Set<String> result = new HashSet<String>();
 
     // a location to file pattern map so that we only need to list the
@@ -1825,38 +1613,33 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
     String cwd = systemGetProperty("user.dir");
 
-    for (String path : filePathList)
-    {
+    for (String path : filePathList) {
       // replace ~ with user home
       path = path.replace("~", systemGetProperty("user.home"));
 
       // user may also specify files relative to current directory
       // add the current path if that is the case
-      if (!(new File(path)).isAbsolute())
-      {
+      if (!(new File(path)).isAbsolute()) {
         logger.debug("Adding current working dir to relative file path.");
 
         path = cwd + localFSFileSep + path;
       }
 
       // check if the path contains any wildcards
-      if (!path.contains("*") && !path.contains("?") &&
-          !(path.contains("[") && path.contains("]")))
-      {
+      if (!path.contains("*")
+          && !path.contains("?")
+          && !(path.contains("[") && path.contains("]"))) {
         /* this file path doesn't have any wildcard, so we don't need to
          * expand it
          */
         result.add(path);
-      }
-      else
-      {
+      } else {
         // get the directory path
         int lastFileSepIndex = path.lastIndexOf(localFSFileSep);
 
         // SNOW-15203: if we don't find a default file sep, try "/" if it is not
         // the default file sep.
-        if (lastFileSepIndex < 0 && !"/".equals(localFSFileSep))
-        {
+        if (lastFileSepIndex < 0 && !"/".equals(localFSFileSep)) {
           lastFileSepIndex = path.lastIndexOf("/");
         }
 
@@ -1866,8 +1649,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
         List<String> filePatterns = locationToFilePatterns.get(loc);
 
-        if (filePatterns == null)
-        {
+        if (filePatterns == null) {
           filePatterns = new ArrayList<String>();
           locationToFilePatterns.put(loc, filePatterns);
         }
@@ -1877,165 +1659,155 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     }
 
     // For each location, list files and match against the patterns
-    for (Map.Entry<String, List<String>> entry :
-        locationToFilePatterns.entrySet())
-    {
-      try
-      {
+    for (Map.Entry<String, List<String>> entry : locationToFilePatterns.entrySet()) {
+      try {
         java.io.File dir = new java.io.File(entry.getKey());
 
-        logger.debug("Listing files under: {} with patterns: {}",
-                     entry.getKey(), entry.getValue().toString());
+        logger.debug(
+            "Listing files under: {} with patterns: {}",
+            entry.getKey(),
+            entry.getValue().toString());
 
         // The following currently ignore sub directories
-        for (Object file : FileUtils.listFiles(dir,
-                                               new WildcardFileFilter(entry.getValue()),
-                                               null))
-        {
+        for (Object file :
+            FileUtils.listFiles(dir, new WildcardFileFilter(entry.getValue()), null)) {
           result.add(((java.io.File) file).getCanonicalPath());
         }
-      }
-      catch (Exception ex)
-      {
-        throw new SnowflakeSQLException(ex, SqlState.DATA_EXCEPTION,
-                                        ErrorCode.FAIL_LIST_FILES.getMessageCode(),
-                                        "Exception: " + ex.getMessage() + ", Dir=" +
-                                        entry.getKey() + ", Patterns=" +
-                                        entry.getValue().toString());
+      } catch (Exception ex) {
+        throw new SnowflakeSQLException(
+            ex,
+            SqlState.DATA_EXCEPTION,
+            ErrorCode.FAIL_LIST_FILES.getMessageCode(),
+            "Exception: "
+                + ex.getMessage()
+                + ", Dir="
+                + entry.getKey()
+                + ", Patterns="
+                + entry.getValue().toString());
       }
     }
 
     logger.debug("Expanded file paths: ");
 
-    for (String filePath : result)
-    {
+    for (String filePath : result) {
       logger.debug("file: {}", filePath);
     }
 
     return result;
   }
 
-  static private boolean pushFileToLocal(String stageLocation,
-                                         String filePath,
-                                         String destFileName,
-                                         InputStream inputStream,
-                                         FileBackedOutputStream fileBackedOutStr,
-                                         SFSession session)
-  throws SQLException
-  {
-
+  private static boolean pushFileToLocal(
+      String stageLocation,
+      String filePath,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutStr,
+      SFSession session)
+      throws SQLException {
 
     // replace ~ with user home
-    stageLocation = stageLocation.replace("~",
-                                          systemGetProperty("user.home"));
-    try
-    {
-      logger.debug("Copy file. srcFile={}, destination={}, destFileName={}",
-                   filePath, stageLocation, destFileName);
+    stageLocation = stageLocation.replace("~", systemGetProperty("user.home"));
+    try {
+      logger.debug(
+          "Copy file. srcFile={}, destination={}, destFileName={}",
+          filePath,
+          stageLocation,
+          destFileName);
 
-      File destFile = new File(
-          SnowflakeUtil.concatFilePathNames(
-              stageLocation,
-              destFileName,
-              localFSFileSep));
+      File destFile =
+          new File(SnowflakeUtil.concatFilePathNames(stageLocation, destFileName, localFSFileSep));
 
-      if (fileBackedOutStr != null)
-      {
+      if (fileBackedOutStr != null) {
         inputStream = fileBackedOutStr.asByteSource().openStream();
       }
       FileUtils.copyInputStreamToFile(inputStream, destFile);
-    }
-    catch (Exception ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            ex.getMessage());
+    } catch (Exception ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          ex.getMessage());
     }
 
     return true;
   }
 
-  static private boolean pullFileFromLocal(String sourceLocation,
-                                           String filePath,
-                                           String destLocation,
-                                           String destFileName,
-                                           SFSession session)
-  throws SQLException
-  {
-    try
-    {
-      logger.debug("Copy file. srcFile={}, destination={}, destFileName={}",
-                   sourceLocation + localFSFileSep + filePath, destLocation, destFileName);
+  private static boolean pullFileFromLocal(
+      String sourceLocation,
+      String filePath,
+      String destLocation,
+      String destFileName,
+      SFSession session)
+      throws SQLException {
+    try {
+      logger.debug(
+          "Copy file. srcFile={}, destination={}, destFileName={}",
+          sourceLocation + localFSFileSep + filePath,
+          destLocation,
+          destFileName);
 
-      File srcFile = new File(
-          SnowflakeUtil.concatFilePathNames(
-              sourceLocation,
-              filePath,
-              localFSFileSep));
+      File srcFile =
+          new File(SnowflakeUtil.concatFilePathNames(sourceLocation, filePath, localFSFileSep));
 
       FileUtils.copyFileToDirectory(srcFile, new File(destLocation));
-    }
-    catch (Exception ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            ex.getMessage());
+    } catch (Exception ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          ex.getMessage());
     }
 
     return true;
   }
 
-  static private void pushFileToRemoteStore(StageInfo stage,
-                                            String destFileName,
-                                            InputStream inputStream,
-                                            FileBackedOutputStream fileBackedOutStr,
-                                            long uploadSize,
-                                            String digest,
-                                            FileCompressionType compressionType,
-                                            SnowflakeStorageClient initialClient,
-                                            SFSession session,
-                                            String command,
-                                            int parallel,
-                                            File srcFile,
-                                            boolean uploadFromStream,
-                                            RemoteStoreFileEncryptionMaterial encMat)
-  throws SQLException, IOException
-  {
+  private static void pushFileToRemoteStore(
+      StageInfo stage,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutStr,
+      long uploadSize,
+      String digest,
+      FileCompressionType compressionType,
+      SnowflakeStorageClient initialClient,
+      SFSession session,
+      String command,
+      int parallel,
+      File srcFile,
+      boolean uploadFromStream,
+      RemoteStoreFileEncryptionMaterial encMat)
+      throws SQLException, IOException {
     remoteLocation remoteLocation = extractLocationAndPath(stage.getLocation());
 
     String origDestFileName = destFileName;
-    if (remoteLocation.path != null && !remoteLocation.path.isEmpty())
-    {
-      destFileName = remoteLocation.path +
-                     (!remoteLocation.path.endsWith("/") ? "/" : "")
-                     + destFileName;
+    if (remoteLocation.path != null && !remoteLocation.path.isEmpty()) {
+      destFileName =
+          remoteLocation.path + (!remoteLocation.path.endsWith("/") ? "/" : "") + destFileName;
     }
 
-    logger.debug("upload object. location={}, key={}, srcFile={}, encryption={}",
-                 remoteLocation.location, destFileName, srcFile,
-                 (ArgSupplier) () -> (
-                     encMat == null
-                     ? "NULL"
-                     : encMat.getSmkId() + "|" + encMat.getQueryId()));
+    logger.debug(
+        "upload object. location={}, key={}, srcFile={}, encryption={}",
+        remoteLocation.location,
+        destFileName,
+        srcFile,
+        (ArgSupplier)
+            () -> (encMat == null ? "NULL" : encMat.getSmkId() + "|" + encMat.getQueryId()));
 
     StorageObjectMetadata meta = storageFactory.createStorageMetadataObj(stage.getStageType());
     meta.setContentLength(uploadSize);
-    if (digest != null)
-    {
+    if (digest != null) {
       initialClient.addDigestMetadata(meta, digest);
     }
 
-    if (compressionType != null &&
-        compressionType.isSupported())
-    {
+    if (compressionType != null && compressionType.isSupported()) {
       meta.setContentEncoding(compressionType.name().toLowerCase());
     }
 
-    try
-    {
+    try {
       String presignedUrl = "";
-      if (initialClient.requirePresignedUrl())
-      {
+      if (initialClient.requirePresignedUrl()) {
         // need to replace file://mypath/myfile?.csv with file://mypath/myfile1.csv.gz
         String localFilePath = getLocalFilePathFromCommand(command, false);
         String commandWithExactPath = command.replace(localFilePath, origDestFileName);
@@ -2043,21 +1815,25 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         SFStatement statement = new SFStatement(session);
         JsonNode jsonNode = parseCommandInGS(statement, commandWithExactPath);
 
-        if (!jsonNode.path("data").path("stageInfo").path("presignedUrl").isMissingNode())
-        {
+        if (!jsonNode.path("data").path("stageInfo").path("presignedUrl").isMissingNode()) {
           presignedUrl = jsonNode.path("data").path("stageInfo").path("presignedUrl").asText();
         }
       }
-      initialClient.upload(session, command, parallel,
-                           uploadFromStream,
-                           remoteLocation.location, srcFile, destFileName,
-                           inputStream, fileBackedOutStr, meta, stage.getRegion(),
-                           presignedUrl);
-    }
-    finally
-    {
-      if (uploadFromStream && inputStream != null)
-      {
+      initialClient.upload(
+          session,
+          command,
+          parallel,
+          uploadFromStream,
+          remoteLocation.location,
+          srcFile,
+          destFileName,
+          inputStream,
+          fileBackedOutStr,
+          meta,
+          stage.getRegion(),
+          presignedUrl);
+    } finally {
+      if (uploadFromStream && inputStream != null) {
         inputStream.close();
       }
     }
@@ -2065,15 +1841,13 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
   /**
    * Static API function to upload data without JDBC session.
-   * <p>
-   * NOTE: This function is developed based on getUploadFileCallable().
+   *
+   * <p>NOTE: This function is developed based on getUploadFileCallable().
    *
    * @param config Configuration to upload a file to cloud storage
    * @throws Exception if error occurs while data upload.
    */
-  static public void uploadWithoutConnection(SnowflakeFileTransferConfig config)
-  throws Exception
-  {
+  public static void uploadWithoutConnection(SnowflakeFileTransferConfig config) throws Exception {
     logger.debug("Entering uploadWithoutConnection...");
 
     SnowflakeFileTransferMetadataV1 metadata =
@@ -2099,35 +1873,28 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     // Temp file that needs to be cleaned up when upload was successful
     FileBackedOutputStream fileBackedOutputStream = null;
 
-    RemoteStoreFileEncryptionMaterial encMat =
-        metadata.getEncryptionMaterial();
+    RemoteStoreFileEncryptionMaterial encMat = metadata.getEncryptionMaterial();
     // SNOW-16082: we should capture exception if we fail to compress or
     // calculate digest.
-    try
-    {
-      if (requireCompress)
-      {
+    try {
+      if (requireCompress) {
         InputStreamWithMetadata compressedSizeAndStream =
-            (encMat == null ? compressStreamWithGZIPNoDigest(uploadStream, /* session = */ null)
-                            : compressStreamWithGZIP(uploadStream, /* session = */ null));
+            (encMat == null
+                ? compressStreamWithGZIPNoDigest(uploadStream, /* session = */ null)
+                : compressStreamWithGZIP(uploadStream, /* session = */ null));
 
-        fileBackedOutputStream =
-            compressedSizeAndStream.fileBackedOutputStream;
+        fileBackedOutputStream = compressedSizeAndStream.fileBackedOutputStream;
 
         // update the size
         uploadSize = compressedSizeAndStream.size;
         digest = compressedSizeAndStream.digest;
 
-        if (compressedSizeAndStream.fileBackedOutputStream.getFile() != null)
-        {
-          fileToUpload =
-              compressedSizeAndStream.fileBackedOutputStream.getFile();
+        if (compressedSizeAndStream.fileBackedOutputStream.getFile() != null) {
+          fileToUpload = compressedSizeAndStream.fileBackedOutputStream.getFile();
         }
 
         logger.debug("New size after compression: {}", uploadSize);
-      }
-      else
-      {
+      } else {
         // If it's not local_fs, we store our digest in the metadata
         // In local_fs, we don't need digest, and if we turn it on,
         // we will consume whole uploadStream, which local_fs uses.
@@ -2136,43 +1903,45 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         fileBackedOutputStream = result.fileBackedOutputStream;
         uploadSize = result.size;
 
-        if (result.fileBackedOutputStream.getFile() != null)
-        {
+        if (result.fileBackedOutputStream.getFile() != null) {
           fileToUpload = result.fileBackedOutputStream.getFile();
         }
       }
 
       logger.debug(
           "Started copying file to {}:{} destName: {} compressed ? {} size={}",
-          stageInfo.getStageType().name(), stageInfo.getLocation(),
-          destFileName, (requireCompress ? "yes" : "no"), uploadSize);
+          stageInfo.getStageType().name(),
+          stageInfo.getLocation(),
+          destFileName,
+          (requireCompress ? "yes" : "no"),
+          uploadSize);
 
       SnowflakeStorageClient initialClient =
           storageFactory.createClient(stageInfo, 1, encMat, /*session = */ null);
       pushFileToRemoteStoreWithPresignedUrl(
           metadata.getStageInfo(),
           metadata.getPresignedUrlFileName(),
-          uploadStream, fileBackedOutputStream, uploadSize,
-          digest, (requireCompress ? FileCompressionType.GZIP : null),
-          initialClient, networkTimeoutInMilli, ocspMode, 1,
-          null, true, encMat, metadata.getPresignedUrl());
-    }
-    catch (Exception ex)
-    {
-      logger.error(
-          "Exception encountered during file upload: ", ex.getMessage());
+          uploadStream,
+          fileBackedOutputStream,
+          uploadSize,
+          digest,
+          (requireCompress ? FileCompressionType.GZIP : null),
+          initialClient,
+          networkTimeoutInMilli,
+          ocspMode,
+          1,
+          null,
+          true,
+          encMat,
+          metadata.getPresignedUrl());
+    } catch (Exception ex) {
+      logger.error("Exception encountered during file upload: ", ex.getMessage());
       throw ex;
-    }
-    finally
-    {
-      if (fileBackedOutputStream != null)
-      {
-        try
-        {
+    } finally {
+      if (fileBackedOutputStream != null) {
+        try {
           fileBackedOutputStream.reset();
-        }
-        catch (IOException ex)
-        {
+        } catch (IOException ex) {
           logger.debug("failed to clean up temp file: {}", ex);
         }
       }
@@ -2180,14 +1949,12 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
   }
 
   /**
-   * Push a file (or stream) to remote store with pre-signed URL
-   * without JDBC session.
-   * <p>
-   * NOTE: This function is developed based on pushFileToRemoteStore().
-   * The main difference is that the caller needs to provide
-   * pre-signed URL and the upload doesn't need JDBC session.
+   * Push a file (or stream) to remote store with pre-signed URL without JDBC session.
+   *
+   * <p>NOTE: This function is developed based on pushFileToRemoteStore(). The main difference is
+   * that the caller needs to provide pre-signed URL and the upload doesn't need JDBC session.
    */
-  static private void pushFileToRemoteStoreWithPresignedUrl(
+  private static void pushFileToRemoteStoreWithPresignedUrl(
       StageInfo stage,
       String destFileName,
       InputStream inputStream,
@@ -2203,70 +1970,67 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
       boolean uploadFromStream,
       RemoteStoreFileEncryptionMaterial encMat,
       String presignedUrl)
-  throws SQLException, IOException
-  {
+      throws SQLException, IOException {
     remoteLocation remoteLocation = extractLocationAndPath(stage.getLocation());
 
     String origDestFileName = destFileName;
-    if (remoteLocation.path != null && !remoteLocation.path.isEmpty())
-    {
-      destFileName = remoteLocation.path +
-                     (!remoteLocation.path.endsWith("/") ? "/" : "") +
-                     destFileName;
+    if (remoteLocation.path != null && !remoteLocation.path.isEmpty()) {
+      destFileName =
+          remoteLocation.path + (!remoteLocation.path.endsWith("/") ? "/" : "") + destFileName;
     }
 
-    logger.debug("upload object. location={}, key={}, srcFile={}, encryption={}",
-                 remoteLocation.location, destFileName, srcFile,
-                 (ArgSupplier) () -> (
-                     encMat == null
-                     ? "NULL"
-                     : encMat.getSmkId() + "|" + encMat.getQueryId()));
+    logger.debug(
+        "upload object. location={}, key={}, srcFile={}, encryption={}",
+        remoteLocation.location,
+        destFileName,
+        srcFile,
+        (ArgSupplier)
+            () -> (encMat == null ? "NULL" : encMat.getSmkId() + "|" + encMat.getQueryId()));
 
-    StorageObjectMetadata meta =
-        storageFactory.createStorageMetadataObj(stage.getStageType());
+    StorageObjectMetadata meta = storageFactory.createStorageMetadataObj(stage.getStageType());
     meta.setContentLength(uploadSize);
-    if (digest != null)
-    {
+    if (digest != null) {
       initialClient.addDigestMetadata(meta, digest);
     }
 
-    if (compressionType != null && compressionType.isSupported())
-    {
+    if (compressionType != null && compressionType.isSupported()) {
       meta.setContentEncoding(compressionType.name().toLowerCase());
     }
 
-    try
-    {
+    try {
       initialClient.uploadWithPresignedUrlWithoutConnection(
-          networkTimeoutInMilli, ocspMode, parallel,
+          networkTimeoutInMilli,
+          ocspMode,
+          parallel,
           uploadFromStream,
-          remoteLocation.location, srcFile, destFileName,
-          inputStream, fileBackedOutStr, meta, stage.getRegion(),
+          remoteLocation.location,
+          srcFile,
+          destFileName,
+          inputStream,
+          fileBackedOutStr,
+          meta,
+          stage.getRegion(),
           presignedUrl);
-    }
-    finally
-    {
-      if (uploadFromStream && inputStream != null)
-      {
+    } finally {
+      if (uploadFromStream && inputStream != null) {
         inputStream.close();
       }
     }
   }
 
   /**
-   * This static method is called when we are handling an expired token exception
-   * It retrieves a fresh token from GS and then calls .renew() on the storage
-   * client to refresh itself with the new token
+   * This static method is called when we are handling an expired token exception It retrieves a
+   * fresh token from GS and then calls .renew() on the storage client to refresh itself with the
+   * new token
    *
    * @param session a session object
    * @param command a command to be retried
-   * @param client  a Snowflake Storage client object
+   * @param client a Snowflake Storage client object
    * @throws SnowflakeSQLException if any error occurs
    */
-  static public void renewExpiredToken(SFSession session, String command,
-                                       SnowflakeStorageClient client)
-  throws SnowflakeSQLException
-  {
+  public static void renewExpiredToken(
+      SFSession session, String command, SnowflakeStorageClient client)
+      throws SnowflakeSQLException {
     SFStatement statement = new SFStatement(session);
     JsonNode jsonNode = parseCommandInGS(statement, command);
     Map<?, ?> stageCredentials = extractStageCreds(jsonNode);
@@ -2276,53 +2040,56 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     client.renew(stageCredentials);
   }
 
-  static private void pullFileFromRemoteStore(StageInfo stage,
-                                              String filePath,
-                                              String destFileName,
-                                              String localLocation,
-                                              SnowflakeStorageClient initialClient,
-                                              SFSession session,
-                                              String command,
-                                              int parallel,
-                                              RemoteStoreFileEncryptionMaterial encMat,
-                                              String presignedUrl)
-  throws SQLException
-  {
+  private static void pullFileFromRemoteStore(
+      StageInfo stage,
+      String filePath,
+      String destFileName,
+      String localLocation,
+      SnowflakeStorageClient initialClient,
+      SFSession session,
+      String command,
+      int parallel,
+      RemoteStoreFileEncryptionMaterial encMat,
+      String presignedUrl)
+      throws SQLException {
     remoteLocation remoteLocation = extractLocationAndPath(stage.getLocation());
 
     String stageFilePath = filePath;
 
-    if (!remoteLocation.path.isEmpty())
-    {
-      stageFilePath = SnowflakeUtil.concatFilePathNames(remoteLocation.path,
-                                                        filePath, "/");
+    if (!remoteLocation.path.isEmpty()) {
+      stageFilePath = SnowflakeUtil.concatFilePathNames(remoteLocation.path, filePath, "/");
     }
 
-    logger.debug("Download object. location={}, key={}, srcFile={}, encryption={}",
-                 remoteLocation.location, stageFilePath, filePath,
-                 (ArgSupplier) () -> (
-                     encMat == null
-                     ? "NULL"
-                     : encMat.getSmkId() + "|" + encMat.getQueryId()));
+    logger.debug(
+        "Download object. location={}, key={}, srcFile={}, encryption={}",
+        remoteLocation.location,
+        stageFilePath,
+        filePath,
+        (ArgSupplier)
+            () -> (encMat == null ? "NULL" : encMat.getSmkId() + "|" + encMat.getQueryId()));
 
-    initialClient.download(session, command,
-                           localLocation, destFileName, parallel,
-                           remoteLocation.location, stageFilePath, stage.getRegion(),
-                           presignedUrl);
+    initialClient.download(
+        session,
+        command,
+        localLocation,
+        destFileName,
+        parallel,
+        remoteLocation.location,
+        stageFilePath,
+        stage.getRegion(),
+        presignedUrl);
   }
 
   /**
-   * From the set of files intended to be uploaded/downloaded, derive a common
-   * prefix and use the listObjects API to get the object summary for each
-   * object that has the common prefix.
-   * <p>
-   * For each returned object, we compare the size and digest with the local file
-   * and if they are the same, we will not upload/download the file.
+   * From the set of files intended to be uploaded/downloaded, derive a common prefix and use the
+   * listObjects API to get the object summary for each object that has the common prefix.
+   *
+   * <p>For each returned object, we compare the size and digest with the local file and if they are
+   * the same, we will not upload/download the file.
    *
    * @throws SnowflakeSQLException if any error occurs
    */
-  private void filterExistingFiles() throws SnowflakeSQLException
-  {
+  private void filterExistingFiles() throws SnowflakeSQLException {
     /*
      * Build a reverse map from destination file name to source file path
      * The map will be used for looking up the source file for destination
@@ -2334,33 +2101,25 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
     logger.debug("Build reverse map from destination file name to source file");
 
-    for (Map.Entry<String, FileMetadata> entry : fileMetadataMap.entrySet())
-    {
-      if (entry.getValue().destFileName != null)
-      {
+    for (Map.Entry<String, FileMetadata> entry : fileMetadataMap.entrySet()) {
+      if (entry.getValue().destFileName != null) {
         String prevSrcFile =
-            destFileNameToSrcFileMap.put(entry.getValue().destFileName,
-                                         entry.getKey());
+            destFileNameToSrcFileMap.put(entry.getValue().destFileName, entry.getKey());
 
-        if (prevSrcFile != null)
-        {
+        if (prevSrcFile != null) {
           FileMetadata prevFileMetadata = fileMetadataMap.get(prevSrcFile);
 
           prevFileMetadata.resultStatus = ResultStatus.COLLISION;
-          prevFileMetadata.errorDetails = prevSrcFile + " has same name as " +
-                                          entry.getKey();
+          prevFileMetadata.errorDetails = prevSrcFile + " has same name as " + entry.getKey();
         }
-      }
-      else
-      {
+      } else {
         logger.debug("No dest file name found for: {}", entry.getKey());
         logger.debug("Status: {}", entry.getValue().resultStatus);
       }
     }
 
     // no files to be processed
-    if (destFileNameToSrcFileMap.size() == 0)
-    {
+    if (destFileNameToSrcFileMap.size() == 0) {
       return;
     }
 
@@ -2369,30 +2128,25 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     // with local files
     String[] stageFileNames;
 
-    if (commandType == CommandType.UPLOAD)
-    {
+    if (commandType == CommandType.UPLOAD) {
       stageFileNames = destFileNameToSrcFileMap.keySet().toArray(new String[0]);
-    }
-    else
-    {
-      stageFileNames =
-          destFileNameToSrcFileMap.values().toArray(new String[0]);
+    } else {
+      stageFileNames = destFileNameToSrcFileMap.values().toArray(new String[0]);
     }
 
     // find greatest common prefix for all stage file names
     Arrays.sort(stageFileNames);
 
     String greatestCommonPrefix =
-        SnowflakeUtil.greatestCommonPrefix(stageFileNames[0],
-                                           stageFileNames[stageFileNames.length - 1]);
+        SnowflakeUtil.greatestCommonPrefix(
+            stageFileNames[0], stageFileNames[stageFileNames.length - 1]);
 
     logger.debug("Greatest common prefix: {}", greatestCommonPrefix);
 
     // use the greatest common prefix to list objects under stage location
-    if (stageInfo.getStageType() == StageInfo.StageType.S3 ||
-        stageInfo.getStageType() == StageInfo.StageType.AZURE ||
-        stageInfo.getStageType() == StageInfo.StageType.GCS)
-    {
+    if (stageInfo.getStageType() == StageInfo.StageType.S3
+        || stageInfo.getStageType() == StageInfo.StageType.AZURE
+        || stageInfo.getStageType() == StageInfo.StageType.GCS) {
       logger.debug("check existing files on remote storage for the common prefix");
 
       remoteLocation storeLocation = extractLocationAndPath(stageInfo.getLocation());
@@ -2401,33 +2155,25 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
       int retryCount = 0;
 
-      do
-      {
-        try
-        {
-          objectSummaries = storageClient.listObjects(storeLocation.location,
-                                                      SnowflakeUtil.concatFilePathNames(
-                                                          storeLocation.path,
-                                                          greatestCommonPrefix, "/"));
+      do {
+        try {
+          objectSummaries =
+              storageClient.listObjects(
+                  storeLocation.location,
+                  SnowflakeUtil.concatFilePathNames(storeLocation.path, greatestCommonPrefix, "/"));
 
           // exit retry loop
           break;
-        }
-        catch (Exception ex)
-        {
-          logger.debug("Listing objects for filtering encountered exception: {}",
-                       ex.getMessage());
+        } catch (Exception ex) {
+          logger.debug("Listing objects for filtering encountered exception: {}", ex.getMessage());
 
           storageClient.handleStorageException(ex, ++retryCount, "listObjects", session, command);
         }
-      }
-      while (retryCount <= storageClient.getMaxRetries());
+      } while (retryCount <= storageClient.getMaxRetries());
 
-      for (StorageObjectSummary obj : objectSummaries)
-      {
+      for (StorageObjectSummary obj : objectSummaries) {
         logger.debug(
-            "Existing object: key={} size={} md5={}",
-            obj.getKey(), obj.getSize(), obj.getMD5());
+            "Existing object: key={} size={} md5={}", obj.getKey(), obj.getSize(), obj.getMD5());
 
         int idxOfLastFileSep = obj.getKey().lastIndexOf("/");
         String objFileName = obj.getKey().substring(idxOfLastFileSep + 1);
@@ -2436,43 +2182,43 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         String mappedSrcFile = destFileNameToSrcFileMap.get(objFileName);
 
         // skip objects that don't have a corresponding file to be uploaded
-        if (mappedSrcFile == null)
-        {
+        if (mappedSrcFile == null) {
           continue;
         }
 
-        logger.debug("Next compare digest for {} against {} on the remote store", mappedSrcFile, objFileName);
+        logger.debug(
+            "Next compare digest for {} against {} on the remote store",
+            mappedSrcFile,
+            objFileName);
 
         String localFile = null;
         final boolean remoteEncrypted;
 
-        try
-        {
-          localFile = (commandType == CommandType.UPLOAD) ?
-                      mappedSrcFile : (localLocation + objFileName);
+        try {
+          localFile =
+              (commandType == CommandType.UPLOAD) ? mappedSrcFile : (localLocation + objFileName);
 
-          if (commandType == CommandType.DOWNLOAD &&
-              !(new File(localFile)).exists())
-          {
-            logger.debug("File does not exist locally, will download {}",
-                         mappedSrcFile);
+          if (commandType == CommandType.DOWNLOAD && !(new File(localFile)).exists()) {
+            logger.debug("File does not exist locally, will download {}", mappedSrcFile);
             continue;
           }
 
-          // if it's an upload and there's already a file existing remotely with the same name, skip uploading it
-          if (commandType == CommandType.UPLOAD && objFileName.equals(fileMetadataMap.get(mappedSrcFile).destFileName))
-          {
+          // if it's an upload and there's already a file existing remotely with the same name, skip
+          // uploading it
+          if (commandType == CommandType.UPLOAD
+              && objFileName.equals(fileMetadataMap.get(mappedSrcFile).destFileName)) {
             skipFile(mappedSrcFile, objFileName);
             continue;
           }
 
           // Check file size first, if their difference is bigger than the block
           // size, we don't need to compare digests
-          if (!fileMetadataMap.get(mappedSrcFile).requireCompress &&
-              Math.abs(obj.getSize() - (new File(localFile)).length()) > 16)
-          {
-            logger.debug("Size diff between remote and local, will {} {}",
-                         commandType.name().toLowerCase(), mappedSrcFile);
+          if (!fileMetadataMap.get(mappedSrcFile).requireCompress
+              && Math.abs(obj.getSize() - (new File(localFile)).length()) > 16) {
+            logger.debug(
+                "Size diff between remote and local, will {} {}",
+                commandType.name().toLowerCase(),
+                mappedSrcFile);
             continue;
           }
 
@@ -2480,56 +2226,47 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
           //
           StorageObjectMetadata meta;
 
-          try
-          {
-            meta = storageClient.getObjectMetadata(obj.getLocation(),
-                                                   obj.getKey());
-          }
-          catch (StorageProviderException spEx)
-          {
+          try {
+            meta = storageClient.getObjectMetadata(obj.getLocation(), obj.getKey());
+          } catch (StorageProviderException spEx) {
             // SNOW-14521: when file is not found, ok to upload
-            if (spEx.isServiceException404())
-            {
+            if (spEx.isServiceException404()) {
               // log it
-              logger.debug("File returned from listing but found missing {} when getting its" +
-                           " metadata. Location={}, key={}",
-                           obj.getLocation(), obj.getKey());
+              logger.debug(
+                  "File returned from listing but found missing {} when getting its"
+                      + " metadata. Location={}, key={}",
+                  obj.getLocation(),
+                  obj.getKey());
 
               // the file is not found, ok to upload
               continue;
             }
 
-
             // for any other exception, log an error
-            logger.error("Fetching object metadata encountered exception: {}",
-                         spEx.getMessage());
+            logger.error("Fetching object metadata encountered exception: {}", spEx.getMessage());
 
             throw spEx;
           }
 
           String objDigest = storageClient.getDigestMetadata(meta);
 
-          remoteEncrypted = MatDesc.parse(
-              meta.getUserMetadata().get(storageClient.getMatdescKey())) != null;
+          remoteEncrypted =
+              MatDesc.parse(meta.getUserMetadata().get(storageClient.getMatdescKey())) != null;
 
           // calculate the digest hash of the local file
           InputStream fileStream = null;
           String hashText = null;
 
           // Streams (potentially with temp files) to clean up
-          final List<FileBackedOutputStream> fileBackedOutputStreams
-              = new ArrayList<>();
-          try
-          {
+          final List<FileBackedOutputStream> fileBackedOutputStreams = new ArrayList<>();
+          try {
             fileStream = new FileInputStream(localFile);
-            if (fileMetadataMap.get(mappedSrcFile).requireCompress)
-            {
+            if (fileMetadataMap.get(mappedSrcFile).requireCompress) {
               logger.debug("Compressing stream for digest check");
 
               InputStreamWithMetadata res = compressStreamWithGZIP(fileStream, session);
 
-              fileStream =
-                  res.fileBackedOutputStream.asByteSource().openStream();
+              fileStream = res.fileBackedOutputStream.asByteSource().openStream();
               fileBackedOutputStreams.add(res.fileBackedOutputStream);
             }
 
@@ -2540,35 +2277,24 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
             // of the S3 file.
             // Otherwise (remote file is encrypted, but has no sfc-digest),
             // no comparison is performed
-            if (objDigest != null)
-            {
+            if (objDigest != null) {
               InputStreamWithMetadata res = computeDigest(fileStream, false);
               hashText = res.digest;
               fileBackedOutputStreams.add(res.fileBackedOutputStream);
 
-            }
-            else if (!remoteEncrypted)
-            {
+            } else if (!remoteEncrypted) {
               hashText = DigestUtils.md5Hex(fileStream);
             }
-          }
-          finally
-          {
-            if (fileStream != null)
-            {
+          } finally {
+            if (fileStream != null) {
               fileStream.close();
             }
 
-            for (FileBackedOutputStream stream : fileBackedOutputStreams)
-            {
-              if (stream != null)
-              {
-                try
-                {
+            for (FileBackedOutputStream stream : fileBackedOutputStreams) {
+              if (stream != null) {
+                try {
                   stream.reset();
-                }
-                catch (IOException ex)
-                {
+                } catch (IOException ex) {
                   logger.debug("failed to clean up temp file: {}", ex);
                 }
               }
@@ -2576,71 +2302,75 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
           }
 
           // continue so that we will upload the file
-          if (hashText == null || // remote is encrypted & has no digest
-              (objDigest != null && !hashText.equals(objDigest)) || // digest mismatch
+          if (hashText == null
+              || // remote is encrypted & has no digest
+              (objDigest != null && !hashText.equals(objDigest))
+              || // digest mismatch
               (objDigest == null && !hashText.equals(obj.getMD5()))) // ETag/MD5 mismatch
           {
             logger.debug(
-                "digest diff between remote store and local, will {} {}, " +
-                "local digest: {}, remote store md5: {}",
+                "digest diff between remote store and local, will {} {}, "
+                    + "local digest: {}, remote store md5: {}",
                 commandType.name().toLowerCase(),
-                mappedSrcFile, hashText, obj.getMD5());
+                mappedSrcFile,
+                hashText,
+                obj.getMD5());
             continue;
           }
-        }
-        catch (IOException | NoSuchAlgorithmException ex)
-        {
-          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "Error reading: " + localFile);
+        } catch (IOException | NoSuchAlgorithmException ex) {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "Error reading: " + localFile);
         }
 
-        logger.debug("digest same between remote store and local, will not upload {} {}",
-                     commandType.name().toLowerCase(), mappedSrcFile);
+        logger.debug(
+            "digest same between remote store and local, will not upload {} {}",
+            commandType.name().toLowerCase(),
+            mappedSrcFile);
 
         skipFile(mappedSrcFile, objFileName);
       }
-    }
-    else if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
-    {
-      for (String stageFileName : stageFileNames)
-      {
+    } else if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) {
+      for (String stageFileName : stageFileNames) {
         String stageFilePath =
-            SnowflakeUtil.concatFilePathNames(stageInfo.getLocation(),
-                                              stageFileName,
-                                              localFSFileSep);
+            SnowflakeUtil.concatFilePathNames(
+                stageInfo.getLocation(), stageFileName, localFSFileSep);
 
         File stageFile = new File(stageFilePath);
 
         // if stage file doesn't exist, no need to skip whether for
         // upload/download
-        if (!stageFile.exists())
-        {
+        if (!stageFile.exists()) {
           continue;
         }
 
-        String mappedSrcFile = (commandType == CommandType.UPLOAD) ?
-                               destFileNameToSrcFileMap.get(stageFileName) :
-                               stageFileName;
+        String mappedSrcFile =
+            (commandType == CommandType.UPLOAD)
+                ? destFileNameToSrcFileMap.get(stageFileName)
+                : stageFileName;
 
-        String localFile = (commandType == CommandType.UPLOAD) ?
-                           mappedSrcFile :
-                           (localLocation +
-                            fileMetadataMap.get(mappedSrcFile).destFileName);
+        String localFile =
+            (commandType == CommandType.UPLOAD)
+                ? mappedSrcFile
+                : (localLocation + fileMetadataMap.get(mappedSrcFile).destFileName);
 
-        if (commandType == CommandType.UPLOAD && stageFileName.equals(fileMetadataMap.get(mappedSrcFile).destFileName))
-        {
+        if (commandType == CommandType.UPLOAD
+            && stageFileName.equals(fileMetadataMap.get(mappedSrcFile).destFileName)) {
           skipFile(mappedSrcFile, stageFileName);
           continue;
         }
 
         // Check file size first, if they are different, we don't need
         // to check digest
-        if (!fileMetadataMap.get(mappedSrcFile).requireCompress &&
-            stageFile.length() != (new File(localFile)).length())
-        {
-          logger.debug("Size diff between stage and local, will {} {}",
-                       commandType.name().toLowerCase(), mappedSrcFile);
+        if (!fileMetadataMap.get(mappedSrcFile).requireCompress
+            && stageFile.length() != (new File(localFile)).length()) {
+          logger.debug(
+              "Size diff between stage and local, will {} {}",
+              commandType.name().toLowerCase(),
+              mappedSrcFile);
           continue;
         }
 
@@ -2652,45 +2382,35 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
         List<FileBackedOutputStream> fileBackedOutputStreams = new ArrayList<>();
         InputStream localFileStream = null;
-        try
-        {
+        try {
           // calculate the digest hash of the local file
           localFileStream = new FileInputStream(localFile);
 
-          if (fileMetadataMap.get(mappedSrcFile).requireCompress)
-          {
+          if (fileMetadataMap.get(mappedSrcFile).requireCompress) {
             logger.debug("Compressing stream for digest check");
 
-            InputStreamWithMetadata res =
-                compressStreamWithGZIP(localFileStream, session);
+            InputStreamWithMetadata res = compressStreamWithGZIP(localFileStream, session);
             fileBackedOutputStreams.add(res.fileBackedOutputStream);
 
-            localFileStream =
-                res.fileBackedOutputStream.asByteSource().openStream();
+            localFileStream = res.fileBackedOutputStream.asByteSource().openStream();
           }
 
           InputStreamWithMetadata res = computeDigest(localFileStream, false);
           localFileHashText = res.digest;
           fileBackedOutputStreams.add(res.fileBackedOutputStream);
-        }
-        catch (IOException | NoSuchAlgorithmException ex)
-        {
-          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "Error reading local file: " + localFile);
-        }
-        finally
-        {
-          for (FileBackedOutputStream stream : fileBackedOutputStreams)
-          {
-            if (stream != null)
-            {
-              try
-              {
+        } catch (IOException | NoSuchAlgorithmException ex) {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "Error reading local file: " + localFile);
+        } finally {
+          for (FileBackedOutputStream stream : fileBackedOutputStreams) {
+            if (stream != null) {
+              try {
                 stream.reset();
-              }
-              catch (IOException ex)
-              {
+              } catch (IOException ex) {
                 logger.debug("failed to clean up temp file: {}", ex);
               }
             }
@@ -2700,8 +2420,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
 
         FileBackedOutputStream fileBackedOutputStream = null;
         InputStream stageFileStream = null;
-        try
-        {
+        try {
           // calculate digst for stage file
           stageFileStream = new FileInputStream(stageFilePath);
 
@@ -2709,40 +2428,33 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
           stageFileHashText = res.digest;
           fileBackedOutputStream = res.fileBackedOutputStream;
 
-        }
-        catch (IOException | NoSuchAlgorithmException ex)
-        {
-          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "Error reading stage file: " + stageFilePath);
-        }
-        finally
-        {
-          try
-          {
-            if (fileBackedOutputStream != null)
-            {
+        } catch (IOException | NoSuchAlgorithmException ex) {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "Error reading stage file: " + stageFilePath);
+        } finally {
+          try {
+            if (fileBackedOutputStream != null) {
               fileBackedOutputStream.reset();
             }
-          }
-          catch (IOException ex)
-          {
+          } catch (IOException ex) {
             logger.debug("failed to clean up temp file: {}", ex);
           }
           IOUtils.closeQuietly(stageFileStream);
         }
 
         // continue if digest is different so that we will process the file
-        if (!stageFileHashText.equals(localFileHashText))
-        {
-          logger.debug("digest diff between local and stage, will {} {}",
-                       commandType.name().toLowerCase(), mappedSrcFile);
+        if (!stageFileHashText.equals(localFileHashText)) {
+          logger.debug(
+              "digest diff between local and stage, will {} {}",
+              commandType.name().toLowerCase(),
+              mappedSrcFile);
           continue;
-        }
-        else
-        {
-          logger.debug("digest matches between local and stage, will skip {}",
-                       mappedSrcFile);
+        } else {
+          logger.debug("digest matches between local and stage, will skip {}", mappedSrcFile);
 
           // skip the file given that the check sum is the same b/w source
           // and destination
@@ -2752,49 +2464,37 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
     }
   }
 
-  private void skipFile(String srcFilePath, String destFileName)
-  {
+  private void skipFile(String srcFilePath, String destFileName) {
     FileMetadata fileMetadata = fileMetadataMap.get(srcFilePath);
 
-    if (fileMetadata != null)
-    {
-      if (fileMetadata.resultStatus == null ||
-          fileMetadata.resultStatus == ResultStatus.UNKNOWN)
-      {
+    if (fileMetadata != null) {
+      if (fileMetadata.resultStatus == null || fileMetadata.resultStatus == ResultStatus.UNKNOWN) {
         logger.debug("Mark {} as skipped", srcFilePath);
 
         fileMetadata.resultStatus = ResultStatus.SKIPPED;
         fileMetadata.errorDetails =
-            "File with same destination name and checksum already exists: "
-            + destFileName;
-      }
-      else
-      {
-        logger.debug("No need to mark as skipped for: {} status was already marked as: {}",
-                     srcFilePath, fileMetadata.resultStatus);
+            "File with same destination name and checksum already exists: " + destFileName;
+      } else {
+        logger.debug(
+            "No need to mark as skipped for: {} status was already marked as: {}",
+            srcFilePath,
+            fileMetadata.resultStatus);
       }
     }
   }
 
-  private void initFileMetadata()
-  throws SnowflakeSQLException
-  {
+  private void initFileMetadata() throws SnowflakeSQLException {
     // file metadata is keyed on source file names (which are local file names
     // for upload command and stage file names for download command)
     fileMetadataMap = new HashMap<String, FileMetadata>(sourceFiles.size());
 
-    if (commandType == CommandType.UPLOAD)
-    {
-      if (sourceFromStream)
-      {
+    if (commandType == CommandType.UPLOAD) {
+      if (sourceFromStream) {
         FileMetadata fileMetadata = new FileMetadata();
         fileMetadataMap.put(SRC_FILE_NAME_FOR_STREAM, fileMetadata);
         fileMetadata.srcFileName = SRC_FILE_NAME_FOR_STREAM;
-      }
-      else
-      {
-        for (String sourceFile : sourceFiles)
-        {
+      } else {
+        for (String sourceFile : sourceFiles) {
           FileMetadata fileMetadata = new FileMetadata();
           fileMetadataMap.put(sourceFile, fileMetadata);
           File file = new File(sourceFile);
@@ -2802,35 +2502,33 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
           fileMetadata.srcFileName = file.getName();
           fileMetadata.srcFileSize = file.length();
 
-          if (!file.exists())
-          {
+          if (!file.exists()) {
             logger.debug("File doesn't exist: {}", sourceFile);
 
-            throw new SnowflakeSQLLoggedException(SqlState.DATA_EXCEPTION,
-                                                  ErrorCode.FILE_NOT_FOUND.getMessageCode(), session,
-                                                  sourceFile);
-          }
-          else if (file.isDirectory())
-          {
+            throw new SnowflakeSQLLoggedException(
+                SqlState.DATA_EXCEPTION,
+                ErrorCode.FILE_NOT_FOUND.getMessageCode(),
+                session,
+                sourceFile);
+          } else if (file.isDirectory()) {
             logger.debug("Not a file, but directory: {}", sourceFile);
 
-            throw new SnowflakeSQLException(SqlState.DATA_EXCEPTION,
-                                            ErrorCode.FILE_IS_DIRECTORY.getMessageCode(), session,
-                                            sourceFile);
+            throw new SnowflakeSQLException(
+                SqlState.DATA_EXCEPTION,
+                ErrorCode.FILE_IS_DIRECTORY.getMessageCode(),
+                session,
+                sourceFile);
           }
         }
       }
-    }
-    else if (commandType == CommandType.DOWNLOAD)
-    {
-      for (String sourceFile : sourceFiles)
-      {
+    } else if (commandType == CommandType.DOWNLOAD) {
+      for (String sourceFile : sourceFiles) {
         FileMetadata fileMetadata = new FileMetadata();
         fileMetadataMap.put(sourceFile, fileMetadata);
         fileMetadata.srcFileName = sourceFile;
 
-        fileMetadata.destFileName = sourceFile.substring(
-            sourceFile.lastIndexOf("/") + 1); // s3 uses / as separator
+        fileMetadata.destFileName =
+            sourceFile.substring(sourceFile.lastIndexOf("/") + 1); // s3 uses / as separator
       }
     }
   }
@@ -2841,29 +2539,22 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
    * @param mimeTypeStr The mime type passed to us
    * @return the Optional for the compression type or Optional.empty()
    */
-  static Optional<FileCompressionType> mimeTypeToCompressionType(String mimeTypeStr)
-  {
-    if (mimeTypeStr == null)
-    {
+  static Optional<FileCompressionType> mimeTypeToCompressionType(String mimeTypeStr) {
+    if (mimeTypeStr == null) {
       return Optional.empty();
     }
     int slashIndex = mimeTypeStr.indexOf('/');
-    if (slashIndex < 0)
-    {
+    if (slashIndex < 0) {
       return Optional.empty(); // unable to find sub type
     }
     int semiColonIndex = mimeTypeStr.indexOf(';');
     String subType;
-    if (semiColonIndex < 0)
-    {
+    if (semiColonIndex < 0) {
       subType = mimeTypeStr.substring(slashIndex + 1).trim().toLowerCase(Locale.ENGLISH);
-    }
-    else
-    {
+    } else {
       subType = mimeTypeStr.substring(slashIndex + 1, semiColonIndex);
     }
-    if (Strings.isNullOrEmpty(subType))
-    {
+    if (Strings.isNullOrEmpty(subType)) {
       return Optional.empty();
     }
     return FileCompressionType.lookupByMimeSubType(subType);
@@ -2872,54 +2563,44 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
   /**
    * Detect file compression type for all files to be uploaded
    *
-   * @throws SnowflakeSQLException Will be thrown if the compression type is
-   *                               unknown or unsupported
+   * @throws SnowflakeSQLException Will be thrown if the compression type is unknown or unsupported
    */
-  private void processFileCompressionTypes() throws SnowflakeSQLException
-  {
+  private void processFileCompressionTypes() throws SnowflakeSQLException {
     // see what user has told us about the source file compression types
     boolean autoDetect = true;
     FileCompressionType userSpecifiedSourceCompression = null;
 
-    if (SOURCE_COMPRESSION_AUTO_DETECT.equalsIgnoreCase(sourceCompression))
-    {
+    if (SOURCE_COMPRESSION_AUTO_DETECT.equalsIgnoreCase(sourceCompression)) {
       autoDetect = true;
-    }
-    else if (SOURCE_COMPRESSION_NONE.equalsIgnoreCase(sourceCompression))
-    {
+    } else if (SOURCE_COMPRESSION_NONE.equalsIgnoreCase(sourceCompression)) {
       autoDetect = false;
-    }
-    else
-    {
+    } else {
       Optional<FileCompressionType> foundCompType =
           FileCompressionType.lookupByMimeSubType(sourceCompression.toLowerCase());
-      if (!foundCompType.isPresent())
-      {
-        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                        ErrorCode.COMPRESSION_TYPE_NOT_KNOWN.getMessageCode(),
-                                        sourceCompression);
+      if (!foundCompType.isPresent()) {
+        throw new SnowflakeSQLException(
+            SqlState.FEATURE_NOT_SUPPORTED,
+            ErrorCode.COMPRESSION_TYPE_NOT_KNOWN.getMessageCode(),
+            sourceCompression);
       }
       userSpecifiedSourceCompression = foundCompType.get();
 
-      if (!userSpecifiedSourceCompression.isSupported())
-      {
-        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                        ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
-                                        sourceCompression);
+      if (!userSpecifiedSourceCompression.isSupported()) {
+        throw new SnowflakeSQLException(
+            SqlState.FEATURE_NOT_SUPPORTED,
+            ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
+            sourceCompression);
       }
 
       autoDetect = false;
     }
 
-    if (!sourceFromStream)
-    {
-      for (String srcFile : sourceFiles)
-      {
+    if (!sourceFromStream) {
+      for (String srcFile : sourceFiles) {
         FileMetadata fileMetadata = fileMetadataMap.get(srcFile);
 
-        if (fileMetadata.resultStatus == ResultStatus.NONEXIST ||
-            fileMetadata.resultStatus == ResultStatus.DIRECTORY)
-        {
+        if (fileMetadata.resultStatus == ResultStatus.NONEXIST
+            || fileMetadata.resultStatus == ResultStatus.DIRECTORY) {
           continue;
         }
 
@@ -2929,91 +2610,72 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
         String mimeTypeStr = null;
         FileCompressionType currentFileCompressionType = null;
 
-        try
-        {
-          if (autoDetect)
-          {
+        try {
+          if (autoDetect) {
             // probe the file for compression type using tika file type detector
             mimeTypeStr = Files.probeContentType(file.toPath());
 
-            if (mimeTypeStr == null)
-            {
-              try (FileInputStream f = new FileInputStream(file))
-              {
+            if (mimeTypeStr == null) {
+              try (FileInputStream f = new FileInputStream(file)) {
                 byte[] magic = new byte[4];
-                if (f.read(magic, 0, 4) == 4)
-                {
-                  if (Arrays.equals(magic, new byte[]{'P', 'A', 'R', '1'}))
-                  {
+                if (f.read(magic, 0, 4) == 4) {
+                  if (Arrays.equals(magic, new byte[] {'P', 'A', 'R', '1'})) {
                     mimeTypeStr = "snowflake/parquet";
-                  }
-                  else if (Arrays.equals(
-                      Arrays.copyOfRange(magic, 0, 3), new byte[]{'O', 'R', 'C'}))
-                  {
+                  } else if (Arrays.equals(
+                      Arrays.copyOfRange(magic, 0, 3), new byte[] {'O', 'R', 'C'})) {
                     mimeTypeStr = "snowflake/orc";
                   }
                 }
               }
             }
 
-            if (mimeTypeStr != null)
-            {
+            if (mimeTypeStr != null) {
               logger.debug("Mime type for {} is: {}", srcFile, mimeTypeStr);
 
-              Optional<FileCompressionType> foundCompType =
-                  mimeTypeToCompressionType(mimeTypeStr);
-              if (foundCompType.isPresent())
-              {
+              Optional<FileCompressionType> foundCompType = mimeTypeToCompressionType(mimeTypeStr);
+              if (foundCompType.isPresent()) {
                 currentFileCompressionType = foundCompType.get();
               }
             }
 
             // fallback: use file extension
-            if (currentFileCompressionType == null)
-            {
+            if (currentFileCompressionType == null) {
               mimeTypeStr = getMimeTypeFromFileExtension(srcFile);
 
-              if (mimeTypeStr != null)
-              {
+              if (mimeTypeStr != null) {
                 logger.debug("Mime type for {} is: {}", srcFile, mimeTypeStr);
                 Optional<FileCompressionType> foundCompType =
                     mimeTypeToCompressionType(mimeTypeStr);
-                if (foundCompType.isPresent())
-                {
+                if (foundCompType.isPresent()) {
                   currentFileCompressionType = foundCompType.get();
                 }
               }
             }
-          }
-          else
-          {
+          } else {
             currentFileCompressionType = userSpecifiedSourceCompression;
           }
 
           // check if the compression type is supported by us
-          if (currentFileCompressionType != null)
-          {
+          if (currentFileCompressionType != null) {
             fileMetadata.srcCompressionType = currentFileCompressionType;
 
-            if (currentFileCompressionType.isSupported())
-            {
+            if (currentFileCompressionType.isSupported()) {
               // remember the compression type if supported
               fileMetadata.destCompressionType = currentFileCompressionType;
               fileMetadata.requireCompress = false;
               fileMetadata.destFileName = srcFileName;
-              logger.debug("File compression detected as {} for: {}",
-                           currentFileCompressionType.name(), srcFile);
-            }
-            else
-            {
+              logger.debug(
+                  "File compression detected as {} for: {}",
+                  currentFileCompressionType.name(),
+                  srcFile);
+            } else {
               // error if not supported
-              throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                              ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
-                                              currentFileCompressionType.name());
+              throw new SnowflakeSQLException(
+                  SqlState.FEATURE_NOT_SUPPORTED,
+                  ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
+                  currentFileCompressionType.name());
             }
-          }
-          else
-          {
+          } else {
             // we want to auto compress the files unless the user has disabled it
             logger.debug("Compression not found for file: {}", srcFile);
 
@@ -3021,69 +2683,47 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
             fileMetadata.requireCompress = autoCompress;
             fileMetadata.srcCompressionType = null;
 
-            if (autoCompress)
-            {
+            if (autoCompress) {
               // We only support gzip auto compression
-              fileMetadata.destFileName = srcFileName +
-                                          FileCompressionType.GZIP.getFileExtension();
+              fileMetadata.destFileName = srcFileName + FileCompressionType.GZIP.getFileExtension();
               fileMetadata.destCompressionType = FileCompressionType.GZIP;
-            }
-            else
-            {
+            } else {
               fileMetadata.destFileName = srcFileName;
               fileMetadata.destCompressionType = null;
             }
           }
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
 
           // SNOW-13146: don't log severe message for user error
-          if (ex instanceof SnowflakeSQLException)
-          {
-            logger.debug(
-                "Exception encountered when processing file compression types",
-                ex);
-          }
-          else
-          {
-            logger.debug(
-                "Exception encountered when processing file compression types",
-                ex);
+          if (ex instanceof SnowflakeSQLException) {
+            logger.debug("Exception encountered when processing file compression types", ex);
+          } else {
+            logger.debug("Exception encountered when processing file compression types", ex);
           }
 
           fileMetadata.resultStatus = ResultStatus.ERROR;
           fileMetadata.errorDetails = ex.getMessage();
         }
       }
-    }
-    else
-    {
+    } else {
       // source from stream case
       FileMetadata fileMetadata = fileMetadataMap.get(SRC_FILE_NAME_FOR_STREAM);
       fileMetadata.srcCompressionType = userSpecifiedSourceCompression;
 
-      if (compressSourceFromStream)
-      {
+      if (compressSourceFromStream) {
         fileMetadata.destCompressionType = FileCompressionType.GZIP;
         fileMetadata.requireCompress = true;
-      }
-      else
-      {
+      } else {
         fileMetadata.destCompressionType = userSpecifiedSourceCompression;
         fileMetadata.requireCompress = false;
       }
 
       // add gz extension if file name doesn't have it
-      if (compressSourceFromStream &&
-          !destFileNameForStreamSource.endsWith(
-              FileCompressionType.GZIP.getFileExtension()))
-      {
-        fileMetadata.destFileName = destFileNameForStreamSource +
-                                    FileCompressionType.GZIP.getFileExtension();
-      }
-      else
-      {
+      if (compressSourceFromStream
+          && !destFileNameForStreamSource.endsWith(FileCompressionType.GZIP.getFileExtension())) {
+        fileMetadata.destFileName =
+            destFileNameForStreamSource + FileCompressionType.GZIP.getFileExtension();
+      } else {
         fileMetadata.destFileName = destFileNameForStreamSource;
       }
     }
@@ -3095,16 +2735,12 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
    * @param srcFile The source file name
    * @return the mime type derived from the file extension
    */
-  private String getMimeTypeFromFileExtension(String srcFile)
-  {
+  private String getMimeTypeFromFileExtension(String srcFile) {
     String srcFileLowCase = srcFile.toLowerCase();
 
-    for (FileCompressionType compressionType : FileCompressionType.values())
-    {
-      if (srcFileLowCase.endsWith(compressionType.getFileExtension()))
-      {
-        return compressionType.getMimeType() + "/" +
-               compressionType.getMimeSubTypes().get(0);
+    for (FileCompressionType compressionType : FileCompressionType.values()) {
+      if (srcFileLowCase.endsWith(compressionType.getFileExtension())) {
+        return compressionType.getMimeType() + "/" + compressionType.getMimeSubTypes().get(0);
       }
     }
 
@@ -3117,14 +2753,12 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
    * @param stageLocationPath stage location
    * @return remoteLocation object
    */
-  static public remoteLocation extractLocationAndPath(String stageLocationPath)
-  {
+  public static remoteLocation extractLocationAndPath(String stageLocationPath) {
     String location = stageLocationPath;
     String path = "";
 
     // split stage location as location name and path
-    if (stageLocationPath.contains("/"))
-    {
+    if (stageLocationPath.contains("/")) {
       location = stageLocationPath.substring(0, stageLocationPath.indexOf("/"));
       path = stageLocationPath.substring(stageLocationPath.indexOf("/") + 1);
     }
@@ -3139,157 +2773,142 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
    * @throws Exception failed to construct list
    */
   @Override
-  public List<SnowflakeColumnMetadata> describeColumns(SFSession session) throws Exception
-  {
+  public List<SnowflakeColumnMetadata> describeColumns(SFSession session) throws Exception {
     return SnowflakeUtil.describeFixedViewColumns(
-        commandType == CommandType.UPLOAD ?
-        (showEncryptionParameter ?
-         UploadCommandEncryptionFacade.class : UploadCommandFacade.class) :
-        (showEncryptionParameter ?
-         DownloadCommandEncryptionFacade.class : DownloadCommandFacade.class), session);
+        commandType == CommandType.UPLOAD
+            ? (showEncryptionParameter
+                ? UploadCommandEncryptionFacade.class
+                : UploadCommandFacade.class)
+            : (showEncryptionParameter
+                ? DownloadCommandEncryptionFacade.class
+                : DownloadCommandFacade.class),
+        session);
   }
 
   @Override
-  public List<Object> getNextRow() throws Exception
-  {
-    if (currentRowIndex < statusRows.size())
-    {
+  public List<Object> getNextRow() throws Exception {
+    if (currentRowIndex < statusRows.size()) {
       return ClassUtil.getFixedViewObjectAsRow(
-          commandType == CommandType.UPLOAD ?
-          (showEncryptionParameter ?
-           UploadCommandEncryptionFacade.class : UploadCommandFacade.class) :
-          (showEncryptionParameter ?
-           DownloadCommandEncryptionFacade.class : DownloadCommandFacade.class),
+          commandType == CommandType.UPLOAD
+              ? (showEncryptionParameter
+                  ? UploadCommandEncryptionFacade.class
+                  : UploadCommandFacade.class)
+              : (showEncryptionParameter
+                  ? DownloadCommandEncryptionFacade.class
+                  : DownloadCommandFacade.class),
           statusRows.get(currentRowIndex++));
-    }
-    else
-    {
+    } else {
       return null;
     }
   }
 
-  /**
-   * Generate status rows for each file
-   */
-  private void populateStatusRows()
-  {
-    for (Map.Entry<String, FileMetadata> entry : fileMetadataMap.entrySet())
-    {
+  /** Generate status rows for each file */
+  private void populateStatusRows() {
+    for (Map.Entry<String, FileMetadata> entry : fileMetadataMap.entrySet()) {
       FileMetadata fileMetadata = entry.getValue();
 
-      if (commandType == CommandType.UPLOAD)
-      {
-        statusRows.add(showEncryptionParameter ?
-                       new UploadCommandEncryptionFacade(
-                           fileMetadata.srcFileName,
-                           fileMetadata.destFileName,
-                           fileMetadata.resultStatus.name(),
-                           fileMetadata.errorDetails,
-                           fileMetadata.srcFileSize,
-                           fileMetadata.destFileSize,
-                           (fileMetadata.srcCompressionType == null) ?
-                           "NONE" : fileMetadata.srcCompressionType.name(),
-                           (fileMetadata.destCompressionType == null) ?
-                           "NONE" : fileMetadata.destCompressionType.name(),
-                           fileMetadata.isEncrypted) :
-                       new UploadCommandFacade(
-                           fileMetadata.srcFileName,
-                           fileMetadata.destFileName,
-                           fileMetadata.resultStatus.name(),
-                           fileMetadata.errorDetails,
-                           fileMetadata.srcFileSize,
-                           fileMetadata.destFileSize,
-                           (fileMetadata.srcCompressionType == null) ?
-                           "NONE" : fileMetadata.srcCompressionType.name(),
-                           (fileMetadata.destCompressionType == null) ?
-                           "NONE" : fileMetadata.destCompressionType.name()));
+      if (commandType == CommandType.UPLOAD) {
+        statusRows.add(
+            showEncryptionParameter
+                ? new UploadCommandEncryptionFacade(
+                    fileMetadata.srcFileName,
+                    fileMetadata.destFileName,
+                    fileMetadata.resultStatus.name(),
+                    fileMetadata.errorDetails,
+                    fileMetadata.srcFileSize,
+                    fileMetadata.destFileSize,
+                    (fileMetadata.srcCompressionType == null)
+                        ? "NONE"
+                        : fileMetadata.srcCompressionType.name(),
+                    (fileMetadata.destCompressionType == null)
+                        ? "NONE"
+                        : fileMetadata.destCompressionType.name(),
+                    fileMetadata.isEncrypted)
+                : new UploadCommandFacade(
+                    fileMetadata.srcFileName,
+                    fileMetadata.destFileName,
+                    fileMetadata.resultStatus.name(),
+                    fileMetadata.errorDetails,
+                    fileMetadata.srcFileSize,
+                    fileMetadata.destFileSize,
+                    (fileMetadata.srcCompressionType == null)
+                        ? "NONE"
+                        : fileMetadata.srcCompressionType.name(),
+                    (fileMetadata.destCompressionType == null)
+                        ? "NONE"
+                        : fileMetadata.destCompressionType.name()));
+      } else if (commandType == CommandType.DOWNLOAD) {
+        statusRows.add(
+            showEncryptionParameter
+                ? new DownloadCommandEncryptionFacade(
+                    fileMetadata.srcFileName.startsWith("/")
+                        ? fileMetadata.srcFileName.substring(1)
+                        : fileMetadata.srcFileName,
+                    fileMetadata.resultStatus.name(),
+                    fileMetadata.errorDetails,
+                    fileMetadata.destFileSize,
+                    fileMetadata.isEncrypted)
+                : new DownloadCommandFacade(
+                    fileMetadata.srcFileName.startsWith("/")
+                        ? fileMetadata.srcFileName.substring(1)
+                        : fileMetadata.srcFileName,
+                    fileMetadata.resultStatus.name(),
+                    fileMetadata.errorDetails,
+                    fileMetadata.destFileSize));
       }
-      else if (commandType == CommandType.DOWNLOAD)
-      {
-        statusRows.add(showEncryptionParameter ?
-                       new DownloadCommandEncryptionFacade(
-                           fileMetadata.srcFileName.startsWith("/") ?
-                           fileMetadata.srcFileName.substring(1) :
-                           fileMetadata.srcFileName,
-                           fileMetadata.resultStatus.name(),
-                           fileMetadata.errorDetails,
-                           fileMetadata.destFileSize,
-                           fileMetadata.isEncrypted) :
-                       new DownloadCommandFacade(
-                           fileMetadata.srcFileName.startsWith("/") ?
-                           fileMetadata.srcFileName.substring(1) :
-                           fileMetadata.srcFileName,
-                           fileMetadata.resultStatus.name(),
-                           fileMetadata.errorDetails,
-                           fileMetadata.destFileSize));
-      }
-
     }
 
     /* we sort the result if the connection is in sorting mode
      */
     Object sortProperty = null;
 
-    sortProperty =
-        session.getSFSessionProperty("sort");
+    sortProperty = session.getSFSessionProperty("sort");
 
     boolean sortResult = sortProperty != null && (Boolean) sortProperty;
 
-    if (sortResult)
-    {
+    if (sortResult) {
       Comparator<Object> comparator =
-          (commandType == CommandType.UPLOAD) ?
-          new Comparator<Object>()
-          {
-            public int compare(Object a, Object b)
-            {
-              String srcFileNameA = ((UploadCommandFacade) a).srcFile;
-              String srcFileNameB = ((UploadCommandFacade) b).srcFile;
+          (commandType == CommandType.UPLOAD)
+              ? new Comparator<Object>() {
+                public int compare(Object a, Object b) {
+                  String srcFileNameA = ((UploadCommandFacade) a).srcFile;
+                  String srcFileNameB = ((UploadCommandFacade) b).srcFile;
 
-              return srcFileNameA.compareTo(srcFileNameB);
-            }
-          } :
-          new Comparator<Object>()
-          {
-            public int compare(Object a, Object b)
-            {
-              String srcFileNameA = ((DownloadCommandFacade) a).file;
-              String srcFileNameB = ((DownloadCommandFacade) b).file;
+                  return srcFileNameA.compareTo(srcFileNameB);
+                }
+              }
+              : new Comparator<Object>() {
+                public int compare(Object a, Object b) {
+                  String srcFileNameA = ((DownloadCommandFacade) a).file;
+                  String srcFileNameB = ((DownloadCommandFacade) b).file;
 
-              return srcFileNameA.compareTo(srcFileNameB);
-            }
-          };
+                  return srcFileNameA.compareTo(srcFileNameB);
+                }
+              };
 
       // sort the rows by source file names
       Collections.sort(statusRows, comparator);
     }
   }
 
-  public Object getResultSet()
-  throws SnowflakeSQLException
-  {
+  public Object getResultSet() throws SnowflakeSQLException {
     return new SFFixedViewResultSet(this, this.commandType);
   }
 
-  public CommandType getCommandType()
-  {
+  public CommandType getCommandType() {
     return commandType;
   }
 
-  public void setSourceStream(InputStream sourceStream)
-  {
+  public void setSourceStream(InputStream sourceStream) {
     this.sourceStream = sourceStream;
     this.sourceFromStream = true;
   }
 
-  public void setDestFileNameForStreamSource(
-      String destFileNameForStreamSource)
-  {
+  public void setDestFileNameForStreamSource(String destFileNameForStreamSource) {
     this.destFileNameForStreamSource = destFileNameForStreamSource;
   }
 
-  public void setCompressSourceFromStream(boolean compressSourceFromStream)
-  {
+  public void setCompressSourceFromStream(boolean compressSourceFromStream) {
     this.compressSourceFromStream = compressSourceFromStream;
   }
 
@@ -3301,31 +2920,31 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView
    * @throws throws the error as a SnowflakeSQLException
    */
   public static void throwJCEMissingError(String operation, Exception ex)
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     // Most likely cause: Unlimited strength policy files not installed
-    String msg = "Strong encryption with Java JRE requires JCE " +
-                 "Unlimited Strength Jurisdiction Policy files. " +
-                 "Follow JDBC client installation instructions " +
-                 "provided by Snowflake or contact Snowflake Support.";
+    String msg =
+        "Strong encryption with Java JRE requires JCE "
+            + "Unlimited Strength Jurisdiction Policy files. "
+            + "Follow JDBC client installation instructions "
+            + "provided by Snowflake or contact Snowflake Support.";
 
-    logger.error("JCE Unlimited Strength policy files missing: {}. {}.",
-                 ex.getMessage(), ex.getCause().getMessage());
+    logger.error(
+        "JCE Unlimited Strength policy files missing: {}. {}.",
+        ex.getMessage(),
+        ex.getCause().getMessage());
 
     String bootLib = systemGetProperty("sun.boot.library.path");
-    if (bootLib != null)
-    {
-      msg += " The target directory on your system is: " +
-             Paths.get(bootLib, "security").toString();
+    if (bootLib != null) {
+      msg +=
+          " The target directory on your system is: " + Paths.get(bootLib, "security").toString();
       logger.error(msg);
     }
-    throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-                                    ErrorCode.AWS_CLIENT_ERROR.getMessageCode(), operation, msg);
+    throw new SnowflakeSQLException(
+        ex, SqlState.SYSTEM_ERROR, ErrorCode.AWS_CLIENT_ERROR.getMessageCode(), operation, msg);
   }
 
   @Override
-  public int getTotalRows()
-  {
+  public int getTotalRows() {
     return statusRows.size();
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -4,7 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -14,19 +13,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.DigestOutputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.GZIPOutputStream;
 import net.snowflake.client.core.*;
 import net.snowflake.client.jdbc.cloud.storage.*;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
@@ -43,27 +29,46 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 /**
  * Class for uploading/downloading files
  *
  * @author jhuang
  */
-public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
-  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeFileTransferAgent.class);
+public class SnowflakeFileTransferAgent implements SnowflakeFixedView
+{
+  final static SFLogger logger =
+      SFLoggerFactory.getLogger(SnowflakeFileTransferAgent.class);
 
-  static final StorageClientFactory storageFactory = StorageClientFactory.getFactory();
+  final static StorageClientFactory storageFactory = StorageClientFactory.getFactory();
 
-  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+  private static final ObjectMapper mapper =
+      ObjectMapperFactory.getObjectMapper();
 
   // We will allow buffering of upto 128M data before spilling to disk during
   // compression and digest computation
-  static final int MAX_BUFFER_SIZE = 1 << 27;
+  final static int MAX_BUFFER_SIZE = 1 << 27;
   public static final String SRC_FILE_NAME_FOR_STREAM = "stream";
 
   private static final String FILE_PROTOCOL = "file://";
 
-  private static String localFSFileSep = systemGetProperty("file.separator");
-  private static int DEFAULT_PARALLEL = 10;
+  static private String localFSFileSep = systemGetProperty("file.separator");
+  static private int DEFAULT_PARALLEL = 10;
 
   private String command;
 
@@ -79,7 +84,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
   // with 4 threads by default
   private Set<String> smallSourceFiles;
 
-  private static final int BIG_FILE_THRESHOLD = 64 * 1024 * 1024;
+  static final private int BIG_FILE_THRESHOLD = 64 * 1024 * 1024;
 
   private Map<String, FileMetadata> fileMetadataMap;
 
@@ -103,7 +108,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
   private String destFileNameForStreamSource;
 
-  public StageInfo getStageInfo() {
+  public StageInfo getStageInfo()
+  {
     return this.stageInfo;
   }
 
@@ -119,63 +125,78 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
   // Index: Source file to presigned URL
   HashMap<String, String> srcFileToPresignedUrl;
 
-  public Map<?, ?> getStageCredentials() {
+  public Map<?, ?> getStageCredentials()
+  {
     return new HashMap<>(stageInfo.getCredentials());
   }
 
-  public List<RemoteStoreFileEncryptionMaterial> getEncryptionMaterial() {
+  public List<RemoteStoreFileEncryptionMaterial> getEncryptionMaterial()
+  {
     return new ArrayList<>(encryptionMaterial);
   }
 
-  public Map<String, RemoteStoreFileEncryptionMaterial> getSrcToMaterialsMap() {
+  public Map<String, RemoteStoreFileEncryptionMaterial> getSrcToMaterialsMap()
+  {
     return new HashMap<>(srcFileToEncMat);
   }
 
-  public Map<String, String> getSrcToPresignedUrlMap() {
+  public Map<String, String> getSrcToPresignedUrlMap()
+  {
     return new HashMap<>(srcFileToPresignedUrl);
   }
 
-  public String getStageLocation() {
+  public String getStageLocation()
+  {
     return stageInfo.getLocation();
   }
 
   private void initEncryptionMaterial(CommandType commandType, JsonNode jsonNode)
-      throws SnowflakeSQLException, JsonProcessingException {
+  throws SnowflakeSQLException, JsonProcessingException
+  {
     encryptionMaterial = new ArrayList<>();
     JsonNode rootNode = jsonNode.path("data").path("encryptionMaterial");
-    if (commandType == CommandType.UPLOAD) {
+    if (commandType == CommandType.UPLOAD)
+    {
       logger.debug("initEncryptionMaterial: UPLOAD");
 
       RemoteStoreFileEncryptionMaterial encMat = null;
-      if (!rootNode.isMissingNode() && !rootNode.isNull()) {
+      if (!rootNode.isMissingNode() && !rootNode.isNull())
+      {
         encMat = mapper.treeToValue(rootNode, RemoteStoreFileEncryptionMaterial.class);
       }
       encryptionMaterial.add(encMat);
 
-    } else {
+    }
+    else
+    {
       logger.debug("initEncryptionMaterial: DOWNLOAD");
 
-      if (!rootNode.isMissingNode() && !rootNode.isNull()) {
-        encryptionMaterial =
-            Arrays.asList(mapper.treeToValue(rootNode, RemoteStoreFileEncryptionMaterial[].class));
+      if (!rootNode.isMissingNode() && !rootNode.isNull())
+      {
+        encryptionMaterial = Arrays.asList(
+            mapper.treeToValue(rootNode, RemoteStoreFileEncryptionMaterial[].class));
       }
     }
   }
 
   private void initPresignedUrls(CommandType commandType, JsonNode jsonNode)
-      throws SnowflakeSQLException, JsonProcessingException, IOException {
+  throws SnowflakeSQLException, JsonProcessingException, IOException
+  {
     presignedUrls = new ArrayList<>();
     JsonNode rootNode = jsonNode.path("data").path("presignedUrls");
-    if (commandType == CommandType.DOWNLOAD) {
+    if (commandType == CommandType.DOWNLOAD)
+    {
       logger.debug("initEncryptionMaterial: DOWNLOAD");
 
-      if (!rootNode.isMissingNode() && !rootNode.isNull()) {
+      if (!rootNode.isMissingNode() && !rootNode.isNull())
+      {
         presignedUrls = Arrays.asList(mapper.readValue(rootNode.toString(), String[].class));
       }
     }
   }
 
-  public enum CommandType {
+  public enum CommandType
+  {
     UPLOAD,
     DOWNLOAD
   }
@@ -198,8 +219,11 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
   private ExecutorService threadExecutor = null;
   private Boolean canceled = false;
 
-  /** Result status enum */
-  public enum ResultStatus {
+  /**
+   * Result status enum
+   */
+  public enum ResultStatus
+  {
     UNKNOWN("Unknown status"),
     UPLOADED("File uploaded"),
     UNSUPPORTED("File type not supported"),
@@ -212,28 +236,39 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     private String desc;
 
-    public String getDesc() {
+    public String getDesc()
+    {
       return desc;
     }
 
-    private ResultStatus(String desc) {
+    private ResultStatus(String desc)
+    {
       this.desc = desc;
     }
   }
 
-  /** Remote object location location: "bucket" for S3, "container" for Azure BLOB */
-  private static class remoteLocation {
+  /**
+   * Remote object location
+   * location: "bucket" for S3, "container" for Azure BLOB
+   */
+  private static class remoteLocation
+  {
     String location;
     String path;
 
-    public remoteLocation(String remoteStorageLocation, String remotePath) {
+    public remoteLocation(String remoteStorageLocation, String remotePath)
+    {
       location = remoteStorageLocation;
       path = remotePath;
     }
   }
 
-  /** A class for encapsulating the columns to return for the upload command */
-  public enum UploadColumns {
+  /**
+   * A class for encapsulating the columns to return for the upload command
+   */
+  public enum UploadColumns
+  {
+
     source,
     target,
     source_size,
@@ -243,9 +278,13 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     status,
     encryption,
     message
-  };
 
-  public class UploadCommandFacade {
+  }
+
+  ;
+
+  public class UploadCommandFacade
+  {
 
     @FixedViewColumn(name = "source", ordinal = 10)
     private String srcFile;
@@ -271,15 +310,13 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     @FixedViewColumn(name = "message", ordinal = 80)
     private String errorDetails;
 
-    public UploadCommandFacade(
-        String srcFile,
-        String destFile,
-        String resultStatus,
-        String errorDetails,
-        long srcSize,
-        long destSize,
-        String srcCompressionType,
-        String destCompressionType) {
+    public UploadCommandFacade(String srcFile, String destFile,
+                               String resultStatus,
+                               String errorDetails,
+                               long srcSize, long destSize,
+                               String srcCompressionType,
+                               String destCompressionType)
+    {
       this.srcFile = srcFile;
       this.destFile = destFile;
       this.resultStatus = resultStatus;
@@ -291,35 +328,30 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     }
   }
 
-  public class UploadCommandEncryptionFacade extends UploadCommandFacade {
+  public class UploadCommandEncryptionFacade extends UploadCommandFacade
+  {
     @FixedViewColumn(name = "encryption", ordinal = 75)
     private String encryption;
 
-    public UploadCommandEncryptionFacade(
-        String srcFile,
-        String destFile,
-        String resultStatus,
-        String errorDetails,
-        long srcSize,
-        long destSize,
-        String srcCompressionType,
-        String destCompressionType,
-        boolean isEncrypted) {
-      super(
-          srcFile,
-          destFile,
-          resultStatus,
-          errorDetails,
-          srcSize,
-          destSize,
-          srcCompressionType,
-          destCompressionType);
+    public UploadCommandEncryptionFacade(String srcFile, String destFile,
+                                         String resultStatus,
+                                         String errorDetails,
+                                         long srcSize, long destSize,
+                                         String srcCompressionType,
+                                         String destCompressionType,
+                                         boolean isEncrypted)
+    {
+      super(srcFile, destFile, resultStatus, errorDetails, srcSize, destSize,
+            srcCompressionType, destCompressionType);
       this.encryption = isEncrypted ? "ENCRYPTED" : "";
     }
   }
 
-  /** A class for encapsulating the columns to return for the download command */
-  public class DownloadCommandFacade {
+  /**
+   * A class for encapsulating the columns to return for the download command
+   */
+  public class DownloadCommandFacade
+  {
     @FixedViewColumn(name = "file", ordinal = 10)
     private String file;
 
@@ -332,7 +364,11 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     @FixedViewColumn(name = "message", ordinal = 40)
     private String errorDetails;
 
-    public DownloadCommandFacade(String file, String resultStatus, String errorDetails, long size) {
+    public DownloadCommandFacade(String file,
+                                 String resultStatus,
+                                 String errorDetails,
+                                 long size)
+    {
       this.file = file;
       this.resultStatus = resultStatus;
       this.errorDetails = errorDetails;
@@ -340,22 +376,28 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     }
   }
 
-  public class DownloadCommandEncryptionFacade extends DownloadCommandFacade {
+  public class DownloadCommandEncryptionFacade extends DownloadCommandFacade
+  {
     @FixedViewColumn(name = "encryption", ordinal = 35)
     private String encryption;
 
-    public DownloadCommandEncryptionFacade(
-        String file, String resultStatus, String errorDetails, long size, boolean isEncrypted) {
+    public DownloadCommandEncryptionFacade(String file,
+                                           String resultStatus,
+                                           String errorDetails,
+                                           long size,
+                                           boolean isEncrypted)
+    {
       super(file, resultStatus, errorDetails, size);
       this.encryption = isEncrypted ? "DECRYPTED" : "";
     }
   }
 
   /**
-   * File metadata with everything we care so we don't need to repeat same processing to get these
-   * info.
+   * File metadata with everything we care so we don't need to repeat
+   * same processing to get these info.
    */
-  private class FileMetadata {
+  private class FileMetadata
+  {
     public String srcFileName;
     public long srcFileSize;
     public String destFileName;
@@ -368,7 +410,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     public boolean isEncrypted = false;
   }
 
-  static class InputStreamWithMetadata {
+  static class InputStreamWithMetadata
+  {
     long size;
     String digest;
 
@@ -376,8 +419,9 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     // the input stream has been consumed entirely
     FileBackedOutputStream fileBackedOutputStream;
 
-    InputStreamWithMetadata(
-        long size, String digest, FileBackedOutputStream fileBackedOutputStream) {
+    InputStreamWithMetadata(long size, String digest,
+                            FileBackedOutputStream fileBackedOutputStream)
+    {
       this.size = size;
       this.digest = digest;
       this.fileBackedOutputStream = fileBackedOutputStream;
@@ -385,22 +429,28 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
   }
 
   /**
-   * Compress an input stream with GZIP and return the result size, digest and compressed stream.
+   * Compress an input stream with GZIP and return the result size, digest and
+   * compressed stream.
    *
    * @param inputStream data input
+   * @param session     the session
    * @return result size, digest and compressed stream
    * @throws SnowflakeSQLException if encountered exception when compressing
    */
-  private static InputStreamWithMetadata compressStreamWithGZIP(InputStream inputStream)
-      throws SnowflakeSQLException {
-    FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+  private static InputStreamWithMetadata compressStreamWithGZIP(
+      InputStream inputStream, SFSession session) throws SnowflakeSQLException
+  {
+    FileBackedOutputStream tempStream =
+        new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
 
-    try {
+    try
+    {
 
-      DigestOutputStream digestStream =
-          new DigestOutputStream(tempStream, MessageDigest.getInstance("SHA-256"));
+      DigestOutputStream digestStream = new DigestOutputStream(tempStream,
+                                                               MessageDigest.getInstance("SHA-256"));
 
-      CountingOutputStream countingStream = new CountingOutputStream(digestStream);
+      CountingOutputStream countingStream =
+          new CountingOutputStream(digestStream);
 
       // construct a gzip stream with sync_flush mode
       GZIPOutputStream gzipStream;
@@ -416,37 +466,43 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
       countingStream.flush();
 
-      return new InputStreamWithMetadata(
-          countingStream.getCount(),
-          Base64.encodeAsString(digestStream.getMessageDigest().digest()),
-          tempStream);
+      return new InputStreamWithMetadata(countingStream.getCount(),
+                                         Base64.encodeAsString(digestStream.getMessageDigest().digest()),
+                                         tempStream);
 
-    } catch (IOException | NoSuchAlgorithmException ex) {
+    }
+    catch (IOException | NoSuchAlgorithmException ex)
+    {
       logger.error("Exception compressing input stream", ex);
 
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "error encountered for compression");
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "error encountered for compression");
     }
+
   }
 
   /**
-   * Compress an input stream with GZIP and return the result size, digest and compressed stream.
+   * Compress an input stream with GZIP and return the result size, digest and
+   * compressed stream.
    *
    * @param inputStream The input stream to compress
    * @return the compressed stream
-   * @throws SnowflakeSQLException Will be thrown if there is a problem with compression
+   * @throws SnowflakeSQLException Will be thrown if there is a problem with
+   *                               compression
    * @deprecated Can be removed when all accounts are encrypted
    */
   @Deprecated
-  private static InputStreamWithMetadata compressStreamWithGZIPNoDigest(InputStream inputStream)
-      throws SnowflakeSQLException {
-    try {
-      FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+  private static InputStreamWithMetadata compressStreamWithGZIPNoDigest(
+      InputStream inputStream, SFSession session) throws SnowflakeSQLException
+  {
+    try
+    {
+      FileBackedOutputStream tempStream =
+          new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
 
-      CountingOutputStream countingStream = new CountingOutputStream(tempStream);
+      CountingOutputStream countingStream =
+          new CountingOutputStream(tempStream);
 
       // construct a gzip stream with sync_flush mode
       GZIPOutputStream gzipStream;
@@ -462,64 +518,73 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
       countingStream.flush();
 
-      return new InputStreamWithMetadata(countingStream.getCount(), null, tempStream);
+      return new InputStreamWithMetadata(countingStream.getCount(),
+                                         null, tempStream);
 
-    } catch (IOException ex) {
+    }
+    catch (IOException ex)
+    {
       logger.error("Exception compressing input stream", ex);
 
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "error encountered for compression");
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "error encountered for compression");
     }
+
   }
 
-  private static InputStreamWithMetadata computeDigest(InputStream is, boolean resetStream)
-      throws NoSuchAlgorithmException, IOException {
+  private static InputStreamWithMetadata computeDigest(InputStream is,
+                                                       boolean resetStream)
+  throws NoSuchAlgorithmException, IOException
+  {
     MessageDigest md = MessageDigest.getInstance("SHA-256");
-    if (resetStream) {
-      FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+    if (resetStream)
+    {
+      FileBackedOutputStream tempStream =
+          new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
 
-      CountingOutputStream countingOutputStream = new CountingOutputStream(tempStream);
+      CountingOutputStream countingOutputStream =
+          new CountingOutputStream(tempStream);
 
       DigestOutputStream digestStream = new DigestOutputStream(countingOutputStream, md);
 
       IOUtils.copy(is, digestStream);
 
-      return new InputStreamWithMetadata(
-          countingOutputStream.getCount(),
-          Base64.encodeAsString(digestStream.getMessageDigest().digest()),
-          tempStream);
-    } else {
+      return new InputStreamWithMetadata(countingOutputStream.getCount(),
+                                         Base64.encodeAsString(digestStream.getMessageDigest().digest()),
+                                         tempStream);
+    }
+    else
+    {
       CountingOutputStream countingOutputStream =
           new CountingOutputStream(ByteStreams.nullOutputStream());
 
-      DigestOutputStream digestStream = new DigestOutputStream(countingOutputStream, md);
+      DigestOutputStream digestStream = new DigestOutputStream(
+          countingOutputStream,
+          md);
       IOUtils.copy(is, digestStream);
-      return new InputStreamWithMetadata(
-          countingOutputStream.getCount(),
-          Base64.encodeAsString(digestStream.getMessageDigest().digest()),
-          null);
+      return new InputStreamWithMetadata(countingOutputStream.getCount(),
+                                         Base64.encodeAsString(digestStream.getMessageDigest().digest()), null);
     }
   }
 
   /**
    * A callable that can be executed in a separate thread using exeuctor service.
+   * <p>
+   * The callable does compression if needed and upload the result to the
+   * table's staging area.
    *
-   * <p>The callable does compression if needed and upload the result to the table's staging area.
-   *
-   * @param stage information about the stage
-   * @param srcFilePath source file path
-   * @param metadata file metadata
-   * @param client client object used to communicate with c3
-   * @param session session object
-   * @param command command string
-   * @param inputStream null if upload source is file
+   * @param stage            information about the stage
+   * @param srcFilePath      source file path
+   * @param metadata         file metadata
+   * @param client           client object used to communicate with c3
+   * @param session          session object
+   * @param command          command string
+   * @param inputStream      null if upload source is file
    * @param sourceFromStream whether upload source is file or stream
-   * @param parallel number of threads for parallel uploading
-   * @param srcFile source file name
-   * @param encMat not null if encryption is required
+   * @param parallel         number of threads for parallel uploading
+   * @param srcFile          source file name
+   * @param encMat           not null if encryption is required
    * @return a callable that uploading file to the remote store
    */
   public static Callable<Void> getUploadFileCallable(
@@ -533,9 +598,12 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       final boolean sourceFromStream,
       final int parallel,
       final File srcFile,
-      final RemoteStoreFileEncryptionMaterial encMat) {
-    return new Callable<Void>() {
-      public Void call() throws Exception {
+      final RemoteStoreFileEncryptionMaterial encMat)
+  {
+    return new Callable<Void>()
+    {
+      public Void call() throws Exception
+      {
 
         logger.debug("Entering getUploadFileCallable...");
 
@@ -546,10 +614,14 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
         File fileToUpload = null;
 
-        if (uploadStream == null) {
-          try {
+        if (uploadStream == null)
+        {
+          try
+          {
             uploadStream = new FileInputStream(srcFilePath);
-          } catch (FileNotFoundException ex) {
+          }
+          catch (FileNotFoundException ex)
+          {
             metadata.resultStatus = ResultStatus.ERROR;
             metadata.errorDetails = ex.getMessage();
             throw ex;
@@ -557,12 +629,11 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
         }
 
         // this shouldn't happen
-        if (metadata == null) {
-          throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              session,
-              "missing file metadata for: " + srcFilePath);
+        if (metadata == null)
+        {
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "missing file metadata for: " + srcFilePath);
         }
 
         String destFileName = metadata.destFileName;
@@ -578,40 +649,52 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
         // SNOW-16082: we should catpure exception if we fail to compress or
         // calcuate digest.
-        try {
-          if (metadata.requireCompress) {
-            InputStreamWithMetadata compressedSizeAndStream =
-                (encMat == null
-                    ? compressStreamWithGZIPNoDigest(uploadStream)
-                    : compressStreamWithGZIP(uploadStream));
+        try
+        {
+          if (metadata.requireCompress)
+          {
+            InputStreamWithMetadata compressedSizeAndStream = (encMat == null ?
+                                                               compressStreamWithGZIPNoDigest(uploadStream, session) :
+                                                               compressStreamWithGZIP(uploadStream, session));
 
-            fileBackedOutputStream = compressedSizeAndStream.fileBackedOutputStream;
+            fileBackedOutputStream =
+                compressedSizeAndStream.fileBackedOutputStream;
 
             // update the size
             uploadSize = compressedSizeAndStream.size;
             digest = compressedSizeAndStream.digest;
 
-            if (compressedSizeAndStream.fileBackedOutputStream.getFile() != null) {
-              fileToUpload = compressedSizeAndStream.fileBackedOutputStream.getFile();
+            if (compressedSizeAndStream.fileBackedOutputStream.getFile() != null)
+            {
+              fileToUpload =
+                  compressedSizeAndStream.fileBackedOutputStream.getFile();
             }
 
             logger.debug("New size after compression: {}", uploadSize);
-          } else if (stage.getStageType() != StageInfo.StageType.LOCAL_FS) {
+          }
+          else if (stage.getStageType() != StageInfo.StageType.LOCAL_FS)
+          {
             // If it's not local_fs, we store our digest in the metadata
-            // In local_fs, we don't need digest, and if we turn it on, we will consume whole
-            // uploadStream, which local_fs uses.
-            InputStreamWithMetadata result = computeDigest(uploadStream, sourceFromStream);
+            // In local_fs, we don't need digest, and if we turn it on, we will consume whole uploadStream, which local_fs uses.
+            InputStreamWithMetadata result = computeDigest(uploadStream,
+                                                           sourceFromStream);
             digest = result.digest;
             fileBackedOutputStream = result.fileBackedOutputStream;
             uploadSize = result.size;
 
-            if (!sourceFromStream) {
+            if (!sourceFromStream)
+            {
               fileToUpload = srcFile;
-            } else if (result.fileBackedOutputStream.getFile() != null) {
+            }
+            else if (result.fileBackedOutputStream.getFile() != null)
+            {
               fileToUpload = result.fileBackedOutputStream.getFile();
             }
-          } else {
-            if (!sourceFromStream && (srcFile != null)) {
+          }
+          else
+          {
+            if (!sourceFromStream && (srcFile != null))
+            {
               fileToUpload = srcFile;
             }
 
@@ -621,78 +704,77 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
             uploadSize = sourceFromStream ? 0 : srcFile.length();
           }
 
-          logger.debug(
-              "Started copying file from: {} to {}:{} destName: {} "
-                  + "auto compressed? {} size={}",
-              srcFilePath,
-              stage.getStageType().name(),
-              stage.getLocation(),
-              destFileName,
-              (metadata.requireCompress ? "yes" : "no"),
-              uploadSize);
+          logger.debug("Started copying file from: {} to {}:{} destName: {} " +
+                       "auto compressed? {} size={}", srcFilePath, stage.getStageType().name(), stage.getLocation(),
+                       destFileName, (metadata.requireCompress ? "yes" : "no"),
+                       uploadSize);
 
           // Simulated failure code.
-          if (session.getInjectFileUploadFailure() != null
-              && srcFilePath.endsWith((session).getInjectFileUploadFailure())) {
+          if (session.getInjectFileUploadFailure()
+              != null && srcFilePath.endsWith(
+              (session).getInjectFileUploadFailure()))
+          {
             throw new SnowflakeSimulatedUploadFailure(
                 srcFile != null ? srcFile.getName() : "Unknown");
           }
 
           // upload it
-          switch (stage.getStageType()) {
+          switch (stage.getStageType())
+          {
             case LOCAL_FS:
-              pushFileToLocal(
-                  stage.getLocation(),
-                  srcFilePath,
-                  destFileName,
-                  uploadStream,
-                  fileBackedOutputStream);
+              pushFileToLocal(stage.getLocation(),
+                              srcFilePath, destFileName, uploadStream,
+                              fileBackedOutputStream, session);
               break;
 
             case S3:
             case AZURE:
             case GCS:
-              pushFileToRemoteStore(
-                  stage,
-                  destFileName,
-                  uploadStream,
-                  fileBackedOutputStream,
-                  uploadSize,
-                  digest,
-                  metadata.destCompressionType,
-                  client,
-                  session,
-                  command,
-                  parallel,
-                  fileToUpload,
-                  (fileToUpload == null),
-                  encMat);
+              pushFileToRemoteStore(stage,
+                                    destFileName,
+                                    uploadStream, fileBackedOutputStream, uploadSize,
+                                    digest, metadata.destCompressionType,
+                                    client, session, command, parallel, fileToUpload,
+                                    (fileToUpload == null), encMat);
               metadata.isEncrypted = encMat != null;
               break;
           }
-        } catch (SnowflakeSimulatedUploadFailure ex) {
+        }
+        catch (SnowflakeSimulatedUploadFailure ex)
+        {
           // This code path is used for Simulated failure code in tests.
           // Never happen in production
           metadata.resultStatus = ResultStatus.ERROR;
           metadata.errorDetails = ex.getMessage();
           throw ex;
-        } catch (Throwable ex) {
-          logger.error("Exception encountered during file upload", ex);
+        }
+        catch (Throwable ex)
+        {
+          logger.error(
+              "Exception encountered during file upload", ex);
           metadata.resultStatus = ResultStatus.ERROR;
           metadata.errorDetails = ex.getMessage();
           throw ex;
-        } finally {
-          if (fileBackedOutputStream != null) {
-            try {
+        }
+        finally
+        {
+          if (fileBackedOutputStream != null)
+          {
+            try
+            {
               fileBackedOutputStream.reset();
-            } catch (IOException ex) {
+            }
+            catch (IOException ex)
+            {
               logger.debug("failed to clean up temp file: {}", ex);
             }
           }
-          if (inputStream == null) {
+          if (inputStream == null)
+          {
             IOUtils.closeQuietly(uploadStream);
           }
         }
+
 
         logger.debug("filePath: {}", srcFilePath);
 
@@ -709,19 +791,19 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
   /**
    * A callable that can be executed in a separate thread using executor service.
+   * <p>
+   * The callable download files from a stage location to a local location
    *
-   * <p>The callable download files from a stage location to a local location
-   *
-   * @param stage stage information
-   * @param srcFilePath path that stores the downloaded file
-   * @param localLocation local location
+   * @param stage           stage information
+   * @param srcFilePath     path that stores the downloaded file
+   * @param localLocation   local location
    * @param fileMetadataMap file metadata map
-   * @param client remote store client
-   * @param session session object
-   * @param command command string
-   * @param encMat remote store encryption material
-   * @param parallel number of parallel threads for downloading
-   * @param presignedUrl Presigned URL for file download
+   * @param client          remote store client
+   * @param session         session object
+   * @param command         command string
+   * @param encMat          remote store encryption material
+   * @param parallel        number of parallel threads for downloading
+   * @param presignedUrl    Presigned URL for file download
    * @return a callable responsible for downloading files
    */
   public static Callable<Void> getDownloadFileCallable(
@@ -734,9 +816,12 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       final String command,
       final int parallel,
       final RemoteStoreFileEncryptionMaterial encMat,
-      final String presignedUrl) {
-    return new Callable<Void>() {
-      public Void call() throws Exception {
+      final String presignedUrl)
+  {
+    return new Callable<Void>()
+    {
+      public Void call() throws Exception
+      {
 
         logger.debug("Entering getDownloadFileCallable...");
 
@@ -746,48 +831,49 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
         FileMetadata metadata = fileMetadataMap.get(srcFilePath);
 
         // this shouldn't happen
-        if (metadata == null) {
-          throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              session,
-              "missing file metadata for: " + srcFilePath);
+        if (metadata == null)
+        {
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "missing file metadata for: " + srcFilePath);
         }
 
         String destFileName = metadata.destFileName;
-        logger.debug(
-            "Started copying file from: {}:{} file path:{} to {} destName:{}",
-            stage.getStageType().name(),
-            stage.getLocation(),
-            srcFilePath,
-            localLocation,
-            destFileName);
+        logger.debug("Started copying file from: {}:{} file path:{} to {} destName:{}",
+                     stage.getStageType().name(), stage.getLocation(), srcFilePath, localLocation, destFileName);
 
-        try {
-          switch (stage.getStageType()) {
+        try
+        {
+          switch (stage.getStageType())
+          {
             case LOCAL_FS:
-              pullFileFromLocal(stage.getLocation(), srcFilePath, localLocation, destFileName);
+              pullFileFromLocal(stage.getLocation(),
+                                srcFilePath,
+                                localLocation,
+                                destFileName, session);
               break;
 
             case AZURE:
             case S3:
             case GCS:
-              pullFileFromRemoteStore(
-                  stage,
-                  srcFilePath,
-                  destFileName,
-                  localLocation,
-                  client,
-                  session,
-                  command,
-                  parallel,
-                  encMat,
-                  presignedUrl);
+              pullFileFromRemoteStore(stage,
+                                      srcFilePath,
+                                      destFileName,
+                                      localLocation,
+                                      client,
+                                      session,
+                                      command,
+                                      parallel,
+                                      encMat,
+                                      presignedUrl);
               metadata.isEncrypted = encMat != null;
               break;
           }
-        } catch (Throwable ex) {
-          logger.error("Exception encountered during file download", ex);
+        }
+        catch (Throwable ex)
+        {
+          logger.error(
+              "Exception encountered during file download", ex);
 
           metadata.resultStatus = ResultStatus.ERROR;
           metadata.errorDetails = ex.getMessage();
@@ -810,8 +896,11 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     };
   }
 
-  public SnowflakeFileTransferAgent(String command, SFSession session, SFStatement statement)
-      throws SnowflakeSQLException {
+  public SnowflakeFileTransferAgent(String command,
+                                    SFSession session,
+                                    SFStatement statement)
+  throws SnowflakeSQLException
+  {
     this.command = command;
     this.session = session;
     this.statement = statement;
@@ -822,24 +911,26 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     parseCommand();
 
-    if (stageInfo.getStageType() != StageInfo.StageType.LOCAL_FS) {
+    if (stageInfo.getStageType() != StageInfo.StageType.LOCAL_FS)
+    {
       storageClient = storageFactory.createClient(stageInfo, parallel, null, session);
     }
   }
 
   /**
    * Parse the put/get command.
-   *
-   * <p>We send the command to the GS to do the parsing. In the future, we will delegate more work
-   * to GS such as copying files from HTTP to the remote store.
+   * <p>
+   * We send the command to the GS to do the parsing. In the future, we
+   * will delegate more work to GS such as copying files from HTTP to the remote store.
    *
    * @throws SnowflakeSQLException failure to parse the PUT/GET command
    */
-  private void parseCommand() throws SnowflakeSQLException {
+  private void parseCommand() throws SnowflakeSQLException
+  {
     // For AWS and Azure, this command returns enough info for us to get creds
     // we can use for each of the GETs/PUTs. For GCS, we need to issue a separate
     // call to GS to get creds (in the form of a presigned URL) for each file
-    // we're uploading or downloading. This call gets our src_location and
+    // we're uploading or downloading. This call gets our src_location and 
     // encryption material, which we'll use for all the subsequent calls to GS
     // for creds for each file. Those calls are made from pushFileToRemoteStore
     // and pullFileFromRemoteStore if the storage slient requires a presigned
@@ -847,8 +938,10 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     JsonNode jsonNode = parseCommandInGS(statement, command);
 
     // get command type
-    if (!jsonNode.path("data").path("command").isMissingNode()) {
-      commandType = CommandType.valueOf(jsonNode.path("data").path("command").asText());
+    if (!jsonNode.path("data").path("command").isMissingNode())
+    {
+      commandType = CommandType.valueOf(
+          jsonNode.path("data").path("command").asText());
     }
 
     // get source file locations as array (apply to both upload and download)
@@ -858,53 +951,68 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     String[] src_locations;
 
-    try {
+    try
+    {
       src_locations = mapper.readValue(locationsNode.toString(), String[].class);
       initEncryptionMaterial(commandType, jsonNode);
       initPresignedUrls(commandType, jsonNode);
-    } catch (Exception ex) {
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Failed to parse the locations due to: " + ex.getMessage());
+    }
+    catch (Exception ex)
+    {
+      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                                      "Failed to parse the locations due to: " + ex.getMessage());
     }
 
-    showEncryptionParameter =
-        jsonNode.path("data").path("clientShowEncryptionParameter").asBoolean();
+    showEncryptionParameter = jsonNode.path("data")
+        .path("clientShowEncryptionParameter")
+        .asBoolean();
 
     String localFilePathFromGS = null;
 
     // do upload command specific parsing
-    if (commandType == CommandType.UPLOAD) {
-      if (src_locations.length > 0) {
+    if (commandType == CommandType.UPLOAD)
+    {
+      if (src_locations.length > 0)
+      {
         localFilePathFromGS = src_locations[0];
       }
 
       sourceFiles = expandFileNames(src_locations);
 
-      autoCompress = jsonNode.path("data").path("autoCompress").asBoolean(true);
+      autoCompress =
+          jsonNode.path("data").path("autoCompress").asBoolean(true);
 
-      if (!jsonNode.path("data").path("sourceCompression").isMissingNode()) {
-        sourceCompression = jsonNode.path("data").path("sourceCompression").asText();
+      if (!jsonNode.path("data").path("sourceCompression").isMissingNode())
+      {
+        sourceCompression =
+            jsonNode.path("data").path("sourceCompression").asText();
       }
 
-    } else {
+    }
+    else
+    {
       // do download command specific parsing
       srcFileToEncMat = new HashMap<>();
 
       // create mapping from source file to encryption materials
-      if (src_locations.length == encryptionMaterial.size()) {
-        for (int srcFileIdx = 0; srcFileIdx < src_locations.length; srcFileIdx++) {
-          srcFileToEncMat.put(src_locations[srcFileIdx], encryptionMaterial.get(srcFileIdx));
+      if (src_locations.length == encryptionMaterial.size())
+      {
+        for (int srcFileIdx = 0; srcFileIdx < src_locations.length; srcFileIdx++)
+        {
+          srcFileToEncMat.put(src_locations[srcFileIdx],
+                              encryptionMaterial.get(srcFileIdx));
         }
       }
 
       // create mapping from source file to presigned URLs
       srcFileToPresignedUrl = new HashMap<>();
-      if (src_locations.length == presignedUrls.size()) {
-        for (int srcFileIdx = 0; srcFileIdx < src_locations.length; srcFileIdx++) {
-          srcFileToPresignedUrl.put(src_locations[srcFileIdx], presignedUrls.get(srcFileIdx));
+      if (src_locations.length == presignedUrls.size())
+      {
+        for (int srcFileIdx = 0; srcFileIdx < src_locations.length; srcFileIdx++)
+        {
+          srcFileToPresignedUrl.put(src_locations[srcFileIdx],
+                                    presignedUrls.get(srcFileIdx));
         }
       }
 
@@ -914,18 +1022,19 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
       localFilePathFromGS = localLocation;
 
-      if (localLocation.startsWith("~")) {
+      if (localLocation.startsWith("~"))
+      {
         // replace ~ with user home
-        localLocation = systemGetProperty("user.home") + localLocation.substring(1);
+        localLocation = systemGetProperty("user.home") +
+                        localLocation.substring(1);
       }
 
       // it should not contain any ~ after the above replacement
-      if (localLocation.contains("~")) {
-        throw new SnowflakeSQLLoggedException(
-            SqlState.IO_ERROR,
-            ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(),
-            session,
-            localLocation);
+      if (localLocation.contains("~"))
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
+                                              ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), session,
+                                              localLocation);
       }
 
       // todo: replace ~userid with the home directory of a given userid
@@ -934,7 +1043,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
       // user may also specify files relative to current directory
       // add the current path if that is the case
-      if (!(new File(localLocation)).isAbsolute()) {
+      if (!(new File(localLocation)).isAbsolute())
+      {
         String cwd = systemGetProperty("user.dir");
 
         logger.debug("Adding current working dir to relative file path.");
@@ -943,12 +1053,10 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       }
 
       // local location should be a directory
-      if ((new File(localLocation)).isFile()) {
-        throw new SnowflakeSQLLoggedException(
-            SqlState.IO_ERROR,
-            ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(),
-            session,
-            localLocation);
+      if ((new File(localLocation)).isFile())
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.IO_ERROR,
+                                              ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(), session, localLocation);
       }
     }
 
@@ -956,25 +1064,29 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     verifyLocalFilePath(localFilePathFromGS);
 
     // more parameters common to upload/download
-    String stageLocation = jsonNode.path("data").path("stageInfo").path("location").asText();
+    String stageLocation = jsonNode.path("data").path("stageInfo").
+        path("location").asText();
 
     parallel = jsonNode.path("data").path("parallel").asInt();
 
     overwrite = jsonNode.path("data").path("overwrite").asBoolean(false);
 
-    String stageLocationType =
-        jsonNode.path("data").path("stageInfo").path("locationType").asText();
+    String stageLocationType = jsonNode.path("data").path("stageInfo").
+        path("locationType").asText();
 
     String stageRegion = null;
-    if (!jsonNode.path("data").path("stageInfo").path("region").isMissingNode()) {
-      stageRegion = jsonNode.path("data").path("stageInfo").path("region").asText();
+    if (!jsonNode.path("data").path("stageInfo").path("region").isMissingNode())
+    {
+      stageRegion = jsonNode.path("data").path("stageInfo")
+          .path("region").asText();
     }
 
-    // endPoint and storageAccount are only available in Azure stages. Value
+    // endPoint and storageAccount are only available in Azure stages. Value 
     // will be present but null in other platforms.
     String endPoint = null;
     String stgAcct = null;
-    if ("AZURE".equalsIgnoreCase(stageLocationType)) {
+    if ("AZURE".equalsIgnoreCase(stageLocationType))
+    {
       // Jackson is doing some very strange things trying to pull the value of
       // the storageAccount node after adding the GCP library dependencies.
       // If we try to pull the value by name, we get back null, but clearly the
@@ -985,47 +1097,57 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       // "sto", this should work fine.
       endPoint = jsonNode.path("data").path("stageInfo").findValue("endPoint").asText();
       Iterator<Entry<String, JsonNode>> fields = jsonNode.path("data").path("stageInfo").fields();
-      while (fields.hasNext()) {
+      while (fields.hasNext())
+      {
         Entry<String, JsonNode> jsonField = fields.next();
-        if (jsonField.getKey().startsWith("sto")) {
-          stgAcct =
-              jsonField
-                  .getValue()
-                  .toString()
-                  .trim()
-                  .substring(1, jsonField.getValue().toString().trim().lastIndexOf("\""));
+        if (jsonField.getKey().startsWith("sto"))
+        {
+          stgAcct = jsonField.getValue()
+              .toString()
+              .trim()
+              .substring(1, jsonField.getValue().toString().trim().lastIndexOf("\""));
         }
       }
     }
 
-    if ("LOCAL_FS".equalsIgnoreCase(stageLocationType)) {
-      if (stageLocation.startsWith("~")) {
+    if ("LOCAL_FS".equalsIgnoreCase(stageLocationType))
+    {
+      if (stageLocation.startsWith("~"))
+      {
         // replace ~ with user home
-        stageLocation = systemGetProperty("user.home") + stageLocation.substring(1);
+        stageLocation = systemGetProperty("user.home") +
+                        stageLocation.substring(1);
       }
 
-      if (!(new File(stageLocation)).isAbsolute()) {
+      if (!(new File(stageLocation)).isAbsolute())
+      {
         String cwd = systemGetProperty("user.dir");
 
         logger.debug("Adding current working dir to stage file path.");
 
         stageLocation = cwd + localFSFileSep + stageLocation;
       }
+
     }
 
-    if (logger.isDebugEnabled()) {
+    if (logger.isDebugEnabled())
+    {
       logger.debug("Command type: {}", commandType);
 
-      if (commandType == CommandType.UPLOAD) {
+      if (commandType == CommandType.UPLOAD)
+      {
         logger.debug("autoCompress: {}", autoCompress);
 
         logger.debug("source compression: {}", sourceCompression);
-      } else {
+      }
+      else
+      {
         logger.debug("local download location: {}", localLocation);
       }
 
       logger.debug("Source files:");
-      for (String srcFile : sourceFiles) {
+      for (String srcFile : sourceFiles)
+      {
         logger.debug("file: {}", srcFile);
       }
 
@@ -1046,16 +1168,19 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     Map<?, ?> stageCredentials = extractStageCreds(jsonNode);
 
-    stageInfo =
-        StageInfo.createStageInfo(
-            stageLocationType, stageLocation, stageCredentials, stageRegion, endPoint, stgAcct);
+    stageInfo = StageInfo.createStageInfo(stageLocationType, stageLocation,
+                                          stageCredentials, stageRegion, endPoint, stgAcct);
 
     // Setup pre-signed URL into stage info if pre-signed URL is returned.
-    if (stageInfo.getStageType() == StageInfo.StageType.GCS) {
-      JsonNode presignedUrlNode = jsonNode.path("data").path("stageInfo").path("presignedUrl");
-      if (!presignedUrlNode.isMissingNode()) {
+    if (stageInfo.getStageType() == StageInfo.StageType.GCS)
+    {
+      JsonNode presignedUrlNode =
+          jsonNode.path("data").path("stageInfo").path("presignedUrl");
+      if (!presignedUrlNode.isMissingNode())
+      {
         String presignedUrl = presignedUrlNode.asText();
-        if (!Strings.isNullOrEmpty(presignedUrl)) {
+        if (!Strings.isNullOrEmpty(presignedUrl))
+        {
           stageInfo.setPresignedUrl(presignedUrl);
         }
       }
@@ -1063,86 +1188,110 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
   }
 
   /**
-   * A helper method to verify if the local file path from GS matches what's parsed locally. This is
-   * for security purpose as documented in SNOW-15153.
+   * A helper method to verify if the local file path from GS matches
+   * what's parsed locally. This is for security purpose as documented in
+   * SNOW-15153.
    *
    * @param localFilePathFromGS the local file path to verify
-   * @throws SnowflakeSQLException Will be thrown if the log path if empty or if it doesn't match
-   *     what comes back from GS
+   * @throws SnowflakeSQLException Will be thrown if the log path if empty or
+   *                               if it doesn't match what comes back from GS
    */
-  private void verifyLocalFilePath(String localFilePathFromGS) throws SnowflakeSQLException {
+  private void verifyLocalFilePath(String localFilePathFromGS)
+  throws SnowflakeSQLException
+  {
     String localFilePath = getLocalFilePathFromCommand(command, true);
 
-    if (!localFilePath.isEmpty() && !localFilePath.equals(localFilePathFromGS)) {
-      throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
-          "Unexpected local file path from GS. From GS: "
-              + localFilePathFromGS
-              + ", expected: "
-              + localFilePath);
-    } else if (localFilePath.isEmpty()) {
-      logger.debug("fail to parse local file path from command: {}", command);
-    } else {
-      logger.trace("local file path from GS matches local parsing: {}", localFilePath);
+    if (!localFilePath.isEmpty() && !localFilePath.equals(localFilePathFromGS))
+    {
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Unexpected local file path from GS. From GS: " +
+                                            localFilePathFromGS + ", expected: " + localFilePath);
+    }
+    else if (localFilePath.isEmpty())
+    {
+      logger.debug(
+          "fail to parse local file path from command: {}", command);
+    }
+    else
+    {
+      logger.trace(
+          "local file path from GS matches local parsing: {}", localFilePath);
     }
   }
 
   /**
-   * Parses out the local file path from the command. We need this to get the file paths to expand
-   * wildcards and make sure the paths GS returns are correct
+   * Parses out the local file path from the command. We need this to get the
+   * file paths to expand wildcards and make sure the paths GS returns are
+   * correct
    *
-   * @param command The GET/PUT command we send to GS
+   * @param command  The GET/PUT command we send to GS
    * @param unescape True to unescape backslashes coming from GS
    * @return Path to the local file
    */
-  private static String getLocalFilePathFromCommand(String command, boolean unescape) {
-    if (command == null) {
+  private static String getLocalFilePathFromCommand(String command, boolean unescape)
+  {
+    if (command == null)
+    {
       logger.error("null command");
       return null;
     }
 
-    if (command.indexOf(FILE_PROTOCOL) < 0) {
-      logger.error("file:// prefix not found in command: {}", command);
+    if (command.indexOf(FILE_PROTOCOL) < 0)
+    {
+      logger.error(
+          "file:// prefix not found in command: {}", command);
       return null;
     }
 
-    int localFilePathBeginIdx = command.indexOf(FILE_PROTOCOL) + FILE_PROTOCOL.length();
+    int localFilePathBeginIdx = command.indexOf(FILE_PROTOCOL) +
+                                FILE_PROTOCOL.length();
     boolean isLocalFilePathQuoted =
-        (localFilePathBeginIdx > FILE_PROTOCOL.length())
-            && (command.charAt(localFilePathBeginIdx - 1 - FILE_PROTOCOL.length()) == '\'');
+        (localFilePathBeginIdx > FILE_PROTOCOL.length()) &&
+        (command.charAt(localFilePathBeginIdx - 1 - FILE_PROTOCOL.length()) == '\'');
 
     // the ending index is exclusive
     int localFilePathEndIdx = 0;
     String localFilePath = "";
 
-    if (isLocalFilePathQuoted) {
+    if (isLocalFilePathQuoted)
+    {
       // look for the matching quote
       localFilePathEndIdx = command.indexOf("'", localFilePathBeginIdx);
-      if (localFilePathEndIdx > localFilePathBeginIdx) {
-        localFilePath = command.substring(localFilePathBeginIdx, localFilePathEndIdx);
+      if (localFilePathEndIdx > localFilePathBeginIdx)
+      {
+        localFilePath = command.substring(localFilePathBeginIdx,
+                                          localFilePathEndIdx);
       }
       // unescape backslashes to match the file name from GS
-      if (unescape) {
+      if (unescape)
+      {
         localFilePath = localFilePath.replaceAll("\\\\\\\\", "\\\\");
       }
-    } else {
+    }
+    else
+    {
       // look for the first space or new line or semi colon
       List<Integer> indexList = new ArrayList<>();
       char[] delimiterChars = {' ', '\n', ';'};
-      for (int i = 0; i < delimiterChars.length; i++) {
+      for (int i = 0; i < delimiterChars.length; i++)
+      {
         int charIndex = command.indexOf(delimiterChars[i], localFilePathBeginIdx);
-        if (charIndex != -1) {
+        if (charIndex != -1)
+        {
           indexList.add(charIndex);
         }
       }
 
       localFilePathEndIdx = indexList.isEmpty() ? -1 : Collections.min(indexList);
 
-      if (localFilePathEndIdx > localFilePathBeginIdx) {
-        localFilePath = command.substring(localFilePathBeginIdx, localFilePathEndIdx);
-      } else if (localFilePathEndIdx == -1) {
+      if (localFilePathEndIdx > localFilePathBeginIdx)
+      {
+        localFilePath = command.substring(localFilePathBeginIdx,
+                                          localFilePathEndIdx);
+      }
+      else if (localFilePathEndIdx == -1)
+      {
         localFilePath = command.substring(localFilePathBeginIdx);
       }
     }
@@ -1152,24 +1301,29 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
   /**
    * @return JSON doc containing the command options returned by GS
-   * @throws SnowflakeSQLException Will be thrown if parsing the command by GS fails
+   * @throws SnowflakeSQLException Will be thrown if parsing the command by
+   *                               GS fails
    */
-  private static JsonNode parseCommandInGS(SFStatement statement, String command)
-      throws SnowflakeSQLException {
+  private static JsonNode parseCommandInGS(SFStatement statement,
+                                           String command)
+  throws SnowflakeSQLException
+  {
     Object result = null;
     // send the command to GS
-    try {
-      result =
-          statement.executeHelper(
-              command,
-              "application/json",
-              null, // bindValues
-              false, // describeOnly
-              false, // internal
-              false // async
-              );
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(ex, ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    try
+    {
+      result = statement.executeHelper(command,
+                                       "application/json",
+                                       null, // bindValues
+                                       false, // describeOnly
+                                       false, // internal
+                                       false // async
+      );
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex, ex.getSqlState(),
+                                      ex.getVendorCode(), ex.getParams());
     }
 
     JsonNode jsonNode = (JsonNode) result;
@@ -1181,26 +1335,31 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
   /**
    * @param rootNode JSON doc returned by GS
-   * @throws SnowflakeSQLException Will be thrown if we fail to parse the stage credentials
+   * @throws SnowflakeSQLException Will be thrown if we fail to parse the
+   *                               stage credentials
    */
-  private static Map<?, ?> extractStageCreds(JsonNode rootNode) throws SnowflakeSQLException {
+  private static Map<?, ?> extractStageCreds(JsonNode rootNode)
+  throws SnowflakeSQLException
+  {
     JsonNode credsNode = rootNode.path("data").path("stageInfo").path("creds");
     Map<?, ?> stageCredentials = null;
 
-    try {
-      TypeReference<HashMap<String, String>> typeRef =
-          new TypeReference<HashMap<String, String>>() {};
+    try
+    {
+      TypeReference<HashMap<String, String>> typeRef
+          = new TypeReference<HashMap<String, String>>()
+      {
+      };
       stageCredentials = mapper.readValue(credsNode.toString(), typeRef);
 
-    } catch (Exception ex) {
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Failed to parse the credentials ("
-              + (credsNode != null ? credsNode.toString() : "null")
-              + ") due to exception: "
-              + ex.getMessage());
+    }
+    catch (Exception ex)
+    {
+      throw new SnowflakeSQLException(ex, SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                                      "Failed to parse the credentials (" +
+                                      (credsNode != null ? credsNode.toString() : "null") +
+                                      ") due to exception: " + ex.getMessage());
     }
 
     return stageCredentials;
@@ -1208,49 +1367,51 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
   /**
    * This is API function to retrieve the File Transfer Metadatas.
-   *
-   * <p>NOTE: It only supports PUT on GCP when it is created.
+   * <p>
+   * NOTE: It only supports PUT on GCP when it is created.
    *
    * @return The file transfer metadatas for to-be-transferred files.
    * @throws SnowflakeSQLException if any error occurs
    */
   public List<SnowflakeFileTransferMetadata> getFileTransferMetadatas()
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
     List<SnowflakeFileTransferMetadata> result = new ArrayList<>();
-    if (stageInfo.getStageType() != StageInfo.StageType.GCS) {
-      throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
-          "This API only supports GCS");
+    if (stageInfo.getStageType() != StageInfo.StageType.GCS)
+    {
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "This API only supports GCS");
     }
 
-    if (commandType != CommandType.UPLOAD) {
-      throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
-          "This API only supports PUT command");
+    if (commandType != CommandType.UPLOAD)
+    {
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "This API only supports PUT command");
     }
 
-    for (String sourceFilePath : sourceFiles) {
-      String sourceFileName = sourceFilePath.substring(sourceFilePath.lastIndexOf("/") + 1);
-      result.add(
-          new SnowflakeFileTransferMetadataV1(
-              stageInfo.getPresignedUrl(),
-              sourceFileName,
-              encryptionMaterial.get(0).getQueryStageMasterKey(),
-              encryptionMaterial.get(0).getQueryId(),
-              encryptionMaterial.get(0).getSmkId(),
-              commandType,
-              stageInfo));
+    for (String sourceFilePath : sourceFiles)
+    {
+      String sourceFileName =
+          sourceFilePath.substring(sourceFilePath.lastIndexOf("/") + 1);
+      result.add(new SnowflakeFileTransferMetadataV1(
+          stageInfo.getPresignedUrl(),
+          sourceFileName,
+          encryptionMaterial.get(0).getQueryStageMasterKey(),
+          encryptionMaterial.get(0).getQueryId(),
+          encryptionMaterial.get(0).getSmkId(),
+          commandType,
+          stageInfo));
     }
 
     return result;
   }
 
-  public boolean execute() throws SQLException {
-    try {
+  public boolean execute() throws SQLException
+  {
+    try
+    {
       logger.debug("Start init metadata");
 
       // initialize file metadata map
@@ -1259,21 +1420,25 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       logger.debug("Start checking file types");
 
       // check file compression type
-      if (commandType == CommandType.UPLOAD) {
+      if (commandType == CommandType.UPLOAD)
+      {
         processFileCompressionTypes();
       }
 
       // Filter out files that are already existing in the destination.
       // GCS doesn't have permission to list in the presigned url, so we'll
       // always overwrite.
-      if (!overwrite && stageInfo.getStageType() != StageInfo.StageType.GCS) {
+      if (!overwrite && stageInfo.getStageType() != StageInfo.StageType.GCS)
+      {
         logger.debug("Start filtering");
 
         filterExistingFiles();
       }
 
-      synchronized (canceled) {
-        if (canceled) {
+      synchronized (canceled)
+      {
+        if (canceled)
+        {
           logger.debug("File transfer canceled by user");
           threadExecutor = null;
           return false;
@@ -1281,34 +1446,45 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       }
 
       // create target directory for download command
-      if (commandType == CommandType.DOWNLOAD) {
+      if (commandType == CommandType.DOWNLOAD)
+      {
         File dir = new File(localLocation);
-        if (!dir.exists()) {
+        if (!dir.exists())
+        {
           boolean created = dir.mkdirs();
 
-          if (created) {
+          if (created)
+          {
             logger.debug("directory created: {}", localLocation);
-          } else {
+          }
+          else
+          {
             logger.debug("directory not created {}", localLocation);
           }
         }
 
         downloadFiles();
-      } else if (sourceFromStream) {
+      }
+      else if (sourceFromStream)
+      {
         uploadStream();
-      } else {
+      }
+      else
+      {
         // separate files to big files list and small files list
         // big files will be uploaded in serial, while small files will be
         // uploaded concurrently.
         segregateFilesBySize();
 
-        if (bigSourceFiles != null) {
+        if (bigSourceFiles != null)
+        {
           logger.debug("start uploading big files");
           uploadFiles(bigSourceFiles, 1);
           logger.debug("end uploading big files");
         }
 
-        if (smallSourceFiles != null) {
+        if (smallSourceFiles != null)
+        {
           logger.debug("start uploading small files");
           uploadFiles(smallSourceFiles, parallel);
           logger.debug("end uploading small files");
@@ -1319,28 +1495,36 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       populateStatusRows();
 
       return true;
-    } finally {
-      if (storageClient != null) {
+    }
+    finally
+    {
+      if (storageClient != null)
+      {
         storageClient.shutdown();
       }
     }
   }
 
-  /** Helper to upload data from a stream */
-  private void uploadStream() throws SnowflakeSQLException {
-    try {
-      threadExecutor = SnowflakeUtil.createDefaultExecutorService("sf-stream-upload-worker-", 1);
+  /**
+   * Helper to upload data from a stream
+   */
+  private void uploadStream() throws SnowflakeSQLException
+  {
+    try
+    {
+      threadExecutor = SnowflakeUtil.createDefaultExecutorService(
+          "sf-stream-upload-worker-", 1);
 
       RemoteStoreFileEncryptionMaterial encMat = encryptionMaterial.get(0);
-      if (commandType == CommandType.UPLOAD) {
+      if (commandType == CommandType.UPLOAD)
+      {
         threadExecutor.submit(
             getUploadFileCallable(
                 stageInfo,
                 SRC_FILE_NAME_FOR_STREAM,
                 fileMetadataMap.get(SRC_FILE_NAME_FOR_STREAM),
-                (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
-                    ? null
-                    : storageFactory.createClient(stageInfo, parallel, encMat, session),
+                (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
+                null : storageFactory.createClient(stageInfo, parallel, encMat, session),
                 session,
                 command,
                 sourceStream,
@@ -1348,115 +1532,129 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
                 parallel,
                 null,
                 encMat));
-      } else if (commandType == CommandType.DOWNLOAD) {
-        throw new SnowflakeSQLLoggedException(
-            SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), session);
+      }
+      else if (commandType == CommandType.DOWNLOAD)
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session);
       }
 
       threadExecutor.shutdown();
 
-      try {
+      try
+      {
         // wait for all threads to complete without timeout
         threadExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-      } catch (InterruptedException ex) {
-        throw new SnowflakeSQLException(
-            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
+      }
+      catch (InterruptedException ex)
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
       logger.debug("Done with uploading from a stream");
-    } finally {
-      if (threadExecutor != null) {
+    }
+    finally
+    {
+      if (threadExecutor != null)
+      {
         threadExecutor.shutdownNow();
         threadExecutor = null;
       }
     }
   }
 
-  /** Download a file from remote, and return an input stream */
-  InputStream downloadStream(String fileName) throws SnowflakeSQLException {
-    if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) {
+  /**
+   * Download a file from remote, and return an input stream
+   */
+  InputStream downloadStream(String fileName) throws SnowflakeSQLException
+  {
+    if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
+    {
       logger.error("downloadStream function doesn't support local file system");
 
-      throw new SnowflakeSQLException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
-          "downloadStream function only supported in remote stages");
+      throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+                                      ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                      "downloadStream function only supported in remote stages");
     }
 
-    remoteLocation remoteLocation = extractLocationAndPath(stageInfo.getLocation());
+    remoteLocation remoteLocation =
+        extractLocationAndPath(stageInfo.getLocation());
 
     String stageFilePath = fileName;
 
-    if (!remoteLocation.path.isEmpty()) {
-      stageFilePath = SnowflakeUtil.concatFilePathNames(remoteLocation.path, fileName, "/");
+    if (!remoteLocation.path.isEmpty())
+    {
+      stageFilePath = SnowflakeUtil.concatFilePathNames(remoteLocation.path,
+                                                        fileName, "/");
     }
 
     RemoteStoreFileEncryptionMaterial encMat = srcFileToEncMat.get(fileName);
     String presignedUrl = srcFileToPresignedUrl.get(fileName);
 
-    return storageFactory
-        .createClient(stageInfo, parallel, encMat, session)
-        .downloadToStream(
-            session,
-            command,
-            parallel,
-            remoteLocation.location,
-            stageFilePath,
-            stageInfo.getRegion(),
-            presignedUrl);
+    return storageFactory.createClient(stageInfo, parallel, encMat, session)
+        .downloadToStream(session, command, parallel, remoteLocation.location,
+                          stageFilePath, stageInfo.getRegion(), presignedUrl);
   }
 
-  /** Helper to download files from remote */
-  private void downloadFiles() throws SnowflakeSQLException {
-    try {
-      threadExecutor = SnowflakeUtil.createDefaultExecutorService("sf-file-download-worker-", 1);
+  /**
+   * Helper to download files from remote
+   */
+  private void downloadFiles() throws SnowflakeSQLException
+  {
+    try
+    {
+      threadExecutor = SnowflakeUtil.createDefaultExecutorService(
+          "sf-file-download-worker-", 1);
 
-      for (String srcFile : sourceFiles) {
+      for (String srcFile : sourceFiles)
+      {
         FileMetadata fileMetadata = fileMetadataMap.get(srcFile);
 
         // Check if the result status is already set so that we don't need to
         // upload it
-        if (fileMetadata.resultStatus != ResultStatus.UNKNOWN) {
-          logger.debug(
-              "Skipping {}, status: {}, details: {}",
-              srcFile,
-              fileMetadata.resultStatus,
-              fileMetadata.errorDetails);
+        if (fileMetadata.resultStatus != ResultStatus.UNKNOWN)
+        {
+          logger.debug("Skipping {}, status: {}, details: {}",
+                       srcFile, fileMetadata.resultStatus, fileMetadata.errorDetails);
           continue;
         }
 
         RemoteStoreFileEncryptionMaterial encMat = srcFileToEncMat.get(srcFile);
         String presignedUrl = srcFileToPresignedUrl.get(srcFile);
-        threadExecutor.submit(
-            getDownloadFileCallable(
-                stageInfo,
-                srcFile,
-                localLocation,
-                fileMetadataMap,
-                (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
-                    ? null
-                    : storageFactory.createClient(stageInfo, parallel, encMat, session),
-                session,
-                command,
-                parallel,
-                encMat,
-                presignedUrl));
+        threadExecutor.submit(getDownloadFileCallable(
+            stageInfo,
+            srcFile,
+            localLocation,
+            fileMetadataMap,
+            (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
+            null : storageFactory.createClient(stageInfo, parallel, encMat, session),
+            session,
+            command,
+            parallel,
+            encMat,
+            presignedUrl));
 
         logger.debug("submitted download job for: {}", srcFile);
       }
 
       threadExecutor.shutdown();
 
-      try {
+      try
+      {
         // wait for all threads to complete without timeout
         threadExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-      } catch (InterruptedException ex) {
-        throw new SnowflakeSQLException(
-            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
+      }
+      catch (InterruptedException ex)
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
       logger.debug("Done with downloading");
-    } finally {
-      if (threadExecutor != null) {
+    }
+    finally
+    {
+      if (threadExecutor != null)
+      {
         threadExecutor.shutdownNow();
         threadExecutor = null;
       }
@@ -1464,46 +1662,52 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
   }
 
   /**
-   * This method is used in uploadFiles to delay the file upload for the given time, which is set as
-   * a session parameter called "inject_wait_in_put." Normally this value is 0, but it is used in
-   * testing.
+   * This method is used in uploadFiles to delay the file upload for the given time, which is set as a session
+   * parameter called "inject_wait_in_put." Normally this value is 0, but it is used in testing.
    *
    * @param delayTime the number of seconds to sleep before uploading the file
    */
-  private void setUploadDelay(int delayTime) {
-    if (delayTime > 0) {
-      try {
+  private void setUploadDelay(int delayTime)
+  {
+    if (delayTime > 0)
+    {
+      try
+      {
         TimeUnit.SECONDS.sleep(delayTime);
-      } catch (InterruptedException ie) {
+      }
+      catch (InterruptedException ie)
+      {
         Thread.currentThread().interrupt();
       }
     }
   }
 
   /**
-   * This method create a thread pool based on requested number of threads and upload the files
-   * using the thread pool.
+   * This method create a thread pool based on requested number of threads
+   * and upload the files using the thread pool.
    *
    * @param fileList The set of files to upload
    * @param parallel degree of parallelism for the upload
    * @throws SnowflakeSQLException Will be thrown if uploading the files fails
    */
-  private void uploadFiles(Set<String> fileList, int parallel) throws SnowflakeSQLException {
-    try {
-      threadExecutor =
-          SnowflakeUtil.createDefaultExecutorService("sf-file-upload-worker-", parallel);
+  private void uploadFiles(Set<String> fileList,
+                           int parallel) throws SnowflakeSQLException
+  {
+    try
+    {
+      threadExecutor = SnowflakeUtil.createDefaultExecutorService(
+          "sf-file-upload-worker-", parallel);
 
-      for (String srcFile : fileList) {
+      for (String srcFile : fileList)
+      {
         FileMetadata fileMetadata = fileMetadataMap.get(srcFile);
 
         // Check if the result status is already set so that we don't need to
         // upload it
-        if (fileMetadata.resultStatus != ResultStatus.UNKNOWN) {
-          logger.debug(
-              "Skipping {}, status: {}, details: {}",
-              srcFile,
-              fileMetadata.resultStatus,
-              fileMetadata.errorDetails);
+        if (fileMetadata.resultStatus != ResultStatus.UNKNOWN)
+        {
+          logger.debug("Skipping {}, status: {}, details: {}",
+                       srcFile, fileMetadata.resultStatus, fileMetadata.errorDetails);
 
           continue;
         }
@@ -1520,22 +1724,15 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
         int delay = session.getInjectWaitInPut();
         setUploadDelay(delay);
 
-        threadExecutor.submit(
-            getUploadFileCallable(
-                stageInfo,
-                srcFile,
-                fileMetadata,
-                (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
-                    ? null
-                    : storageFactory.createClient(
-                        stageInfo, parallel, encryptionMaterial.get(0), session),
-                session,
-                command,
-                null,
-                false,
-                (parallel > 1 ? 1 : this.parallel),
-                srcFileObj,
-                encryptionMaterial.get(0)));
+        threadExecutor.submit(getUploadFileCallable(
+            stageInfo,
+            srcFile,
+            fileMetadata,
+            (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) ?
+            null : storageFactory.createClient(stageInfo, parallel, encryptionMaterial.get(0), session),
+            session, command,
+            null, false,
+            (parallel > 1 ? 1 : this.parallel), srcFileObj, encryptionMaterial.get(0)));
 
         logger.debug("submitted copy job for: {}", srcFile);
       }
@@ -1543,34 +1740,47 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       // shut down the thread executor
       threadExecutor.shutdown();
 
-      try {
+      try
+      {
         // wait for all threads to complete without timeout
         threadExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-      } catch (InterruptedException ex) {
-        throw new SnowflakeSQLException(
-            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode());
+      }
+      catch (InterruptedException ex)
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.QUERY_CANCELED,
+                                              ErrorCode.INTERRUPTED.getMessageCode(), session);
       }
       logger.debug("Done with uploading");
 
-    } finally {
+    }
+    finally
+    {
       // shut down the thread pool in any case
-      if (threadExecutor != null) {
+      if (threadExecutor != null)
+      {
         threadExecutor.shutdownNow();
         threadExecutor = null;
       }
     }
   }
 
-  private void segregateFilesBySize() {
-    for (String srcFile : sourceFiles) {
-      if ((new File(srcFile)).length() > BIG_FILE_THRESHOLD) {
-        if (bigSourceFiles == null) {
+  private void segregateFilesBySize()
+  {
+    for (String srcFile : sourceFiles)
+    {
+      if ((new File(srcFile)).length() > BIG_FILE_THRESHOLD)
+      {
+        if (bigSourceFiles == null)
+        {
           bigSourceFiles = new HashSet<String>(sourceFiles.size());
         }
 
         bigSourceFiles.add(srcFile);
-      } else {
-        if (smallSourceFiles == null) {
+      }
+      else
+      {
+        if (smallSourceFiles == null)
+        {
           smallSourceFiles = new HashSet<String>(sourceFiles.size());
         }
 
@@ -1579,25 +1789,32 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     }
   }
 
-  public void cancel() {
-    synchronized (canceled) {
-      if (threadExecutor != null) {
+  public void cancel()
+  {
+    synchronized (canceled)
+    {
+      if (threadExecutor != null)
+      {
         threadExecutor.shutdownNow();
         threadExecutor = null;
       }
       canceled = true;
+
     }
   }
 
   /**
-   * process a list of file paths separated by "," and expand the wildcards if any to generate the
-   * list of paths for all files matched by the wildcards
+   * process a list of file paths separated by "," and expand the wildcards
+   * if any to generate the list of paths for all files matched by the
+   * wildcards
    *
    * @param filePathList file path list
    * @return a set of file names that is matched
    * @throws SnowflakeSQLException if cannot find the file
    */
-  static Set<String> expandFileNames(String[] filePathList) throws SnowflakeSQLException {
+  static Set<String> expandFileNames(String[] filePathList)
+  throws SnowflakeSQLException
+  {
     Set<String> result = new HashSet<String>();
 
     // a location to file pattern map so that we only need to list the
@@ -1608,33 +1825,38 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     String cwd = systemGetProperty("user.dir");
 
-    for (String path : filePathList) {
+    for (String path : filePathList)
+    {
       // replace ~ with user home
       path = path.replace("~", systemGetProperty("user.home"));
 
       // user may also specify files relative to current directory
       // add the current path if that is the case
-      if (!(new File(path)).isAbsolute()) {
+      if (!(new File(path)).isAbsolute())
+      {
         logger.debug("Adding current working dir to relative file path.");
 
         path = cwd + localFSFileSep + path;
       }
 
       // check if the path contains any wildcards
-      if (!path.contains("*")
-          && !path.contains("?")
-          && !(path.contains("[") && path.contains("]"))) {
+      if (!path.contains("*") && !path.contains("?") &&
+          !(path.contains("[") && path.contains("]")))
+      {
         /* this file path doesn't have any wildcard, so we don't need to
          * expand it
          */
         result.add(path);
-      } else {
+      }
+      else
+      {
         // get the directory path
         int lastFileSepIndex = path.lastIndexOf(localFSFileSep);
 
         // SNOW-15203: if we don't find a default file sep, try "/" if it is not
         // the default file sep.
-        if (lastFileSepIndex < 0 && !"/".equals(localFSFileSep)) {
+        if (lastFileSepIndex < 0 && !"/".equals(localFSFileSep))
+        {
           lastFileSepIndex = path.lastIndexOf("/");
         }
 
@@ -1644,7 +1866,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
         List<String> filePatterns = locationToFilePatterns.get(loc);
 
-        if (filePatterns == null) {
+        if (filePatterns == null)
+        {
           filePatterns = new ArrayList<String>();
           locationToFilePatterns.put(loc, filePatterns);
         }
@@ -1654,142 +1877,165 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     }
 
     // For each location, list files and match against the patterns
-    for (Map.Entry<String, List<String>> entry : locationToFilePatterns.entrySet()) {
-      try {
+    for (Map.Entry<String, List<String>> entry :
+        locationToFilePatterns.entrySet())
+    {
+      try
+      {
         java.io.File dir = new java.io.File(entry.getKey());
 
-        logger.debug(
-            "Listing files under: {} with patterns: {}",
-            entry.getKey(),
-            entry.getValue().toString());
+        logger.debug("Listing files under: {} with patterns: {}",
+                     entry.getKey(), entry.getValue().toString());
 
         // The following currently ignore sub directories
-        for (Object file :
-            FileUtils.listFiles(dir, new WildcardFileFilter(entry.getValue()), null)) {
+        for (Object file : FileUtils.listFiles(dir,
+                                               new WildcardFileFilter(entry.getValue()),
+                                               null))
+        {
           result.add(((java.io.File) file).getCanonicalPath());
         }
-      } catch (Exception ex) {
-        throw new SnowflakeSQLException(
-            ex,
-            SqlState.DATA_EXCEPTION,
-            ErrorCode.FAIL_LIST_FILES.getMessageCode(),
-            "Exception: "
-                + ex.getMessage()
-                + ", Dir="
-                + entry.getKey()
-                + ", Patterns="
-                + entry.getValue().toString());
+      }
+      catch (Exception ex)
+      {
+        throw new SnowflakeSQLException(ex, SqlState.DATA_EXCEPTION,
+                                        ErrorCode.FAIL_LIST_FILES.getMessageCode(),
+                                        "Exception: " + ex.getMessage() + ", Dir=" +
+                                        entry.getKey() + ", Patterns=" +
+                                        entry.getValue().toString());
       }
     }
 
     logger.debug("Expanded file paths: ");
 
-    for (String filePath : result) {
+    for (String filePath : result)
+    {
       logger.debug("file: {}", filePath);
     }
 
     return result;
   }
 
-  private static boolean pushFileToLocal(
-      String stageLocation,
-      String filePath,
-      String destFileName,
-      InputStream inputStream,
-      FileBackedOutputStream fileBackedOutStr)
-      throws SQLException {
+  static private boolean pushFileToLocal(String stageLocation,
+                                         String filePath,
+                                         String destFileName,
+                                         InputStream inputStream,
+                                         FileBackedOutputStream fileBackedOutStr,
+                                         SFSession session)
+  throws SQLException
+  {
+
 
     // replace ~ with user home
-    stageLocation = stageLocation.replace("~", systemGetProperty("user.home"));
-    try {
-      logger.debug(
-          "Copy file. srcFile={}, destination={}, destFileName={}",
-          filePath,
-          stageLocation,
-          destFileName);
+    stageLocation = stageLocation.replace("~",
+                                          systemGetProperty("user.home"));
+    try
+    {
+      logger.debug("Copy file. srcFile={}, destination={}, destFileName={}",
+                   filePath, stageLocation, destFileName);
 
-      File destFile =
-          new File(SnowflakeUtil.concatFilePathNames(stageLocation, destFileName, localFSFileSep));
+      File destFile = new File(
+          SnowflakeUtil.concatFilePathNames(
+              stageLocation,
+              destFileName,
+              localFSFileSep));
 
-      if (fileBackedOutStr != null) {
+      if (fileBackedOutStr != null)
+      {
         inputStream = fileBackedOutStr.asByteSource().openStream();
       }
       FileUtils.copyInputStreamToFile(inputStream, destFile);
-    } catch (Exception ex) {
-      throw new SnowflakeSQLException(
-          ex, SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), ex.getMessage());
+    }
+    catch (Exception ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            ex.getMessage());
     }
 
     return true;
   }
 
-  private static boolean pullFileFromLocal(
-      String sourceLocation, String filePath, String destLocation, String destFileName)
-      throws SQLException {
-    try {
-      logger.debug(
-          "Copy file. srcFile={}, destination={}, destFileName={}",
-          sourceLocation + localFSFileSep + filePath,
-          destLocation,
-          destFileName);
+  static private boolean pullFileFromLocal(String sourceLocation,
+                                           String filePath,
+                                           String destLocation,
+                                           String destFileName,
+                                           SFSession session)
+  throws SQLException
+  {
+    try
+    {
+      logger.debug("Copy file. srcFile={}, destination={}, destFileName={}",
+                   sourceLocation + localFSFileSep + filePath, destLocation, destFileName);
 
-      File srcFile =
-          new File(SnowflakeUtil.concatFilePathNames(sourceLocation, filePath, localFSFileSep));
+      File srcFile = new File(
+          SnowflakeUtil.concatFilePathNames(
+              sourceLocation,
+              filePath,
+              localFSFileSep));
 
       FileUtils.copyFileToDirectory(srcFile, new File(destLocation));
-    } catch (Exception ex) {
-      throw new SnowflakeSQLException(
-          ex, SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), ex.getMessage());
+    }
+    catch (Exception ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            ex.getMessage());
     }
 
     return true;
   }
 
-  private static void pushFileToRemoteStore(
-      StageInfo stage,
-      String destFileName,
-      InputStream inputStream,
-      FileBackedOutputStream fileBackedOutStr,
-      long uploadSize,
-      String digest,
-      FileCompressionType compressionType,
-      SnowflakeStorageClient initialClient,
-      SFSession session,
-      String command,
-      int parallel,
-      File srcFile,
-      boolean uploadFromStream,
-      RemoteStoreFileEncryptionMaterial encMat)
-      throws SQLException, IOException {
+  static private void pushFileToRemoteStore(StageInfo stage,
+                                            String destFileName,
+                                            InputStream inputStream,
+                                            FileBackedOutputStream fileBackedOutStr,
+                                            long uploadSize,
+                                            String digest,
+                                            FileCompressionType compressionType,
+                                            SnowflakeStorageClient initialClient,
+                                            SFSession session,
+                                            String command,
+                                            int parallel,
+                                            File srcFile,
+                                            boolean uploadFromStream,
+                                            RemoteStoreFileEncryptionMaterial encMat)
+  throws SQLException, IOException
+  {
     remoteLocation remoteLocation = extractLocationAndPath(stage.getLocation());
 
     String origDestFileName = destFileName;
-    if (remoteLocation.path != null && !remoteLocation.path.isEmpty()) {
-      destFileName =
-          remoteLocation.path + (!remoteLocation.path.endsWith("/") ? "/" : "") + destFileName;
+    if (remoteLocation.path != null && !remoteLocation.path.isEmpty())
+    {
+      destFileName = remoteLocation.path +
+                     (!remoteLocation.path.endsWith("/") ? "/" : "")
+                     + destFileName;
     }
 
-    logger.debug(
-        "upload object. location={}, key={}, srcFile={}, encryption={}",
-        remoteLocation.location,
-        destFileName,
-        srcFile,
-        (ArgSupplier)
-            () -> (encMat == null ? "NULL" : encMat.getSmkId() + "|" + encMat.getQueryId()));
+    logger.debug("upload object. location={}, key={}, srcFile={}, encryption={}",
+                 remoteLocation.location, destFileName, srcFile,
+                 (ArgSupplier) () -> (
+                     encMat == null
+                     ? "NULL"
+                     : encMat.getSmkId() + "|" + encMat.getQueryId()));
 
     StorageObjectMetadata meta = storageFactory.createStorageMetadataObj(stage.getStageType());
     meta.setContentLength(uploadSize);
-    if (digest != null) {
+    if (digest != null)
+    {
       initialClient.addDigestMetadata(meta, digest);
     }
 
-    if (compressionType != null && compressionType.isSupported()) {
+    if (compressionType != null &&
+        compressionType.isSupported())
+    {
       meta.setContentEncoding(compressionType.name().toLowerCase());
     }
 
-    try {
+    try
+    {
       String presignedUrl = "";
-      if (initialClient.requirePresignedUrl()) {
+      if (initialClient.requirePresignedUrl())
+      {
         // need to replace file://mypath/myfile?.csv with file://mypath/myfile1.csv.gz
         String localFilePath = getLocalFilePathFromCommand(command, false);
         String commandWithExactPath = command.replace(localFilePath, origDestFileName);
@@ -1797,39 +2043,37 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
         SFStatement statement = new SFStatement(session);
         JsonNode jsonNode = parseCommandInGS(statement, commandWithExactPath);
 
-        if (!jsonNode.path("data").path("stageInfo").path("presignedUrl").isMissingNode()) {
+        if (!jsonNode.path("data").path("stageInfo").path("presignedUrl").isMissingNode())
+        {
           presignedUrl = jsonNode.path("data").path("stageInfo").path("presignedUrl").asText();
         }
       }
-      initialClient.upload(
-          session,
-          command,
-          parallel,
-          uploadFromStream,
-          remoteLocation.location,
-          srcFile,
-          destFileName,
-          inputStream,
-          fileBackedOutStr,
-          meta,
-          stage.getRegion(),
-          presignedUrl);
-    } finally {
-      if (uploadFromStream && inputStream != null) {
+      initialClient.upload(session, command, parallel,
+                           uploadFromStream,
+                           remoteLocation.location, srcFile, destFileName,
+                           inputStream, fileBackedOutStr, meta, stage.getRegion(),
+                           presignedUrl);
+    }
+    finally
+    {
+      if (uploadFromStream && inputStream != null)
+      {
         inputStream.close();
       }
     }
   }
 
   /**
-   * Static API function to upload data without JDBC connection.
-   *
-   * <p>NOTE: This function is developed based on getUploadFileCallable().
+   * Static API function to upload data without JDBC session.
+   * <p>
+   * NOTE: This function is developed based on getUploadFileCallable().
    *
    * @param config Configuration to upload a file to cloud storage
    * @throws Exception if error occurs while data upload.
    */
-  public static void uploadWithoutConnection(SnowflakeFileTransferConfig config) throws Exception {
+  static public void uploadWithoutConnection(SnowflakeFileTransferConfig config)
+  throws Exception
+  {
     logger.debug("Entering uploadWithoutConnection...");
 
     SnowflakeFileTransferMetadataV1 metadata =
@@ -1855,28 +2099,35 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     // Temp file that needs to be cleaned up when upload was successful
     FileBackedOutputStream fileBackedOutputStream = null;
 
-    RemoteStoreFileEncryptionMaterial encMat = metadata.getEncryptionMaterial();
+    RemoteStoreFileEncryptionMaterial encMat =
+        metadata.getEncryptionMaterial();
     // SNOW-16082: we should capture exception if we fail to compress or
     // calculate digest.
-    try {
-      if (requireCompress) {
+    try
+    {
+      if (requireCompress)
+      {
         InputStreamWithMetadata compressedSizeAndStream =
-            (encMat == null
-                ? compressStreamWithGZIPNoDigest(uploadStream)
-                : compressStreamWithGZIP(uploadStream));
+            (encMat == null ? compressStreamWithGZIPNoDigest(uploadStream, /* session = */ null)
+                            : compressStreamWithGZIP(uploadStream, /* session = */ null));
 
-        fileBackedOutputStream = compressedSizeAndStream.fileBackedOutputStream;
+        fileBackedOutputStream =
+            compressedSizeAndStream.fileBackedOutputStream;
 
         // update the size
         uploadSize = compressedSizeAndStream.size;
         digest = compressedSizeAndStream.digest;
 
-        if (compressedSizeAndStream.fileBackedOutputStream.getFile() != null) {
-          fileToUpload = compressedSizeAndStream.fileBackedOutputStream.getFile();
+        if (compressedSizeAndStream.fileBackedOutputStream.getFile() != null)
+        {
+          fileToUpload =
+              compressedSizeAndStream.fileBackedOutputStream.getFile();
         }
 
         logger.debug("New size after compression: {}", uploadSize);
-      } else {
+      }
+      else
+      {
         // If it's not local_fs, we store our digest in the metadata
         // In local_fs, we don't need digest, and if we turn it on,
         // we will consume whole uploadStream, which local_fs uses.
@@ -1885,45 +2136,43 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
         fileBackedOutputStream = result.fileBackedOutputStream;
         uploadSize = result.size;
 
-        if (result.fileBackedOutputStream.getFile() != null) {
+        if (result.fileBackedOutputStream.getFile() != null)
+        {
           fileToUpload = result.fileBackedOutputStream.getFile();
         }
       }
 
       logger.debug(
           "Started copying file to {}:{} destName: {} compressed ? {} size={}",
-          stageInfo.getStageType().name(),
-          stageInfo.getLocation(),
-          destFileName,
-          (requireCompress ? "yes" : "no"),
-          uploadSize);
+          stageInfo.getStageType().name(), stageInfo.getLocation(),
+          destFileName, (requireCompress ? "yes" : "no"), uploadSize);
 
       SnowflakeStorageClient initialClient =
           storageFactory.createClient(stageInfo, 1, encMat, /*session = */ null);
       pushFileToRemoteStoreWithPresignedUrl(
           metadata.getStageInfo(),
           metadata.getPresignedUrlFileName(),
-          uploadStream,
-          fileBackedOutputStream,
-          uploadSize,
-          digest,
-          (requireCompress ? FileCompressionType.GZIP : null),
-          initialClient,
-          networkTimeoutInMilli,
-          ocspMode,
-          1,
-          null,
-          true,
-          encMat,
-          metadata.getPresignedUrl());
-    } catch (Exception ex) {
-      logger.error("Exception encountered during file upload: ", ex.getMessage());
+          uploadStream, fileBackedOutputStream, uploadSize,
+          digest, (requireCompress ? FileCompressionType.GZIP : null),
+          initialClient, networkTimeoutInMilli, ocspMode, 1,
+          null, true, encMat, metadata.getPresignedUrl());
+    }
+    catch (Exception ex)
+    {
+      logger.error(
+          "Exception encountered during file upload: ", ex.getMessage());
       throw ex;
-    } finally {
-      if (fileBackedOutputStream != null) {
-        try {
+    }
+    finally
+    {
+      if (fileBackedOutputStream != null)
+      {
+        try
+        {
           fileBackedOutputStream.reset();
-        } catch (IOException ex) {
+        }
+        catch (IOException ex)
+        {
           logger.debug("failed to clean up temp file: {}", ex);
         }
       }
@@ -1931,12 +2180,14 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
   }
 
   /**
-   * Push a file (or stream) to remote store with pre-signed URL without JDBC connection.
-   *
-   * <p>NOTE: This function is developed based on pushFileToRemoteStore(). The main difference is
-   * that the caller needs to provide pre-signed URL and the upload doesn't need JDBC connection.
+   * Push a file (or stream) to remote store with pre-signed URL
+   * without JDBC session.
+   * <p>
+   * NOTE: This function is developed based on pushFileToRemoteStore().
+   * The main difference is that the caller needs to provide
+   * pre-signed URL and the upload doesn't need JDBC session.
    */
-  private static void pushFileToRemoteStoreWithPresignedUrl(
+  static private void pushFileToRemoteStoreWithPresignedUrl(
       StageInfo stage,
       String destFileName,
       InputStream inputStream,
@@ -1952,68 +2203,71 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       boolean uploadFromStream,
       RemoteStoreFileEncryptionMaterial encMat,
       String presignedUrl)
-      throws SQLException, IOException {
+  throws SQLException, IOException
+  {
     remoteLocation remoteLocation = extractLocationAndPath(stage.getLocation());
 
     String origDestFileName = destFileName;
-    if (remoteLocation.path != null && !remoteLocation.path.isEmpty()) {
-      destFileName =
-          remoteLocation.path + (!remoteLocation.path.endsWith("/") ? "/" : "") + destFileName;
+    if (remoteLocation.path != null && !remoteLocation.path.isEmpty())
+    {
+      destFileName = remoteLocation.path +
+                     (!remoteLocation.path.endsWith("/") ? "/" : "") +
+                     destFileName;
     }
 
-    logger.debug(
-        "upload object. location={}, key={}, srcFile={}, encryption={}",
-        remoteLocation.location,
-        destFileName,
-        srcFile,
-        (ArgSupplier)
-            () -> (encMat == null ? "NULL" : encMat.getSmkId() + "|" + encMat.getQueryId()));
+    logger.debug("upload object. location={}, key={}, srcFile={}, encryption={}",
+                 remoteLocation.location, destFileName, srcFile,
+                 (ArgSupplier) () -> (
+                     encMat == null
+                     ? "NULL"
+                     : encMat.getSmkId() + "|" + encMat.getQueryId()));
 
-    StorageObjectMetadata meta = storageFactory.createStorageMetadataObj(stage.getStageType());
+    StorageObjectMetadata meta =
+        storageFactory.createStorageMetadataObj(stage.getStageType());
     meta.setContentLength(uploadSize);
-    if (digest != null) {
+    if (digest != null)
+    {
       initialClient.addDigestMetadata(meta, digest);
     }
 
-    if (compressionType != null && compressionType.isSupported()) {
+    if (compressionType != null && compressionType.isSupported())
+    {
       meta.setContentEncoding(compressionType.name().toLowerCase());
     }
 
-    try {
+    try
+    {
       initialClient.uploadWithPresignedUrlWithoutConnection(
-          networkTimeoutInMilli,
-          ocspMode,
-          parallel,
+          networkTimeoutInMilli, ocspMode, parallel,
           uploadFromStream,
-          remoteLocation.location,
-          srcFile,
-          destFileName,
-          inputStream,
-          fileBackedOutStr,
-          meta,
-          stage.getRegion(),
+          remoteLocation.location, srcFile, destFileName,
+          inputStream, fileBackedOutStr, meta, stage.getRegion(),
           presignedUrl);
-    } finally {
-      if (uploadFromStream && inputStream != null) {
+    }
+    finally
+    {
+      if (uploadFromStream && inputStream != null)
+      {
         inputStream.close();
       }
     }
   }
 
   /**
-   * This static method is called when we are handling an expired token exception It retrieves a
-   * fresh token from GS and then calls .renew() on the storage client to refresh itself with the
-   * new token
+   * This static method is called when we are handling an expired token exception
+   * It retrieves a fresh token from GS and then calls .renew() on the storage
+   * client to refresh itself with the new token
    *
-   * @param connection a connection object
+   * @param session a session object
    * @param command a command to be retried
-   * @param client a Snowflake Storage client object
+   * @param client  a Snowflake Storage client object
    * @throws SnowflakeSQLException if any error occurs
    */
-  public static void renewExpiredToken(
-      SFSession connection, String command, SnowflakeStorageClient client)
-      throws SnowflakeSQLException {
-    SFStatement statement = new SFStatement(connection);
+  static public void renewExpiredToken(SFSession session, String command,
+                                       SnowflakeStorageClient client)
+  throws SnowflakeSQLException
+  {
+    SFStatement statement = new SFStatement(session);
     JsonNode jsonNode = parseCommandInGS(statement, command);
     Map<?, ?> stageCredentials = extractStageCreds(jsonNode);
 
@@ -2022,56 +2276,53 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     client.renew(stageCredentials);
   }
 
-  private static void pullFileFromRemoteStore(
-      StageInfo stage,
-      String filePath,
-      String destFileName,
-      String localLocation,
-      SnowflakeStorageClient initialClient,
-      SFSession session,
-      String command,
-      int parallel,
-      RemoteStoreFileEncryptionMaterial encMat,
-      String presignedUrl)
-      throws SQLException {
+  static private void pullFileFromRemoteStore(StageInfo stage,
+                                              String filePath,
+                                              String destFileName,
+                                              String localLocation,
+                                              SnowflakeStorageClient initialClient,
+                                              SFSession session,
+                                              String command,
+                                              int parallel,
+                                              RemoteStoreFileEncryptionMaterial encMat,
+                                              String presignedUrl)
+  throws SQLException
+  {
     remoteLocation remoteLocation = extractLocationAndPath(stage.getLocation());
 
     String stageFilePath = filePath;
 
-    if (!remoteLocation.path.isEmpty()) {
-      stageFilePath = SnowflakeUtil.concatFilePathNames(remoteLocation.path, filePath, "/");
+    if (!remoteLocation.path.isEmpty())
+    {
+      stageFilePath = SnowflakeUtil.concatFilePathNames(remoteLocation.path,
+                                                        filePath, "/");
     }
 
-    logger.debug(
-        "Download object. location={}, key={}, srcFile={}, encryption={}",
-        remoteLocation.location,
-        stageFilePath,
-        filePath,
-        (ArgSupplier)
-            () -> (encMat == null ? "NULL" : encMat.getSmkId() + "|" + encMat.getQueryId()));
+    logger.debug("Download object. location={}, key={}, srcFile={}, encryption={}",
+                 remoteLocation.location, stageFilePath, filePath,
+                 (ArgSupplier) () -> (
+                     encMat == null
+                     ? "NULL"
+                     : encMat.getSmkId() + "|" + encMat.getQueryId()));
 
-    initialClient.download(
-        session,
-        command,
-        localLocation,
-        destFileName,
-        parallel,
-        remoteLocation.location,
-        stageFilePath,
-        stage.getRegion(),
-        presignedUrl);
+    initialClient.download(session, command,
+                           localLocation, destFileName, parallel,
+                           remoteLocation.location, stageFilePath, stage.getRegion(),
+                           presignedUrl);
   }
 
   /**
-   * From the set of files intended to be uploaded/downloaded, derive a common prefix and use the
-   * listObjects API to get the object summary for each object that has the common prefix.
-   *
-   * <p>For each returned object, we compare the size and digest with the local file and if they are
-   * the same, we will not upload/download the file.
+   * From the set of files intended to be uploaded/downloaded, derive a common
+   * prefix and use the listObjects API to get the object summary for each
+   * object that has the common prefix.
+   * <p>
+   * For each returned object, we compare the size and digest with the local file
+   * and if they are the same, we will not upload/download the file.
    *
    * @throws SnowflakeSQLException if any error occurs
    */
-  private void filterExistingFiles() throws SnowflakeSQLException {
+  private void filterExistingFiles() throws SnowflakeSQLException
+  {
     /*
      * Build a reverse map from destination file name to source file path
      * The map will be used for looking up the source file for destination
@@ -2083,25 +2334,33 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     logger.debug("Build reverse map from destination file name to source file");
 
-    for (Map.Entry<String, FileMetadata> entry : fileMetadataMap.entrySet()) {
-      if (entry.getValue().destFileName != null) {
+    for (Map.Entry<String, FileMetadata> entry : fileMetadataMap.entrySet())
+    {
+      if (entry.getValue().destFileName != null)
+      {
         String prevSrcFile =
-            destFileNameToSrcFileMap.put(entry.getValue().destFileName, entry.getKey());
+            destFileNameToSrcFileMap.put(entry.getValue().destFileName,
+                                         entry.getKey());
 
-        if (prevSrcFile != null) {
+        if (prevSrcFile != null)
+        {
           FileMetadata prevFileMetadata = fileMetadataMap.get(prevSrcFile);
 
           prevFileMetadata.resultStatus = ResultStatus.COLLISION;
-          prevFileMetadata.errorDetails = prevSrcFile + " has same name as " + entry.getKey();
+          prevFileMetadata.errorDetails = prevSrcFile + " has same name as " +
+                                          entry.getKey();
         }
-      } else {
+      }
+      else
+      {
         logger.debug("No dest file name found for: {}", entry.getKey());
         logger.debug("Status: {}", entry.getValue().resultStatus);
       }
     }
 
     // no files to be processed
-    if (destFileNameToSrcFileMap.size() == 0) {
+    if (destFileNameToSrcFileMap.size() == 0)
+    {
       return;
     }
 
@@ -2110,25 +2369,30 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     // with local files
     String[] stageFileNames;
 
-    if (commandType == CommandType.UPLOAD) {
+    if (commandType == CommandType.UPLOAD)
+    {
       stageFileNames = destFileNameToSrcFileMap.keySet().toArray(new String[0]);
-    } else {
-      stageFileNames = destFileNameToSrcFileMap.values().toArray(new String[0]);
+    }
+    else
+    {
+      stageFileNames =
+          destFileNameToSrcFileMap.values().toArray(new String[0]);
     }
 
     // find greatest common prefix for all stage file names
     Arrays.sort(stageFileNames);
 
     String greatestCommonPrefix =
-        SnowflakeUtil.greatestCommonPrefix(
-            stageFileNames[0], stageFileNames[stageFileNames.length - 1]);
+        SnowflakeUtil.greatestCommonPrefix(stageFileNames[0],
+                                           stageFileNames[stageFileNames.length - 1]);
 
     logger.debug("Greatest common prefix: {}", greatestCommonPrefix);
 
     // use the greatest common prefix to list objects under stage location
-    if (stageInfo.getStageType() == StageInfo.StageType.S3
-        || stageInfo.getStageType() == StageInfo.StageType.AZURE
-        || stageInfo.getStageType() == StageInfo.StageType.GCS) {
+    if (stageInfo.getStageType() == StageInfo.StageType.S3 ||
+        stageInfo.getStageType() == StageInfo.StageType.AZURE ||
+        stageInfo.getStageType() == StageInfo.StageType.GCS)
+    {
       logger.debug("check existing files on remote storage for the common prefix");
 
       remoteLocation storeLocation = extractLocationAndPath(stageInfo.getLocation());
@@ -2137,25 +2401,33 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
       int retryCount = 0;
 
-      do {
-        try {
-          objectSummaries =
-              storageClient.listObjects(
-                  storeLocation.location,
-                  SnowflakeUtil.concatFilePathNames(storeLocation.path, greatestCommonPrefix, "/"));
+      do
+      {
+        try
+        {
+          objectSummaries = storageClient.listObjects(storeLocation.location,
+                                                      SnowflakeUtil.concatFilePathNames(
+                                                          storeLocation.path,
+                                                          greatestCommonPrefix, "/"));
 
           // exit retry loop
           break;
-        } catch (Exception ex) {
-          logger.debug("Listing objects for filtering encountered exception: {}", ex.getMessage());
+        }
+        catch (Exception ex)
+        {
+          logger.debug("Listing objects for filtering encountered exception: {}",
+                       ex.getMessage());
 
           storageClient.handleStorageException(ex, ++retryCount, "listObjects", session, command);
         }
-      } while (retryCount <= storageClient.getMaxRetries());
+      }
+      while (retryCount <= storageClient.getMaxRetries());
 
-      for (StorageObjectSummary obj : objectSummaries) {
+      for (StorageObjectSummary obj : objectSummaries)
+      {
         logger.debug(
-            "Existing object: key={} size={} md5={}", obj.getKey(), obj.getSize(), obj.getMD5());
+            "Existing object: key={} size={} md5={}",
+            obj.getKey(), obj.getSize(), obj.getMD5());
 
         int idxOfLastFileSep = obj.getKey().lastIndexOf("/");
         String objFileName = obj.getKey().substring(idxOfLastFileSep + 1);
@@ -2164,43 +2436,43 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
         String mappedSrcFile = destFileNameToSrcFileMap.get(objFileName);
 
         // skip objects that don't have a corresponding file to be uploaded
-        if (mappedSrcFile == null) {
+        if (mappedSrcFile == null)
+        {
           continue;
         }
 
-        logger.debug(
-            "Next compare digest for {} against {} on the remote store",
-            mappedSrcFile,
-            objFileName);
+        logger.debug("Next compare digest for {} against {} on the remote store", mappedSrcFile, objFileName);
 
         String localFile = null;
         final boolean remoteEncrypted;
 
-        try {
-          localFile =
-              (commandType == CommandType.UPLOAD) ? mappedSrcFile : (localLocation + objFileName);
+        try
+        {
+          localFile = (commandType == CommandType.UPLOAD) ?
+                      mappedSrcFile : (localLocation + objFileName);
 
-          if (commandType == CommandType.DOWNLOAD && !(new File(localFile)).exists()) {
-            logger.debug("File does not exist locally, will download {}", mappedSrcFile);
+          if (commandType == CommandType.DOWNLOAD &&
+              !(new File(localFile)).exists())
+          {
+            logger.debug("File does not exist locally, will download {}",
+                         mappedSrcFile);
             continue;
           }
 
-          // if it's an upload and there's already a file existing remotely with the same name, skip
-          // uploading it
-          if (commandType == CommandType.UPLOAD
-              && objFileName.equals(fileMetadataMap.get(mappedSrcFile).destFileName)) {
+          // if it's an upload and there's already a file existing remotely with the same name, skip uploading it
+          if (commandType == CommandType.UPLOAD && objFileName.equals(fileMetadataMap.get(mappedSrcFile).destFileName))
+          {
             skipFile(mappedSrcFile, objFileName);
             continue;
           }
 
           // Check file size first, if their difference is bigger than the block
           // size, we don't need to compare digests
-          if (!fileMetadataMap.get(mappedSrcFile).requireCompress
-              && Math.abs(obj.getSize() - (new File(localFile)).length()) > 16) {
-            logger.debug(
-                "Size diff between remote and local, will {} {}",
-                commandType.name().toLowerCase(),
-                mappedSrcFile);
+          if (!fileMetadataMap.get(mappedSrcFile).requireCompress &&
+              Math.abs(obj.getSize() - (new File(localFile)).length()) > 16)
+          {
+            logger.debug("Size diff between remote and local, will {} {}",
+                         commandType.name().toLowerCase(), mappedSrcFile);
             continue;
           }
 
@@ -2208,47 +2480,56 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
           //
           StorageObjectMetadata meta;
 
-          try {
-            meta = storageClient.getObjectMetadata(obj.getLocation(), obj.getKey());
-          } catch (StorageProviderException spEx) {
+          try
+          {
+            meta = storageClient.getObjectMetadata(obj.getLocation(),
+                                                   obj.getKey());
+          }
+          catch (StorageProviderException spEx)
+          {
             // SNOW-14521: when file is not found, ok to upload
-            if (spEx.isServiceException404()) {
+            if (spEx.isServiceException404())
+            {
               // log it
-              logger.debug(
-                  "File returned from listing but found missing {} when getting its"
-                      + " metadata. Location={}, key={}",
-                  obj.getLocation(),
-                  obj.getKey());
+              logger.debug("File returned from listing but found missing {} when getting its" +
+                           " metadata. Location={}, key={}",
+                           obj.getLocation(), obj.getKey());
 
               // the file is not found, ok to upload
               continue;
             }
 
+
             // for any other exception, log an error
-            logger.error("Fetching object metadata encountered exception: {}", spEx.getMessage());
+            logger.error("Fetching object metadata encountered exception: {}",
+                         spEx.getMessage());
 
             throw spEx;
           }
 
           String objDigest = storageClient.getDigestMetadata(meta);
 
-          remoteEncrypted =
-              MatDesc.parse(meta.getUserMetadata().get(storageClient.getMatdescKey())) != null;
+          remoteEncrypted = MatDesc.parse(
+              meta.getUserMetadata().get(storageClient.getMatdescKey())) != null;
 
           // calculate the digest hash of the local file
           InputStream fileStream = null;
           String hashText = null;
 
           // Streams (potentially with temp files) to clean up
-          final List<FileBackedOutputStream> fileBackedOutputStreams = new ArrayList<>();
-          try {
+          final List<FileBackedOutputStream> fileBackedOutputStreams
+              = new ArrayList<>();
+          try
+          {
             fileStream = new FileInputStream(localFile);
-            if (fileMetadataMap.get(mappedSrcFile).requireCompress) {
+            if (fileMetadataMap.get(mappedSrcFile).requireCompress)
+            {
               logger.debug("Compressing stream for digest check");
 
-              InputStreamWithMetadata res = compressStreamWithGZIP(fileStream);
+              InputStreamWithMetadata res = compressStreamWithGZIP(fileStream, session);
 
-              fileStream = res.fileBackedOutputStream.asByteSource().openStream();
+              fileStream =
+                  res.fileBackedOutputStream.asByteSource().openStream();
               fileBackedOutputStreams.add(res.fileBackedOutputStream);
             }
 
@@ -2259,24 +2540,35 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
             // of the S3 file.
             // Otherwise (remote file is encrypted, but has no sfc-digest),
             // no comparison is performed
-            if (objDigest != null) {
+            if (objDigest != null)
+            {
               InputStreamWithMetadata res = computeDigest(fileStream, false);
               hashText = res.digest;
               fileBackedOutputStreams.add(res.fileBackedOutputStream);
 
-            } else if (!remoteEncrypted) {
+            }
+            else if (!remoteEncrypted)
+            {
               hashText = DigestUtils.md5Hex(fileStream);
             }
-          } finally {
-            if (fileStream != null) {
+          }
+          finally
+          {
+            if (fileStream != null)
+            {
               fileStream.close();
             }
 
-            for (FileBackedOutputStream stream : fileBackedOutputStreams) {
-              if (stream != null) {
-                try {
+            for (FileBackedOutputStream stream : fileBackedOutputStreams)
+            {
+              if (stream != null)
+              {
+                try
+                {
                   stream.reset();
-                } catch (IOException ex) {
+                }
+                catch (IOException ex)
+                {
                   logger.debug("failed to clean up temp file: {}", ex);
                 }
               }
@@ -2284,74 +2576,71 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
           }
 
           // continue so that we will upload the file
-          if (hashText == null
-              || // remote is encrypted & has no digest
-              (objDigest != null && !hashText.equals(objDigest))
-              || // digest mismatch
+          if (hashText == null || // remote is encrypted & has no digest
+              (objDigest != null && !hashText.equals(objDigest)) || // digest mismatch
               (objDigest == null && !hashText.equals(obj.getMD5()))) // ETag/MD5 mismatch
           {
             logger.debug(
-                "digest diff between remote store and local, will {} {}, "
-                    + "local digest: {}, remote store md5: {}",
+                "digest diff between remote store and local, will {} {}, " +
+                "local digest: {}, remote store md5: {}",
                 commandType.name().toLowerCase(),
-                mappedSrcFile,
-                hashText,
-                obj.getMD5());
+                mappedSrcFile, hashText, obj.getMD5());
             continue;
           }
-        } catch (IOException | NoSuchAlgorithmException ex) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Error reading: " + localFile);
+        }
+        catch (IOException | NoSuchAlgorithmException ex)
+        {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "Error reading: " + localFile);
         }
 
-        logger.debug(
-            "digest same between remote store and local, will not upload {} {}",
-            commandType.name().toLowerCase(),
-            mappedSrcFile);
+        logger.debug("digest same between remote store and local, will not upload {} {}",
+                     commandType.name().toLowerCase(), mappedSrcFile);
 
         skipFile(mappedSrcFile, objFileName);
       }
-    } else if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) {
-      for (String stageFileName : stageFileNames) {
+    }
+    else if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
+    {
+      for (String stageFileName : stageFileNames)
+      {
         String stageFilePath =
-            SnowflakeUtil.concatFilePathNames(
-                stageInfo.getLocation(), stageFileName, localFSFileSep);
+            SnowflakeUtil.concatFilePathNames(stageInfo.getLocation(),
+                                              stageFileName,
+                                              localFSFileSep);
 
         File stageFile = new File(stageFilePath);
 
         // if stage file doesn't exist, no need to skip whether for
         // upload/download
-        if (!stageFile.exists()) {
+        if (!stageFile.exists())
+        {
           continue;
         }
 
-        String mappedSrcFile =
-            (commandType == CommandType.UPLOAD)
-                ? destFileNameToSrcFileMap.get(stageFileName)
-                : stageFileName;
+        String mappedSrcFile = (commandType == CommandType.UPLOAD) ?
+                               destFileNameToSrcFileMap.get(stageFileName) :
+                               stageFileName;
 
-        String localFile =
-            (commandType == CommandType.UPLOAD)
-                ? mappedSrcFile
-                : (localLocation + fileMetadataMap.get(mappedSrcFile).destFileName);
+        String localFile = (commandType == CommandType.UPLOAD) ?
+                           mappedSrcFile :
+                           (localLocation +
+                            fileMetadataMap.get(mappedSrcFile).destFileName);
 
-        if (commandType == CommandType.UPLOAD
-            && stageFileName.equals(fileMetadataMap.get(mappedSrcFile).destFileName)) {
+        if (commandType == CommandType.UPLOAD && stageFileName.equals(fileMetadataMap.get(mappedSrcFile).destFileName))
+        {
           skipFile(mappedSrcFile, stageFileName);
           continue;
         }
 
         // Check file size first, if they are different, we don't need
         // to check digest
-        if (!fileMetadataMap.get(mappedSrcFile).requireCompress
-            && stageFile.length() != (new File(localFile)).length()) {
-          logger.debug(
-              "Size diff between stage and local, will {} {}",
-              commandType.name().toLowerCase(),
-              mappedSrcFile);
+        if (!fileMetadataMap.get(mappedSrcFile).requireCompress &&
+            stageFile.length() != (new File(localFile)).length())
+        {
+          logger.debug("Size diff between stage and local, will {} {}",
+                       commandType.name().toLowerCase(), mappedSrcFile);
           continue;
         }
 
@@ -2363,34 +2652,45 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
         List<FileBackedOutputStream> fileBackedOutputStreams = new ArrayList<>();
         InputStream localFileStream = null;
-        try {
+        try
+        {
           // calculate the digest hash of the local file
           localFileStream = new FileInputStream(localFile);
 
-          if (fileMetadataMap.get(mappedSrcFile).requireCompress) {
+          if (fileMetadataMap.get(mappedSrcFile).requireCompress)
+          {
             logger.debug("Compressing stream for digest check");
 
-            InputStreamWithMetadata res = compressStreamWithGZIP(localFileStream);
+            InputStreamWithMetadata res =
+                compressStreamWithGZIP(localFileStream, session);
             fileBackedOutputStreams.add(res.fileBackedOutputStream);
 
-            localFileStream = res.fileBackedOutputStream.asByteSource().openStream();
+            localFileStream =
+                res.fileBackedOutputStream.asByteSource().openStream();
           }
 
           InputStreamWithMetadata res = computeDigest(localFileStream, false);
           localFileHashText = res.digest;
           fileBackedOutputStreams.add(res.fileBackedOutputStream);
-        } catch (IOException | NoSuchAlgorithmException ex) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Error reading local file: " + localFile);
-        } finally {
-          for (FileBackedOutputStream stream : fileBackedOutputStreams) {
-            if (stream != null) {
-              try {
+        }
+        catch (IOException | NoSuchAlgorithmException ex)
+        {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "Error reading local file: " + localFile);
+        }
+        finally
+        {
+          for (FileBackedOutputStream stream : fileBackedOutputStreams)
+          {
+            if (stream != null)
+            {
+              try
+              {
                 stream.reset();
-              } catch (IOException ex) {
+              }
+              catch (IOException ex)
+              {
                 logger.debug("failed to clean up temp file: {}", ex);
               }
             }
@@ -2400,7 +2700,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
         FileBackedOutputStream fileBackedOutputStream = null;
         InputStream stageFileStream = null;
-        try {
+        try
+        {
           // calculate digst for stage file
           stageFileStream = new FileInputStream(stageFilePath);
 
@@ -2408,32 +2709,40 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
           stageFileHashText = res.digest;
           fileBackedOutputStream = res.fileBackedOutputStream;
 
-        } catch (IOException | NoSuchAlgorithmException ex) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Error reading stage file: " + stageFilePath);
-        } finally {
-          try {
-            if (fileBackedOutputStream != null) {
+        }
+        catch (IOException | NoSuchAlgorithmException ex)
+        {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "Error reading stage file: " + stageFilePath);
+        }
+        finally
+        {
+          try
+          {
+            if (fileBackedOutputStream != null)
+            {
               fileBackedOutputStream.reset();
             }
-          } catch (IOException ex) {
+          }
+          catch (IOException ex)
+          {
             logger.debug("failed to clean up temp file: {}", ex);
           }
           IOUtils.closeQuietly(stageFileStream);
         }
 
         // continue if digest is different so that we will process the file
-        if (!stageFileHashText.equals(localFileHashText)) {
-          logger.debug(
-              "digest diff between local and stage, will {} {}",
-              commandType.name().toLowerCase(),
-              mappedSrcFile);
+        if (!stageFileHashText.equals(localFileHashText))
+        {
+          logger.debug("digest diff between local and stage, will {} {}",
+                       commandType.name().toLowerCase(), mappedSrcFile);
           continue;
-        } else {
-          logger.debug("digest matches between local and stage, will skip {}", mappedSrcFile);
+        }
+        else
+        {
+          logger.debug("digest matches between local and stage, will skip {}",
+                       mappedSrcFile);
 
           // skip the file given that the check sum is the same b/w source
           // and destination
@@ -2443,37 +2752,49 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     }
   }
 
-  private void skipFile(String srcFilePath, String destFileName) {
+  private void skipFile(String srcFilePath, String destFileName)
+  {
     FileMetadata fileMetadata = fileMetadataMap.get(srcFilePath);
 
-    if (fileMetadata != null) {
-      if (fileMetadata.resultStatus == null || fileMetadata.resultStatus == ResultStatus.UNKNOWN) {
+    if (fileMetadata != null)
+    {
+      if (fileMetadata.resultStatus == null ||
+          fileMetadata.resultStatus == ResultStatus.UNKNOWN)
+      {
         logger.debug("Mark {} as skipped", srcFilePath);
 
         fileMetadata.resultStatus = ResultStatus.SKIPPED;
         fileMetadata.errorDetails =
-            "File with same destination name and checksum already exists: " + destFileName;
-      } else {
-        logger.debug(
-            "No need to mark as skipped for: {} status was already marked as: {}",
-            srcFilePath,
-            fileMetadata.resultStatus);
+            "File with same destination name and checksum already exists: "
+            + destFileName;
+      }
+      else
+      {
+        logger.debug("No need to mark as skipped for: {} status was already marked as: {}",
+                     srcFilePath, fileMetadata.resultStatus);
       }
     }
   }
 
-  private void initFileMetadata() throws SnowflakeSQLException {
+  private void initFileMetadata()
+  throws SnowflakeSQLException
+  {
     // file metadata is keyed on source file names (which are local file names
     // for upload command and stage file names for download command)
     fileMetadataMap = new HashMap<String, FileMetadata>(sourceFiles.size());
 
-    if (commandType == CommandType.UPLOAD) {
-      if (sourceFromStream) {
+    if (commandType == CommandType.UPLOAD)
+    {
+      if (sourceFromStream)
+      {
         FileMetadata fileMetadata = new FileMetadata();
         fileMetadataMap.put(SRC_FILE_NAME_FOR_STREAM, fileMetadata);
         fileMetadata.srcFileName = SRC_FILE_NAME_FOR_STREAM;
-      } else {
-        for (String sourceFile : sourceFiles) {
+      }
+      else
+      {
+        for (String sourceFile : sourceFiles)
+        {
           FileMetadata fileMetadata = new FileMetadata();
           fileMetadataMap.put(sourceFile, fileMetadata);
           File file = new File(sourceFile);
@@ -2481,33 +2802,35 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
           fileMetadata.srcFileName = file.getName();
           fileMetadata.srcFileSize = file.length();
 
-          if (!file.exists()) {
+          if (!file.exists())
+          {
             logger.debug("File doesn't exist: {}", sourceFile);
 
-            throw new SnowflakeSQLLoggedException(
-                SqlState.DATA_EXCEPTION,
-                ErrorCode.FILE_NOT_FOUND.getMessageCode(),
-                session,
-                sourceFile);
-          } else if (file.isDirectory()) {
+            throw new SnowflakeSQLLoggedException(SqlState.DATA_EXCEPTION,
+                                                  ErrorCode.FILE_NOT_FOUND.getMessageCode(), session,
+                                                  sourceFile);
+          }
+          else if (file.isDirectory())
+          {
             logger.debug("Not a file, but directory: {}", sourceFile);
 
-            throw new SnowflakeSQLException(
-                SqlState.DATA_EXCEPTION,
-                ErrorCode.FILE_IS_DIRECTORY.getMessageCode(),
-                session,
-                sourceFile);
+            throw new SnowflakeSQLException(SqlState.DATA_EXCEPTION,
+                                            ErrorCode.FILE_IS_DIRECTORY.getMessageCode(), session,
+                                            sourceFile);
           }
         }
       }
-    } else if (commandType == CommandType.DOWNLOAD) {
-      for (String sourceFile : sourceFiles) {
+    }
+    else if (commandType == CommandType.DOWNLOAD)
+    {
+      for (String sourceFile : sourceFiles)
+      {
         FileMetadata fileMetadata = new FileMetadata();
         fileMetadataMap.put(sourceFile, fileMetadata);
         fileMetadata.srcFileName = sourceFile;
 
-        fileMetadata.destFileName =
-            sourceFile.substring(sourceFile.lastIndexOf("/") + 1); // s3 uses / as separator
+        fileMetadata.destFileName = sourceFile.substring(
+            sourceFile.lastIndexOf("/") + 1); // s3 uses / as separator
       }
     }
   }
@@ -2518,22 +2841,29 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
    * @param mimeTypeStr The mime type passed to us
    * @return the Optional for the compression type or Optional.empty()
    */
-  static Optional<FileCompressionType> mimeTypeToCompressionType(String mimeTypeStr) {
-    if (mimeTypeStr == null) {
+  static Optional<FileCompressionType> mimeTypeToCompressionType(String mimeTypeStr)
+  {
+    if (mimeTypeStr == null)
+    {
       return Optional.empty();
     }
     int slashIndex = mimeTypeStr.indexOf('/');
-    if (slashIndex < 0) {
+    if (slashIndex < 0)
+    {
       return Optional.empty(); // unable to find sub type
     }
     int semiColonIndex = mimeTypeStr.indexOf(';');
     String subType;
-    if (semiColonIndex < 0) {
+    if (semiColonIndex < 0)
+    {
       subType = mimeTypeStr.substring(slashIndex + 1).trim().toLowerCase(Locale.ENGLISH);
-    } else {
+    }
+    else
+    {
       subType = mimeTypeStr.substring(slashIndex + 1, semiColonIndex);
     }
-    if (Strings.isNullOrEmpty(subType)) {
+    if (Strings.isNullOrEmpty(subType))
+    {
       return Optional.empty();
     }
     return FileCompressionType.lookupByMimeSubType(subType);
@@ -2542,44 +2872,54 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
   /**
    * Detect file compression type for all files to be uploaded
    *
-   * @throws SnowflakeSQLException Will be thrown if the compression type is unknown or unsupported
+   * @throws SnowflakeSQLException Will be thrown if the compression type is
+   *                               unknown or unsupported
    */
-  private void processFileCompressionTypes() throws SnowflakeSQLException {
+  private void processFileCompressionTypes() throws SnowflakeSQLException
+  {
     // see what user has told us about the source file compression types
     boolean autoDetect = true;
     FileCompressionType userSpecifiedSourceCompression = null;
 
-    if (SOURCE_COMPRESSION_AUTO_DETECT.equalsIgnoreCase(sourceCompression)) {
+    if (SOURCE_COMPRESSION_AUTO_DETECT.equalsIgnoreCase(sourceCompression))
+    {
       autoDetect = true;
-    } else if (SOURCE_COMPRESSION_NONE.equalsIgnoreCase(sourceCompression)) {
+    }
+    else if (SOURCE_COMPRESSION_NONE.equalsIgnoreCase(sourceCompression))
+    {
       autoDetect = false;
-    } else {
+    }
+    else
+    {
       Optional<FileCompressionType> foundCompType =
           FileCompressionType.lookupByMimeSubType(sourceCompression.toLowerCase());
-      if (!foundCompType.isPresent()) {
-        throw new SnowflakeSQLException(
-            SqlState.FEATURE_NOT_SUPPORTED,
-            ErrorCode.COMPRESSION_TYPE_NOT_KNOWN.getMessageCode(),
-            sourceCompression);
+      if (!foundCompType.isPresent())
+      {
+        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+                                        ErrorCode.COMPRESSION_TYPE_NOT_KNOWN.getMessageCode(),
+                                        sourceCompression);
       }
       userSpecifiedSourceCompression = foundCompType.get();
 
-      if (!userSpecifiedSourceCompression.isSupported()) {
-        throw new SnowflakeSQLException(
-            SqlState.FEATURE_NOT_SUPPORTED,
-            ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
-            sourceCompression);
+      if (!userSpecifiedSourceCompression.isSupported())
+      {
+        throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+                                        ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
+                                        sourceCompression);
       }
 
       autoDetect = false;
     }
 
-    if (!sourceFromStream) {
-      for (String srcFile : sourceFiles) {
+    if (!sourceFromStream)
+    {
+      for (String srcFile : sourceFiles)
+      {
         FileMetadata fileMetadata = fileMetadataMap.get(srcFile);
 
-        if (fileMetadata.resultStatus == ResultStatus.NONEXIST
-            || fileMetadata.resultStatus == ResultStatus.DIRECTORY) {
+        if (fileMetadata.resultStatus == ResultStatus.NONEXIST ||
+            fileMetadata.resultStatus == ResultStatus.DIRECTORY)
+        {
           continue;
         }
 
@@ -2589,72 +2929,91 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
         String mimeTypeStr = null;
         FileCompressionType currentFileCompressionType = null;
 
-        try {
-          if (autoDetect) {
+        try
+        {
+          if (autoDetect)
+          {
             // probe the file for compression type using tika file type detector
             mimeTypeStr = Files.probeContentType(file.toPath());
 
-            if (mimeTypeStr == null) {
-              try (FileInputStream f = new FileInputStream(file)) {
+            if (mimeTypeStr == null)
+            {
+              try (FileInputStream f = new FileInputStream(file))
+              {
                 byte[] magic = new byte[4];
-                if (f.read(magic, 0, 4) == 4) {
-                  if (Arrays.equals(magic, new byte[] {'P', 'A', 'R', '1'})) {
+                if (f.read(magic, 0, 4) == 4)
+                {
+                  if (Arrays.equals(magic, new byte[]{'P', 'A', 'R', '1'}))
+                  {
                     mimeTypeStr = "snowflake/parquet";
-                  } else if (Arrays.equals(
-                      Arrays.copyOfRange(magic, 0, 3), new byte[] {'O', 'R', 'C'})) {
+                  }
+                  else if (Arrays.equals(
+                      Arrays.copyOfRange(magic, 0, 3), new byte[]{'O', 'R', 'C'}))
+                  {
                     mimeTypeStr = "snowflake/orc";
                   }
                 }
               }
             }
 
-            if (mimeTypeStr != null) {
+            if (mimeTypeStr != null)
+            {
               logger.debug("Mime type for {} is: {}", srcFile, mimeTypeStr);
 
-              Optional<FileCompressionType> foundCompType = mimeTypeToCompressionType(mimeTypeStr);
-              if (foundCompType.isPresent()) {
+              Optional<FileCompressionType> foundCompType =
+                  mimeTypeToCompressionType(mimeTypeStr);
+              if (foundCompType.isPresent())
+              {
                 currentFileCompressionType = foundCompType.get();
               }
             }
 
             // fallback: use file extension
-            if (currentFileCompressionType == null) {
+            if (currentFileCompressionType == null)
+            {
               mimeTypeStr = getMimeTypeFromFileExtension(srcFile);
 
-              if (mimeTypeStr != null) {
+              if (mimeTypeStr != null)
+              {
                 logger.debug("Mime type for {} is: {}", srcFile, mimeTypeStr);
                 Optional<FileCompressionType> foundCompType =
                     mimeTypeToCompressionType(mimeTypeStr);
-                if (foundCompType.isPresent()) {
+                if (foundCompType.isPresent())
+                {
                   currentFileCompressionType = foundCompType.get();
                 }
               }
             }
-          } else {
+          }
+          else
+          {
             currentFileCompressionType = userSpecifiedSourceCompression;
           }
 
           // check if the compression type is supported by us
-          if (currentFileCompressionType != null) {
+          if (currentFileCompressionType != null)
+          {
             fileMetadata.srcCompressionType = currentFileCompressionType;
 
-            if (currentFileCompressionType.isSupported()) {
+            if (currentFileCompressionType.isSupported())
+            {
               // remember the compression type if supported
               fileMetadata.destCompressionType = currentFileCompressionType;
               fileMetadata.requireCompress = false;
               fileMetadata.destFileName = srcFileName;
-              logger.debug(
-                  "File compression detected as {} for: {}",
-                  currentFileCompressionType.name(),
-                  srcFile);
-            } else {
-              // error if not supported
-              throw new SnowflakeSQLException(
-                  SqlState.FEATURE_NOT_SUPPORTED,
-                  ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
-                  currentFileCompressionType.name());
+              logger.debug("File compression detected as {} for: {}",
+                           currentFileCompressionType.name(), srcFile);
             }
-          } else {
+            else
+            {
+              // error if not supported
+              throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+                                              ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
+                                              currentFileCompressionType.name());
+            }
+          }
+          else
+          {
             // we want to auto compress the files unless the user has disabled it
             logger.debug("Compression not found for file: {}", srcFile);
 
@@ -2662,47 +3021,69 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
             fileMetadata.requireCompress = autoCompress;
             fileMetadata.srcCompressionType = null;
 
-            if (autoCompress) {
+            if (autoCompress)
+            {
               // We only support gzip auto compression
-              fileMetadata.destFileName = srcFileName + FileCompressionType.GZIP.getFileExtension();
+              fileMetadata.destFileName = srcFileName +
+                                          FileCompressionType.GZIP.getFileExtension();
               fileMetadata.destCompressionType = FileCompressionType.GZIP;
-            } else {
+            }
+            else
+            {
               fileMetadata.destFileName = srcFileName;
               fileMetadata.destCompressionType = null;
             }
           }
-        } catch (Exception ex) {
+        }
+        catch (Exception ex)
+        {
 
           // SNOW-13146: don't log severe message for user error
-          if (ex instanceof SnowflakeSQLException) {
-            logger.debug("Exception encountered when processing file compression types", ex);
-          } else {
-            logger.debug("Exception encountered when processing file compression types", ex);
+          if (ex instanceof SnowflakeSQLException)
+          {
+            logger.debug(
+                "Exception encountered when processing file compression types",
+                ex);
+          }
+          else
+          {
+            logger.debug(
+                "Exception encountered when processing file compression types",
+                ex);
           }
 
           fileMetadata.resultStatus = ResultStatus.ERROR;
           fileMetadata.errorDetails = ex.getMessage();
         }
       }
-    } else {
+    }
+    else
+    {
       // source from stream case
       FileMetadata fileMetadata = fileMetadataMap.get(SRC_FILE_NAME_FOR_STREAM);
       fileMetadata.srcCompressionType = userSpecifiedSourceCompression;
 
-      if (compressSourceFromStream) {
+      if (compressSourceFromStream)
+      {
         fileMetadata.destCompressionType = FileCompressionType.GZIP;
         fileMetadata.requireCompress = true;
-      } else {
+      }
+      else
+      {
         fileMetadata.destCompressionType = userSpecifiedSourceCompression;
         fileMetadata.requireCompress = false;
       }
 
       // add gz extension if file name doesn't have it
-      if (compressSourceFromStream
-          && !destFileNameForStreamSource.endsWith(FileCompressionType.GZIP.getFileExtension())) {
-        fileMetadata.destFileName =
-            destFileNameForStreamSource + FileCompressionType.GZIP.getFileExtension();
-      } else {
+      if (compressSourceFromStream &&
+          !destFileNameForStreamSource.endsWith(
+              FileCompressionType.GZIP.getFileExtension()))
+      {
+        fileMetadata.destFileName = destFileNameForStreamSource +
+                                    FileCompressionType.GZIP.getFileExtension();
+      }
+      else
+      {
         fileMetadata.destFileName = destFileNameForStreamSource;
       }
     }
@@ -2714,12 +3095,16 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
    * @param srcFile The source file name
    * @return the mime type derived from the file extension
    */
-  private String getMimeTypeFromFileExtension(String srcFile) {
+  private String getMimeTypeFromFileExtension(String srcFile)
+  {
     String srcFileLowCase = srcFile.toLowerCase();
 
-    for (FileCompressionType compressionType : FileCompressionType.values()) {
-      if (srcFileLowCase.endsWith(compressionType.getFileExtension())) {
-        return compressionType.getMimeType() + "/" + compressionType.getMimeSubTypes().get(0);
+    for (FileCompressionType compressionType : FileCompressionType.values())
+    {
+      if (srcFileLowCase.endsWith(compressionType.getFileExtension()))
+      {
+        return compressionType.getMimeType() + "/" +
+               compressionType.getMimeSubTypes().get(0);
       }
     }
 
@@ -2732,12 +3117,14 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
    * @param stageLocationPath stage location
    * @return remoteLocation object
    */
-  public static remoteLocation extractLocationAndPath(String stageLocationPath) {
+  static public remoteLocation extractLocationAndPath(String stageLocationPath)
+  {
     String location = stageLocationPath;
     String path = "";
 
     // split stage location as location name and path
-    if (stageLocationPath.contains("/")) {
+    if (stageLocationPath.contains("/"))
+    {
       location = stageLocationPath.substring(0, stageLocationPath.indexOf("/"));
       path = stageLocationPath.substring(stageLocationPath.indexOf("/") + 1);
     }
@@ -2752,142 +3139,157 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
    * @throws Exception failed to construct list
    */
   @Override
-  public List<SnowflakeColumnMetadata> describeColumns(SFSession session) throws Exception {
+  public List<SnowflakeColumnMetadata> describeColumns(SFSession session) throws Exception
+  {
     return SnowflakeUtil.describeFixedViewColumns(
-        commandType == CommandType.UPLOAD
-            ? (showEncryptionParameter
-                ? UploadCommandEncryptionFacade.class
-                : UploadCommandFacade.class)
-            : (showEncryptionParameter
-                ? DownloadCommandEncryptionFacade.class
-                : DownloadCommandFacade.class),
-        session);
+        commandType == CommandType.UPLOAD ?
+        (showEncryptionParameter ?
+         UploadCommandEncryptionFacade.class : UploadCommandFacade.class) :
+        (showEncryptionParameter ?
+         DownloadCommandEncryptionFacade.class : DownloadCommandFacade.class), session);
   }
 
   @Override
-  public List<Object> getNextRow() throws Exception {
-    if (currentRowIndex < statusRows.size()) {
+  public List<Object> getNextRow() throws Exception
+  {
+    if (currentRowIndex < statusRows.size())
+    {
       return ClassUtil.getFixedViewObjectAsRow(
-          commandType == CommandType.UPLOAD
-              ? (showEncryptionParameter
-                  ? UploadCommandEncryptionFacade.class
-                  : UploadCommandFacade.class)
-              : (showEncryptionParameter
-                  ? DownloadCommandEncryptionFacade.class
-                  : DownloadCommandFacade.class),
+          commandType == CommandType.UPLOAD ?
+          (showEncryptionParameter ?
+           UploadCommandEncryptionFacade.class : UploadCommandFacade.class) :
+          (showEncryptionParameter ?
+           DownloadCommandEncryptionFacade.class : DownloadCommandFacade.class),
           statusRows.get(currentRowIndex++));
-    } else {
+    }
+    else
+    {
       return null;
     }
   }
 
-  /** Generate status rows for each file */
-  private void populateStatusRows() {
-    for (Map.Entry<String, FileMetadata> entry : fileMetadataMap.entrySet()) {
+  /**
+   * Generate status rows for each file
+   */
+  private void populateStatusRows()
+  {
+    for (Map.Entry<String, FileMetadata> entry : fileMetadataMap.entrySet())
+    {
       FileMetadata fileMetadata = entry.getValue();
 
-      if (commandType == CommandType.UPLOAD) {
-        statusRows.add(
-            showEncryptionParameter
-                ? new UploadCommandEncryptionFacade(
-                    fileMetadata.srcFileName,
-                    fileMetadata.destFileName,
-                    fileMetadata.resultStatus.name(),
-                    fileMetadata.errorDetails,
-                    fileMetadata.srcFileSize,
-                    fileMetadata.destFileSize,
-                    (fileMetadata.srcCompressionType == null)
-                        ? "NONE"
-                        : fileMetadata.srcCompressionType.name(),
-                    (fileMetadata.destCompressionType == null)
-                        ? "NONE"
-                        : fileMetadata.destCompressionType.name(),
-                    fileMetadata.isEncrypted)
-                : new UploadCommandFacade(
-                    fileMetadata.srcFileName,
-                    fileMetadata.destFileName,
-                    fileMetadata.resultStatus.name(),
-                    fileMetadata.errorDetails,
-                    fileMetadata.srcFileSize,
-                    fileMetadata.destFileSize,
-                    (fileMetadata.srcCompressionType == null)
-                        ? "NONE"
-                        : fileMetadata.srcCompressionType.name(),
-                    (fileMetadata.destCompressionType == null)
-                        ? "NONE"
-                        : fileMetadata.destCompressionType.name()));
-      } else if (commandType == CommandType.DOWNLOAD) {
-        statusRows.add(
-            showEncryptionParameter
-                ? new DownloadCommandEncryptionFacade(
-                    fileMetadata.srcFileName.startsWith("/")
-                        ? fileMetadata.srcFileName.substring(1)
-                        : fileMetadata.srcFileName,
-                    fileMetadata.resultStatus.name(),
-                    fileMetadata.errorDetails,
-                    fileMetadata.destFileSize,
-                    fileMetadata.isEncrypted)
-                : new DownloadCommandFacade(
-                    fileMetadata.srcFileName.startsWith("/")
-                        ? fileMetadata.srcFileName.substring(1)
-                        : fileMetadata.srcFileName,
-                    fileMetadata.resultStatus.name(),
-                    fileMetadata.errorDetails,
-                    fileMetadata.destFileSize));
+      if (commandType == CommandType.UPLOAD)
+      {
+        statusRows.add(showEncryptionParameter ?
+                       new UploadCommandEncryptionFacade(
+                           fileMetadata.srcFileName,
+                           fileMetadata.destFileName,
+                           fileMetadata.resultStatus.name(),
+                           fileMetadata.errorDetails,
+                           fileMetadata.srcFileSize,
+                           fileMetadata.destFileSize,
+                           (fileMetadata.srcCompressionType == null) ?
+                           "NONE" : fileMetadata.srcCompressionType.name(),
+                           (fileMetadata.destCompressionType == null) ?
+                           "NONE" : fileMetadata.destCompressionType.name(),
+                           fileMetadata.isEncrypted) :
+                       new UploadCommandFacade(
+                           fileMetadata.srcFileName,
+                           fileMetadata.destFileName,
+                           fileMetadata.resultStatus.name(),
+                           fileMetadata.errorDetails,
+                           fileMetadata.srcFileSize,
+                           fileMetadata.destFileSize,
+                           (fileMetadata.srcCompressionType == null) ?
+                           "NONE" : fileMetadata.srcCompressionType.name(),
+                           (fileMetadata.destCompressionType == null) ?
+                           "NONE" : fileMetadata.destCompressionType.name()));
       }
+      else if (commandType == CommandType.DOWNLOAD)
+      {
+        statusRows.add(showEncryptionParameter ?
+                       new DownloadCommandEncryptionFacade(
+                           fileMetadata.srcFileName.startsWith("/") ?
+                           fileMetadata.srcFileName.substring(1) :
+                           fileMetadata.srcFileName,
+                           fileMetadata.resultStatus.name(),
+                           fileMetadata.errorDetails,
+                           fileMetadata.destFileSize,
+                           fileMetadata.isEncrypted) :
+                       new DownloadCommandFacade(
+                           fileMetadata.srcFileName.startsWith("/") ?
+                           fileMetadata.srcFileName.substring(1) :
+                           fileMetadata.srcFileName,
+                           fileMetadata.resultStatus.name(),
+                           fileMetadata.errorDetails,
+                           fileMetadata.destFileSize));
+      }
+
     }
 
     /* we sort the result if the connection is in sorting mode
      */
     Object sortProperty = null;
 
-    sortProperty = session.getSFSessionProperty("sort");
+    sortProperty =
+        session.getSFSessionProperty("sort");
 
     boolean sortResult = sortProperty != null && (Boolean) sortProperty;
 
-    if (sortResult) {
+    if (sortResult)
+    {
       Comparator<Object> comparator =
-          (commandType == CommandType.UPLOAD)
-              ? new Comparator<Object>() {
-                public int compare(Object a, Object b) {
-                  String srcFileNameA = ((UploadCommandFacade) a).srcFile;
-                  String srcFileNameB = ((UploadCommandFacade) b).srcFile;
+          (commandType == CommandType.UPLOAD) ?
+          new Comparator<Object>()
+          {
+            public int compare(Object a, Object b)
+            {
+              String srcFileNameA = ((UploadCommandFacade) a).srcFile;
+              String srcFileNameB = ((UploadCommandFacade) b).srcFile;
 
-                  return srcFileNameA.compareTo(srcFileNameB);
-                }
-              }
-              : new Comparator<Object>() {
-                public int compare(Object a, Object b) {
-                  String srcFileNameA = ((DownloadCommandFacade) a).file;
-                  String srcFileNameB = ((DownloadCommandFacade) b).file;
+              return srcFileNameA.compareTo(srcFileNameB);
+            }
+          } :
+          new Comparator<Object>()
+          {
+            public int compare(Object a, Object b)
+            {
+              String srcFileNameA = ((DownloadCommandFacade) a).file;
+              String srcFileNameB = ((DownloadCommandFacade) b).file;
 
-                  return srcFileNameA.compareTo(srcFileNameB);
-                }
-              };
+              return srcFileNameA.compareTo(srcFileNameB);
+            }
+          };
 
       // sort the rows by source file names
       Collections.sort(statusRows, comparator);
     }
   }
 
-  public Object getResultSet() throws SnowflakeSQLException {
+  public Object getResultSet()
+  throws SnowflakeSQLException
+  {
     return new SFFixedViewResultSet(this, this.commandType);
   }
 
-  public CommandType getCommandType() {
+  public CommandType getCommandType()
+  {
     return commandType;
   }
 
-  public void setSourceStream(InputStream sourceStream) {
+  public void setSourceStream(InputStream sourceStream)
+  {
     this.sourceStream = sourceStream;
     this.sourceFromStream = true;
   }
 
-  public void setDestFileNameForStreamSource(String destFileNameForStreamSource) {
+  public void setDestFileNameForStreamSource(
+      String destFileNameForStreamSource)
+  {
     this.destFileNameForStreamSource = destFileNameForStreamSource;
   }
 
-  public void setCompressSourceFromStream(boolean compressSourceFromStream) {
+  public void setCompressSourceFromStream(boolean compressSourceFromStream)
+  {
     this.compressSourceFromStream = compressSourceFromStream;
   }
 
@@ -2899,31 +3301,31 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
    * @throws throws the error as a SnowflakeSQLException
    */
   public static void throwJCEMissingError(String operation, Exception ex)
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
     // Most likely cause: Unlimited strength policy files not installed
-    String msg =
-        "Strong encryption with Java JRE requires JCE "
-            + "Unlimited Strength Jurisdiction Policy files. "
-            + "Follow JDBC client installation instructions "
-            + "provided by Snowflake or contact Snowflake Support.";
+    String msg = "Strong encryption with Java JRE requires JCE " +
+                 "Unlimited Strength Jurisdiction Policy files. " +
+                 "Follow JDBC client installation instructions " +
+                 "provided by Snowflake or contact Snowflake Support.";
 
-    logger.error(
-        "JCE Unlimited Strength policy files missing: {}. {}.",
-        ex.getMessage(),
-        ex.getCause().getMessage());
+    logger.error("JCE Unlimited Strength policy files missing: {}. {}.",
+                 ex.getMessage(), ex.getCause().getMessage());
 
     String bootLib = systemGetProperty("sun.boot.library.path");
-    if (bootLib != null) {
-      msg +=
-          " The target directory on your system is: " + Paths.get(bootLib, "security").toString();
+    if (bootLib != null)
+    {
+      msg += " The target directory on your system is: " +
+             Paths.get(bootLib, "security").toString();
       logger.error(msg);
     }
-    throw new SnowflakeSQLException(
-        ex, SqlState.SYSTEM_ERROR, ErrorCode.AWS_CLIENT_ERROR.getMessageCode(), operation, msg);
+    throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
+                                    ErrorCode.AWS_CLIENT_ERROR.getMessageCode(), operation, msg);
   }
 
   @Override
-  public int getTotalRows() {
+  public int getTotalRows()
+  {
     return statusRows.size();
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -4,16 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.ParameterBindingDTO;
-import net.snowflake.client.core.ResultUtil;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFStatementMetaData;
-import net.snowflake.client.core.StmtUtil;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SqlState;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -45,63 +35,53 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import net.snowflake.client.core.ParameterBindingDTO;
+import net.snowflake.client.core.ResultUtil;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFStatementMetaData;
+import net.snowflake.client.core.StmtUtil;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SqlState;
 
 class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
-    implements PreparedStatement, SnowflakePreparedStatement
-{
-  static final SFLogger logger = SFLoggerFactory.getLogger(
-      SnowflakePreparedStatementV1.class);
-  /**
-   * Error code returned when describing a statement that is binding table name
-   */
+    implements PreparedStatement, SnowflakePreparedStatement {
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakePreparedStatementV1.class);
+  /** Error code returned when describing a statement that is binding table name */
   private static final Integer ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET = 2128;
-  /**
-   * Error code when preparing statement with binding object names
-   */
+  /** Error code when preparing statement with binding object names */
   private static final Integer ERROR_CODE_OBJECT_BIND_NOT_SET = 2129;
-  /**
-   * Error code returned when describing a ddl command
-   */
+  /** Error code returned when describing a ddl command */
   private static final Integer ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED = 7;
-  /**
-   * snow-44393 Workaround for compiler cannot prepare to_timestamp(?, 3)
-   */
+  /** snow-44393 Workaround for compiler cannot prepare to_timestamp(?, 3) */
   private static final Integer ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING = 1026;
-  /**
-   * A hash set that contains the error code that will not lead to exception
-   * in describe mode
-   */
-  private static final Set<Integer> errorCodesIgnoredInDescribeMode
-      = new HashSet<>(Arrays.asList(
-      ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET,
-      ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED,
-      ERROR_CODE_OBJECT_BIND_NOT_SET,
-      ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING));
+  /** A hash set that contains the error code that will not lead to exception in describe mode */
+  private static final Set<Integer> errorCodesIgnoredInDescribeMode =
+      new HashSet<>(
+          Arrays.asList(
+              ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET,
+              ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED,
+              ERROR_CODE_OBJECT_BIND_NOT_SET,
+              ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING));
 
   private final String sql;
 
   private boolean showStatementParameters;
 
-  /**
-   * statement and result metadata from describe phase
-   */
+  /** statement and result metadata from describe phase */
   private SFStatementMetaData statementMetaData;
   /**
    * map of bind name to bind values for single query execution
-   * <p>
-   * Currently, bind name is just value index
+   *
+   * <p>Currently, bind name is just value index
    */
   private Map<String, ParameterBindingDTO> parameterBindings = new HashMap<>();
-  /**
-   * map of bind values for batch query executions
-   */
-  private Map<String, ParameterBindingDTO> batchParameterBindings =
-      new HashMap<>();
+  /** map of bind values for batch query executions */
+  private Map<String, ParameterBindingDTO> batchParameterBindings = new HashMap<>();
+
   private Map<String, Boolean> wasPrevValueNull = new HashMap<>();
-  /**
-   * Counter for batch size if we are executing a statement with array bind
-   * supported
-   */
+  /** Counter for batch size if we are executing a statement with array bind supported */
   private int batchSize = 0;
 
   private boolean alreadyDescribed = false;
@@ -109,11 +89,11 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   /**
    * Construct SnowflakePreparedStatementV1
    *
-   * @param connection           connection object
-   * @param sql                  sql
-   * @param skipParsing          true if the applications want to skip parsing
-   *                             to get metadata. false by default.
-   * @param resultSetType        result set type: ResultSet.TYPE_FORWARD_ONLY.
+   * @param connection connection object
+   * @param sql sql
+   * @param skipParsing true if the applications want to skip parsing to get metadata. false by
+   *     default.
+   * @param resultSetType result set type: ResultSet.TYPE_FORWARD_ONLY.
    * @param resultSetConcurrency result set conconcurrency: ResultSet.CONCUR_READ_ONLY.
    * @param resultSetHoldability result set holdability: ResultSet.CLOSE_CURSORS_AT_COMMIT
    * @throws SQLException if any SQL error occurs.
@@ -124,9 +104,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       boolean skipParsing,
       int resultSetType,
       int resultSetConcurrency,
-      int resultSetHoldability
-  ) throws SQLException
-  {
+      int resultSetHoldability)
+      throws SQLException {
     super(connection, resultSetType, resultSetConcurrency, resultSetHoldability);
     this.sql = sql;
     this.statementMetaData = SFStatementMetaData.emptyMetaData();
@@ -134,32 +113,21 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   /**
-   * This method will check alreadyDescribed flag. And if it is false, it will
-   * try to issue a describe request to server. If true, it will skip
-   * describe request.
+   * This method will check alreadyDescribed flag. And if it is false, it will try to issue a
+   * describe request to server. If true, it will skip describe request.
    *
    * @throws SQLException
    */
-  private void describeSqlIfNotTried() throws SQLException
-  {
-    if (!alreadyDescribed)
-    {
-      try
-      {
+  private void describeSqlIfNotTried() throws SQLException {
+    if (!alreadyDescribed) {
+      try {
         this.statementMetaData = sfStatement.describe(sql);
-      }
-      catch (SFException e)
-      {
+      } catch (SFException e) {
         throw new SnowflakeSQLLoggedException(e, connection.getSfSession());
-      }
-      catch (SnowflakeSQLException e)
-      {
-        if (!errorCodesIgnoredInDescribeMode.contains(e.getErrorCode()))
-        {
+      } catch (SnowflakeSQLException e) {
+        if (!errorCodesIgnoredInDescribeMode.contains(e.getErrorCode())) {
           throw e;
-        }
-        else
-        {
+        } else {
           statementMetaData = SFStatementMetaData.emptyMetaData();
         }
       }
@@ -168,14 +136,10 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public ResultSet executeQuery() throws SQLException
-  {
-    if (showStatementParameters)
-    {
+  public ResultSet executeQuery() throws SQLException {
+    if (showStatementParameters) {
       logger.info("executeQuery()");
-    }
-    else
-    {
+    } else {
       logger.debug("executeQuery()");
     }
     return executeQueryInternal(sql, false, parameterBindings);
@@ -187,185 +151,168 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
    * @return ResultSet containing results
    * @throws SQLException
    */
-  public ResultSet executeAsyncQuery() throws SQLException
-  {
-    if (showStatementParameters)
-    {
+  public ResultSet executeAsyncQuery() throws SQLException {
+    if (showStatementParameters) {
       logger.info("executeAsyncQuery()");
-    }
-    else
-    {
+    } else {
       logger.debug("executeAsyncQuery()");
     }
     return executeQueryInternal(sql, true, parameterBindings);
   }
 
   @Override
-  public long executeLargeUpdate() throws SQLException
-  {
+  public long executeLargeUpdate() throws SQLException {
     logger.debug("executeLargeUpdate()");
 
     return executeUpdateInternal(sql, parameterBindings, true);
   }
 
   @Override
-  public int executeUpdate() throws SQLException
-  {
+  public int executeUpdate() throws SQLException {
     logger.debug("executeUpdate()");
 
     return (int) executeLargeUpdate();
   }
 
   @Override
-  public void setNull(int parameterIndex, int sqlType) throws SQLException
-  {
-    logger.debug("setNull(parameterIndex: {}, sqlType: {})",
-                 parameterIndex, SnowflakeType.JavaSQLType.find(sqlType));
+  public void setNull(int parameterIndex, int sqlType) throws SQLException {
+    logger.debug(
+        "setNull(parameterIndex: {}, sqlType: {})",
+        parameterIndex,
+        SnowflakeType.JavaSQLType.find(sqlType));
     raiseSQLExceptionIfStatementIsClosed();
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeType.ANY.toString(), null);
+    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeType.ANY.toString(), null);
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBoolean(int parameterIndex, boolean x) throws SQLException
-  {
-    logger.debug(
-        "setBoolean(parameterIndex: {}, boolean x)", parameterIndex);
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN), String.valueOf(x));
+  public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+    logger.debug("setBoolean(parameterIndex: {}, boolean x)", parameterIndex);
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setByte(int parameterIndex, byte x) throws SQLException
-  {
+  public void setByte(int parameterIndex, byte x) throws SQLException {
     logger.debug("setByte(parameterIndex: {}, byte x)", parameterIndex);
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.TINYINT), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.TINYINT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setShort(int parameterIndex, short x) throws SQLException
-  {
+  public void setShort(int parameterIndex, short x) throws SQLException {
     logger.debug("setShort(parameterIndex: {}, short x)", parameterIndex);
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
-                                                              .javaTypeToSFTypeString(Types.SMALLINT), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.SMALLINT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setInt(int parameterIndex, int x) throws SQLException
-  {
+  public void setInt(int parameterIndex, int x) throws SQLException {
     logger.debug("setInt(parameterIndex: {}, int x)", parameterIndex);
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
-                                                              .javaTypeToSFTypeString(Types.INTEGER), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.INTEGER), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setLong(int parameterIndex, long x) throws SQLException
-  {
+  public void setLong(int parameterIndex, long x) throws SQLException {
     logger.debug("setLong(parameterIndex: {}, long x)", parameterIndex);
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setFloat(int parameterIndex, float x) throws SQLException
-  {
+  public void setFloat(int parameterIndex, float x) throws SQLException {
     logger.debug("setFloat(parameterIndex: {}, float x)", parameterIndex);
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setDouble(int parameterIndex, double x) throws SQLException
-  {
+  public void setDouble(int parameterIndex, double x) throws SQLException {
     logger.debug("setDouble(parameterIndex: {}, double x)", parameterIndex);
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE), String.valueOf(x));
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException
-  {
+  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
     logger.debug("setBigDecimal(parameterIndex: {}, BigDecimal x)", parameterIndex);
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, Types.DECIMAL);
-    }
-    else
-    {
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-          SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL), String.valueOf(x));
+    } else {
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL), String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setString(int parameterIndex, String x) throws SQLException
-  {
+  public void setString(int parameterIndex, String x) throws SQLException {
     logger.debug("setString(parameterIndex: {}, String x)", parameterIndex);
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(
-        SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR), x);
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR), x);
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBytes(int parameterIndex, byte[] x) throws SQLException
-  {
+  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
     logger.debug("setBytes(parameterIndex: {}, byte[] x)", parameterIndex);
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
-                                                              .javaTypeToSFTypeString(Types.BINARY), new SFBinary(x).toHex());
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BINARY), new SFBinary(x).toHex());
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x) throws SQLException
-  {
+  public void setDate(int parameterIndex, Date x) throws SQLException {
     logger.debug("setDate(parameterIndex: {}, Date x)", parameterIndex);
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, Types.DATE);
-    }
-    else
-    {
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-          SnowflakeUtil.javaTypeToSFTypeString(Types.DATE),
-          String.valueOf(x.getTime() +
-                         TimeZone.getDefault().getOffset(x.getTime()) -
-                         ResultUtil.msDiffJulianToGregorian(x)));
+    } else {
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(Types.DATE),
+              String.valueOf(
+                  x.getTime()
+                      + TimeZone.getDefault().getOffset(x.getTime())
+                      - ResultUtil.msDiffJulianToGregorian(x)));
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x) throws SQLException
-  {
+  public void setTime(int parameterIndex, Time x) throws SQLException {
     logger.debug("setTime(parameterIndex: {}, Time x)", parameterIndex);
 
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, Types.TIME);
-    }
-    else
-    {
+    } else {
       // Convert to nanoseconds since midnight using the input time mod 24 hours.
       final long MS_IN_DAY = 86400 * 1000;
       long msSinceEpoch = x.getTime();
@@ -374,9 +321,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       long msSinceMidnight = (msSinceEpoch % MS_IN_DAY + MS_IN_DAY) % MS_IN_DAY;
       long nanosSinceMidnight = msSinceMidnight * 1000 * 1000;
 
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-          SnowflakeUtil.javaTypeToSFTypeString(Types.TIME),
-          String.valueOf(nanosSinceMidnight));
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(Types.TIME), String.valueOf(nanosSinceMidnight));
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
       sfStatement.setHasUnsupportedStageBind(true);
@@ -384,20 +331,21 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException
-  {
+  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
     logger.debug("setTimestamp(parameterIndex: {}, Timestamp x)", parameterIndex);
 
     // convert the timestamp from being in local time zone to be in UTC timezone
-    String value = x == null ? null :
-                   String.valueOf(
-                       BigDecimal.valueOf((x.getTime() - ResultUtil.msDiffJulianToGregorian(x)) / 1000).
-                           scaleByPowerOfTen(9).add(BigDecimal.valueOf(x.getNanos())));
+    String value =
+        x == null
+            ? null
+            : String.valueOf(
+                BigDecimal.valueOf((x.getTime() - ResultUtil.msDiffJulianToGregorian(x)) / 1000)
+                    .scaleByPowerOfTen(9)
+                    .add(BigDecimal.valueOf(x.getNanos())));
 
     SnowflakeType sfType = SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP);
 
-    if (sfType == SnowflakeType.TIMESTAMP)
-    {
+    if (sfType == SnowflakeType.TIMESTAMP) {
       sfType = connection.getSfSession().getTimestampMappedType();
     }
 
@@ -406,211 +354,152 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, int length)
-  throws SQLException
-  {
+  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   @Deprecated
-  public void setUnicodeStream(int parameterIndex, InputStream x, int length)
-  throws SQLException
-  {
+  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, int length)
-  throws SQLException
-  {
+  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void clearParameters() throws SQLException
-  {
+  public void clearParameters() throws SQLException {
     parameterBindings.clear();
-    if (batchParameterBindings.isEmpty())
-    {
+    if (batchParameterBindings.isEmpty()) {
       sfStatement.setHasUnsupportedStageBind(false);
     }
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException
-  {
-    if (x == null)
-    {
+  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    if (x == null) {
       setNull(parameterIndex, targetSqlType);
-    }
-    else if (targetSqlType == Types.DATE)
-    {
+    } else if (targetSqlType == Types.DATE) {
       setDate(parameterIndex, (Date) x);
-    }
-    else if (targetSqlType == Types.TIME)
-    {
+    } else if (targetSqlType == Types.TIME) {
       setTime(parameterIndex, (Time) x);
-    }
-    else if (targetSqlType == Types.TIMESTAMP)
-    {
+    } else if (targetSqlType == Types.TIMESTAMP) {
       setTimestamp(parameterIndex, (Timestamp) x);
-    }
-    else
-    {
-      logger.debug("setObject(parameterIndex: {}, Object x, sqlType: {})",
-                   parameterIndex, SnowflakeType.JavaSQLType.find(targetSqlType));
+    } else {
+      logger.debug(
+          "setObject(parameterIndex: {}, Object x, sqlType: {})",
+          parameterIndex,
+          SnowflakeType.JavaSQLType.find(targetSqlType));
 
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-          SnowflakeUtil.javaTypeToSFTypeString(targetSqlType),
-          String.valueOf(x));
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(targetSqlType), String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x) throws SQLException
-  {
-    if (x == null)
-    {
+  public void setObject(int parameterIndex, Object x) throws SQLException {
+    if (x == null) {
       setNull(parameterIndex, Types.NULL);
-    }
-    else if (x instanceof String)
-    {
+    } else if (x instanceof String) {
       setString(parameterIndex, (String) x);
-    }
-    else if (x instanceof BigDecimal)
-    {
+    } else if (x instanceof BigDecimal) {
       setBigDecimal(parameterIndex, (BigDecimal) x);
-    }
-    else if (x instanceof Short)
-    {
+    } else if (x instanceof Short) {
       setShort(parameterIndex, (Short) x);
-    }
-    else if (x instanceof Integer)
-    {
+    } else if (x instanceof Integer) {
       setInt(parameterIndex, (Integer) x);
-    }
-    else if (x instanceof Long)
-    {
+    } else if (x instanceof Long) {
       setLong(parameterIndex, (Long) x);
-    }
-    else if (x instanceof Float)
-    {
+    } else if (x instanceof Float) {
       setFloat(parameterIndex, (Float) x);
-    }
-    else if (x instanceof Double)
-    {
+    } else if (x instanceof Double) {
       setDouble(parameterIndex, (Double) x);
-    }
-    else if (x instanceof Date)
-    {
+    } else if (x instanceof Date) {
       setDate(parameterIndex, (Date) x);
-    }
-    else if (x instanceof Time)
-    {
+    } else if (x instanceof Time) {
       setTime(parameterIndex, (Time) x);
-    }
-    else if (x instanceof Timestamp)
-    {
+    } else if (x instanceof Timestamp) {
       setTimestamp(parameterIndex, (Timestamp) x);
-    }
-    else if (x instanceof Boolean)
-    {
+    } else if (x instanceof Boolean) {
       setBoolean(parameterIndex, (Boolean) x);
-    }
-    else
-    {
-      throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                      ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
-                                      "Object type: " + x.getClass());
+    } else {
+      throw new SnowflakeSQLException(
+          SqlState.FEATURE_NOT_SUPPORTED,
+          ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
+          "Object type: " + x.getClass());
     }
   }
 
   @Override
-  public boolean execute() throws SQLException
-  {
+  public boolean execute() throws SQLException {
     logger.debug("execute: {}", sql);
 
     return executeInternal(sql, parameterBindings);
   }
 
   @Override
-  public void addBatch() throws SQLException
-  {
+  public void addBatch() throws SQLException {
     logger.debug("addBatch()");
 
     raiseSQLExceptionIfStatementIsClosed();
 
     describeSqlIfNotTried();
-    if (statementMetaData.isArrayBindSupported())
-    {
-      for (Map.Entry<String, ParameterBindingDTO> binding :
-          parameterBindings.entrySet())
-      {
+    if (statementMetaData.isArrayBindSupported()) {
+      for (Map.Entry<String, ParameterBindingDTO> binding : parameterBindings.entrySet()) {
         // get the entry for the bind variable in the batch binding map
-        ParameterBindingDTO bindingValueAndType =
-            batchParameterBindings.get(binding.getKey());
+        ParameterBindingDTO bindingValueAndType = batchParameterBindings.get(binding.getKey());
 
         List<String> values;
 
         Object newValue = binding.getValue().getValue();
         // create binding value and type for the first time
-        if (bindingValueAndType == null)
-        {
+        if (bindingValueAndType == null) {
           // create the value list
           values = new ArrayList<>();
 
-          bindingValueAndType = new ParameterBindingDTO(
-              binding.getValue().getType(), values);
+          bindingValueAndType = new ParameterBindingDTO(binding.getValue().getType(), values);
 
           // put the new map into the batch
-          batchParameterBindings.put(binding.getKey(),
-                                     bindingValueAndType);
+          batchParameterBindings.put(binding.getKey(), bindingValueAndType);
 
-          wasPrevValueNull.put(
-              binding.getKey(), binding.getValue().getValue() == null);
-        }
-        else
-        {
+          wasPrevValueNull.put(binding.getKey(), binding.getValue().getValue() == null);
+        } else {
           // make sure type matches except for null values
           String prevType = bindingValueAndType.getType();
           String newType = binding.getValue().getType();
 
-          if (wasPrevValueNull.get(binding.getKey()) && newValue != null)
-          {
+          if (wasPrevValueNull.get(binding.getKey()) && newValue != null) {
             // if previous value is null and the current value is not null
             // override the data type.
-            bindingValueAndType = batchParameterBindings.remove(
-                binding.getKey());
+            bindingValueAndType = batchParameterBindings.remove(binding.getKey());
             bindingValueAndType.setType(newType);
-            batchParameterBindings.put(binding.getKey(),
-                                       bindingValueAndType);
+            batchParameterBindings.put(binding.getKey(), bindingValueAndType);
             prevType = newType;
             wasPrevValueNull.put(binding.getKey(), false);
           }
 
           // if previous type is null, replace it with new type
-          if (SnowflakeType.ANY.name().equalsIgnoreCase(prevType) &&
-              !SnowflakeType.ANY.name().equalsIgnoreCase(newType))
-          {
+          if (SnowflakeType.ANY.name().equalsIgnoreCase(prevType)
+              && !SnowflakeType.ANY.name().equalsIgnoreCase(newType)) {
             bindingValueAndType.setType(newType);
-          }
-          else if (binding.getValue().getValue() != null &&
-                   !prevType.equalsIgnoreCase(newType))
-          {
+          } else if (binding.getValue().getValue() != null && !prevType.equalsIgnoreCase(newType)) {
             String row = "Unknown";
-            if (bindingValueAndType.getValue() instanceof Collection)
-            {
+            if (bindingValueAndType.getValue() instanceof Collection) {
               final List<String> typeCheckedList = (List<String>) bindingValueAndType.getValue();
               values = typeCheckedList;
               row = Integer.toString(values.size() + 1);
             }
-            throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
-                                            ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
-                                            SnowflakeType.getJavaType(SnowflakeType.fromString(prevType)).name(),
-                                            SnowflakeType.getJavaType(SnowflakeType.fromString(newType)).name(),
-                                            binding.getKey(), row);
+            throw new SnowflakeSQLException(
+                SqlState.FEATURE_NOT_SUPPORTED,
+                ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
+                SnowflakeType.getJavaType(SnowflakeType.fromString(prevType)).name(),
+                SnowflakeType.getJavaType(SnowflakeType.fromString(newType)).name(),
+                binding.getKey(),
+                row);
           }
 
           // found the existing map so just get the value list
@@ -623,9 +512,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
         bindingValueAndType.setValue(values);
       }
       batchSize++;
-    }
-    else
-    {
+    } else {
       batch.add(new BatchEntry(this.sql, parameterBindings));
       parameterBindings = new HashMap<>();
     }
@@ -633,119 +520,102 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, int length)
-  throws SQLException
-  {
+      throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setRef(int parameterIndex, Ref x) throws SQLException
-  {
+  public void setRef(int parameterIndex, Ref x) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBlob(int parameterIndex, Blob x) throws SQLException
-  {
+  public void setBlob(int parameterIndex, Blob x) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setClob(int parameterIndex, Clob x) throws SQLException
-  {
+  public void setClob(int parameterIndex, Clob x) throws SQLException {
     setString(parameterIndex, x.toString());
   }
 
   @Override
-  public void setArray(int parameterIndex, Array x) throws SQLException
-  {
+  public void setArray(int parameterIndex, Array x) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public ResultSetMetaData getMetaData() throws SQLException
-  {
+  public ResultSetMetaData getMetaData() throws SQLException {
     logger.debug("getMetaData()");
 
     raiseSQLExceptionIfStatementIsClosed();
 
     describeSqlIfNotTried();
-    return new SnowflakeResultSetMetaDataV1(
-        this.statementMetaData.getResultSetMetaData());
+    return new SnowflakeResultSetMetaDataV1(this.statementMetaData.getResultSetMetaData());
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x, Calendar cal)
-  throws SQLException
-  {
+  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
     logger.debug("setDate(int parameterIndex, Date x, Calendar cal)");
 
     raiseSQLExceptionIfStatementIsClosed();
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, Types.DATE);
-    }
-    else
-    {
+    } else {
       // convert the date from to be in local time zone to be in UTC
-      String value = String.valueOf(x.getTime() +
-                                    cal.getTimeZone().getOffset(x.getTime())
-                                    - ResultUtil.msDiffJulianToGregorian(x));
+      String value =
+          String.valueOf(
+              x.getTime()
+                  + cal.getTimeZone().getOffset(x.getTime())
+                  - ResultUtil.msDiffJulianToGregorian(x));
 
-      ParameterBindingDTO binding = new ParameterBindingDTO(
-          SnowflakeUtil.javaTypeToSFTypeString(Types.DATE), value);
+      ParameterBindingDTO binding =
+          new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(Types.DATE), value);
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x, Calendar cal)
-  throws SQLException
-  {
+  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
     logger.debug("setTime(int parameterIndex, Time x, Calendar cal)");
     raiseSQLExceptionIfStatementIsClosed();
     setTime(parameterIndex, x);
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal)
-  throws SQLException
-  {
+  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
     logger.debug("setTimestamp(int parameterIndex, Timestamp x, Calendar cal)");
     raiseSQLExceptionIfStatementIsClosed();
 
     // convert the time from being in UTC to be in local time zone
     String value = null;
     SnowflakeType sfType = SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP);
-    if (x != null)
-    {
+    if (x != null) {
       long milliSecSinceEpoch = x.getTime();
 
-      if (sfType == SnowflakeType.TIMESTAMP)
-      {
+      if (sfType == SnowflakeType.TIMESTAMP) {
         sfType = connection.getSfSession().getTimestampMappedType();
       }
       // if type is timestamp_tz, keep the offset and the time value separate.
       // store the offset, in minutes, as amount it's off from UTC
-      if (sfType == SnowflakeType.TIMESTAMP_TZ)
-      {
-        value = String.valueOf(
-            BigDecimal.valueOf(milliSecSinceEpoch / 1000).
-                scaleByPowerOfTen(9).add(BigDecimal.valueOf(x.getNanos())));
+      if (sfType == SnowflakeType.TIMESTAMP_TZ) {
+        value =
+            String.valueOf(
+                BigDecimal.valueOf(milliSecSinceEpoch / 1000)
+                    .scaleByPowerOfTen(9)
+                    .add(BigDecimal.valueOf(x.getNanos())));
 
         int offset = cal.getTimeZone().getOffset(milliSecSinceEpoch) / 60000 + 1440;
         value += " " + offset;
-      }
-      else
-      {
-        milliSecSinceEpoch = milliSecSinceEpoch +
-                             cal.getTimeZone().getOffset(milliSecSinceEpoch);
+      } else {
+        milliSecSinceEpoch = milliSecSinceEpoch + cal.getTimeZone().getOffset(milliSecSinceEpoch);
 
-        value = String.valueOf(
-            BigDecimal.valueOf(milliSecSinceEpoch / 1000).
-                scaleByPowerOfTen(9).add(BigDecimal.valueOf(x.getNanos())));
+        value =
+            String.valueOf(
+                BigDecimal.valueOf(milliSecSinceEpoch / 1000)
+                    .scaleByPowerOfTen(9)
+                    .add(BigDecimal.valueOf(x.getNanos())));
       }
-
     }
 
     ParameterBindingDTO binding = new ParameterBindingDTO(sfType.name(), value);
@@ -753,176 +623,135 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setNull(int parameterIndex, int sqlType, String typeName)
-  throws SQLException
-  {
+  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
     logger.debug("setNull(int parameterIndex, int sqlType, String typeName)");
 
     setNull(parameterIndex, sqlType);
   }
 
   @Override
-  public void setURL(int parameterIndex, URL x) throws SQLException
-  {
+  public void setURL(int parameterIndex, URL x) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public ParameterMetaData getParameterMetaData() throws SQLException
-  {
+  public ParameterMetaData getParameterMetaData() throws SQLException {
     describeSqlIfNotTried();
     return new SnowflakeParameterMetadata(statementMetaData);
   }
 
   @Override
-  public void setRowId(int parameterIndex, RowId x) throws SQLException
-  {
+  public void setRowId(int parameterIndex, RowId x) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNString(int parameterIndex, String value) throws SQLException
-  {
+  public void setNString(int parameterIndex, String value) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void setNCharacterStream(int parameterIndex, Reader value, long length)
-  throws SQLException
-  {
+      throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNClob(int parameterIndex, NClob value) throws SQLException
-  {
+  public void setNClob(int parameterIndex, NClob value) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader, long length)
-  throws SQLException
-  {
+  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void setBlob(int parameterIndex, InputStream inputStream, long length)
-  throws SQLException
-  {
+      throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader, long length)
-  throws SQLException
-  {
+  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setSQLXML(int parameterIndex, SQLXML xmlObject)
-  throws SQLException
-  {
+  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType,
-                        int scaleOrLength) throws SQLException
-  {
-    logger.debug(
-        "setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)");
+  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+      throws SQLException {
+    logger.debug("setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)");
 
     raiseSQLExceptionIfStatementIsClosed();
-    if (x == null)
-    {
+    if (x == null) {
       setNull(parameterIndex, targetSqlType);
-    }
-    else if (targetSqlType == Types.DECIMAL ||
-             targetSqlType == Types.NUMERIC)
-    {
+    } else if (targetSqlType == Types.DECIMAL || targetSqlType == Types.NUMERIC) {
       BigDecimal decimalObj = new BigDecimal(String.valueOf(x));
       decimalObj.setScale(scaleOrLength);
       setBigDecimal(parameterIndex, decimalObj);
-    }
-    else
-    {
+    } else {
       setObject(parameterIndex, x, targetSqlType);
     }
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, long length)
-  throws SQLException
-  {
+  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, long length)
-  throws SQLException
-  {
+  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, long length)
-  throws SQLException
-  {
+      throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x)
-  throws SQLException
-  {
+  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x)
-  throws SQLException
-  {
+  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader)
-  throws SQLException
-  {
+  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value)
-  throws SQLException
-  {
+  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader) throws SQLException
-  {
+  public void setClob(int parameterIndex, Reader reader) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream)
-  throws SQLException
-  {
+  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader) throws SQLException
-  {
+  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql) throws SQLException
-  {
+  public int executeUpdate(String sql) throws SQLException {
     logger.debug("executeUpdate(String sql)");
 
     throw new SnowflakeSQLException(
@@ -930,8 +759,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public boolean execute(String sql) throws SQLException
-  {
+  public boolean execute(String sql) throws SQLException {
     logger.debug("execute(String sql)");
 
     throw new SnowflakeSQLException(
@@ -939,15 +767,13 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void addBatch(String sql) throws SQLException
-  {
+  public void addBatch(String sql) throws SQLException {
     throw new SnowflakeSQLException(
         ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, StmtUtil.truncateSQL(sql));
   }
 
   @Override
-  public void clearBatch() throws SQLException
-  {
+  public void clearBatch() throws SQLException {
     super.clearBatch();
     batchParameterBindings.clear();
     parameterBindings.clear();
@@ -957,46 +783,33 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public int[] executeBatch() throws SQLException
-  {
+  public int[] executeBatch() throws SQLException {
     logger.debug("executeBatch()");
     raiseSQLExceptionIfStatementIsClosed();
 
     describeSqlIfNotTried();
-    if (this.statementMetaData.getStatementType().isGenerateResultSet())
-    {
+    if (this.statementMetaData.getStatementType().isGenerateResultSet()) {
       throw new SnowflakeSQLException(
           ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, StmtUtil.truncateSQL(sql));
     }
 
     int[] updateCounts = null;
-    try
-    {
-      if (this.statementMetaData.isArrayBindSupported())
-      {
-        int updateCount = (int) executeUpdateInternal(
-            this.sql, batchParameterBindings, false);
+    try {
+      if (this.statementMetaData.isArrayBindSupported()) {
+        int updateCount = (int) executeUpdateInternal(this.sql, batchParameterBindings, false);
 
         // when update count is the same as the number of bindings in the batch,
         // expand the update count into an array (SNOW-14034)
-        if (updateCount == batchSize)
-        {
+        if (updateCount == batchSize) {
           updateCounts = new int[updateCount];
-          for (int idx = 0; idx < updateCount; idx++)
-            updateCounts[idx] = 1;
+          for (int idx = 0; idx < updateCount; idx++) updateCounts[idx] = 1;
+        } else {
+          updateCounts = new int[] {updateCount};
         }
-        else
-        {
-          updateCounts = new int[]{updateCount};
-        }
-      }
-      else
-      {
+      } else {
         updateCounts = executeBatchInternal(false).intArr;
       }
-    }
-    finally
-    {
+    } finally {
       this.clearBatch();
     }
 
@@ -1004,51 +817,42 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public int executeUpdate(String sql, int autoGeneratedKeys)
-  throws SQLException
-  {
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException
-  {
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql, String[] columnNames) throws SQLException
-  {
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException
-  {
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, int[] columnIndexes) throws SQLException
-  {
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, String[] columnNames) throws SQLException
-  {
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   // For testing use only
-  Map<String, ParameterBindingDTO> getBatchParameterBindings()
-  {
+  Map<String, ParameterBindingDTO> getBatchParameterBindings() {
     return batchParameterBindings;
   }
 
   // package private for testing purpose only
-  Map<String, ParameterBindingDTO> getParameterBindings()
-  {
+  Map<String, ParameterBindingDTO> getParameterBindings() {
     return parameterBindings;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -4,6 +4,16 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.ParameterBindingDTO;
+import net.snowflake.client.core.ResultUtil;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFStatementMetaData;
+import net.snowflake.client.core.StmtUtil;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SqlState;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -35,53 +45,63 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import net.snowflake.client.core.ParameterBindingDTO;
-import net.snowflake.client.core.ResultUtil;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFStatementMetaData;
-import net.snowflake.client.core.StmtUtil;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SqlState;
 
 class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
-    implements PreparedStatement, SnowflakePreparedStatement {
-  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakePreparedStatementV1.class);
-  /** Error code returned when describing a statement that is binding table name */
+    implements PreparedStatement, SnowflakePreparedStatement
+{
+  static final SFLogger logger = SFLoggerFactory.getLogger(
+      SnowflakePreparedStatementV1.class);
+  /**
+   * Error code returned when describing a statement that is binding table name
+   */
   private static final Integer ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET = 2128;
-  /** Error code when preparing statement with binding object names */
+  /**
+   * Error code when preparing statement with binding object names
+   */
   private static final Integer ERROR_CODE_OBJECT_BIND_NOT_SET = 2129;
-  /** Error code returned when describing a ddl command */
+  /**
+   * Error code returned when describing a ddl command
+   */
   private static final Integer ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED = 7;
-  /** snow-44393 Workaround for compiler cannot prepare to_timestamp(?, 3) */
+  /**
+   * snow-44393 Workaround for compiler cannot prepare to_timestamp(?, 3)
+   */
   private static final Integer ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING = 1026;
-  /** A hash set that contains the error code that will not lead to exception in describe mode */
-  private static final Set<Integer> errorCodesIgnoredInDescribeMode =
-      new HashSet<>(
-          Arrays.asList(
-              ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET,
-              ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED,
-              ERROR_CODE_OBJECT_BIND_NOT_SET,
-              ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING));
+  /**
+   * A hash set that contains the error code that will not lead to exception
+   * in describe mode
+   */
+  private static final Set<Integer> errorCodesIgnoredInDescribeMode
+      = new HashSet<>(Arrays.asList(
+      ERROR_CODE_TABLE_BIND_VARIABLE_NOT_SET,
+      ERROR_CODE_STATEMENT_CANNOT_BE_PREPARED,
+      ERROR_CODE_OBJECT_BIND_NOT_SET,
+      ERROR_CODE_FORMAT_ARGUMENT_NOT_STRING));
 
   private final String sql;
 
   private boolean showStatementParameters;
 
-  /** statement and result metadata from describe phase */
+  /**
+   * statement and result metadata from describe phase
+   */
   private SFStatementMetaData statementMetaData;
   /**
    * map of bind name to bind values for single query execution
-   *
-   * <p>Currently, bind name is just value index
+   * <p>
+   * Currently, bind name is just value index
    */
   private Map<String, ParameterBindingDTO> parameterBindings = new HashMap<>();
-  /** map of bind values for batch query executions */
-  private Map<String, ParameterBindingDTO> batchParameterBindings = new HashMap<>();
-
+  /**
+   * map of bind values for batch query executions
+   */
+  private Map<String, ParameterBindingDTO> batchParameterBindings =
+      new HashMap<>();
   private Map<String, Boolean> wasPrevValueNull = new HashMap<>();
-  /** Counter for batch size if we are executing a statement with array bind supported */
+  /**
+   * Counter for batch size if we are executing a statement with array bind
+   * supported
+   */
   private int batchSize = 0;
 
   private boolean alreadyDescribed = false;
@@ -89,11 +109,11 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   /**
    * Construct SnowflakePreparedStatementV1
    *
-   * @param connection connection object
-   * @param sql sql
-   * @param skipParsing true if the applications want to skip parsing to get metadata. false by
-   *     default.
-   * @param resultSetType result set type: ResultSet.TYPE_FORWARD_ONLY.
+   * @param connection           connection object
+   * @param sql                  sql
+   * @param skipParsing          true if the applications want to skip parsing
+   *                             to get metadata. false by default.
+   * @param resultSetType        result set type: ResultSet.TYPE_FORWARD_ONLY.
    * @param resultSetConcurrency result set conconcurrency: ResultSet.CONCUR_READ_ONLY.
    * @param resultSetHoldability result set holdability: ResultSet.CLOSE_CURSORS_AT_COMMIT
    * @throws SQLException if any SQL error occurs.
@@ -104,8 +124,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       boolean skipParsing,
       int resultSetType,
       int resultSetConcurrency,
-      int resultSetHoldability)
-      throws SQLException {
+      int resultSetHoldability
+  ) throws SQLException
+  {
     super(connection, resultSetType, resultSetConcurrency, resultSetHoldability);
     this.sql = sql;
     this.statementMetaData = SFStatementMetaData.emptyMetaData();
@@ -113,21 +134,32 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   /**
-   * This method will check alreadyDescribed flag. And if it is false, it will try to issue a
-   * describe request to server. If true, it will skip describe request.
+   * This method will check alreadyDescribed flag. And if it is false, it will
+   * try to issue a describe request to server. If true, it will skip
+   * describe request.
    *
    * @throws SQLException
    */
-  private void describeSqlIfNotTried() throws SQLException {
-    if (!alreadyDescribed) {
-      try {
+  private void describeSqlIfNotTried() throws SQLException
+  {
+    if (!alreadyDescribed)
+    {
+      try
+      {
         this.statementMetaData = sfStatement.describe(sql);
-      } catch (SFException e) {
-        throw new SnowflakeSQLException(e);
-      } catch (SnowflakeSQLException e) {
-        if (!errorCodesIgnoredInDescribeMode.contains(e.getErrorCode())) {
+      }
+      catch (SFException e)
+      {
+        throw new SnowflakeSQLLoggedException(e, connection.getSfSession());
+      }
+      catch (SnowflakeSQLException e)
+      {
+        if (!errorCodesIgnoredInDescribeMode.contains(e.getErrorCode()))
+        {
           throw e;
-        } else {
+        }
+        else
+        {
           statementMetaData = SFStatementMetaData.emptyMetaData();
         }
       }
@@ -136,10 +168,14 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public ResultSet executeQuery() throws SQLException {
-    if (showStatementParameters) {
+  public ResultSet executeQuery() throws SQLException
+  {
+    if (showStatementParameters)
+    {
       logger.info("executeQuery()");
-    } else {
+    }
+    else
+    {
       logger.debug("executeQuery()");
     }
     return executeQueryInternal(sql, false, parameterBindings);
@@ -151,168 +187,185 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
    * @return ResultSet containing results
    * @throws SQLException
    */
-  public ResultSet executeAsyncQuery() throws SQLException {
-    if (showStatementParameters) {
+  public ResultSet executeAsyncQuery() throws SQLException
+  {
+    if (showStatementParameters)
+    {
       logger.info("executeAsyncQuery()");
-    } else {
+    }
+    else
+    {
       logger.debug("executeAsyncQuery()");
     }
     return executeQueryInternal(sql, true, parameterBindings);
   }
 
   @Override
-  public long executeLargeUpdate() throws SQLException {
+  public long executeLargeUpdate() throws SQLException
+  {
     logger.debug("executeLargeUpdate()");
 
     return executeUpdateInternal(sql, parameterBindings, true);
   }
 
   @Override
-  public int executeUpdate() throws SQLException {
+  public int executeUpdate() throws SQLException
+  {
     logger.debug("executeUpdate()");
 
     return (int) executeLargeUpdate();
   }
 
   @Override
-  public void setNull(int parameterIndex, int sqlType) throws SQLException {
-    logger.debug(
-        "setNull(parameterIndex: {}, sqlType: {})",
-        parameterIndex,
-        SnowflakeType.JavaSQLType.find(sqlType));
+  public void setNull(int parameterIndex, int sqlType) throws SQLException
+  {
+    logger.debug("setNull(parameterIndex: {}, sqlType: {})",
+                 parameterIndex, SnowflakeType.JavaSQLType.find(sqlType));
     raiseSQLExceptionIfStatementIsClosed();
 
-    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeType.ANY.toString(), null);
+    ParameterBindingDTO binding = new ParameterBindingDTO(
+        SnowflakeType.ANY.toString(), null);
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBoolean(int parameterIndex, boolean x) throws SQLException {
-    logger.debug("setBoolean(parameterIndex: {}, boolean x)", parameterIndex);
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN), String.valueOf(x));
+  public void setBoolean(int parameterIndex, boolean x) throws SQLException
+  {
+    logger.debug(
+        "setBoolean(parameterIndex: {}, boolean x)", parameterIndex);
+    ParameterBindingDTO binding = new ParameterBindingDTO(
+        SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setByte(int parameterIndex, byte x) throws SQLException {
+  public void setByte(int parameterIndex, byte x) throws SQLException
+  {
     logger.debug("setByte(parameterIndex: {}, byte x)", parameterIndex);
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.TINYINT), String.valueOf(x));
+    ParameterBindingDTO binding = new ParameterBindingDTO(
+        SnowflakeUtil.javaTypeToSFTypeString(Types.TINYINT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setShort(int parameterIndex, short x) throws SQLException {
+  public void setShort(int parameterIndex, short x) throws SQLException
+  {
     logger.debug("setShort(parameterIndex: {}, short x)", parameterIndex);
 
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.SMALLINT), String.valueOf(x));
+    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
+                                                              .javaTypeToSFTypeString(Types.SMALLINT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setInt(int parameterIndex, int x) throws SQLException {
+  public void setInt(int parameterIndex, int x) throws SQLException
+  {
     logger.debug("setInt(parameterIndex: {}, int x)", parameterIndex);
 
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.INTEGER), String.valueOf(x));
+    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
+                                                              .javaTypeToSFTypeString(Types.INTEGER), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setLong(int parameterIndex, long x) throws SQLException {
+  public void setLong(int parameterIndex, long x) throws SQLException
+  {
     logger.debug("setLong(parameterIndex: {}, long x)", parameterIndex);
 
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT), String.valueOf(x));
+    ParameterBindingDTO binding = new ParameterBindingDTO(
+        SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setFloat(int parameterIndex, float x) throws SQLException {
+  public void setFloat(int parameterIndex, float x) throws SQLException
+  {
     logger.debug("setFloat(parameterIndex: {}, float x)", parameterIndex);
 
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT), String.valueOf(x));
+    ParameterBindingDTO binding = new ParameterBindingDTO(
+        SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setDouble(int parameterIndex, double x) throws SQLException {
+  public void setDouble(int parameterIndex, double x) throws SQLException
+  {
     logger.debug("setDouble(parameterIndex: {}, double x)", parameterIndex);
 
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE), String.valueOf(x));
+    ParameterBindingDTO binding = new ParameterBindingDTO(
+        SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE), String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException
+  {
     logger.debug("setBigDecimal(parameterIndex: {}, BigDecimal x)", parameterIndex);
 
-    if (x == null) {
+    if (x == null)
+    {
       setNull(parameterIndex, Types.DECIMAL);
-    } else {
-      ParameterBindingDTO binding =
-          new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL), String.valueOf(x));
+    }
+    else
+    {
+      ParameterBindingDTO binding = new ParameterBindingDTO(
+          SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL), String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setString(int parameterIndex, String x) throws SQLException {
+  public void setString(int parameterIndex, String x) throws SQLException
+  {
     logger.debug("setString(parameterIndex: {}, String x)", parameterIndex);
 
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR), x);
+    ParameterBindingDTO binding = new ParameterBindingDTO(
+        SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR), x);
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+  public void setBytes(int parameterIndex, byte[] x) throws SQLException
+  {
     logger.debug("setBytes(parameterIndex: {}, byte[] x)", parameterIndex);
 
-    ParameterBindingDTO binding =
-        new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BINARY), new SFBinary(x).toHex());
+    ParameterBindingDTO binding = new ParameterBindingDTO(SnowflakeUtil
+                                                              .javaTypeToSFTypeString(Types.BINARY), new SFBinary(x).toHex());
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x) throws SQLException {
+  public void setDate(int parameterIndex, Date x) throws SQLException
+  {
     logger.debug("setDate(parameterIndex: {}, Date x)", parameterIndex);
 
-    if (x == null) {
+    if (x == null)
+    {
       setNull(parameterIndex, Types.DATE);
-    } else {
-      ParameterBindingDTO binding =
-          new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.DATE),
-              String.valueOf(
-                  x.getTime()
-                      + TimeZone.getDefault().getOffset(x.getTime())
-                      - ResultUtil.msDiffJulianToGregorian(x)));
+    }
+    else
+    {
+      ParameterBindingDTO binding = new ParameterBindingDTO(
+          SnowflakeUtil.javaTypeToSFTypeString(Types.DATE),
+          String.valueOf(x.getTime() +
+                         TimeZone.getDefault().getOffset(x.getTime()) -
+                         ResultUtil.msDiffJulianToGregorian(x)));
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x) throws SQLException {
+  public void setTime(int parameterIndex, Time x) throws SQLException
+  {
     logger.debug("setTime(parameterIndex: {}, Time x)", parameterIndex);
 
-    if (x == null) {
+    if (x == null)
+    {
       setNull(parameterIndex, Types.TIME);
-    } else {
+    }
+    else
+    {
       // Convert to nanoseconds since midnight using the input time mod 24 hours.
       final long MS_IN_DAY = 86400 * 1000;
       long msSinceEpoch = x.getTime();
@@ -321,9 +374,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       long msSinceMidnight = (msSinceEpoch % MS_IN_DAY + MS_IN_DAY) % MS_IN_DAY;
       long nanosSinceMidnight = msSinceMidnight * 1000 * 1000;
 
-      ParameterBindingDTO binding =
-          new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.TIME), String.valueOf(nanosSinceMidnight));
+      ParameterBindingDTO binding = new ParameterBindingDTO(
+          SnowflakeUtil.javaTypeToSFTypeString(Types.TIME),
+          String.valueOf(nanosSinceMidnight));
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
       sfStatement.setHasUnsupportedStageBind(true);
@@ -331,21 +384,20 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException
+  {
     logger.debug("setTimestamp(parameterIndex: {}, Timestamp x)", parameterIndex);
 
     // convert the timestamp from being in local time zone to be in UTC timezone
-    String value =
-        x == null
-            ? null
-            : String.valueOf(
-                BigDecimal.valueOf((x.getTime() - ResultUtil.msDiffJulianToGregorian(x)) / 1000)
-                    .scaleByPowerOfTen(9)
-                    .add(BigDecimal.valueOf(x.getNanos())));
+    String value = x == null ? null :
+                   String.valueOf(
+                       BigDecimal.valueOf((x.getTime() - ResultUtil.msDiffJulianToGregorian(x)) / 1000).
+                           scaleByPowerOfTen(9).add(BigDecimal.valueOf(x.getNanos())));
 
     SnowflakeType sfType = SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP);
 
-    if (sfType == SnowflakeType.TIMESTAMP) {
+    if (sfType == SnowflakeType.TIMESTAMP)
+    {
       sfType = connection.getSfSession().getTimestampMappedType();
     }
 
@@ -354,152 +406,211 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setAsciiStream(int parameterIndex, InputStream x, int length)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   @Deprecated
-  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setUnicodeStream(int parameterIndex, InputStream x, int length)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setBinaryStream(int parameterIndex, InputStream x, int length)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void clearParameters() throws SQLException {
+  public void clearParameters() throws SQLException
+  {
     parameterBindings.clear();
-    if (batchParameterBindings.isEmpty()) {
+    if (batchParameterBindings.isEmpty())
+    {
       sfStatement.setHasUnsupportedStageBind(false);
     }
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
-    if (x == null) {
+  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException
+  {
+    if (x == null)
+    {
       setNull(parameterIndex, targetSqlType);
-    } else if (targetSqlType == Types.DATE) {
+    }
+    else if (targetSqlType == Types.DATE)
+    {
       setDate(parameterIndex, (Date) x);
-    } else if (targetSqlType == Types.TIME) {
+    }
+    else if (targetSqlType == Types.TIME)
+    {
       setTime(parameterIndex, (Time) x);
-    } else if (targetSqlType == Types.TIMESTAMP) {
+    }
+    else if (targetSqlType == Types.TIMESTAMP)
+    {
       setTimestamp(parameterIndex, (Timestamp) x);
-    } else {
-      logger.debug(
-          "setObject(parameterIndex: {}, Object x, sqlType: {})",
-          parameterIndex,
-          SnowflakeType.JavaSQLType.find(targetSqlType));
+    }
+    else
+    {
+      logger.debug("setObject(parameterIndex: {}, Object x, sqlType: {})",
+                   parameterIndex, SnowflakeType.JavaSQLType.find(targetSqlType));
 
-      ParameterBindingDTO binding =
-          new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(targetSqlType), String.valueOf(x));
+      ParameterBindingDTO binding = new ParameterBindingDTO(
+          SnowflakeUtil.javaTypeToSFTypeString(targetSqlType),
+          String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x) throws SQLException {
-    if (x == null) {
+  public void setObject(int parameterIndex, Object x) throws SQLException
+  {
+    if (x == null)
+    {
       setNull(parameterIndex, Types.NULL);
-    } else if (x instanceof String) {
+    }
+    else if (x instanceof String)
+    {
       setString(parameterIndex, (String) x);
-    } else if (x instanceof BigDecimal) {
+    }
+    else if (x instanceof BigDecimal)
+    {
       setBigDecimal(parameterIndex, (BigDecimal) x);
-    } else if (x instanceof Short) {
+    }
+    else if (x instanceof Short)
+    {
       setShort(parameterIndex, (Short) x);
-    } else if (x instanceof Integer) {
+    }
+    else if (x instanceof Integer)
+    {
       setInt(parameterIndex, (Integer) x);
-    } else if (x instanceof Long) {
+    }
+    else if (x instanceof Long)
+    {
       setLong(parameterIndex, (Long) x);
-    } else if (x instanceof Float) {
+    }
+    else if (x instanceof Float)
+    {
       setFloat(parameterIndex, (Float) x);
-    } else if (x instanceof Double) {
+    }
+    else if (x instanceof Double)
+    {
       setDouble(parameterIndex, (Double) x);
-    } else if (x instanceof Date) {
+    }
+    else if (x instanceof Date)
+    {
       setDate(parameterIndex, (Date) x);
-    } else if (x instanceof Time) {
+    }
+    else if (x instanceof Time)
+    {
       setTime(parameterIndex, (Time) x);
-    } else if (x instanceof Timestamp) {
+    }
+    else if (x instanceof Timestamp)
+    {
       setTimestamp(parameterIndex, (Timestamp) x);
-    } else if (x instanceof Boolean) {
+    }
+    else if (x instanceof Boolean)
+    {
       setBoolean(parameterIndex, (Boolean) x);
-    } else {
-      throw new SnowflakeSQLException(
-          SqlState.FEATURE_NOT_SUPPORTED,
-          ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
-          "Object type: " + x.getClass());
+    }
+    else
+    {
+      throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+                                      ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
+                                      "Object type: " + x.getClass());
     }
   }
 
   @Override
-  public boolean execute() throws SQLException {
+  public boolean execute() throws SQLException
+  {
     logger.debug("execute: {}", sql);
 
     return executeInternal(sql, parameterBindings);
   }
 
   @Override
-  public void addBatch() throws SQLException {
+  public void addBatch() throws SQLException
+  {
     logger.debug("addBatch()");
 
     raiseSQLExceptionIfStatementIsClosed();
 
     describeSqlIfNotTried();
-    if (statementMetaData.isArrayBindSupported()) {
-      for (Map.Entry<String, ParameterBindingDTO> binding : parameterBindings.entrySet()) {
+    if (statementMetaData.isArrayBindSupported())
+    {
+      for (Map.Entry<String, ParameterBindingDTO> binding :
+          parameterBindings.entrySet())
+      {
         // get the entry for the bind variable in the batch binding map
-        ParameterBindingDTO bindingValueAndType = batchParameterBindings.get(binding.getKey());
+        ParameterBindingDTO bindingValueAndType =
+            batchParameterBindings.get(binding.getKey());
 
         List<String> values;
 
         Object newValue = binding.getValue().getValue();
         // create binding value and type for the first time
-        if (bindingValueAndType == null) {
+        if (bindingValueAndType == null)
+        {
           // create the value list
           values = new ArrayList<>();
 
-          bindingValueAndType = new ParameterBindingDTO(binding.getValue().getType(), values);
+          bindingValueAndType = new ParameterBindingDTO(
+              binding.getValue().getType(), values);
 
           // put the new map into the batch
-          batchParameterBindings.put(binding.getKey(), bindingValueAndType);
+          batchParameterBindings.put(binding.getKey(),
+                                     bindingValueAndType);
 
-          wasPrevValueNull.put(binding.getKey(), binding.getValue().getValue() == null);
-        } else {
+          wasPrevValueNull.put(
+              binding.getKey(), binding.getValue().getValue() == null);
+        }
+        else
+        {
           // make sure type matches except for null values
           String prevType = bindingValueAndType.getType();
           String newType = binding.getValue().getType();
 
-          if (wasPrevValueNull.get(binding.getKey()) && newValue != null) {
+          if (wasPrevValueNull.get(binding.getKey()) && newValue != null)
+          {
             // if previous value is null and the current value is not null
             // override the data type.
-            bindingValueAndType = batchParameterBindings.remove(binding.getKey());
+            bindingValueAndType = batchParameterBindings.remove(
+                binding.getKey());
             bindingValueAndType.setType(newType);
-            batchParameterBindings.put(binding.getKey(), bindingValueAndType);
+            batchParameterBindings.put(binding.getKey(),
+                                       bindingValueAndType);
             prevType = newType;
             wasPrevValueNull.put(binding.getKey(), false);
           }
 
           // if previous type is null, replace it with new type
-          if (SnowflakeType.ANY.name().equalsIgnoreCase(prevType)
-              && !SnowflakeType.ANY.name().equalsIgnoreCase(newType)) {
+          if (SnowflakeType.ANY.name().equalsIgnoreCase(prevType) &&
+              !SnowflakeType.ANY.name().equalsIgnoreCase(newType))
+          {
             bindingValueAndType.setType(newType);
-          } else if (binding.getValue().getValue() != null && !prevType.equalsIgnoreCase(newType)) {
+          }
+          else if (binding.getValue().getValue() != null &&
+                   !prevType.equalsIgnoreCase(newType))
+          {
             String row = "Unknown";
-            if (bindingValueAndType.getValue() instanceof Collection) {
+            if (bindingValueAndType.getValue() instanceof Collection)
+            {
               final List<String> typeCheckedList = (List<String>) bindingValueAndType.getValue();
               values = typeCheckedList;
               row = Integer.toString(values.size() + 1);
             }
-            throw new SnowflakeSQLException(
-                SqlState.FEATURE_NOT_SUPPORTED,
-                ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
-                SnowflakeType.getJavaType(SnowflakeType.fromString(prevType)).name(),
-                SnowflakeType.getJavaType(SnowflakeType.fromString(newType)).name(),
-                binding.getKey(),
-                row);
+            throw new SnowflakeSQLException(SqlState.FEATURE_NOT_SUPPORTED,
+                                            ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
+                                            SnowflakeType.getJavaType(SnowflakeType.fromString(prevType)).name(),
+                                            SnowflakeType.getJavaType(SnowflakeType.fromString(newType)).name(),
+                                            binding.getKey(), row);
           }
 
           // found the existing map so just get the value list
@@ -512,7 +623,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
         bindingValueAndType.setValue(values);
       }
       batchSize++;
-    } else {
+    }
+    else
+    {
       batch.add(new BatchEntry(this.sql, parameterBindings));
       parameterBindings = new HashMap<>();
     }
@@ -520,102 +633,119 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, int length)
-      throws SQLException {
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setRef(int parameterIndex, Ref x) throws SQLException {
+  public void setRef(int parameterIndex, Ref x) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBlob(int parameterIndex, Blob x) throws SQLException {
+  public void setBlob(int parameterIndex, Blob x) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setClob(int parameterIndex, Clob x) throws SQLException {
+  public void setClob(int parameterIndex, Clob x) throws SQLException
+  {
     setString(parameterIndex, x.toString());
   }
 
   @Override
-  public void setArray(int parameterIndex, Array x) throws SQLException {
+  public void setArray(int parameterIndex, Array x) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public ResultSetMetaData getMetaData() throws SQLException {
+  public ResultSetMetaData getMetaData() throws SQLException
+  {
     logger.debug("getMetaData()");
 
     raiseSQLExceptionIfStatementIsClosed();
 
     describeSqlIfNotTried();
-    return new SnowflakeResultSetMetaDataV1(this.statementMetaData.getResultSetMetaData());
+    return new SnowflakeResultSetMetaDataV1(
+        this.statementMetaData.getResultSetMetaData());
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+  public void setDate(int parameterIndex, Date x, Calendar cal)
+  throws SQLException
+  {
     logger.debug("setDate(int parameterIndex, Date x, Calendar cal)");
 
     raiseSQLExceptionIfStatementIsClosed();
-    if (x == null) {
+    if (x == null)
+    {
       setNull(parameterIndex, Types.DATE);
-    } else {
+    }
+    else
+    {
       // convert the date from to be in local time zone to be in UTC
-      String value =
-          String.valueOf(
-              x.getTime()
-                  + cal.getTimeZone().getOffset(x.getTime())
-                  - ResultUtil.msDiffJulianToGregorian(x));
+      String value = String.valueOf(x.getTime() +
+                                    cal.getTimeZone().getOffset(x.getTime())
+                                    - ResultUtil.msDiffJulianToGregorian(x));
 
-      ParameterBindingDTO binding =
-          new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(Types.DATE), value);
+      ParameterBindingDTO binding = new ParameterBindingDTO(
+          SnowflakeUtil.javaTypeToSFTypeString(Types.DATE), value);
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+  public void setTime(int parameterIndex, Time x, Calendar cal)
+  throws SQLException
+  {
     logger.debug("setTime(int parameterIndex, Time x, Calendar cal)");
     raiseSQLExceptionIfStatementIsClosed();
     setTime(parameterIndex, x);
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal)
+  throws SQLException
+  {
     logger.debug("setTimestamp(int parameterIndex, Timestamp x, Calendar cal)");
     raiseSQLExceptionIfStatementIsClosed();
 
     // convert the time from being in UTC to be in local time zone
     String value = null;
     SnowflakeType sfType = SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP);
-    if (x != null) {
+    if (x != null)
+    {
       long milliSecSinceEpoch = x.getTime();
 
-      if (sfType == SnowflakeType.TIMESTAMP) {
+      if (sfType == SnowflakeType.TIMESTAMP)
+      {
         sfType = connection.getSfSession().getTimestampMappedType();
       }
       // if type is timestamp_tz, keep the offset and the time value separate.
       // store the offset, in minutes, as amount it's off from UTC
-      if (sfType == SnowflakeType.TIMESTAMP_TZ) {
-        value =
-            String.valueOf(
-                BigDecimal.valueOf(milliSecSinceEpoch / 1000)
-                    .scaleByPowerOfTen(9)
-                    .add(BigDecimal.valueOf(x.getNanos())));
+      if (sfType == SnowflakeType.TIMESTAMP_TZ)
+      {
+        value = String.valueOf(
+            BigDecimal.valueOf(milliSecSinceEpoch / 1000).
+                scaleByPowerOfTen(9).add(BigDecimal.valueOf(x.getNanos())));
 
         int offset = cal.getTimeZone().getOffset(milliSecSinceEpoch) / 60000 + 1440;
         value += " " + offset;
-      } else {
-        milliSecSinceEpoch = milliSecSinceEpoch + cal.getTimeZone().getOffset(milliSecSinceEpoch);
-
-        value =
-            String.valueOf(
-                BigDecimal.valueOf(milliSecSinceEpoch / 1000)
-                    .scaleByPowerOfTen(9)
-                    .add(BigDecimal.valueOf(x.getNanos())));
       }
+      else
+      {
+        milliSecSinceEpoch = milliSecSinceEpoch +
+                             cal.getTimeZone().getOffset(milliSecSinceEpoch);
+
+        value = String.valueOf(
+            BigDecimal.valueOf(milliSecSinceEpoch / 1000).
+                scaleByPowerOfTen(9).add(BigDecimal.valueOf(x.getNanos())));
+      }
+
     }
 
     ParameterBindingDTO binding = new ParameterBindingDTO(sfType.name(), value);
@@ -623,135 +753,176 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+  public void setNull(int parameterIndex, int sqlType, String typeName)
+  throws SQLException
+  {
     logger.debug("setNull(int parameterIndex, int sqlType, String typeName)");
 
     setNull(parameterIndex, sqlType);
   }
 
   @Override
-  public void setURL(int parameterIndex, URL x) throws SQLException {
+  public void setURL(int parameterIndex, URL x) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public ParameterMetaData getParameterMetaData() throws SQLException {
+  public ParameterMetaData getParameterMetaData() throws SQLException
+  {
     describeSqlIfNotTried();
     return new SnowflakeParameterMetadata(statementMetaData);
   }
 
   @Override
-  public void setRowId(int parameterIndex, RowId x) throws SQLException {
+  public void setRowId(int parameterIndex, RowId x) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNString(int parameterIndex, String value) throws SQLException {
+  public void setNString(int parameterIndex, String value) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void setNCharacterStream(int parameterIndex, Reader value, long length)
-      throws SQLException {
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNClob(int parameterIndex, NClob value) throws SQLException {
+  public void setNClob(int parameterIndex, NClob value) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+  public void setClob(int parameterIndex, Reader reader, long length)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void setBlob(int parameterIndex, InputStream inputStream, long length)
-      throws SQLException {
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+  public void setNClob(int parameterIndex, Reader reader, long length)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+  public void setSQLXML(int parameterIndex, SQLXML xmlObject)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
-      throws SQLException {
-    logger.debug("setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)");
+  public void setObject(int parameterIndex, Object x, int targetSqlType,
+                        int scaleOrLength) throws SQLException
+  {
+    logger.debug(
+        "setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)");
 
     raiseSQLExceptionIfStatementIsClosed();
-    if (x == null) {
+    if (x == null)
+    {
       setNull(parameterIndex, targetSqlType);
-    } else if (targetSqlType == Types.DECIMAL || targetSqlType == Types.NUMERIC) {
+    }
+    else if (targetSqlType == Types.DECIMAL ||
+             targetSqlType == Types.NUMERIC)
+    {
       BigDecimal decimalObj = new BigDecimal(String.valueOf(x));
       decimalObj.setScale(scaleOrLength);
       setBigDecimal(parameterIndex, decimalObj);
-    } else {
+    }
+    else
+    {
       setObject(parameterIndex, x, targetSqlType);
     }
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+  public void setAsciiStream(int parameterIndex, InputStream x, long length)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+  public void setBinaryStream(int parameterIndex, InputStream x, long length)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, long length)
-      throws SQLException {
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+  public void setAsciiStream(int parameterIndex, InputStream x)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+  public void setBinaryStream(int parameterIndex, InputStream x)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+  public void setCharacterStream(int parameterIndex, Reader reader)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+  public void setNCharacterStream(int parameterIndex, Reader value)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader) throws SQLException {
+  public void setClob(int parameterIndex, Reader reader) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+  public void setBlob(int parameterIndex, InputStream inputStream)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+  public void setNClob(int parameterIndex, Reader reader) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql) throws SQLException {
+  public int executeUpdate(String sql) throws SQLException
+  {
     logger.debug("executeUpdate(String sql)");
 
     throw new SnowflakeSQLException(
@@ -759,7 +930,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public boolean execute(String sql) throws SQLException {
+  public boolean execute(String sql) throws SQLException
+  {
     logger.debug("execute(String sql)");
 
     throw new SnowflakeSQLException(
@@ -767,13 +939,15 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void addBatch(String sql) throws SQLException {
+  public void addBatch(String sql) throws SQLException
+  {
     throw new SnowflakeSQLException(
         ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, StmtUtil.truncateSQL(sql));
   }
 
   @Override
-  public void clearBatch() throws SQLException {
+  public void clearBatch() throws SQLException
+  {
     super.clearBatch();
     batchParameterBindings.clear();
     parameterBindings.clear();
@@ -783,33 +957,46 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public int[] executeBatch() throws SQLException {
+  public int[] executeBatch() throws SQLException
+  {
     logger.debug("executeBatch()");
     raiseSQLExceptionIfStatementIsClosed();
 
     describeSqlIfNotTried();
-    if (this.statementMetaData.getStatementType().isGenerateResultSet()) {
+    if (this.statementMetaData.getStatementType().isGenerateResultSet())
+    {
       throw new SnowflakeSQLException(
           ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, StmtUtil.truncateSQL(sql));
     }
 
     int[] updateCounts = null;
-    try {
-      if (this.statementMetaData.isArrayBindSupported()) {
-        int updateCount = (int) executeUpdateInternal(this.sql, batchParameterBindings, false);
+    try
+    {
+      if (this.statementMetaData.isArrayBindSupported())
+      {
+        int updateCount = (int) executeUpdateInternal(
+            this.sql, batchParameterBindings, false);
 
         // when update count is the same as the number of bindings in the batch,
         // expand the update count into an array (SNOW-14034)
-        if (updateCount == batchSize) {
+        if (updateCount == batchSize)
+        {
           updateCounts = new int[updateCount];
-          for (int idx = 0; idx < updateCount; idx++) updateCounts[idx] = 1;
-        } else {
-          updateCounts = new int[] {updateCount};
+          for (int idx = 0; idx < updateCount; idx++)
+            updateCounts[idx] = 1;
         }
-      } else {
+        else
+        {
+          updateCounts = new int[]{updateCount};
+        }
+      }
+      else
+      {
         updateCounts = executeBatchInternal(false).intArr;
       }
-    } finally {
+    }
+    finally
+    {
       this.clearBatch();
     }
 
@@ -817,42 +1004,51 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+  public int executeUpdate(String sql, int autoGeneratedKeys)
+  throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, String[] columnNames) throws SQLException {
+  public boolean execute(String sql, String[] columnNames) throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   // For testing use only
-  Map<String, ParameterBindingDTO> getBatchParameterBindings() {
+  Map<String, ParameterBindingDTO> getBatchParameterBindings()
+  {
     return batchParameterBindings;
   }
 
   // package private for testing purpose only
-  Map<String, ParameterBindingDTO> getParameterBindings() {
+  Map<String, ParameterBindingDTO> getParameterBindings()
+  {
     return parameterBindings;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaDataV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaDataV1.java
@@ -4,165 +4,128 @@
 
 package net.snowflake.client.jdbc;
 
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.List;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.core.SFResultSetMetaData;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.util.List;
+/** Snowflake ResultSetMetaData */
+class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResultSetMetaData {
 
-/**
- * Snowflake ResultSetMetaData
- */
-class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResultSetMetaData
-{
-
-  public enum QueryType
-  {
+  public enum QueryType {
     ASYNC,
     SYNC
-  }
+  };
 
-  ;
-  static final
-  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetMetaDataV1.class);
+  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetMetaDataV1.class);
 
   private SFResultSetMetaData resultSetMetaData;
   private String queryId;
   private QueryType queryType = QueryType.SYNC;
   private SFSession session;
 
-  SnowflakeResultSetMetaDataV1(SFResultSetMetaData resultSetMetaData)
-  throws SnowflakeSQLException
-  {
+  SnowflakeResultSetMetaDataV1(SFResultSetMetaData resultSetMetaData) throws SnowflakeSQLException {
     this.resultSetMetaData = resultSetMetaData;
     this.queryId = resultSetMetaData.getQueryId();
     this.session = resultSetMetaData.getSession();
   }
 
-  public void setQueryType(QueryType type)
-  {
+  public void setQueryType(QueryType type) {
     this.queryType = type;
   }
 
-  /**
-   * @return query id
-   */
-  public String getQueryID() throws SQLException
-  {
+  /** @return query id */
+  public String getQueryID() throws SQLException {
     return this.queryId;
   }
 
   /**
-   * Override the original query ID to provide the accurate query ID for metadata
-   * produced from an SFAsyncResultSet. The original query ID is from the
-   * result_scan query. The user expects to retrieve the query ID from the
-   * original query instead.
+   * Override the original query ID to provide the accurate query ID for metadata produced from an
+   * SFAsyncResultSet. The original query ID is from the result_scan query. The user expects to
+   * retrieve the query ID from the original query instead.
    */
-  public void setQueryIdForAsyncResults(String queryId)
-  {
+  public void setQueryIdForAsyncResults(String queryId) {
     this.queryId = queryId;
   }
 
-  /**
-   * @return list of column names
-   */
-  public List<String> getColumnNames() throws SQLException
-  {
+  /** @return list of column names */
+  public List<String> getColumnNames() throws SQLException {
     return resultSetMetaData.getColumnNames();
   }
 
-  /**
-   * @return index of the column by name, index starts from zero
-   */
-  public int getColumnIndex(String columnName) throws SQLException
-  {
+  /** @return index of the column by name, index starts from zero */
+  public int getColumnIndex(String columnName) throws SQLException {
     return resultSetMetaData.getColumnIndex(columnName);
   }
 
-  public int getInternalColumnType(int column) throws SQLException
-  {
-    try
-    {
+  public int getInternalColumnType(int column) throws SQLException {
+    try {
       return resultSetMetaData.getInternalColumnType(column);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(),
-                                            ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
     }
   }
 
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException
-  {
+  public <T> T unwrap(Class<T> iface) throws SQLException {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this))
-    {
+    if (!iface.isInstance(this)) {
       throw new SQLException(
-          this.getClass().getName() + " not unwrappable from " + iface
-              .getName());
+          this.getClass().getName() + " not unwrappable from " + iface.getName());
     }
     return (T) this;
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException
-  {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
     logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
   }
 
   @Override
-  public boolean isAutoIncrement(int column) throws SQLException
-  {
+  public boolean isAutoIncrement(int column) throws SQLException {
     return false;
   }
 
   @Override
-  public boolean isCaseSensitive(int column) throws SQLException
-  {
+  public boolean isCaseSensitive(int column) throws SQLException {
     return false;
   }
 
   @Override
-  public boolean isSearchable(int column) throws SQLException
-  {
+  public boolean isSearchable(int column) throws SQLException {
     return true;
   }
 
   @Override
-  public boolean isCurrency(int column) throws SQLException
-  {
+  public boolean isCurrency(int column) throws SQLException {
     return false;
   }
 
   @Override
-  public boolean isReadOnly(int column) throws SQLException
-  {
+  public boolean isReadOnly(int column) throws SQLException {
     return true; // metadata column is always readonly
   }
 
   @Override
-  public boolean isWritable(int column) throws SQLException
-  {
+  public boolean isWritable(int column) throws SQLException {
     return false; // never writable
   }
 
   @Override
-  public boolean isDefinitelyWritable(int column) throws SQLException
-  {
+  public boolean isDefinitelyWritable(int column) throws SQLException {
     return false; // never writable
   }
 
   @Override
-  public String getColumnClassName(int column) throws SQLException
-  {
+  public String getColumnClassName(int column) throws SQLException {
     logger.debug("public String getColumnClassName(int column)");
 
     int type = this.getColumnType(column);
@@ -170,115 +133,91 @@ class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResult
     return SnowflakeType.javaTypeToClassName(type);
   }
 
-
   /**
    * @return column count
    * @throws java.sql.SQLException if failed to get column count
    */
   @Override
-  public int getColumnCount() throws SQLException
-  {
+  public int getColumnCount() throws SQLException {
     return resultSetMetaData.getColumnCount();
   }
 
   @Override
-  public boolean isSigned(int column) throws SQLException
-  {
+  public boolean isSigned(int column) throws SQLException {
     return resultSetMetaData.isSigned(column);
   }
 
   @Override
-  public String getColumnLabel(int column) throws SQLException
-  {
+  public String getColumnLabel(int column) throws SQLException {
     return resultSetMetaData.getColumnLabel(column);
   }
 
   @Override
-  public String getColumnName(int column) throws SQLException
-  {
+  public String getColumnName(int column) throws SQLException {
     return resultSetMetaData.getColumnName(column);
   }
 
   @Override
-  public int getPrecision(int column) throws SQLException
-  {
+  public int getPrecision(int column) throws SQLException {
     return resultSetMetaData.getPrecision(column);
   }
 
   @Override
-  public int getScale(int column) throws SQLException
-  {
+  public int getScale(int column) throws SQLException {
     return resultSetMetaData.getScale(column);
   }
 
   @Override
-  public int getColumnType(int column) throws SQLException
-  {
-    try
-    {
+  public int getColumnType(int column) throws SQLException {
+    try {
       return resultSetMetaData.getColumnType(column);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(),
-                                            ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
     }
   }
 
   @Override
-  public String getColumnTypeName(int column) throws SQLException
-  {
-    try
-    {
+  public String getColumnTypeName(int column) throws SQLException {
+    try {
       return resultSetMetaData.getColumnTypeName(column);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(),
-                                            ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
     }
   }
 
   @Override
-  public int isNullable(int column) throws SQLException
-  {
+  public int isNullable(int column) throws SQLException {
     return resultSetMetaData.isNullable(column);
   }
 
   @Override
-  public String getCatalogName(int column) throws SQLException
-  {
-    if (this.queryType == QueryType.SYNC)
-    {
+  public String getCatalogName(int column) throws SQLException {
+    if (this.queryType == QueryType.SYNC) {
       return resultSetMetaData.getCatalogName(column);
     }
     return "";
   }
 
   @Override
-  public String getSchemaName(int column) throws SQLException
-  {
-    if (this.queryType == QueryType.SYNC)
-    {
+  public String getSchemaName(int column) throws SQLException {
+    if (this.queryType == QueryType.SYNC) {
       return resultSetMetaData.getSchemaName(column);
     }
     return "";
   }
 
   @Override
-  public String getTableName(int column) throws SQLException
-  {
-    if (this.queryType == QueryType.SYNC)
-    {
+  public String getTableName(int column) throws SQLException {
+    if (this.queryType == QueryType.SYNC) {
       return resultSetMetaData.getTableName(column);
     }
     return "";
   }
 
   @Override
-  public int getColumnDisplaySize(int column) throws SQLException
-  {
+  public int getColumnDisplaySize(int column) throws SQLException {
     return resultSetMetaData.getColumnDisplaySize(column);
   }
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaDataV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaDataV1.java
@@ -4,125 +4,165 @@
 
 package net.snowflake.client.jdbc;
 
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.util.List;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.core.SFResultSetMetaData;
+import net.snowflake.client.core.SFSession;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
-/** Snowflake ResultSetMetaData */
-class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResultSetMetaData {
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.List;
 
-  public enum QueryType {
+/**
+ * Snowflake ResultSetMetaData
+ */
+class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResultSetMetaData
+{
+
+  public enum QueryType
+  {
     ASYNC,
     SYNC
-  };
+  }
 
-  static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetMetaDataV1.class);
+  ;
+  static final
+  SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetMetaDataV1.class);
 
   private SFResultSetMetaData resultSetMetaData;
   private String queryId;
   private QueryType queryType = QueryType.SYNC;
+  private SFSession session;
 
-  SnowflakeResultSetMetaDataV1(SFResultSetMetaData resultSetMetaData) throws SnowflakeSQLException {
+  SnowflakeResultSetMetaDataV1(SFResultSetMetaData resultSetMetaData)
+  throws SnowflakeSQLException
+  {
     this.resultSetMetaData = resultSetMetaData;
     this.queryId = resultSetMetaData.getQueryId();
+    this.session = resultSetMetaData.getSession();
   }
 
-  public void setQueryType(QueryType type) {
+  public void setQueryType(QueryType type)
+  {
     this.queryType = type;
   }
 
-  /** @return query id */
-  public String getQueryID() throws SQLException {
+  /**
+   * @return query id
+   */
+  public String getQueryID() throws SQLException
+  {
     return this.queryId;
   }
 
   /**
-   * Override the original query ID to provide the accurate query ID for metadata produced from an
-   * SFAsyncResultSet. The original query ID is from the result_scan query. The user expects to
-   * retrieve the query ID from the original query instead.
+   * Override the original query ID to provide the accurate query ID for metadata
+   * produced from an SFAsyncResultSet. The original query ID is from the
+   * result_scan query. The user expects to retrieve the query ID from the
+   * original query instead.
    */
-  public void setQueryIdForAsyncResults(String queryId) {
+  public void setQueryIdForAsyncResults(String queryId)
+  {
     this.queryId = queryId;
   }
 
-  /** @return list of column names */
-  public List<String> getColumnNames() throws SQLException {
+  /**
+   * @return list of column names
+   */
+  public List<String> getColumnNames() throws SQLException
+  {
     return resultSetMetaData.getColumnNames();
   }
 
-  /** @return index of the column by name, index starts from zero */
-  public int getColumnIndex(String columnName) throws SQLException {
+  /**
+   * @return index of the column by name, index starts from zero
+   */
+  public int getColumnIndex(String columnName) throws SQLException
+  {
     return resultSetMetaData.getColumnIndex(columnName);
   }
 
-  public int getInternalColumnType(int column) throws SQLException {
-    try {
+  public int getInternalColumnType(int column) throws SQLException
+  {
+    try
+    {
       return resultSetMetaData.getInternalColumnType(column);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(),
+                                            ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
     }
   }
 
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
+  public <T> T unwrap(Class<T> iface) throws SQLException
+  {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this)) {
+    if (!iface.isInstance(this))
+    {
       throw new SQLException(
-          this.getClass().getName() + " not unwrappable from " + iface.getName());
+          this.getClass().getName() + " not unwrappable from " + iface
+              .getName());
     }
     return (T) this;
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException
+  {
     logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
   }
 
   @Override
-  public boolean isAutoIncrement(int column) throws SQLException {
+  public boolean isAutoIncrement(int column) throws SQLException
+  {
     return false;
   }
 
   @Override
-  public boolean isCaseSensitive(int column) throws SQLException {
+  public boolean isCaseSensitive(int column) throws SQLException
+  {
     return false;
   }
 
   @Override
-  public boolean isSearchable(int column) throws SQLException {
+  public boolean isSearchable(int column) throws SQLException
+  {
     return true;
   }
 
   @Override
-  public boolean isCurrency(int column) throws SQLException {
+  public boolean isCurrency(int column) throws SQLException
+  {
     return false;
   }
 
   @Override
-  public boolean isReadOnly(int column) throws SQLException {
+  public boolean isReadOnly(int column) throws SQLException
+  {
     return true; // metadata column is always readonly
   }
 
   @Override
-  public boolean isWritable(int column) throws SQLException {
+  public boolean isWritable(int column) throws SQLException
+  {
     return false; // never writable
   }
 
   @Override
-  public boolean isDefinitelyWritable(int column) throws SQLException {
+  public boolean isDefinitelyWritable(int column) throws SQLException
+  {
     return false; // never writable
   }
 
   @Override
-  public String getColumnClassName(int column) throws SQLException {
+  public String getColumnClassName(int column) throws SQLException
+  {
     logger.debug("public String getColumnClassName(int column)");
 
     int type = this.getColumnType(column);
@@ -130,91 +170,115 @@ class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResult
     return SnowflakeType.javaTypeToClassName(type);
   }
 
+
   /**
    * @return column count
    * @throws java.sql.SQLException if failed to get column count
    */
   @Override
-  public int getColumnCount() throws SQLException {
+  public int getColumnCount() throws SQLException
+  {
     return resultSetMetaData.getColumnCount();
   }
 
   @Override
-  public boolean isSigned(int column) throws SQLException {
+  public boolean isSigned(int column) throws SQLException
+  {
     return resultSetMetaData.isSigned(column);
   }
 
   @Override
-  public String getColumnLabel(int column) throws SQLException {
+  public String getColumnLabel(int column) throws SQLException
+  {
     return resultSetMetaData.getColumnLabel(column);
   }
 
   @Override
-  public String getColumnName(int column) throws SQLException {
+  public String getColumnName(int column) throws SQLException
+  {
     return resultSetMetaData.getColumnName(column);
   }
 
   @Override
-  public int getPrecision(int column) throws SQLException {
+  public int getPrecision(int column) throws SQLException
+  {
     return resultSetMetaData.getPrecision(column);
   }
 
   @Override
-  public int getScale(int column) throws SQLException {
+  public int getScale(int column) throws SQLException
+  {
     return resultSetMetaData.getScale(column);
   }
 
   @Override
-  public int getColumnType(int column) throws SQLException {
-    try {
+  public int getColumnType(int column) throws SQLException
+  {
+    try
+    {
       return resultSetMetaData.getColumnType(column);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(),
+                                            ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
     }
   }
 
   @Override
-  public String getColumnTypeName(int column) throws SQLException {
-    try {
+  public String getColumnTypeName(int column) throws SQLException
+  {
+    try
+    {
       return resultSetMetaData.getColumnTypeName(column);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(),
+                                            ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
     }
   }
 
   @Override
-  public int isNullable(int column) throws SQLException {
+  public int isNullable(int column) throws SQLException
+  {
     return resultSetMetaData.isNullable(column);
   }
 
   @Override
-  public String getCatalogName(int column) throws SQLException {
-    if (this.queryType == QueryType.SYNC) {
+  public String getCatalogName(int column) throws SQLException
+  {
+    if (this.queryType == QueryType.SYNC)
+    {
       return resultSetMetaData.getCatalogName(column);
     }
     return "";
   }
 
   @Override
-  public String getSchemaName(int column) throws SQLException {
-    if (this.queryType == QueryType.SYNC) {
+  public String getSchemaName(int column) throws SQLException
+  {
+    if (this.queryType == QueryType.SYNC)
+    {
       return resultSetMetaData.getSchemaName(column);
     }
     return "";
   }
 
   @Override
-  public String getTableName(int column) throws SQLException {
-    if (this.queryType == QueryType.SYNC) {
+  public String getTableName(int column) throws SQLException
+  {
+    if (this.queryType == QueryType.SYNC)
+    {
       return resultSetMetaData.getTableName(column);
     }
     return "";
   }
 
   @Override
-  public int getColumnDisplaySize(int column) throws SQLException {
+  public int getColumnDisplaySize(int column) throws SQLException
+  {
     return resultSetMetaData.getColumnDisplaySize(column);
   }
+
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -4,8 +4,23 @@
 
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.core.Constants.GB;
+import static net.snowflake.client.core.Constants.MB;
+import static net.snowflake.client.core.SessionUtil.CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE;
+import static net.snowflake.client.core.SessionUtil.CLIENT_MEMORY_LIMIT;
+import static net.snowflake.client.core.SessionUtil.CLIENT_PREFETCH_THREADS;
+import static net.snowflake.client.core.SessionUtil.CLIENT_RESULT_CHUNK_SIZE;
+import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_MEMORY_LIMIT;
+import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_PREFETCH_THREADS;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
 import net.snowflake.client.core.ChunkDownloader;
 import net.snowflake.client.core.MetaDataOfBinds;
 import net.snowflake.client.core.OCSPMode;
@@ -31,39 +46,21 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.Serializable;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
-
-import static net.snowflake.client.core.Constants.GB;
-import static net.snowflake.client.core.Constants.MB;
-import static net.snowflake.client.core.SessionUtil.CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE;
-import static net.snowflake.client.core.SessionUtil.CLIENT_MEMORY_LIMIT;
-import static net.snowflake.client.core.SessionUtil.CLIENT_PREFETCH_THREADS;
-import static net.snowflake.client.core.SessionUtil.CLIENT_RESULT_CHUNK_SIZE;
-import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_MEMORY_LIMIT;
-import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_PREFETCH_THREADS;
-
-
 /**
- * This object is an intermediate object between result JSON from GS and
- * ResultSet. Originally, it is created from result JSON. And it can
- * also be serializable. Logically, it stands for a part of ResultSet.
- * <p>
- * A typical result JSON data section consists of the content of the first chunk
- * file and file metadata for the rest of chunk files e.g. URL, chunk size, etc.
- * So this object consists of one chunk data and a list of chunk file entries.
- * In actual cases, it may only include chunk data or chunk files entries.
- * <p>
- * This object is serializable, so it can be distributed to other threads or
- * worker nodes for distributed processing.
+ * This object is an intermediate object between result JSON from GS and ResultSet. Originally, it
+ * is created from result JSON. And it can also be serializable. Logically, it stands for a part of
+ * ResultSet.
+ *
+ * <p>A typical result JSON data section consists of the content of the first chunk file and file
+ * metadata for the rest of chunk files e.g. URL, chunk size, etc. So this object consists of one
+ * chunk data and a list of chunk file entries. In actual cases, it may only include chunk data or
+ * chunk files entries.
+ *
+ * <p>This object is serializable, so it can be distributed to other threads or worker nodes for
+ * distributed processing.
  */
-public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSerializable,
-                                                         Serializable
-{
+public class SnowflakeResultSetSerializableV1
+    implements SnowflakeResultSetSerializable, Serializable {
   private static final long serialVersionUID = 1L;
 
   static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetSerializableV1.class);
@@ -71,55 +68,43 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
   static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
   private static final long LOW_MAX_MEMORY = GB;
 
-  /**
-   * An Entity class to represent a chunk file metadata.
-   */
-  static public class ChunkFileMetadata implements Serializable
-  {
+  /** An Entity class to represent a chunk file metadata. */
+  public static class ChunkFileMetadata implements Serializable {
     private static final long serialVersionUID = 1L;
     String fileURL;
     int rowCount;
     int compressedByteSize;
     int uncompressedByteSize;
 
-    public ChunkFileMetadata(String fileURL,
-                             int rowCount,
-                             int compressedByteSize,
-                             int uncompressedByteSize)
-    {
+    public ChunkFileMetadata(
+        String fileURL, int rowCount, int compressedByteSize, int uncompressedByteSize) {
       this.fileURL = fileURL;
       this.rowCount = rowCount;
       this.compressedByteSize = compressedByteSize;
       this.uncompressedByteSize = uncompressedByteSize;
     }
 
-    public void setFileURL(String fileURL)
-    {
+    public void setFileURL(String fileURL) {
       this.fileURL = fileURL;
     }
 
-    public String getFileURL()
-    {
+    public String getFileURL() {
       return fileURL;
     }
 
-    public int getRowCount()
-    {
+    public int getRowCount() {
       return rowCount;
     }
 
-    public int getCompressedByteSize()
-    {
+    public int getCompressedByteSize() {
       return compressedByteSize;
     }
 
-    public int getUncompressedByteSize()
-    {
+    public int getUncompressedByteSize() {
       return uncompressedByteSize;
     }
 
-    public String toString()
-    {
+    public String toString() {
       StringBuilder builder = new StringBuilder(1024);
 
       builder.append("RowCount: ").append(rowCount).append(", ");
@@ -162,8 +147,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
   boolean totalRowCountTruncated;
   Map<String, Object> parameters = new HashMap<>();
   int columnCount;
-  private List<SnowflakeColumnMetadata> resultColumnMetadata =
-      new ArrayList<>();
+  private List<SnowflakeColumnMetadata> resultColumnMetadata = new ArrayList<>();
   long resultVersion;
   int numberOfBinds;
   boolean arrayBindSupported;
@@ -190,23 +174,17 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
   transient RootAllocator rootAllocator = null; // only used for ARROW result
   transient SFResultSetMetaData resultSetMetaData = null;
 
-  /**
-   * Default constructor.
-   */
-  public SnowflakeResultSetSerializableV1()
-  {
-
-  }
+  /** Default constructor. */
+  public SnowflakeResultSetSerializableV1() {}
 
   /**
    * This is copy constructor.
-   * <p>
-   * NOTE: The copy is NOT deep copy.
+   *
+   * <p>NOTE: The copy is NOT deep copy.
    *
    * @param toCopy the source object to be copied.
    */
-  private SnowflakeResultSetSerializableV1(SnowflakeResultSetSerializableV1 toCopy)
-  {
+  private SnowflakeResultSetSerializableV1(SnowflakeResultSetSerializableV1 toCopy) {
     // Below fields are for the data fields that this object wraps
     this.firstChunkStringData = toCopy.firstChunkStringData;
     this.firstChunkRowCount = toCopy.firstChunkRowCount;
@@ -265,363 +243,291 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     this.resultSetMetaData = toCopy.resultSetMetaData;
   }
 
-  public void setRootAllocator(RootAllocator rootAllocator)
-  {
+  public void setRootAllocator(RootAllocator rootAllocator) {
     this.rootAllocator = rootAllocator;
   }
 
-  public void setQueryResultFormat(QueryResultFormat queryResultFormat)
-  {
+  public void setQueryResultFormat(QueryResultFormat queryResultFormat) {
     this.queryResultFormat = queryResultFormat;
   }
 
-  public void setChunkFileCount(int chunkFileCount)
-  {
+  public void setChunkFileCount(int chunkFileCount) {
     this.chunkFileCount = chunkFileCount;
   }
 
-  public void setFristChunkStringData(String firstChunkStringData)
-  {
+  public void setFristChunkStringData(String firstChunkStringData) {
     this.firstChunkStringData = firstChunkStringData;
   }
 
-  public void setChunkDownloader(ChunkDownloader chunkDownloader)
-  {
+  public void setChunkDownloader(ChunkDownloader chunkDownloader) {
     this.chunkDownloader = chunkDownloader;
   }
 
-  public SFResultSetMetaData getSFResultSetMetaData()
-  {
+  public SFResultSetMetaData getSFResultSetMetaData() {
     return resultSetMetaData;
   }
 
-  public int getResultSetType()
-  {
+  public int getResultSetType() {
     return resultSetType;
   }
 
-  public int getResultSetConcurrency()
-  {
+  public int getResultSetConcurrency() {
     return resultSetConcurrency;
   }
 
-  public int getResultSetHoldability()
-  {
+  public int getResultSetHoldability() {
     return resultSetHoldability;
   }
 
-  public SnowflakeConnectString getSnowflakeConnectString()
-  {
+  public SnowflakeConnectString getSnowflakeConnectString() {
     return snowflakeConnectionString;
   }
 
-  public OCSPMode getOCSPMode()
-  {
+  public OCSPMode getOCSPMode() {
     return ocspMode;
   }
 
-  public String getQrmk()
-  {
+  public String getQrmk() {
     return qrmk;
   }
 
-  public int getNetworkTimeoutInMilli()
-  {
+  public int getNetworkTimeoutInMilli() {
     return networkTimeoutInMilli;
   }
 
-  public int getResultPrefetchThreads()
-  {
+  public int getResultPrefetchThreads() {
     return resultPrefetchThreads;
   }
 
-  public long getMemoryLimit()
-  {
+  public long getMemoryLimit() {
     return memoryLimit;
   }
 
-  public Map<String, String> getChunkHeadersMap()
-  {
+  public Map<String, String> getChunkHeadersMap() {
     return chunkHeadersMap;
   }
 
-  public List<ChunkFileMetadata> getChunkFileMetadatas()
-  {
+  public List<ChunkFileMetadata> getChunkFileMetadatas() {
     return chunkFileMetadatas;
   }
 
-  public RootAllocator getRootAllocator()
-  {
+  public RootAllocator getRootAllocator() {
     return rootAllocator;
   }
 
-  public QueryResultFormat getQueryResultFormat()
-  {
+  public QueryResultFormat getQueryResultFormat() {
     return queryResultFormat;
   }
 
-  public int getChunkFileCount()
-  {
+  public int getChunkFileCount() {
     return chunkFileCount;
   }
 
-  public boolean isArrayBindSupported()
-  {
+  public boolean isArrayBindSupported() {
     return arrayBindSupported;
   }
 
-  public String getQueryId()
-  {
+  public String getQueryId() {
     return queryId;
   }
 
-  public String getFinalDatabaseName()
-  {
+  public String getFinalDatabaseName() {
     return finalDatabaseName;
   }
 
-  public String getFinalSchemaName()
-  {
+  public String getFinalSchemaName() {
     return finalSchemaName;
   }
 
-  public String getFinalRoleName()
-  {
+  public String getFinalRoleName() {
     return finalRoleName;
   }
 
-  public String getFinalWarehouseName()
-  {
+  public String getFinalWarehouseName() {
     return finalWarehouseName;
   }
 
-  public SFStatementType getStatementType()
-  {
+  public SFStatementType getStatementType() {
     return statementType;
   }
 
-  public boolean isTotalRowCountTruncated()
-  {
+  public boolean isTotalRowCountTruncated() {
     return totalRowCountTruncated;
   }
 
-  public Map<String, Object> getParameters()
-  {
+  public Map<String, Object> getParameters() {
     return parameters;
   }
 
-  public int getColumnCount()
-  {
+  public int getColumnCount() {
     return columnCount;
   }
 
-  public List<SnowflakeColumnMetadata> getResultColumnMetadata()
-  {
+  public List<SnowflakeColumnMetadata> getResultColumnMetadata() {
     return resultColumnMetadata;
   }
 
-  public JsonNode getAndClearFirstChunkRowset()
-  {
+  public JsonNode getAndClearFirstChunkRowset() {
     JsonNode firstChunkRowset = this.firstChunkRowset;
     this.firstChunkRowset = null;
     return firstChunkRowset;
   }
 
-  public int getFirstChunkRowCount()
-  {
+  public int getFirstChunkRowCount() {
     return firstChunkRowCount;
   }
 
-  public long getResultVersion()
-  {
+  public long getResultVersion() {
     return resultVersion;
   }
 
-  public int getNumberOfBinds()
-  {
+  public int getNumberOfBinds() {
     return numberOfBinds;
   }
 
-  public ChunkDownloader getChunkDownloader()
-  {
+  public ChunkDownloader getChunkDownloader() {
     return chunkDownloader;
   }
 
-  public SnowflakeDateTimeFormat getTimestampNTZFormatter()
-  {
+  public SnowflakeDateTimeFormat getTimestampNTZFormatter() {
     return timestampNTZFormatter;
   }
 
-  public SnowflakeDateTimeFormat getTimestampLTZFormatter()
-  {
+  public SnowflakeDateTimeFormat getTimestampLTZFormatter() {
     return timestampLTZFormatter;
   }
 
-  public SnowflakeDateTimeFormat getTimestampTZFormatter()
-  {
+  public SnowflakeDateTimeFormat getTimestampTZFormatter() {
     return timestampTZFormatter;
   }
 
-  public SnowflakeDateTimeFormat getDateFormatter()
-  {
+  public SnowflakeDateTimeFormat getDateFormatter() {
     return dateFormatter;
   }
 
-  public SnowflakeDateTimeFormat getTimeFormatter()
-  {
+  public SnowflakeDateTimeFormat getTimeFormatter() {
     return timeFormatter;
   }
 
-  public TimeZone getTimeZone()
-  {
+  public TimeZone getTimeZone() {
     return timeZone;
   }
 
-  public boolean isHonorClientTZForTimestampNTZ()
-  {
+  public boolean isHonorClientTZForTimestampNTZ() {
     return honorClientTZForTimestampNTZ;
   }
 
-  public SFBinaryFormat getBinaryFormatter()
-  {
+  public SFBinaryFormat getBinaryFormatter() {
     return binaryFormatter;
   }
 
-  public long getSendResultTime()
-  {
+  public long getSendResultTime() {
     return sendResultTime;
   }
 
-  public List<MetaDataOfBinds> getMetaDataOfBinds()
-  {
+  public List<MetaDataOfBinds> getMetaDataOfBinds() {
     return metaDataOfBinds;
   }
 
-  public String getFirstChunkStringData()
-  {
+  public String getFirstChunkStringData() {
     return firstChunkStringData;
   }
 
-  public boolean getTreatNTZAsUTC()
-  {
+  public boolean getTreatNTZAsUTC() {
     return treatNTZAsUTC;
   }
 
-  public Optional<SFSession> getSession()
-  {
+  public Optional<SFSession> getSession() {
     return possibleSession;
   }
 
   /**
-   * A factory function to create SnowflakeResultSetSerializable object
-   * from result JSON node.
+   * A factory function to create SnowflakeResultSetSerializable object from result JSON node.
    *
-   * @param rootNode    result JSON node received from GS
-   * @param sfSession   the Snowflake session
+   * @param rootNode result JSON node received from GS
+   * @param sfSession the Snowflake session
    * @param sfStatement the Snowflake statement
    * @return processed ResultSetSerializable object
    * @throws SnowflakeSQLException if failed to parse the result JSON node
    */
-  static public SnowflakeResultSetSerializableV1 create(
-      JsonNode rootNode,
-      SFSession sfSession,
-      SFStatement sfStatement)
-  throws SnowflakeSQLException
-  {
-    SnowflakeResultSetSerializableV1 resultSetSerializable =
-        new SnowflakeResultSetSerializableV1();
+  public static SnowflakeResultSetSerializableV1 create(
+      JsonNode rootNode, SFSession sfSession, SFStatement sfStatement)
+      throws SnowflakeSQLException {
+    SnowflakeResultSetSerializableV1 resultSetSerializable = new SnowflakeResultSetSerializableV1();
     logger.debug("Entering create()");
 
     SnowflakeUtil.checkErrorAndThrowException(rootNode);
 
     // get the query id
-    resultSetSerializable.queryId =
-        rootNode.path("data").path("queryId").asText();
+    resultSetSerializable.queryId = rootNode.path("data").path("queryId").asText();
 
     JsonNode databaseNode = rootNode.path("data").path("finalDatabaseName");
-    resultSetSerializable.finalDatabaseName =
-        databaseNode.isNull() ? null : databaseNode.asText();
+    resultSetSerializable.finalDatabaseName = databaseNode.isNull() ? null : databaseNode.asText();
 
     JsonNode schemaNode = rootNode.path("data").path("finalSchemaName");
-    resultSetSerializable.finalSchemaName =
-        schemaNode.isNull() ? null : schemaNode.asText();
+    resultSetSerializable.finalSchemaName = schemaNode.isNull() ? null : schemaNode.asText();
 
     JsonNode roleNode = rootNode.path("data").path("finalRoleName");
-    resultSetSerializable.finalRoleName =
-        roleNode.isNull() ? null : roleNode.asText();
+    resultSetSerializable.finalRoleName = roleNode.isNull() ? null : roleNode.asText();
 
     JsonNode warehouseNode = rootNode.path("data").path("finalWarehouseName");
     resultSetSerializable.finalWarehouseName =
         warehouseNode.isNull() ? null : warehouseNode.asText();
 
-    resultSetSerializable.statementType = SFStatementType.lookUpTypeById(
-        rootNode.path("data").path("statementTypeId").asLong());
+    resultSetSerializable.statementType =
+        SFStatementType.lookUpTypeById(rootNode.path("data").path("statementTypeId").asLong());
 
-    resultSetSerializable.totalRowCountTruncated
-        = rootNode.path("data").path("totalTruncated").asBoolean();
+    resultSetSerializable.totalRowCountTruncated =
+        rootNode.path("data").path("totalTruncated").asBoolean();
 
     resultSetSerializable.possibleSession = Optional.ofNullable(sfSession);
 
     logger.debug("query id: {}", resultSetSerializable.queryId);
 
-    Optional<QueryResultFormat> queryResultFormat = QueryResultFormat
-        .lookupByName(rootNode.path("data").path("queryResultFormat").asText());
-    resultSetSerializable.queryResultFormat =
-        queryResultFormat.orElse(QueryResultFormat.JSON);
+    Optional<QueryResultFormat> queryResultFormat =
+        QueryResultFormat.lookupByName(rootNode.path("data").path("queryResultFormat").asText());
+    resultSetSerializable.queryResultFormat = queryResultFormat.orElse(QueryResultFormat.JSON);
 
     // extract parameters
     resultSetSerializable.parameters =
         SessionUtil.getCommonParams(rootNode.path("data").path("parameters"));
 
     // initialize column metadata
-    resultSetSerializable.columnCount =
-        rootNode.path("data").path("rowtype").size();
+    resultSetSerializable.columnCount = rootNode.path("data").path("rowtype").size();
 
-    for (int i = 0; i < resultSetSerializable.columnCount; i++)
-    {
+    for (int i = 0; i < resultSetSerializable.columnCount; i++) {
       JsonNode colNode = rootNode.path("data").path("rowtype").path(i);
 
-      SnowflakeColumnMetadata columnMetadata
-          = SnowflakeUtil.extractColumnMetadata(
-          colNode, sfSession.isJdbcTreatDecimalAsInt(), sfSession);
+      SnowflakeColumnMetadata columnMetadata =
+          SnowflakeUtil.extractColumnMetadata(
+              colNode, sfSession.isJdbcTreatDecimalAsInt(), sfSession);
 
       resultSetSerializable.resultColumnMetadata.add(columnMetadata);
 
-      logger.debug("Get column metadata: {}",
-                   (ArgSupplier) () -> columnMetadata.toString());
+      logger.debug("Get column metadata: {}", (ArgSupplier) () -> columnMetadata.toString());
     }
 
     // process the content of first chunk.
-    if (resultSetSerializable.queryResultFormat == QueryResultFormat.ARROW)
-    {
+    if (resultSetSerializable.queryResultFormat == QueryResultFormat.ARROW) {
       resultSetSerializable.firstChunkStringData =
           rootNode.path("data").path("rowsetBase64").asText();
-      resultSetSerializable.rootAllocator =
-          new RootAllocator(Long.MAX_VALUE);
+      resultSetSerializable.rootAllocator = new RootAllocator(Long.MAX_VALUE);
       // Set first chunk row count from firstChunkStringData
       resultSetSerializable.setFirstChunkRowCountForArrow();
-    }
-    else
-    {
-      resultSetSerializable.firstChunkRowset =
-          rootNode.path("data").path("rowset");
+    } else {
+      resultSetSerializable.firstChunkRowset = rootNode.path("data").path("rowset");
 
-      if (resultSetSerializable.firstChunkRowset == null ||
-          resultSetSerializable.firstChunkRowset.isMissingNode())
-      {
+      if (resultSetSerializable.firstChunkRowset == null
+          || resultSetSerializable.firstChunkRowset.isMissingNode()) {
         resultSetSerializable.firstChunkRowCount = 0;
         resultSetSerializable.firstChunkStringData = null;
-      }
-      else
-      {
-        resultSetSerializable.firstChunkRowCount =
-            resultSetSerializable.firstChunkRowset.size();
+      } else {
+        resultSetSerializable.firstChunkRowCount = resultSetSerializable.firstChunkRowset.size();
         resultSetSerializable.firstChunkStringData =
             resultSetSerializable.firstChunkRowset.toString();
       }
     }
-    logger.debug("First chunk row count: {}",
-                 resultSetSerializable.firstChunkRowCount);
+    logger.debug("First chunk row count: {}", resultSetSerializable.firstChunkRowCount);
 
     // parse file chunks
     resultSetSerializable.parseChunkFiles(rootNode, sfStatement);
@@ -629,28 +535,24 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     // result version
     JsonNode versionNode = rootNode.path("data").path("version");
 
-    if (!versionNode.isMissingNode())
-    {
+    if (!versionNode.isMissingNode()) {
       resultSetSerializable.resultVersion = versionNode.longValue();
     }
 
     // number of binds
     JsonNode numberOfBindsNode = rootNode.path("data").path("numberOfBinds");
 
-    if (!numberOfBindsNode.isMissingNode())
-    {
+    if (!numberOfBindsNode.isMissingNode()) {
       resultSetSerializable.numberOfBinds = numberOfBindsNode.intValue();
     }
 
-    JsonNode arrayBindSupported = rootNode.path("data")
-        .path("arrayBindSupported");
+    JsonNode arrayBindSupported = rootNode.path("data").path("arrayBindSupported");
     resultSetSerializable.arrayBindSupported =
         !arrayBindSupported.isMissingNode() && arrayBindSupported.asBoolean();
 
     // time result sent by GS (epoch time in millis)
     JsonNode sendResultTimeNode = rootNode.path("data").path("sendResultTime");
-    if (!sendResultTimeNode.isMissingNode())
-    {
+    if (!sendResultTimeNode.isMissingNode()) {
       resultSetSerializable.sendResultTime = sendResultTimeNode.longValue();
     }
 
@@ -658,11 +560,9 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
 
     // Bind parameter metadata
     JsonNode bindData = rootNode.path("data").path("metaDataOfBinds");
-    if (!bindData.isMissingNode())
-    {
+    if (!bindData.isMissingNode()) {
       List<MetaDataOfBinds> returnVal = new ArrayList<>();
-      for (JsonNode child : bindData)
-      {
+      for (JsonNode child : bindData) {
         int precision = child.path("precision").asInt();
         boolean nullable = child.path("nullable").asBoolean();
         int scale = child.path("scale").asInt();
@@ -671,8 +571,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
         String name = child.path("name").asText();
         String type = child.path("type").asText();
         MetaDataOfBinds param =
-            new MetaDataOfBinds(precision, nullable, scale, byteLength, length,
-                                name, type);
+            new MetaDataOfBinds(precision, nullable, scale, byteLength, length, name, type);
         returnVal.add(param);
       }
       resultSetSerializable.metaDataOfBinds = returnVal;
@@ -680,14 +579,10 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
 
     // setup fields from sessions.
     resultSetSerializable.ocspMode = sfSession.getOCSPMode();
-    resultSetSerializable.snowflakeConnectionString =
-        sfSession.getSnowflakeConnectionString();
-    resultSetSerializable.networkTimeoutInMilli =
-        sfSession.getNetworkTimeoutInMilli();
-    resultSetSerializable.isResultColumnCaseInsensitive =
-        sfSession.isResultColumnCaseInsensitive();
-    resultSetSerializable.treatNTZAsUTC =
-        sfSession.getTreatNTZAsUTC();
+    resultSetSerializable.snowflakeConnectionString = sfSession.getSnowflakeConnectionString();
+    resultSetSerializable.networkTimeoutInMilli = sfSession.getNetworkTimeoutInMilli();
+    resultSetSerializable.isResultColumnCaseInsensitive = sfSession.isResultColumnCaseInsensitive();
+    resultSetSerializable.treatNTZAsUTC = sfSession.getTreatNTZAsUTC();
 
     // setup transient fields from parameter
     resultSetSerializable.setupFieldsFromParameters();
@@ -696,142 +591,121 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     // first few chunk files in background thread(s)
     resultSetSerializable.chunkDownloader =
         (resultSetSerializable.chunkFileCount > 0)
-        ? new SnowflakeChunkDownloader(resultSetSerializable)
-        : new SnowflakeChunkDownloader.NoOpChunkDownloader();
+            ? new SnowflakeChunkDownloader(resultSetSerializable)
+            : new SnowflakeChunkDownloader.NoOpChunkDownloader();
 
     // Setup ResultSet metadata
     resultSetSerializable.resultSetMetaData =
-        new SFResultSetMetaData(resultSetSerializable.getResultColumnMetadata(),
-                                resultSetSerializable.queryId,
-                                sfSession,
-                                resultSetSerializable.isResultColumnCaseInsensitive,
-                                resultSetSerializable.timestampNTZFormatter,
-                                resultSetSerializable.timestampLTZFormatter,
-                                resultSetSerializable.timestampTZFormatter,
-                                resultSetSerializable.dateFormatter,
-                                resultSetSerializable.timeFormatter);
+        new SFResultSetMetaData(
+            resultSetSerializable.getResultColumnMetadata(),
+            resultSetSerializable.queryId,
+            sfSession,
+            resultSetSerializable.isResultColumnCaseInsensitive,
+            resultSetSerializable.timestampNTZFormatter,
+            resultSetSerializable.timestampLTZFormatter,
+            resultSetSerializable.timestampTZFormatter,
+            resultSetSerializable.dateFormatter,
+            resultSetSerializable.timeFormatter);
 
     return resultSetSerializable;
   }
 
   /**
-   * Some fields are generated from this.parameters, so generate them from
-   * this.parameters instead of serializing them.
+   * Some fields are generated from this.parameters, so generate them from this.parameters instead
+   * of serializing them.
    */
-  private void setupFieldsFromParameters()
-  {
-    String sqlTimestampFormat = (String) ResultUtil.effectiveParamValue(
-        this.parameters, "TIMESTAMP_OUTPUT_FORMAT");
+  private void setupFieldsFromParameters() {
+    String sqlTimestampFormat =
+        (String) ResultUtil.effectiveParamValue(this.parameters, "TIMESTAMP_OUTPUT_FORMAT");
 
     // Special handling of specialized formatters, use a helper function
-    this.timestampNTZFormatter = ResultUtil.specializedFormatter(
-        this.parameters,
-        "timestamp_ntz",
-        "TIMESTAMP_NTZ_OUTPUT_FORMAT",
-        sqlTimestampFormat);
+    this.timestampNTZFormatter =
+        ResultUtil.specializedFormatter(
+            this.parameters, "timestamp_ntz", "TIMESTAMP_NTZ_OUTPUT_FORMAT", sqlTimestampFormat);
 
-    this.timestampLTZFormatter = ResultUtil.specializedFormatter(
-        this.parameters,
-        "timestamp_ltz",
-        "TIMESTAMP_LTZ_OUTPUT_FORMAT",
-        sqlTimestampFormat);
+    this.timestampLTZFormatter =
+        ResultUtil.specializedFormatter(
+            this.parameters, "timestamp_ltz", "TIMESTAMP_LTZ_OUTPUT_FORMAT", sqlTimestampFormat);
 
-    this.timestampTZFormatter = ResultUtil.specializedFormatter(
-        this.parameters,
-        "timestamp_tz",
-        "TIMESTAMP_TZ_OUTPUT_FORMAT",
-        sqlTimestampFormat);
+    this.timestampTZFormatter =
+        ResultUtil.specializedFormatter(
+            this.parameters, "timestamp_tz", "TIMESTAMP_TZ_OUTPUT_FORMAT", sqlTimestampFormat);
 
-    String sqlDateFormat = (String) ResultUtil.effectiveParamValue(
-        this.parameters,
-        "DATE_OUTPUT_FORMAT");
+    String sqlDateFormat =
+        (String) ResultUtil.effectiveParamValue(this.parameters, "DATE_OUTPUT_FORMAT");
 
     this.dateFormatter = SnowflakeDateTimeFormat.fromSqlFormat(sqlDateFormat);
 
-    logger.debug("sql date format: {}, java date format: {}",
-                 sqlDateFormat,
-                 (ArgSupplier) () ->
-                     this.dateFormatter.toSimpleDateTimePattern());
+    logger.debug(
+        "sql date format: {}, java date format: {}",
+        sqlDateFormat,
+        (ArgSupplier) () -> this.dateFormatter.toSimpleDateTimePattern());
 
-    String sqlTimeFormat = (String) ResultUtil.effectiveParamValue(
-        this.parameters,
-        "TIME_OUTPUT_FORMAT");
+    String sqlTimeFormat =
+        (String) ResultUtil.effectiveParamValue(this.parameters, "TIME_OUTPUT_FORMAT");
 
     this.timeFormatter = SnowflakeDateTimeFormat.fromSqlFormat(sqlTimeFormat);
 
-    logger.debug("sql time format: {}, java time format: {}",
-                 sqlTimeFormat,
-                 (ArgSupplier) () ->
-                     this.timeFormatter.toSimpleDateTimePattern());
+    logger.debug(
+        "sql time format: {}, java time format: {}",
+        sqlTimeFormat,
+        (ArgSupplier) () -> this.timeFormatter.toSimpleDateTimePattern());
 
-    String timeZoneName = (String) ResultUtil.effectiveParamValue(
-        this.parameters, "TIMEZONE");
+    String timeZoneName = (String) ResultUtil.effectiveParamValue(this.parameters, "TIMEZONE");
     this.timeZone = TimeZone.getTimeZone(timeZoneName);
 
     this.honorClientTZForTimestampNTZ =
-        (boolean) ResultUtil.effectiveParamValue(
-            this.parameters,
-            "CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ");
+        (boolean)
+            ResultUtil.effectiveParamValue(
+                this.parameters, "CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ");
 
-    logger.debug("Honoring client TZ for timestamp_ntz? {}",
-                 this.honorClientTZForTimestampNTZ);
+    logger.debug("Honoring client TZ for timestamp_ntz? {}", this.honorClientTZForTimestampNTZ);
 
-    String binaryFmt = (String) ResultUtil.effectiveParamValue(
-        this.parameters, "BINARY_OUTPUT_FORMAT");
-    this.binaryFormatter =
-        SFBinaryFormat.getSafeOutputFormat(binaryFmt);
+    String binaryFmt =
+        (String) ResultUtil.effectiveParamValue(this.parameters, "BINARY_OUTPUT_FORMAT");
+    this.binaryFormatter = SFBinaryFormat.getSafeOutputFormat(binaryFmt);
   }
 
   /**
    * Parse the chunk file nodes from result JSON node
    *
-   * @param rootNode    result JSON node received from GS
+   * @param rootNode result JSON node received from GS
    * @param sfStatement the snowflake statement
    */
-  private void parseChunkFiles(JsonNode rootNode,
-                               SFStatement sfStatement)
-  {
+  private void parseChunkFiles(JsonNode rootNode, SFStatement sfStatement) {
     JsonNode chunksNode = rootNode.path("data").path("chunks");
 
-    if (!chunksNode.isMissingNode())
-    {
+    if (!chunksNode.isMissingNode()) {
       this.chunkFileCount = chunksNode.size();
 
       // Try to get the Query Result Master Key
       JsonNode qrmkNode = rootNode.path("data").path("qrmk");
-      this.qrmk = qrmkNode.isMissingNode() ?
-                  null : qrmkNode.textValue();
+      this.qrmk = qrmkNode.isMissingNode() ? null : qrmkNode.textValue();
 
       // Determine the prefetch thread count and memoryLimit
-      if (this.chunkFileCount > 0)
-      {
-        logger.debug("#chunks={}, initialize chunk downloader",
-                     this.chunkFileCount);
+      if (this.chunkFileCount > 0) {
+        logger.debug("#chunks={}, initialize chunk downloader", this.chunkFileCount);
 
         adjustMemorySettings(sfStatement);
 
         // Parse chunk header
         JsonNode chunkHeaders = rootNode.path("data").path("chunkHeaders");
-        if (chunkHeaders != null && !chunkHeaders.isMissingNode())
-        {
-          Iterator<Map.Entry<String, JsonNode>> chunkHeadersIter =
-              chunkHeaders.fields();
+        if (chunkHeaders != null && !chunkHeaders.isMissingNode()) {
+          Iterator<Map.Entry<String, JsonNode>> chunkHeadersIter = chunkHeaders.fields();
 
-          while (chunkHeadersIter.hasNext())
-          {
+          while (chunkHeadersIter.hasNext()) {
             Map.Entry<String, JsonNode> chunkHeader = chunkHeadersIter.next();
 
-            logger.debug("add header key={}, value={}",
-                         chunkHeader.getKey(),
-                         chunkHeader.getValue().asText());
-            this.chunkHeadersMap.put(chunkHeader.getKey(),
-                                     chunkHeader.getValue().asText());
+            logger.debug(
+                "add header key={}, value={}",
+                chunkHeader.getKey(),
+                chunkHeader.getValue().asText());
+            this.chunkHeadersMap.put(chunkHeader.getKey(), chunkHeader.getValue().asText());
           }
         }
 
         // parse chunk files metadata e.g. url and row count
-        for (int idx = 0; idx < this.chunkFileCount; idx++)
-        {
+        for (int idx = 0; idx < this.chunkFileCount; idx++) {
           JsonNode chunkNode = chunksNode.get(idx);
           String url = chunkNode.path("url").asText();
           int rowCount = chunkNode.path("rowCount").asInt();
@@ -839,46 +713,38 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
           int uncompressedSize = chunkNode.path("uncompressedSize").asInt();
 
           this.chunkFileMetadatas.add(
-              new ChunkFileMetadata(url, rowCount, compressedSize,
-                                    uncompressedSize));
+              new ChunkFileMetadata(url, rowCount, compressedSize, uncompressedSize));
 
-          logger.debug("add chunk, url={} rowCount={} " +
-                       "compressedSize={} uncompressedSize={}",
-                       url, rowCount, compressedSize, uncompressedSize);
+          logger.debug(
+              "add chunk, url={} rowCount={} " + "compressedSize={} uncompressedSize={}",
+              url,
+              rowCount,
+              compressedSize,
+              uncompressedSize);
         }
       }
     }
   }
 
-  private void adjustMemorySettings(
-      SFStatement sfStatement)
-  {
+  private void adjustMemorySettings(SFStatement sfStatement) {
     this.resultPrefetchThreads = DEFAULT_CLIENT_PREFETCH_THREADS;
     if (this.statementType.isSelect()
-        && this.parameters
-            .containsKey(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE)
-        && (boolean) this.parameters
-        .get(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE))
-    {
+        && this.parameters.containsKey(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE)
+        && (boolean) this.parameters.get(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE)) {
       // use conservative memory settings
-      this.resultPrefetchThreads =
-          sfStatement.getConservativePrefetchThreads();
+      this.resultPrefetchThreads = sfStatement.getConservativePrefetchThreads();
       this.memoryLimit = sfStatement.getConservativeMemoryLimit();
-      int chunkSize =
-          (int) this.parameters.get(CLIENT_RESULT_CHUNK_SIZE);
+      int chunkSize = (int) this.parameters.get(CLIENT_RESULT_CHUNK_SIZE);
       logger.debug(
-          "enable conservative memory usage with prefetchThreads = {} and memoryLimit = {} and " +
-          "resultChunkSize = {}",
-          this.resultPrefetchThreads, this.memoryLimit,
+          "enable conservative memory usage with prefetchThreads = {} and memoryLimit = {} and "
+              + "resultChunkSize = {}",
+          this.resultPrefetchThreads,
+          this.memoryLimit,
           chunkSize);
-    }
-    else
-    {
+    } else {
       // prefetch threads
-      if (this.parameters.get(CLIENT_PREFETCH_THREADS) != null)
-      {
-        this.resultPrefetchThreads =
-            (int) this.parameters.get(CLIENT_PREFETCH_THREADS);
+      if (this.parameters.get(CLIENT_PREFETCH_THREADS) != null) {
+        this.resultPrefetchThreads = (int) this.parameters.get(CLIENT_PREFETCH_THREADS);
       }
       this.memoryLimit = initMemoryLimit(this.parameters);
     }
@@ -886,13 +752,15 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     long maxChunkSize = (int) this.parameters.get(CLIENT_RESULT_CHUNK_SIZE) * MB;
     if (queryResultFormat == QueryResultFormat.ARROW
         && Runtime.getRuntime().maxMemory() < LOW_MAX_MEMORY
-        && memoryLimit * 2 + maxChunkSize > Runtime.getRuntime().maxMemory())
-    {
+        && memoryLimit * 2 + maxChunkSize > Runtime.getRuntime().maxMemory()) {
       memoryLimit = Runtime.getRuntime().maxMemory() / 2 - maxChunkSize;
-      logger.debug("To avoid OOM for arrow buffer allocation, " +
-                   "memoryLimit {} should be less than half of the " +
-                   "maxMemory {} + maxChunkSize {}",
-                   memoryLimit, Runtime.getRuntime().maxMemory(), maxChunkSize);
+      logger.debug(
+          "To avoid OOM for arrow buffer allocation, "
+              + "memoryLimit {} should be less than half of the "
+              + "maxMemory {} + maxChunkSize {}",
+          memoryLimit,
+          Runtime.getRuntime().maxMemory(),
+          maxChunkSize);
     }
   }
 
@@ -902,21 +770,16 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
    * @param parameters The parameters for result JSON node
    * @return memory limit in bytes
    */
-  private static long initMemoryLimit(Map<String, Object> parameters)
-  {
+  private static long initMemoryLimit(Map<String, Object> parameters) {
     // default setting
     long memoryLimit = DEFAULT_CLIENT_MEMORY_LIMIT * 1024 * 1024;
-    if (parameters.get(CLIENT_MEMORY_LIMIT) != null)
-    {
+    if (parameters.get(CLIENT_MEMORY_LIMIT) != null) {
       // use the settings from the customer
-      memoryLimit =
-          (int) parameters.get(CLIENT_MEMORY_LIMIT) * 1024L * 1024L;
+      memoryLimit = (int) parameters.get(CLIENT_MEMORY_LIMIT) * 1024L * 1024L;
     }
 
     long maxMemoryToUse = Runtime.getRuntime().maxMemory() * 8 / 10;
-    if ((int) parameters.get(CLIENT_MEMORY_LIMIT)
-        == DEFAULT_CLIENT_MEMORY_LIMIT)
-    {
+    if ((int) parameters.get(CLIENT_MEMORY_LIMIT) == DEFAULT_CLIENT_MEMORY_LIMIT) {
       // if the memory limit is the default value and best effort memory is enabled
       // set the memory limit to 80% of the maximum as the best effort
       memoryLimit = Math.max(memoryLimit, maxMemoryToUse);
@@ -934,9 +797,7 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
    *
    * @throws SQLException if fails to setup any transient fields
    */
-  private void setupTransientFields()
-  throws SQLException
-  {
+  private void setupTransientFields() throws SQLException {
     // Setup transient fields from serialized fields
     setupFieldsFromParameters();
 
@@ -944,66 +805,57 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     this.memoryLimit = initMemoryLimit(this.parameters);
 
     // Create below transient fields on the fly.
-    if (QueryResultFormat.ARROW.equals(this.queryResultFormat))
-    {
+    if (QueryResultFormat.ARROW.equals(this.queryResultFormat)) {
       this.rootAllocator = new RootAllocator(Long.MAX_VALUE);
       this.firstChunkRowset = null;
-    }
-    else
-    {
+    } else {
       this.rootAllocator = null;
-      try
-      {
-        this.firstChunkRowset = (this.firstChunkStringData != null)
-                                ? mapper.readTree(this.firstChunkStringData)
-                                : null;
-      }
-      catch (IOException ex)
-      {
-        throw new SnowflakeSQLLoggedException("The JSON data is invalid. The error is: " +
-                                              ex.getMessage(), possibleSession.orElse(/* session = */ null));
+      try {
+        this.firstChunkRowset =
+            (this.firstChunkStringData != null) ? mapper.readTree(this.firstChunkStringData) : null;
+      } catch (IOException ex) {
+        throw new SnowflakeSQLLoggedException(
+            "The JSON data is invalid. The error is: " + ex.getMessage(),
+            possibleSession.orElse(/* session = */ null));
       }
     }
 
     // Setup ResultSet metadata
     this.resultSetMetaData =
-        new SFResultSetMetaData(this.getResultColumnMetadata(),
-                                this.queryId,
-                                null, // This is session less
-                                this.isResultColumnCaseInsensitive,
-                                this.timestampNTZFormatter,
-                                this.timestampLTZFormatter,
-                                this.timestampTZFormatter,
-                                this.dateFormatter,
-                                this.timeFormatter);
+        new SFResultSetMetaData(
+            this.getResultColumnMetadata(),
+            this.queryId,
+            null, // This is session less
+            this.isResultColumnCaseInsensitive,
+            this.timestampNTZFormatter,
+            this.timestampLTZFormatter,
+            this.timestampTZFormatter,
+            this.dateFormatter,
+            this.timeFormatter);
 
     // Allocate chunk downloader if necessary
-    chunkDownloader = (this.chunkFileCount > 0)
-                      ? new SnowflakeChunkDownloader(this)
-                      : new SnowflakeChunkDownloader.NoOpChunkDownloader();
+    chunkDownloader =
+        (this.chunkFileCount > 0)
+            ? new SnowflakeChunkDownloader(this)
+            : new SnowflakeChunkDownloader.NoOpChunkDownloader();
   }
 
   /**
    * Split this object into small pieces based on the user specified data size.
    *
-   * @param maxSizeInBytes the expected max data size wrapped in the result
-   *                       ResultSetSerializables object.
-   *                       NOTE: if a result chunk size is greater than this
-   *                       value, the ResultSetSerializable object will
-   *                       include one result chunk.
+   * @param maxSizeInBytes the expected max data size wrapped in the result ResultSetSerializables
+   *     object. NOTE: if a result chunk size is greater than this value, the ResultSetSerializable
+   *     object will include one result chunk.
    * @return a list of SnowflakeResultSetSerializable
    * @throws SQLException if fails to split objects.
    */
-  public List<SnowflakeResultSetSerializable> splitBySize(long maxSizeInBytes)
-  throws SQLException
-  {
-    List<SnowflakeResultSetSerializable> resultSetSerializables =
-        new ArrayList<>();
+  public List<SnowflakeResultSetSerializable> splitBySize(long maxSizeInBytes) throws SQLException {
+    List<SnowflakeResultSetSerializable> resultSetSerializables = new ArrayList<>();
 
-    if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null)
-    {
-      throw new SnowflakeSQLLoggedException("The Result Set serializable is invalid.",
-                                            this.possibleSession.orElse(/* session = */null));
+    if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null) {
+      throw new SnowflakeSQLLoggedException(
+          "The Result Set serializable is invalid.",
+          this.possibleSession.orElse(/* session = */ null));
     }
 
     // In the beginning, only the first data chunk is included in the result
@@ -1015,23 +867,19 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     curResultSetSerializable.chunkFileMetadatas = new ArrayList<>();
     curResultSetSerializable.chunkFileCount = 0;
 
-    for (int idx = 0; idx < this.chunkFileCount; idx++)
-    {
-      ChunkFileMetadata curChunkFileMetadata =
-          this.getChunkFileMetadatas().get(idx);
+    for (int idx = 0; idx < this.chunkFileCount; idx++) {
+      ChunkFileMetadata curChunkFileMetadata = this.getChunkFileMetadatas().get(idx);
 
       // If the serializable object has reach the max size,
       // save current one and create new one.
-      if ((curResultSetSerializable.getUncompressedDataSizeInBytes() > 0) &&
-          (maxSizeInBytes <
-           (curResultSetSerializable.getUncompressedDataSizeInBytes()
-            + curChunkFileMetadata.getUncompressedByteSize())))
-      {
+      if ((curResultSetSerializable.getUncompressedDataSizeInBytes() > 0)
+          && (maxSizeInBytes
+              < (curResultSetSerializable.getUncompressedDataSizeInBytes()
+                  + curChunkFileMetadata.getUncompressedByteSize()))) {
         resultSetSerializables.add(curResultSetSerializable);
 
         // Create new result serializable and reset it as empty
-        curResultSetSerializable =
-            new SnowflakeResultSetSerializableV1(this);
+        curResultSetSerializable = new SnowflakeResultSetSerializableV1(this);
         curResultSetSerializable.chunkFileMetadatas = new ArrayList<>();
         curResultSetSerializable.chunkFileCount = 0;
         curResultSetSerializable.firstChunkStringData = null;
@@ -1051,25 +899,22 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
   }
 
   /**
-   * Get ResultSet from the ResultSet Serializable object so that the user can
-   * access the data. The ResultSet is sessionless.
+   * Get ResultSet from the ResultSet Serializable object so that the user can access the data. The
+   * ResultSet is sessionless.
    *
    * @return a ResultSet which represents for the data wrapped in the object
    */
-  public ResultSet getResultSet() throws SQLException
-  {
+  public ResultSet getResultSet() throws SQLException {
     return getResultSet(null);
   }
 
   /**
-   * Get ResultSet from the ResultSet Serializable object so that the user can
-   * access the data.
+   * Get ResultSet from the ResultSet Serializable object so that the user can access the data.
    *
    * @param info The proxy sever information if proxy is necessary.
    * @return a ResultSet which represents for the data wrapped in the object
    */
-  public ResultSet getResultSet(Properties info) throws SQLException
-  {
+  public ResultSet getResultSet(Properties info) throws SQLException {
     // Setup proxy info if necessary
     SnowflakeUtil.setupProxyPropertiesIfNecessary(info);
 
@@ -1082,103 +927,86 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
     boolean sortResult = false;
     // Setup base result set.
     SFBaseResultSet sfBaseResultSet = null;
-    switch (getQueryResultFormat())
-    {
+    switch (getQueryResultFormat()) {
       case ARROW:
-      {
-        sfBaseResultSet = new SFArrowResultSet(this, telemetryClient,
-                                               sortResult);
-        break;
-      }
+        {
+          sfBaseResultSet = new SFArrowResultSet(this, telemetryClient, sortResult);
+          break;
+        }
       case JSON:
-      {
-        sfBaseResultSet = new SFResultSet(this, telemetryClient,
-                                          sortResult);
-        break;
-      }
+        {
+          sfBaseResultSet = new SFResultSet(this, telemetryClient, sortResult);
+          break;
+        }
       default:
-        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR,
-                                              this.possibleSession.orElse(/*session = */null),
-                                              "Unsupported query result format: " +
-                                              getQueryResultFormat().name());
+        throw new SnowflakeSQLLoggedException(
+            ErrorCode.INTERNAL_ERROR,
+            this.possibleSession.orElse(/*session = */ null),
+            "Unsupported query result format: " + getQueryResultFormat().name());
     }
 
     // Create result set
-    SnowflakeResultSetV1 resultSetV1 =
-        new SnowflakeResultSetV1(sfBaseResultSet, this);
+    SnowflakeResultSetV1 resultSetV1 = new SnowflakeResultSetV1(sfBaseResultSet, this);
 
     return resultSetV1;
   }
 
   // Set the row count for first result chunk by parsing the chunk data.
-  private void setFirstChunkRowCountForArrow() throws SnowflakeSQLException
-  {
+  private void setFirstChunkRowCountForArrow() throws SnowflakeSQLException {
     firstChunkRowCount = 0;
 
     // If the first chunk doesn't exist or empty, set it as 0
-    if (firstChunkStringData == null || firstChunkStringData.isEmpty())
-    {
+    if (firstChunkStringData == null || firstChunkStringData.isEmpty()) {
       firstChunkRowCount = 0;
     }
     // Parse the Arrow result chunk
-    else if (getQueryResultFormat().equals(QueryResultFormat.ARROW))
-    {
+    else if (getQueryResultFormat().equals(QueryResultFormat.ARROW)) {
       // Below code is developed based on SFArrowResultSet.buildFirstChunk
       // and ArrowResultChunk.readArrowStream()
       byte[] bytes = Base64.getDecoder().decode(firstChunkStringData);
       VectorSchemaRoot root = null;
       RootAllocator localRootAllocator =
-          (rootAllocator != null) ? rootAllocator
-                                  : new RootAllocator(Long.MAX_VALUE);
+          (rootAllocator != null) ? rootAllocator : new RootAllocator(Long.MAX_VALUE);
       try (ByteArrayInputStream is = new ByteArrayInputStream(bytes);
-           ArrowStreamReader reader = new ArrowStreamReader(is, localRootAllocator))
-      {
+          ArrowStreamReader reader = new ArrowStreamReader(is, localRootAllocator)) {
         root = reader.getVectorSchemaRoot();
-        while (reader.loadNextBatch())
-        {
+        while (reader.loadNextBatch()) {
           firstChunkRowCount += root.getRowCount();
           root.clear();
         }
-      }
-      catch (Exception ex)
-      {
-        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, possibleSession.orElse(/* session = */ null),
-                                              "Fail to retrieve row count for first arrow chunk: " +
-                                              ex.getCause());
-      }
-      finally
-      {
-        if (root != null)
-        {
+      } catch (Exception ex) {
+        throw new SnowflakeSQLLoggedException(
+            ErrorCode.INTERNAL_ERROR,
+            possibleSession.orElse(/* session = */ null),
+            "Fail to retrieve row count for first arrow chunk: " + ex.getCause());
+      } finally {
+        if (root != null) {
           root.clear();
         }
       }
-    }
-    else
-    {
+    } else {
       // This shouldn't happen
-      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR,
-                                            this.possibleSession.orElse( /*session = */ null),
-                                            "setFirstChunkRowCountForArrow() should only be called for Arrow.");
+      throw new SnowflakeSQLLoggedException(
+          ErrorCode.INTERNAL_ERROR,
+          this.possibleSession.orElse(/*session = */ null),
+          "setFirstChunkRowCountForArrow() should only be called for Arrow.");
     }
   }
 
   /**
    * Retrieve total row count included in the the ResultSet Serializable object.
-   * <p>
-   * GS sends the data of first chunk and metadata of the other chunk if exist
-   * to client, so this function calculates the row count for all of them.
+   *
+   * <p>GS sends the data of first chunk and metadata of the other chunk if exist to client, so this
+   * function calculates the row count for all of them.
    *
    * @return the total row count from metadata
    */
-  public long getRowCount() throws SQLException
-  {
+  public long getRowCount() throws SQLException {
     // Get row count for first chunk if it exists.
     long totalRowCount = firstChunkRowCount;
 
     // Get row count from chunk file metadata
-    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas)
-    {
+    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas) {
       totalRowCount += chunkFileMetadata.rowCount;
     }
 
@@ -1187,26 +1015,23 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
 
   /**
    * Retrieve compressed data size in the the ResultSet Serializable object.
-   * <p>
-   * GS sends the data of first chunk and metadata of the other chunks if exist
-   * to client, so this function calculates the data size for all of them.
-   * NOTE: if first chunk exists, this function uses its uncompressed data size
-   * as its compressed data size in this calculation though it is not compressed.
+   *
+   * <p>GS sends the data of first chunk and metadata of the other chunks if exist to client, so
+   * this function calculates the data size for all of them. NOTE: if first chunk exists, this
+   * function uses its uncompressed data size as its compressed data size in this calculation though
+   * it is not compressed.
    *
    * @return the total compressed data size in bytes from metadata
    */
-  public long getCompressedDataSizeInBytes() throws SQLException
-  {
+  public long getCompressedDataSizeInBytes() throws SQLException {
     long totalCompressedDataSize = 0;
 
     // Count the data size for the first chunk if it exists.
-    if (firstChunkStringData != null)
-    {
+    if (firstChunkStringData != null) {
       totalCompressedDataSize += firstChunkStringData.length();
     }
 
-    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas)
-    {
+    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas) {
       totalCompressedDataSize += chunkFileMetadata.compressedByteSize;
     }
 
@@ -1215,52 +1040,39 @@ public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSeria
 
   /**
    * Retrieve Uncompressed data size in the the ResultSet Serializable object.
-   * <p>
-   * GS sends the data of first chunk and metadata of the other chunk if exist
-   * to client, so this function calculates the data size for all of them.
+   *
+   * <p>GS sends the data of first chunk and metadata of the other chunk if exist to client, so this
+   * function calculates the data size for all of them.
    *
    * @return the total uncompressed data size in bytes from metadata
    */
-  public long getUncompressedDataSizeInBytes() throws SQLException
-  {
+  public long getUncompressedDataSizeInBytes() throws SQLException {
     long totalUncompressedDataSize = 0;
 
     // Count the data size for the first chunk if it exists.
-    if (firstChunkStringData != null)
-    {
+    if (firstChunkStringData != null) {
       totalUncompressedDataSize += firstChunkStringData.length();
     }
 
-    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas)
-    {
+    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas) {
       totalUncompressedDataSize += chunkFileMetadata.uncompressedByteSize;
     }
 
     return totalUncompressedDataSize;
   }
 
-  public String toString()
-  {
+  public String toString() {
     StringBuilder builder = new StringBuilder(16 * 1024);
 
-    builder.append("hasFirstChunk: ")
-        .append(this.firstChunkStringData != null)
-        .append("\n");
+    builder.append("hasFirstChunk: ").append(this.firstChunkStringData != null).append("\n");
 
-    builder.append("RowCountInFirstChunk: ")
-        .append(this.firstChunkRowCount)
-        .append("\n");
+    builder.append("RowCountInFirstChunk: ").append(this.firstChunkRowCount).append("\n");
 
-    builder.append("queryResultFormat: ")
-        .append(this.queryResultFormat)
-        .append("\n");
+    builder.append("queryResultFormat: ").append(this.queryResultFormat).append("\n");
 
-    builder.append("chunkFileCount: ")
-        .append(this.chunkFileCount)
-        .append("\n");
+    builder.append("chunkFileCount: ").append(this.chunkFileCount).append("\n");
 
-    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas)
-    {
+    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas) {
       builder.append("\t").append(chunkFileMetadata.toString()).append("\n");
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -4,23 +4,8 @@
 
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.core.Constants.GB;
-import static net.snowflake.client.core.Constants.MB;
-import static net.snowflake.client.core.SessionUtil.CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE;
-import static net.snowflake.client.core.SessionUtil.CLIENT_MEMORY_LIMIT;
-import static net.snowflake.client.core.SessionUtil.CLIENT_PREFETCH_THREADS;
-import static net.snowflake.client.core.SessionUtil.CLIENT_RESULT_CHUNK_SIZE;
-import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_MEMORY_LIMIT;
-import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_PREFETCH_THREADS;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.Serializable;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
 import net.snowflake.client.core.ChunkDownloader;
 import net.snowflake.client.core.MetaDataOfBinds;
 import net.snowflake.client.core.OCSPMode;
@@ -46,21 +31,39 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+import static net.snowflake.client.core.Constants.GB;
+import static net.snowflake.client.core.Constants.MB;
+import static net.snowflake.client.core.SessionUtil.CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE;
+import static net.snowflake.client.core.SessionUtil.CLIENT_MEMORY_LIMIT;
+import static net.snowflake.client.core.SessionUtil.CLIENT_PREFETCH_THREADS;
+import static net.snowflake.client.core.SessionUtil.CLIENT_RESULT_CHUNK_SIZE;
+import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_MEMORY_LIMIT;
+import static net.snowflake.client.core.SessionUtil.DEFAULT_CLIENT_PREFETCH_THREADS;
+
+
 /**
- * This object is an intermediate object between result JSON from GS and ResultSet. Originally, it
- * is created from result JSON. And it can also be serializable. Logically, it stands for a part of
- * ResultSet.
- *
- * <p>A typical result JSON data section consists of the content of the first chunk file and file
- * metadata for the rest of chunk files e.g. URL, chunk size, etc. So this object consists of one
- * chunk data and a list of chunk file entries. In actual cases, it may only include chunk data or
- * chunk files entries.
- *
- * <p>This object is serializable, so it can be distributed to other threads or worker nodes for
- * distributed processing.
+ * This object is an intermediate object between result JSON from GS and
+ * ResultSet. Originally, it is created from result JSON. And it can
+ * also be serializable. Logically, it stands for a part of ResultSet.
+ * <p>
+ * A typical result JSON data section consists of the content of the first chunk
+ * file and file metadata for the rest of chunk files e.g. URL, chunk size, etc.
+ * So this object consists of one chunk data and a list of chunk file entries.
+ * In actual cases, it may only include chunk data or chunk files entries.
+ * <p>
+ * This object is serializable, so it can be distributed to other threads or
+ * worker nodes for distributed processing.
  */
-public class SnowflakeResultSetSerializableV1
-    implements SnowflakeResultSetSerializable, Serializable {
+public class SnowflakeResultSetSerializableV1 implements SnowflakeResultSetSerializable,
+                                                         Serializable
+{
   private static final long serialVersionUID = 1L;
 
   static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeResultSetSerializableV1.class);
@@ -68,43 +71,55 @@ public class SnowflakeResultSetSerializableV1
   static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
   private static final long LOW_MAX_MEMORY = GB;
 
-  /** An Entity class to represent a chunk file metadata. */
-  public static class ChunkFileMetadata implements Serializable {
+  /**
+   * An Entity class to represent a chunk file metadata.
+   */
+  static public class ChunkFileMetadata implements Serializable
+  {
     private static final long serialVersionUID = 1L;
     String fileURL;
     int rowCount;
     int compressedByteSize;
     int uncompressedByteSize;
 
-    public ChunkFileMetadata(
-        String fileURL, int rowCount, int compressedByteSize, int uncompressedByteSize) {
+    public ChunkFileMetadata(String fileURL,
+                             int rowCount,
+                             int compressedByteSize,
+                             int uncompressedByteSize)
+    {
       this.fileURL = fileURL;
       this.rowCount = rowCount;
       this.compressedByteSize = compressedByteSize;
       this.uncompressedByteSize = uncompressedByteSize;
     }
 
-    public void setFileURL(String fileURL) {
+    public void setFileURL(String fileURL)
+    {
       this.fileURL = fileURL;
     }
 
-    public String getFileURL() {
+    public String getFileURL()
+    {
       return fileURL;
     }
 
-    public int getRowCount() {
+    public int getRowCount()
+    {
       return rowCount;
     }
 
-    public int getCompressedByteSize() {
+    public int getCompressedByteSize()
+    {
       return compressedByteSize;
     }
 
-    public int getUncompressedByteSize() {
+    public int getUncompressedByteSize()
+    {
       return uncompressedByteSize;
     }
 
-    public String toString() {
+    public String toString()
+    {
       StringBuilder builder = new StringBuilder(1024);
 
       builder.append("RowCount: ").append(rowCount).append(", ");
@@ -147,7 +162,8 @@ public class SnowflakeResultSetSerializableV1
   boolean totalRowCountTruncated;
   Map<String, Object> parameters = new HashMap<>();
   int columnCount;
-  private List<SnowflakeColumnMetadata> resultColumnMetadata = new ArrayList<>();
+  private List<SnowflakeColumnMetadata> resultColumnMetadata =
+      new ArrayList<>();
   long resultVersion;
   int numberOfBinds;
   boolean arrayBindSupported;
@@ -174,17 +190,23 @@ public class SnowflakeResultSetSerializableV1
   transient RootAllocator rootAllocator = null; // only used for ARROW result
   transient SFResultSetMetaData resultSetMetaData = null;
 
-  /** Default constructor. */
-  public SnowflakeResultSetSerializableV1() {}
+  /**
+   * Default constructor.
+   */
+  public SnowflakeResultSetSerializableV1()
+  {
+
+  }
 
   /**
    * This is copy constructor.
-   *
-   * <p>NOTE: The copy is NOT deep copy.
+   * <p>
+   * NOTE: The copy is NOT deep copy.
    *
    * @param toCopy the source object to be copied.
    */
-  private SnowflakeResultSetSerializableV1(SnowflakeResultSetSerializableV1 toCopy) {
+  private SnowflakeResultSetSerializableV1(SnowflakeResultSetSerializableV1 toCopy)
+  {
     // Below fields are for the data fields that this object wraps
     this.firstChunkStringData = toCopy.firstChunkStringData;
     this.firstChunkRowCount = toCopy.firstChunkRowCount;
@@ -243,291 +265,363 @@ public class SnowflakeResultSetSerializableV1
     this.resultSetMetaData = toCopy.resultSetMetaData;
   }
 
-  public void setRootAllocator(RootAllocator rootAllocator) {
+  public void setRootAllocator(RootAllocator rootAllocator)
+  {
     this.rootAllocator = rootAllocator;
   }
 
-  public void setQueryResultFormat(QueryResultFormat queryResultFormat) {
+  public void setQueryResultFormat(QueryResultFormat queryResultFormat)
+  {
     this.queryResultFormat = queryResultFormat;
   }
 
-  public void setChunkFileCount(int chunkFileCount) {
+  public void setChunkFileCount(int chunkFileCount)
+  {
     this.chunkFileCount = chunkFileCount;
   }
 
-  public void setFristChunkStringData(String firstChunkStringData) {
+  public void setFristChunkStringData(String firstChunkStringData)
+  {
     this.firstChunkStringData = firstChunkStringData;
   }
 
-  public void setChunkDownloader(ChunkDownloader chunkDownloader) {
+  public void setChunkDownloader(ChunkDownloader chunkDownloader)
+  {
     this.chunkDownloader = chunkDownloader;
   }
 
-  public SFResultSetMetaData getSFResultSetMetaData() {
+  public SFResultSetMetaData getSFResultSetMetaData()
+  {
     return resultSetMetaData;
   }
 
-  public int getResultSetType() {
+  public int getResultSetType()
+  {
     return resultSetType;
   }
 
-  public int getResultSetConcurrency() {
+  public int getResultSetConcurrency()
+  {
     return resultSetConcurrency;
   }
 
-  public int getResultSetHoldability() {
+  public int getResultSetHoldability()
+  {
     return resultSetHoldability;
   }
 
-  public SnowflakeConnectString getSnowflakeConnectString() {
+  public SnowflakeConnectString getSnowflakeConnectString()
+  {
     return snowflakeConnectionString;
   }
 
-  public OCSPMode getOCSPMode() {
+  public OCSPMode getOCSPMode()
+  {
     return ocspMode;
   }
 
-  public String getQrmk() {
+  public String getQrmk()
+  {
     return qrmk;
   }
 
-  public int getNetworkTimeoutInMilli() {
+  public int getNetworkTimeoutInMilli()
+  {
     return networkTimeoutInMilli;
   }
 
-  public int getResultPrefetchThreads() {
+  public int getResultPrefetchThreads()
+  {
     return resultPrefetchThreads;
   }
 
-  public long getMemoryLimit() {
+  public long getMemoryLimit()
+  {
     return memoryLimit;
   }
 
-  public Map<String, String> getChunkHeadersMap() {
+  public Map<String, String> getChunkHeadersMap()
+  {
     return chunkHeadersMap;
   }
 
-  public List<ChunkFileMetadata> getChunkFileMetadatas() {
+  public List<ChunkFileMetadata> getChunkFileMetadatas()
+  {
     return chunkFileMetadatas;
   }
 
-  public RootAllocator getRootAllocator() {
+  public RootAllocator getRootAllocator()
+  {
     return rootAllocator;
   }
 
-  public QueryResultFormat getQueryResultFormat() {
+  public QueryResultFormat getQueryResultFormat()
+  {
     return queryResultFormat;
   }
 
-  public int getChunkFileCount() {
+  public int getChunkFileCount()
+  {
     return chunkFileCount;
   }
 
-  public boolean isArrayBindSupported() {
+  public boolean isArrayBindSupported()
+  {
     return arrayBindSupported;
   }
 
-  public String getQueryId() {
+  public String getQueryId()
+  {
     return queryId;
   }
 
-  public String getFinalDatabaseName() {
+  public String getFinalDatabaseName()
+  {
     return finalDatabaseName;
   }
 
-  public String getFinalSchemaName() {
+  public String getFinalSchemaName()
+  {
     return finalSchemaName;
   }
 
-  public String getFinalRoleName() {
+  public String getFinalRoleName()
+  {
     return finalRoleName;
   }
 
-  public String getFinalWarehouseName() {
+  public String getFinalWarehouseName()
+  {
     return finalWarehouseName;
   }
 
-  public SFStatementType getStatementType() {
+  public SFStatementType getStatementType()
+  {
     return statementType;
   }
 
-  public boolean isTotalRowCountTruncated() {
+  public boolean isTotalRowCountTruncated()
+  {
     return totalRowCountTruncated;
   }
 
-  public Map<String, Object> getParameters() {
+  public Map<String, Object> getParameters()
+  {
     return parameters;
   }
 
-  public int getColumnCount() {
+  public int getColumnCount()
+  {
     return columnCount;
   }
 
-  public List<SnowflakeColumnMetadata> getResultColumnMetadata() {
+  public List<SnowflakeColumnMetadata> getResultColumnMetadata()
+  {
     return resultColumnMetadata;
   }
 
-  public JsonNode getAndClearFirstChunkRowset() {
+  public JsonNode getAndClearFirstChunkRowset()
+  {
     JsonNode firstChunkRowset = this.firstChunkRowset;
     this.firstChunkRowset = null;
     return firstChunkRowset;
   }
 
-  public int getFirstChunkRowCount() {
+  public int getFirstChunkRowCount()
+  {
     return firstChunkRowCount;
   }
 
-  public long getResultVersion() {
+  public long getResultVersion()
+  {
     return resultVersion;
   }
 
-  public int getNumberOfBinds() {
+  public int getNumberOfBinds()
+  {
     return numberOfBinds;
   }
 
-  public ChunkDownloader getChunkDownloader() {
+  public ChunkDownloader getChunkDownloader()
+  {
     return chunkDownloader;
   }
 
-  public SnowflakeDateTimeFormat getTimestampNTZFormatter() {
+  public SnowflakeDateTimeFormat getTimestampNTZFormatter()
+  {
     return timestampNTZFormatter;
   }
 
-  public SnowflakeDateTimeFormat getTimestampLTZFormatter() {
+  public SnowflakeDateTimeFormat getTimestampLTZFormatter()
+  {
     return timestampLTZFormatter;
   }
 
-  public SnowflakeDateTimeFormat getTimestampTZFormatter() {
+  public SnowflakeDateTimeFormat getTimestampTZFormatter()
+  {
     return timestampTZFormatter;
   }
 
-  public SnowflakeDateTimeFormat getDateFormatter() {
+  public SnowflakeDateTimeFormat getDateFormatter()
+  {
     return dateFormatter;
   }
 
-  public SnowflakeDateTimeFormat getTimeFormatter() {
+  public SnowflakeDateTimeFormat getTimeFormatter()
+  {
     return timeFormatter;
   }
 
-  public TimeZone getTimeZone() {
+  public TimeZone getTimeZone()
+  {
     return timeZone;
   }
 
-  public boolean isHonorClientTZForTimestampNTZ() {
+  public boolean isHonorClientTZForTimestampNTZ()
+  {
     return honorClientTZForTimestampNTZ;
   }
 
-  public SFBinaryFormat getBinaryFormatter() {
+  public SFBinaryFormat getBinaryFormatter()
+  {
     return binaryFormatter;
   }
 
-  public long getSendResultTime() {
+  public long getSendResultTime()
+  {
     return sendResultTime;
   }
 
-  public List<MetaDataOfBinds> getMetaDataOfBinds() {
+  public List<MetaDataOfBinds> getMetaDataOfBinds()
+  {
     return metaDataOfBinds;
   }
 
-  public String getFirstChunkStringData() {
+  public String getFirstChunkStringData()
+  {
     return firstChunkStringData;
   }
 
-  public boolean getTreatNTZAsUTC() {
+  public boolean getTreatNTZAsUTC()
+  {
     return treatNTZAsUTC;
   }
 
-  public Optional<SFSession> getSession() {
+  public Optional<SFSession> getSession()
+  {
     return possibleSession;
   }
 
   /**
-   * A factory function to create SnowflakeResultSetSerializable object from result JSON node.
+   * A factory function to create SnowflakeResultSetSerializable object
+   * from result JSON node.
    *
-   * @param rootNode result JSON node received from GS
-   * @param sfSession the Snowflake session
+   * @param rootNode    result JSON node received from GS
+   * @param sfSession   the Snowflake session
    * @param sfStatement the Snowflake statement
    * @return processed ResultSetSerializable object
    * @throws SnowflakeSQLException if failed to parse the result JSON node
    */
-  public static SnowflakeResultSetSerializableV1 create(
-      JsonNode rootNode, SFSession sfSession, SFStatement sfStatement)
-      throws SnowflakeSQLException {
-    SnowflakeResultSetSerializableV1 resultSetSerializable = new SnowflakeResultSetSerializableV1();
+  static public SnowflakeResultSetSerializableV1 create(
+      JsonNode rootNode,
+      SFSession sfSession,
+      SFStatement sfStatement)
+  throws SnowflakeSQLException
+  {
+    SnowflakeResultSetSerializableV1 resultSetSerializable =
+        new SnowflakeResultSetSerializableV1();
     logger.debug("Entering create()");
 
     SnowflakeUtil.checkErrorAndThrowException(rootNode);
 
     // get the query id
-    resultSetSerializable.queryId = rootNode.path("data").path("queryId").asText();
+    resultSetSerializable.queryId =
+        rootNode.path("data").path("queryId").asText();
 
     JsonNode databaseNode = rootNode.path("data").path("finalDatabaseName");
-    resultSetSerializable.finalDatabaseName = databaseNode.isNull() ? null : databaseNode.asText();
+    resultSetSerializable.finalDatabaseName =
+        databaseNode.isNull() ? null : databaseNode.asText();
 
     JsonNode schemaNode = rootNode.path("data").path("finalSchemaName");
-    resultSetSerializable.finalSchemaName = schemaNode.isNull() ? null : schemaNode.asText();
+    resultSetSerializable.finalSchemaName =
+        schemaNode.isNull() ? null : schemaNode.asText();
 
     JsonNode roleNode = rootNode.path("data").path("finalRoleName");
-    resultSetSerializable.finalRoleName = roleNode.isNull() ? null : roleNode.asText();
+    resultSetSerializable.finalRoleName =
+        roleNode.isNull() ? null : roleNode.asText();
 
     JsonNode warehouseNode = rootNode.path("data").path("finalWarehouseName");
     resultSetSerializable.finalWarehouseName =
         warehouseNode.isNull() ? null : warehouseNode.asText();
 
-    resultSetSerializable.statementType =
-        SFStatementType.lookUpTypeById(rootNode.path("data").path("statementTypeId").asLong());
+    resultSetSerializable.statementType = SFStatementType.lookUpTypeById(
+        rootNode.path("data").path("statementTypeId").asLong());
 
-    resultSetSerializable.totalRowCountTruncated =
-        rootNode.path("data").path("totalTruncated").asBoolean();
+    resultSetSerializable.totalRowCountTruncated
+        = rootNode.path("data").path("totalTruncated").asBoolean();
 
     resultSetSerializable.possibleSession = Optional.ofNullable(sfSession);
 
     logger.debug("query id: {}", resultSetSerializable.queryId);
 
-    Optional<QueryResultFormat> queryResultFormat =
-        QueryResultFormat.lookupByName(rootNode.path("data").path("queryResultFormat").asText());
-    resultSetSerializable.queryResultFormat = queryResultFormat.orElse(QueryResultFormat.JSON);
+    Optional<QueryResultFormat> queryResultFormat = QueryResultFormat
+        .lookupByName(rootNode.path("data").path("queryResultFormat").asText());
+    resultSetSerializable.queryResultFormat =
+        queryResultFormat.orElse(QueryResultFormat.JSON);
 
     // extract parameters
     resultSetSerializable.parameters =
         SessionUtil.getCommonParams(rootNode.path("data").path("parameters"));
 
     // initialize column metadata
-    resultSetSerializable.columnCount = rootNode.path("data").path("rowtype").size();
+    resultSetSerializable.columnCount =
+        rootNode.path("data").path("rowtype").size();
 
-    for (int i = 0; i < resultSetSerializable.columnCount; i++) {
+    for (int i = 0; i < resultSetSerializable.columnCount; i++)
+    {
       JsonNode colNode = rootNode.path("data").path("rowtype").path(i);
 
-      SnowflakeColumnMetadata columnMetadata =
-          SnowflakeUtil.extractColumnMetadata(
-              colNode, sfSession.isJdbcTreatDecimalAsInt(), sfSession);
+      SnowflakeColumnMetadata columnMetadata
+          = SnowflakeUtil.extractColumnMetadata(
+          colNode, sfSession.isJdbcTreatDecimalAsInt(), sfSession);
 
       resultSetSerializable.resultColumnMetadata.add(columnMetadata);
 
-      logger.debug("Get column metadata: {}", (ArgSupplier) () -> columnMetadata.toString());
+      logger.debug("Get column metadata: {}",
+                   (ArgSupplier) () -> columnMetadata.toString());
     }
 
     // process the content of first chunk.
-    if (resultSetSerializable.queryResultFormat == QueryResultFormat.ARROW) {
+    if (resultSetSerializable.queryResultFormat == QueryResultFormat.ARROW)
+    {
       resultSetSerializable.firstChunkStringData =
           rootNode.path("data").path("rowsetBase64").asText();
-      resultSetSerializable.rootAllocator = new RootAllocator(Long.MAX_VALUE);
+      resultSetSerializable.rootAllocator =
+          new RootAllocator(Long.MAX_VALUE);
       // Set first chunk row count from firstChunkStringData
       resultSetSerializable.setFirstChunkRowCountForArrow();
-    } else {
-      resultSetSerializable.firstChunkRowset = rootNode.path("data").path("rowset");
+    }
+    else
+    {
+      resultSetSerializable.firstChunkRowset =
+          rootNode.path("data").path("rowset");
 
-      if (resultSetSerializable.firstChunkRowset == null
-          || resultSetSerializable.firstChunkRowset.isMissingNode()) {
+      if (resultSetSerializable.firstChunkRowset == null ||
+          resultSetSerializable.firstChunkRowset.isMissingNode())
+      {
         resultSetSerializable.firstChunkRowCount = 0;
         resultSetSerializable.firstChunkStringData = null;
-      } else {
-        resultSetSerializable.firstChunkRowCount = resultSetSerializable.firstChunkRowset.size();
+      }
+      else
+      {
+        resultSetSerializable.firstChunkRowCount =
+            resultSetSerializable.firstChunkRowset.size();
         resultSetSerializable.firstChunkStringData =
             resultSetSerializable.firstChunkRowset.toString();
       }
     }
-    logger.debug("First chunk row count: {}", resultSetSerializable.firstChunkRowCount);
+    logger.debug("First chunk row count: {}",
+                 resultSetSerializable.firstChunkRowCount);
 
     // parse file chunks
     resultSetSerializable.parseChunkFiles(rootNode, sfStatement);
@@ -535,24 +629,28 @@ public class SnowflakeResultSetSerializableV1
     // result version
     JsonNode versionNode = rootNode.path("data").path("version");
 
-    if (!versionNode.isMissingNode()) {
+    if (!versionNode.isMissingNode())
+    {
       resultSetSerializable.resultVersion = versionNode.longValue();
     }
 
     // number of binds
     JsonNode numberOfBindsNode = rootNode.path("data").path("numberOfBinds");
 
-    if (!numberOfBindsNode.isMissingNode()) {
+    if (!numberOfBindsNode.isMissingNode())
+    {
       resultSetSerializable.numberOfBinds = numberOfBindsNode.intValue();
     }
 
-    JsonNode arrayBindSupported = rootNode.path("data").path("arrayBindSupported");
+    JsonNode arrayBindSupported = rootNode.path("data")
+        .path("arrayBindSupported");
     resultSetSerializable.arrayBindSupported =
         !arrayBindSupported.isMissingNode() && arrayBindSupported.asBoolean();
 
     // time result sent by GS (epoch time in millis)
     JsonNode sendResultTimeNode = rootNode.path("data").path("sendResultTime");
-    if (!sendResultTimeNode.isMissingNode()) {
+    if (!sendResultTimeNode.isMissingNode())
+    {
       resultSetSerializable.sendResultTime = sendResultTimeNode.longValue();
     }
 
@@ -560,9 +658,11 @@ public class SnowflakeResultSetSerializableV1
 
     // Bind parameter metadata
     JsonNode bindData = rootNode.path("data").path("metaDataOfBinds");
-    if (!bindData.isMissingNode()) {
+    if (!bindData.isMissingNode())
+    {
       List<MetaDataOfBinds> returnVal = new ArrayList<>();
-      for (JsonNode child : bindData) {
+      for (JsonNode child : bindData)
+      {
         int precision = child.path("precision").asInt();
         boolean nullable = child.path("nullable").asBoolean();
         int scale = child.path("scale").asInt();
@@ -571,7 +671,8 @@ public class SnowflakeResultSetSerializableV1
         String name = child.path("name").asText();
         String type = child.path("type").asText();
         MetaDataOfBinds param =
-            new MetaDataOfBinds(precision, nullable, scale, byteLength, length, name, type);
+            new MetaDataOfBinds(precision, nullable, scale, byteLength, length,
+                                name, type);
         returnVal.add(param);
       }
       resultSetSerializable.metaDataOfBinds = returnVal;
@@ -579,10 +680,14 @@ public class SnowflakeResultSetSerializableV1
 
     // setup fields from sessions.
     resultSetSerializable.ocspMode = sfSession.getOCSPMode();
-    resultSetSerializable.snowflakeConnectionString = sfSession.getSnowflakeConnectionString();
-    resultSetSerializable.networkTimeoutInMilli = sfSession.getNetworkTimeoutInMilli();
-    resultSetSerializable.isResultColumnCaseInsensitive = sfSession.isResultColumnCaseInsensitive();
-    resultSetSerializable.treatNTZAsUTC = sfSession.getTreatNTZAsUTC();
+    resultSetSerializable.snowflakeConnectionString =
+        sfSession.getSnowflakeConnectionString();
+    resultSetSerializable.networkTimeoutInMilli =
+        sfSession.getNetworkTimeoutInMilli();
+    resultSetSerializable.isResultColumnCaseInsensitive =
+        sfSession.isResultColumnCaseInsensitive();
+    resultSetSerializable.treatNTZAsUTC =
+        sfSession.getTreatNTZAsUTC();
 
     // setup transient fields from parameter
     resultSetSerializable.setupFieldsFromParameters();
@@ -591,121 +696,142 @@ public class SnowflakeResultSetSerializableV1
     // first few chunk files in background thread(s)
     resultSetSerializable.chunkDownloader =
         (resultSetSerializable.chunkFileCount > 0)
-            ? new SnowflakeChunkDownloader(resultSetSerializable)
-            : new SnowflakeChunkDownloader.NoOpChunkDownloader();
+        ? new SnowflakeChunkDownloader(resultSetSerializable)
+        : new SnowflakeChunkDownloader.NoOpChunkDownloader();
 
     // Setup ResultSet metadata
     resultSetSerializable.resultSetMetaData =
-        new SFResultSetMetaData(
-            resultSetSerializable.getResultColumnMetadata(),
-            resultSetSerializable.queryId,
-            sfSession,
-            resultSetSerializable.isResultColumnCaseInsensitive,
-            resultSetSerializable.timestampNTZFormatter,
-            resultSetSerializable.timestampLTZFormatter,
-            resultSetSerializable.timestampTZFormatter,
-            resultSetSerializable.dateFormatter,
-            resultSetSerializable.timeFormatter);
+        new SFResultSetMetaData(resultSetSerializable.getResultColumnMetadata(),
+                                resultSetSerializable.queryId,
+                                sfSession,
+                                resultSetSerializable.isResultColumnCaseInsensitive,
+                                resultSetSerializable.timestampNTZFormatter,
+                                resultSetSerializable.timestampLTZFormatter,
+                                resultSetSerializable.timestampTZFormatter,
+                                resultSetSerializable.dateFormatter,
+                                resultSetSerializable.timeFormatter);
 
     return resultSetSerializable;
   }
 
   /**
-   * Some fields are generated from this.parameters, so generate them from this.parameters instead
-   * of serializing them.
+   * Some fields are generated from this.parameters, so generate them from
+   * this.parameters instead of serializing them.
    */
-  private void setupFieldsFromParameters() {
-    String sqlTimestampFormat =
-        (String) ResultUtil.effectiveParamValue(this.parameters, "TIMESTAMP_OUTPUT_FORMAT");
+  private void setupFieldsFromParameters()
+  {
+    String sqlTimestampFormat = (String) ResultUtil.effectiveParamValue(
+        this.parameters, "TIMESTAMP_OUTPUT_FORMAT");
 
     // Special handling of specialized formatters, use a helper function
-    this.timestampNTZFormatter =
-        ResultUtil.specializedFormatter(
-            this.parameters, "timestamp_ntz", "TIMESTAMP_NTZ_OUTPUT_FORMAT", sqlTimestampFormat);
+    this.timestampNTZFormatter = ResultUtil.specializedFormatter(
+        this.parameters,
+        "timestamp_ntz",
+        "TIMESTAMP_NTZ_OUTPUT_FORMAT",
+        sqlTimestampFormat);
 
-    this.timestampLTZFormatter =
-        ResultUtil.specializedFormatter(
-            this.parameters, "timestamp_ltz", "TIMESTAMP_LTZ_OUTPUT_FORMAT", sqlTimestampFormat);
+    this.timestampLTZFormatter = ResultUtil.specializedFormatter(
+        this.parameters,
+        "timestamp_ltz",
+        "TIMESTAMP_LTZ_OUTPUT_FORMAT",
+        sqlTimestampFormat);
 
-    this.timestampTZFormatter =
-        ResultUtil.specializedFormatter(
-            this.parameters, "timestamp_tz", "TIMESTAMP_TZ_OUTPUT_FORMAT", sqlTimestampFormat);
+    this.timestampTZFormatter = ResultUtil.specializedFormatter(
+        this.parameters,
+        "timestamp_tz",
+        "TIMESTAMP_TZ_OUTPUT_FORMAT",
+        sqlTimestampFormat);
 
-    String sqlDateFormat =
-        (String) ResultUtil.effectiveParamValue(this.parameters, "DATE_OUTPUT_FORMAT");
+    String sqlDateFormat = (String) ResultUtil.effectiveParamValue(
+        this.parameters,
+        "DATE_OUTPUT_FORMAT");
 
     this.dateFormatter = SnowflakeDateTimeFormat.fromSqlFormat(sqlDateFormat);
 
-    logger.debug(
-        "sql date format: {}, java date format: {}",
-        sqlDateFormat,
-        (ArgSupplier) () -> this.dateFormatter.toSimpleDateTimePattern());
+    logger.debug("sql date format: {}, java date format: {}",
+                 sqlDateFormat,
+                 (ArgSupplier) () ->
+                     this.dateFormatter.toSimpleDateTimePattern());
 
-    String sqlTimeFormat =
-        (String) ResultUtil.effectiveParamValue(this.parameters, "TIME_OUTPUT_FORMAT");
+    String sqlTimeFormat = (String) ResultUtil.effectiveParamValue(
+        this.parameters,
+        "TIME_OUTPUT_FORMAT");
 
     this.timeFormatter = SnowflakeDateTimeFormat.fromSqlFormat(sqlTimeFormat);
 
-    logger.debug(
-        "sql time format: {}, java time format: {}",
-        sqlTimeFormat,
-        (ArgSupplier) () -> this.timeFormatter.toSimpleDateTimePattern());
+    logger.debug("sql time format: {}, java time format: {}",
+                 sqlTimeFormat,
+                 (ArgSupplier) () ->
+                     this.timeFormatter.toSimpleDateTimePattern());
 
-    String timeZoneName = (String) ResultUtil.effectiveParamValue(this.parameters, "TIMEZONE");
+    String timeZoneName = (String) ResultUtil.effectiveParamValue(
+        this.parameters, "TIMEZONE");
     this.timeZone = TimeZone.getTimeZone(timeZoneName);
 
     this.honorClientTZForTimestampNTZ =
-        (boolean)
-            ResultUtil.effectiveParamValue(
-                this.parameters, "CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ");
+        (boolean) ResultUtil.effectiveParamValue(
+            this.parameters,
+            "CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ");
 
-    logger.debug("Honoring client TZ for timestamp_ntz? {}", this.honorClientTZForTimestampNTZ);
+    logger.debug("Honoring client TZ for timestamp_ntz? {}",
+                 this.honorClientTZForTimestampNTZ);
 
-    String binaryFmt =
-        (String) ResultUtil.effectiveParamValue(this.parameters, "BINARY_OUTPUT_FORMAT");
-    this.binaryFormatter = SFBinaryFormat.getSafeOutputFormat(binaryFmt);
+    String binaryFmt = (String) ResultUtil.effectiveParamValue(
+        this.parameters, "BINARY_OUTPUT_FORMAT");
+    this.binaryFormatter =
+        SFBinaryFormat.getSafeOutputFormat(binaryFmt);
   }
 
   /**
    * Parse the chunk file nodes from result JSON node
    *
-   * @param rootNode result JSON node received from GS
+   * @param rootNode    result JSON node received from GS
    * @param sfStatement the snowflake statement
    */
-  private void parseChunkFiles(JsonNode rootNode, SFStatement sfStatement) {
+  private void parseChunkFiles(JsonNode rootNode,
+                               SFStatement sfStatement)
+  {
     JsonNode chunksNode = rootNode.path("data").path("chunks");
 
-    if (!chunksNode.isMissingNode()) {
+    if (!chunksNode.isMissingNode())
+    {
       this.chunkFileCount = chunksNode.size();
 
       // Try to get the Query Result Master Key
       JsonNode qrmkNode = rootNode.path("data").path("qrmk");
-      this.qrmk = qrmkNode.isMissingNode() ? null : qrmkNode.textValue();
+      this.qrmk = qrmkNode.isMissingNode() ?
+                  null : qrmkNode.textValue();
 
       // Determine the prefetch thread count and memoryLimit
-      if (this.chunkFileCount > 0) {
-        logger.debug("#chunks={}, initialize chunk downloader", this.chunkFileCount);
+      if (this.chunkFileCount > 0)
+      {
+        logger.debug("#chunks={}, initialize chunk downloader",
+                     this.chunkFileCount);
 
         adjustMemorySettings(sfStatement);
 
         // Parse chunk header
         JsonNode chunkHeaders = rootNode.path("data").path("chunkHeaders");
-        if (chunkHeaders != null && !chunkHeaders.isMissingNode()) {
-          Iterator<Map.Entry<String, JsonNode>> chunkHeadersIter = chunkHeaders.fields();
+        if (chunkHeaders != null && !chunkHeaders.isMissingNode())
+        {
+          Iterator<Map.Entry<String, JsonNode>> chunkHeadersIter =
+              chunkHeaders.fields();
 
-          while (chunkHeadersIter.hasNext()) {
+          while (chunkHeadersIter.hasNext())
+          {
             Map.Entry<String, JsonNode> chunkHeader = chunkHeadersIter.next();
 
-            logger.debug(
-                "add header key={}, value={}",
-                chunkHeader.getKey(),
-                chunkHeader.getValue().asText());
-            this.chunkHeadersMap.put(chunkHeader.getKey(), chunkHeader.getValue().asText());
+            logger.debug("add header key={}, value={}",
+                         chunkHeader.getKey(),
+                         chunkHeader.getValue().asText());
+            this.chunkHeadersMap.put(chunkHeader.getKey(),
+                                     chunkHeader.getValue().asText());
           }
         }
 
         // parse chunk files metadata e.g. url and row count
-        for (int idx = 0; idx < this.chunkFileCount; idx++) {
+        for (int idx = 0; idx < this.chunkFileCount; idx++)
+        {
           JsonNode chunkNode = chunksNode.get(idx);
           String url = chunkNode.path("url").asText();
           int rowCount = chunkNode.path("rowCount").asInt();
@@ -713,38 +839,46 @@ public class SnowflakeResultSetSerializableV1
           int uncompressedSize = chunkNode.path("uncompressedSize").asInt();
 
           this.chunkFileMetadatas.add(
-              new ChunkFileMetadata(url, rowCount, compressedSize, uncompressedSize));
+              new ChunkFileMetadata(url, rowCount, compressedSize,
+                                    uncompressedSize));
 
-          logger.debug(
-              "add chunk, url={} rowCount={} " + "compressedSize={} uncompressedSize={}",
-              url,
-              rowCount,
-              compressedSize,
-              uncompressedSize);
+          logger.debug("add chunk, url={} rowCount={} " +
+                       "compressedSize={} uncompressedSize={}",
+                       url, rowCount, compressedSize, uncompressedSize);
         }
       }
     }
   }
 
-  private void adjustMemorySettings(SFStatement sfStatement) {
+  private void adjustMemorySettings(
+      SFStatement sfStatement)
+  {
     this.resultPrefetchThreads = DEFAULT_CLIENT_PREFETCH_THREADS;
     if (this.statementType.isSelect()
-        && this.parameters.containsKey(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE)
-        && (boolean) this.parameters.get(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE)) {
+        && this.parameters
+            .containsKey(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE)
+        && (boolean) this.parameters
+        .get(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE))
+    {
       // use conservative memory settings
-      this.resultPrefetchThreads = sfStatement.getConservativePrefetchThreads();
+      this.resultPrefetchThreads =
+          sfStatement.getConservativePrefetchThreads();
       this.memoryLimit = sfStatement.getConservativeMemoryLimit();
-      int chunkSize = (int) this.parameters.get(CLIENT_RESULT_CHUNK_SIZE);
+      int chunkSize =
+          (int) this.parameters.get(CLIENT_RESULT_CHUNK_SIZE);
       logger.debug(
-          "enable conservative memory usage with prefetchThreads = {} and memoryLimit = {} and "
-              + "resultChunkSize = {}",
-          this.resultPrefetchThreads,
-          this.memoryLimit,
+          "enable conservative memory usage with prefetchThreads = {} and memoryLimit = {} and " +
+          "resultChunkSize = {}",
+          this.resultPrefetchThreads, this.memoryLimit,
           chunkSize);
-    } else {
+    }
+    else
+    {
       // prefetch threads
-      if (this.parameters.get(CLIENT_PREFETCH_THREADS) != null) {
-        this.resultPrefetchThreads = (int) this.parameters.get(CLIENT_PREFETCH_THREADS);
+      if (this.parameters.get(CLIENT_PREFETCH_THREADS) != null)
+      {
+        this.resultPrefetchThreads =
+            (int) this.parameters.get(CLIENT_PREFETCH_THREADS);
       }
       this.memoryLimit = initMemoryLimit(this.parameters);
     }
@@ -752,15 +886,13 @@ public class SnowflakeResultSetSerializableV1
     long maxChunkSize = (int) this.parameters.get(CLIENT_RESULT_CHUNK_SIZE) * MB;
     if (queryResultFormat == QueryResultFormat.ARROW
         && Runtime.getRuntime().maxMemory() < LOW_MAX_MEMORY
-        && memoryLimit * 2 + maxChunkSize > Runtime.getRuntime().maxMemory()) {
+        && memoryLimit * 2 + maxChunkSize > Runtime.getRuntime().maxMemory())
+    {
       memoryLimit = Runtime.getRuntime().maxMemory() / 2 - maxChunkSize;
-      logger.debug(
-          "To avoid OOM for arrow buffer allocation, "
-              + "memoryLimit {} should be less than half of the "
-              + "maxMemory {} + maxChunkSize {}",
-          memoryLimit,
-          Runtime.getRuntime().maxMemory(),
-          maxChunkSize);
+      logger.debug("To avoid OOM for arrow buffer allocation, " +
+                   "memoryLimit {} should be less than half of the " +
+                   "maxMemory {} + maxChunkSize {}",
+                   memoryLimit, Runtime.getRuntime().maxMemory(), maxChunkSize);
     }
   }
 
@@ -770,16 +902,21 @@ public class SnowflakeResultSetSerializableV1
    * @param parameters The parameters for result JSON node
    * @return memory limit in bytes
    */
-  private static long initMemoryLimit(Map<String, Object> parameters) {
+  private static long initMemoryLimit(Map<String, Object> parameters)
+  {
     // default setting
     long memoryLimit = DEFAULT_CLIENT_MEMORY_LIMIT * 1024 * 1024;
-    if (parameters.get(CLIENT_MEMORY_LIMIT) != null) {
+    if (parameters.get(CLIENT_MEMORY_LIMIT) != null)
+    {
       // use the settings from the customer
-      memoryLimit = (int) parameters.get(CLIENT_MEMORY_LIMIT) * 1024L * 1024L;
+      memoryLimit =
+          (int) parameters.get(CLIENT_MEMORY_LIMIT) * 1024L * 1024L;
     }
 
     long maxMemoryToUse = Runtime.getRuntime().maxMemory() * 8 / 10;
-    if ((int) parameters.get(CLIENT_MEMORY_LIMIT) == DEFAULT_CLIENT_MEMORY_LIMIT) {
+    if ((int) parameters.get(CLIENT_MEMORY_LIMIT)
+        == DEFAULT_CLIENT_MEMORY_LIMIT)
+    {
       // if the memory limit is the default value and best effort memory is enabled
       // set the memory limit to 80% of the maximum as the best effort
       memoryLimit = Math.max(memoryLimit, maxMemoryToUse);
@@ -797,7 +934,9 @@ public class SnowflakeResultSetSerializableV1
    *
    * @throws SQLException if fails to setup any transient fields
    */
-  private void setupTransientFields() throws SQLException {
+  private void setupTransientFields()
+  throws SQLException
+  {
     // Setup transient fields from serialized fields
     setupFieldsFromParameters();
 
@@ -805,55 +944,66 @@ public class SnowflakeResultSetSerializableV1
     this.memoryLimit = initMemoryLimit(this.parameters);
 
     // Create below transient fields on the fly.
-    if (QueryResultFormat.ARROW.equals(this.queryResultFormat)) {
+    if (QueryResultFormat.ARROW.equals(this.queryResultFormat))
+    {
       this.rootAllocator = new RootAllocator(Long.MAX_VALUE);
       this.firstChunkRowset = null;
-    } else {
+    }
+    else
+    {
       this.rootAllocator = null;
-      try {
-        this.firstChunkRowset =
-            (this.firstChunkStringData != null) ? mapper.readTree(this.firstChunkStringData) : null;
-      } catch (IOException ex) {
-        throw new SQLException("The JSON data is invalid. The error is: " + ex.getMessage());
+      try
+      {
+        this.firstChunkRowset = (this.firstChunkStringData != null)
+                                ? mapper.readTree(this.firstChunkStringData)
+                                : null;
+      }
+      catch (IOException ex)
+      {
+        throw new SnowflakeSQLLoggedException("The JSON data is invalid. The error is: " +
+                                              ex.getMessage(), possibleSession.orElse(/* session = */ null));
       }
     }
 
     // Setup ResultSet metadata
     this.resultSetMetaData =
-        new SFResultSetMetaData(
-            this.getResultColumnMetadata(),
-            this.queryId,
-            null, // This is session less
-            this.isResultColumnCaseInsensitive,
-            this.timestampNTZFormatter,
-            this.timestampLTZFormatter,
-            this.timestampTZFormatter,
-            this.dateFormatter,
-            this.timeFormatter);
+        new SFResultSetMetaData(this.getResultColumnMetadata(),
+                                this.queryId,
+                                null, // This is session less
+                                this.isResultColumnCaseInsensitive,
+                                this.timestampNTZFormatter,
+                                this.timestampLTZFormatter,
+                                this.timestampTZFormatter,
+                                this.dateFormatter,
+                                this.timeFormatter);
 
     // Allocate chunk downloader if necessary
-    chunkDownloader =
-        (this.chunkFileCount > 0)
-            ? new SnowflakeChunkDownloader(this)
-            : new SnowflakeChunkDownloader.NoOpChunkDownloader();
+    chunkDownloader = (this.chunkFileCount > 0)
+                      ? new SnowflakeChunkDownloader(this)
+                      : new SnowflakeChunkDownloader.NoOpChunkDownloader();
   }
 
   /**
    * Split this object into small pieces based on the user specified data size.
    *
-   * @param maxSizeInBytes the expected max data size wrapped in the result ResultSetSerializables
-   *     object. NOTE: if a result chunk size is greater than this value, the ResultSetSerializable
-   *     object will include one result chunk.
+   * @param maxSizeInBytes the expected max data size wrapped in the result
+   *                       ResultSetSerializables object.
+   *                       NOTE: if a result chunk size is greater than this
+   *                       value, the ResultSetSerializable object will
+   *                       include one result chunk.
    * @return a list of SnowflakeResultSetSerializable
    * @throws SQLException if fails to split objects.
    */
-  public List<SnowflakeResultSetSerializable> splitBySize(long maxSizeInBytes) throws SQLException {
-    List<SnowflakeResultSetSerializable> resultSetSerializables = new ArrayList<>();
+  public List<SnowflakeResultSetSerializable> splitBySize(long maxSizeInBytes)
+  throws SQLException
+  {
+    List<SnowflakeResultSetSerializable> resultSetSerializables =
+        new ArrayList<>();
 
-    if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null) {
-      throw new SnowflakeSQLLoggedException(
-          "The Result Set serializable is invalid.",
-          this.possibleSession.orElse(/* session = */ null));
+    if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null)
+    {
+      throw new SnowflakeSQLLoggedException("The Result Set serializable is invalid.",
+                                            this.possibleSession.orElse(/* session = */null));
     }
 
     // In the beginning, only the first data chunk is included in the result
@@ -865,19 +1015,23 @@ public class SnowflakeResultSetSerializableV1
     curResultSetSerializable.chunkFileMetadatas = new ArrayList<>();
     curResultSetSerializable.chunkFileCount = 0;
 
-    for (int idx = 0; idx < this.chunkFileCount; idx++) {
-      ChunkFileMetadata curChunkFileMetadata = this.getChunkFileMetadatas().get(idx);
+    for (int idx = 0; idx < this.chunkFileCount; idx++)
+    {
+      ChunkFileMetadata curChunkFileMetadata =
+          this.getChunkFileMetadatas().get(idx);
 
       // If the serializable object has reach the max size,
       // save current one and create new one.
-      if ((curResultSetSerializable.getUncompressedDataSizeInBytes() > 0)
-          && (maxSizeInBytes
-              < (curResultSetSerializable.getUncompressedDataSizeInBytes()
-                  + curChunkFileMetadata.getUncompressedByteSize()))) {
+      if ((curResultSetSerializable.getUncompressedDataSizeInBytes() > 0) &&
+          (maxSizeInBytes <
+           (curResultSetSerializable.getUncompressedDataSizeInBytes()
+            + curChunkFileMetadata.getUncompressedByteSize())))
+      {
         resultSetSerializables.add(curResultSetSerializable);
 
         // Create new result serializable and reset it as empty
-        curResultSetSerializable = new SnowflakeResultSetSerializableV1(this);
+        curResultSetSerializable =
+            new SnowflakeResultSetSerializableV1(this);
         curResultSetSerializable.chunkFileMetadatas = new ArrayList<>();
         curResultSetSerializable.chunkFileCount = 0;
         curResultSetSerializable.firstChunkStringData = null;
@@ -897,22 +1051,25 @@ public class SnowflakeResultSetSerializableV1
   }
 
   /**
-   * Get ResultSet from the ResultSet Serializable object so that the user can access the data. The
-   * ResultSet is sessionless.
+   * Get ResultSet from the ResultSet Serializable object so that the user can
+   * access the data. The ResultSet is sessionless.
    *
    * @return a ResultSet which represents for the data wrapped in the object
    */
-  public ResultSet getResultSet() throws SQLException {
+  public ResultSet getResultSet() throws SQLException
+  {
     return getResultSet(null);
   }
 
   /**
-   * Get ResultSet from the ResultSet Serializable object so that the user can access the data.
+   * Get ResultSet from the ResultSet Serializable object so that the user can
+   * access the data.
    *
    * @param info The proxy sever information if proxy is necessary.
    * @return a ResultSet which represents for the data wrapped in the object
    */
-  public ResultSet getResultSet(Properties info) throws SQLException {
+  public ResultSet getResultSet(Properties info) throws SQLException
+  {
     // Setup proxy info if necessary
     SnowflakeUtil.setupProxyPropertiesIfNecessary(info);
 
@@ -925,85 +1082,103 @@ public class SnowflakeResultSetSerializableV1
     boolean sortResult = false;
     // Setup base result set.
     SFBaseResultSet sfBaseResultSet = null;
-    switch (getQueryResultFormat()) {
+    switch (getQueryResultFormat())
+    {
       case ARROW:
-        {
-          sfBaseResultSet = new SFArrowResultSet(this, telemetryClient, sortResult);
-          break;
-        }
+      {
+        sfBaseResultSet = new SFArrowResultSet(this, telemetryClient,
+                                               sortResult);
+        break;
+      }
       case JSON:
-        {
-          sfBaseResultSet = new SFResultSet(this, telemetryClient, sortResult);
-          break;
-        }
+      {
+        sfBaseResultSet = new SFResultSet(this, telemetryClient,
+                                          sortResult);
+        break;
+      }
       default:
-        throw new SnowflakeSQLLoggedException(
-            ErrorCode.INTERNAL_ERROR,
-            this.possibleSession.orElse(/*session = */ null),
-            "Unsupported query result format: " + getQueryResultFormat().name());
+        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR,
+                                              this.possibleSession.orElse(/*session = */null),
+                                              "Unsupported query result format: " +
+                                              getQueryResultFormat().name());
     }
 
     // Create result set
-    SnowflakeResultSetV1 resultSetV1 = new SnowflakeResultSetV1(sfBaseResultSet, this);
+    SnowflakeResultSetV1 resultSetV1 =
+        new SnowflakeResultSetV1(sfBaseResultSet, this);
 
     return resultSetV1;
   }
 
   // Set the row count for first result chunk by parsing the chunk data.
-  private void setFirstChunkRowCountForArrow() throws SnowflakeSQLException {
+  private void setFirstChunkRowCountForArrow() throws SnowflakeSQLException
+  {
     firstChunkRowCount = 0;
 
     // If the first chunk doesn't exist or empty, set it as 0
-    if (firstChunkStringData == null || firstChunkStringData.isEmpty()) {
+    if (firstChunkStringData == null || firstChunkStringData.isEmpty())
+    {
       firstChunkRowCount = 0;
     }
     // Parse the Arrow result chunk
-    else if (getQueryResultFormat().equals(QueryResultFormat.ARROW)) {
+    else if (getQueryResultFormat().equals(QueryResultFormat.ARROW))
+    {
       // Below code is developed based on SFArrowResultSet.buildFirstChunk
       // and ArrowResultChunk.readArrowStream()
       byte[] bytes = Base64.getDecoder().decode(firstChunkStringData);
       VectorSchemaRoot root = null;
       RootAllocator localRootAllocator =
-          (rootAllocator != null) ? rootAllocator : new RootAllocator(Long.MAX_VALUE);
+          (rootAllocator != null) ? rootAllocator
+                                  : new RootAllocator(Long.MAX_VALUE);
       try (ByteArrayInputStream is = new ByteArrayInputStream(bytes);
-          ArrowStreamReader reader = new ArrowStreamReader(is, localRootAllocator)) {
+           ArrowStreamReader reader = new ArrowStreamReader(is, localRootAllocator))
+      {
         root = reader.getVectorSchemaRoot();
-        while (reader.loadNextBatch()) {
+        while (reader.loadNextBatch())
+        {
           firstChunkRowCount += root.getRowCount();
           root.clear();
         }
-      } catch (Exception ex) {
-        throw new SnowflakeSQLException(
-            ErrorCode.INTERNAL_ERROR,
-            "Fail to retrieve row count for first arrow chunk: " + ex.getCause());
-      } finally {
-        if (root != null) {
+      }
+      catch (Exception ex)
+      {
+        throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR, possibleSession.orElse(/* session = */ null),
+                                              "Fail to retrieve row count for first arrow chunk: " +
+                                              ex.getCause());
+      }
+      finally
+      {
+        if (root != null)
+        {
           root.clear();
         }
       }
-    } else {
+    }
+    else
+    {
       // This shouldn't happen
-      throw new SnowflakeSQLLoggedException(
-          ErrorCode.INTERNAL_ERROR,
-          this.possibleSession.orElse(/*session = */ null),
-          "setFirstChunkRowCountForArrow() should only be called for Arrow.");
+      throw new SnowflakeSQLLoggedException(ErrorCode.INTERNAL_ERROR,
+                                            this.possibleSession.orElse( /*session = */ null),
+                                            "setFirstChunkRowCountForArrow() should only be called for Arrow.");
     }
   }
 
   /**
    * Retrieve total row count included in the the ResultSet Serializable object.
-   *
-   * <p>GS sends the data of first chunk and metadata of the other chunk if exist to client, so this
-   * function calculates the row count for all of them.
+   * <p>
+   * GS sends the data of first chunk and metadata of the other chunk if exist
+   * to client, so this function calculates the row count for all of them.
    *
    * @return the total row count from metadata
    */
-  public long getRowCount() throws SQLException {
+  public long getRowCount() throws SQLException
+  {
     // Get row count for first chunk if it exists.
     long totalRowCount = firstChunkRowCount;
 
     // Get row count from chunk file metadata
-    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas) {
+    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas)
+    {
       totalRowCount += chunkFileMetadata.rowCount;
     }
 
@@ -1012,23 +1187,26 @@ public class SnowflakeResultSetSerializableV1
 
   /**
    * Retrieve compressed data size in the the ResultSet Serializable object.
-   *
-   * <p>GS sends the data of first chunk and metadata of the other chunks if exist to client, so
-   * this function calculates the data size for all of them. NOTE: if first chunk exists, this
-   * function uses its uncompressed data size as its compressed data size in this calculation though
-   * it is not compressed.
+   * <p>
+   * GS sends the data of first chunk and metadata of the other chunks if exist
+   * to client, so this function calculates the data size for all of them.
+   * NOTE: if first chunk exists, this function uses its uncompressed data size
+   * as its compressed data size in this calculation though it is not compressed.
    *
    * @return the total compressed data size in bytes from metadata
    */
-  public long getCompressedDataSizeInBytes() throws SQLException {
+  public long getCompressedDataSizeInBytes() throws SQLException
+  {
     long totalCompressedDataSize = 0;
 
     // Count the data size for the first chunk if it exists.
-    if (firstChunkStringData != null) {
+    if (firstChunkStringData != null)
+    {
       totalCompressedDataSize += firstChunkStringData.length();
     }
 
-    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas) {
+    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas)
+    {
       totalCompressedDataSize += chunkFileMetadata.compressedByteSize;
     }
 
@@ -1037,39 +1215,52 @@ public class SnowflakeResultSetSerializableV1
 
   /**
    * Retrieve Uncompressed data size in the the ResultSet Serializable object.
-   *
-   * <p>GS sends the data of first chunk and metadata of the other chunk if exist to client, so this
-   * function calculates the data size for all of them.
+   * <p>
+   * GS sends the data of first chunk and metadata of the other chunk if exist
+   * to client, so this function calculates the data size for all of them.
    *
    * @return the total uncompressed data size in bytes from metadata
    */
-  public long getUncompressedDataSizeInBytes() throws SQLException {
+  public long getUncompressedDataSizeInBytes() throws SQLException
+  {
     long totalUncompressedDataSize = 0;
 
     // Count the data size for the first chunk if it exists.
-    if (firstChunkStringData != null) {
+    if (firstChunkStringData != null)
+    {
       totalUncompressedDataSize += firstChunkStringData.length();
     }
 
-    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas) {
+    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas)
+    {
       totalUncompressedDataSize += chunkFileMetadata.uncompressedByteSize;
     }
 
     return totalUncompressedDataSize;
   }
 
-  public String toString() {
+  public String toString()
+  {
     StringBuilder builder = new StringBuilder(16 * 1024);
 
-    builder.append("hasFirstChunk: ").append(this.firstChunkStringData != null).append("\n");
+    builder.append("hasFirstChunk: ")
+        .append(this.firstChunkStringData != null)
+        .append("\n");
 
-    builder.append("RowCountInFirstChunk: ").append(this.firstChunkRowCount).append("\n");
+    builder.append("RowCountInFirstChunk: ")
+        .append(this.firstChunkRowCount)
+        .append("\n");
 
-    builder.append("queryResultFormat: ").append(this.queryResultFormat).append("\n");
+    builder.append("queryResultFormat: ")
+        .append(this.queryResultFormat)
+        .append("\n");
 
-    builder.append("chunkFileCount: ").append(this.chunkFileCount).append("\n");
+    builder.append("chunkFileCount: ")
+        .append(this.chunkFileCount)
+        .append("\n");
 
-    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas) {
+    for (ChunkFileMetadata chunkFileMetadata : chunkFileMetadatas)
+    {
       builder.append("\t").append(chunkFileMetadata.toString()).append("\n");
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -4,10 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.QueryStatus;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -32,42 +28,37 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
 
-/**
- * Snowflake ResultSet implementation
- */
-class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet
-{
+/** Snowflake ResultSet implementation */
+class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet {
   private final SFBaseResultSet sfBaseResultSet;
 
   /**
-   * Constructor takes an inputstream from the API response that we get from
-   * executing a SQL statement.
-   * <p>
-   * The constructor will fetch the first row (if any) so that it can initialize
-   * the ResultSetMetaData.
-   * </p>
+   * Constructor takes an inputstream from the API response that we get from executing a SQL
+   * statement.
+   *
+   * <p>The constructor will fetch the first row (if any) so that it can initialize the
+   * ResultSetMetaData.
    *
    * @param sfBaseResultSet snowflake core base result rest object
-   * @param statement       query statement that generates this result set
+   * @param statement query statement that generates this result set
    * @throws SQLException if failed to construct snowflake result set metadata
    */
-  SnowflakeResultSetV1(
-      SFBaseResultSet sfBaseResultSet,
-      Statement statement)
-  throws SQLException
-  {
+  SnowflakeResultSetV1(SFBaseResultSet sfBaseResultSet, Statement statement) throws SQLException {
     super(statement);
     this.sfBaseResultSet = sfBaseResultSet;
-    try
-    {
-      this.resultSetMetaData =
-          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(),
-                                            ex.getSqlState(), ex.getVendorCode(), sfBaseResultSet.getSession(), ex.getParams());
+    try {
+      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(),
+          ex.getSqlState(),
+          ex.getVendorCode(),
+          sfBaseResultSet.getSession(),
+          ex.getParams());
     }
   }
 
@@ -77,39 +68,34 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
    * @return no return value; exception is always thrown
    * @throws SQLFeatureNotSupportedException
    */
-  public QueryStatus getStatus() throws SQLException
-  {
+  public QueryStatus getStatus() throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
   /**
-   * Constructor takes a result set serializable object to create
-   * a sessionless result set.
+   * Constructor takes a result set serializable object to create a sessionless result set.
    *
-   * @param sfBaseResultSet       snowflake core base result rest object
-   * @param resultSetSerializable The result set serializable object which
-   *                              includes all metadata to create the result
-   *                              set
+   * @param sfBaseResultSet snowflake core base result rest object
+   * @param resultSetSerializable The result set serializable object which includes all metadata to
+   *     create the result set
    * @throws SQLException if fails to create the result set object
    */
   public SnowflakeResultSetV1(
-      SFBaseResultSet sfBaseResultSet,
-      SnowflakeResultSetSerializableV1 resultSetSerializable)
-  throws SQLException
-  {
+      SFBaseResultSet sfBaseResultSet, SnowflakeResultSetSerializableV1 resultSetSerializable)
+      throws SQLException {
     super(resultSetSerializable);
 
     this.sfBaseResultSet = sfBaseResultSet;
 
-    try
-    {
-      this.resultSetMetaData =
-          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex.getCause(),
-                                            ex.getSqlState(), ex.getVendorCode(), sfBaseResultSet.getSession(), ex.getParams());
+    try {
+      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex.getCause(),
+          ex.getSqlState(),
+          ex.getVendorCode(),
+          sfBaseResultSet.getSession(),
+          ex.getParams());
     }
   }
 
@@ -120,314 +106,234 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
    * @throws SQLException if failed to move to the next row
    */
   @Override
-  public boolean next() throws SQLException
-  {
+  public boolean next() throws SQLException {
     // exception
-    try
-    {
+    try {
       return sfBaseResultSet.next();
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void close() throws SQLException
-  {
+  public void close() throws SQLException {
     close(true);
   }
 
-  public void close(boolean removeClosedResultSetFromStatement) throws SQLException
-  {
+  public void close(boolean removeClosedResultSetFromStatement) throws SQLException {
     // no SQLException is raised.
     sfBaseResultSet.close();
-    if (removeClosedResultSetFromStatement && statement.isWrapperFor(SnowflakeStatementV1.class))
-    {
+    if (removeClosedResultSetFromStatement && statement.isWrapperFor(SnowflakeStatementV1.class)) {
       statement.unwrap(SnowflakeStatementV1.class).removeClosedResultSet(this);
     }
   }
 
-  public String getQueryID()
-  {
+  public String getQueryID() {
     return sfBaseResultSet.getQueryId();
   }
 
-
-  public boolean wasNull() throws SQLException
-  {
+  public boolean wasNull() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.wasNull();
   }
 
-  public String getString(int columnIndex) throws SQLException
-  {
+  public String getString(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getString(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public boolean getBoolean(int columnIndex) throws SQLException
-  {
+  public boolean getBoolean(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getBoolean(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public byte getByte(int columnIndex) throws SQLException
-  {
+  public byte getByte(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getByte(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public short getShort(int columnIndex) throws SQLException
-  {
+  public short getShort(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getShort(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public int getInt(int columnIndex) throws SQLException
-  {
+  public int getInt(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getInt(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public long getLong(int columnIndex) throws SQLException
-  {
+  public long getLong(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getLong(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public float getFloat(int columnIndex) throws SQLException
-  {
+  public float getFloat(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getFloat(columnIndex);
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
-    }
-
   }
 
-  public double getDouble(int columnIndex) throws SQLException
-  {
+  public double getDouble(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getDouble(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Date getDate(int columnIndex, TimeZone tz) throws SQLException
-  {
+  public Date getDate(int columnIndex, TimeZone tz) throws SQLException {
     // Note: currently we provide this API but it does not use TimeZone tz.
     // TODO: use the time zone passed from the arguments
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getDate(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Time getTime(int columnIndex) throws SQLException
-  {
+  public Time getTime(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getTime(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz)
-  throws SQLException
-  {
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getTimestamp(columnIndex, tz);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public ResultSetMetaData getMetaData() throws SQLException
-  {
+  public ResultSetMetaData getMetaData() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
 
     return resultSetMetaData;
   }
 
-  public Object getObject(int columnIndex) throws SQLException
-  {
+  public Object getObject(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getObject(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public BigDecimal getBigDecimal(int columnIndex) throws SQLException
-  {
+  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getBigDecimal(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Deprecated
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
-  {
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getBigDecimal(columnIndex, scale);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public byte[] getBytes(int columnIndex) throws SQLException
-  {
+  public byte[] getBytes(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    try
-    {
+    try {
       return sfBaseResultSet.getBytes(columnIndex);
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public int getRow() throws SQLException
-  {
+  public int getRow() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
 
     return sfBaseResultSet.getRow();
   }
 
-  public boolean isFirst() throws SQLException
-  {
+  public boolean isFirst() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.isFirst();
   }
 
-  public boolean isClosed() throws SQLException
-  {
+  public boolean isClosed() throws SQLException {
     // no exception is raised.
     return sfBaseResultSet.isClosed();
   }
 
   @Override
-  public boolean isLast() throws SQLException
-  {
+  public boolean isLast() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.isLast();
   }
 
   @Override
-  public boolean isAfterLast() throws SQLException
-  {
+  public boolean isAfterLast() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.isAfterLast();
   }
 
   @Override
-  public boolean isBeforeFirst() throws SQLException
-  {
+  public boolean isBeforeFirst() throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.isBeforeFirst();
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException
-  {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
     logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -435,15 +341,12 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException
-  {
+  public <T> T unwrap(Class<T> iface) throws SQLException {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this))
-    {
+    if (!iface.isInstance(this)) {
       throw new SQLException(
-          this.getClass().getName() + " not unwrappable from " + iface
-              .getName());
+          this.getClass().getName() + " not unwrappable from " + iface.getName());
     }
     return (T) this;
   }
@@ -451,1334 +354,1096 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
   /**
    * Get a list of ResultSetSerializables for the ResultSet in order to parallel processing
    *
-   * @param maxSizeInBytes The expected max data size wrapped in the
-   *                       ResultSetSerializables object.
-   *                       NOTE: this parameter is intended to make the data
-   *                       size in each serializable object to be less than it.
-   *                       But if user specifies a small value which may be
-   *                       smaller than the data size of one result chunk.
-   *                       So the definition can't be guaranteed completely.
-   *                       For this special case, one serializable object is
-   *                       used to wrap the data chunk.
+   * @param maxSizeInBytes The expected max data size wrapped in the ResultSetSerializables object.
+   *     NOTE: this parameter is intended to make the data size in each serializable object to be
+   *     less than it. But if user specifies a small value which may be smaller than the data size
+   *     of one result chunk. So the definition can't be guaranteed completely. For this special
+   *     case, one serializable object is used to wrap the data chunk.
    * @return a list of ResultSetSerializables
    * @throws if fails to get the ResultSetSerializable objects.
    */
   @Override
   public List<SnowflakeResultSetSerializable> getResultSetSerializables(long maxSizeInBytes)
-  throws SQLException
-  {
+      throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.getResultSetSerializables(maxSizeInBytes);
   }
 
-  /**
-   * Empty result set
-   */
-  static class EmptyResultSet implements ResultSet
-  {
+  /** Empty result set */
+  static class EmptyResultSet implements ResultSet {
     private boolean isClosed;
 
-    EmptyResultSet()
-    {
+    EmptyResultSet() {
       isClosed = false;
     }
 
-    private void raiseSQLExceptionIfResultSetIsClosed() throws SQLException
-    {
-      if (isClosed())
-      {
+    private void raiseSQLExceptionIfResultSetIsClosed() throws SQLException {
+      if (isClosed()) {
         throw new SnowflakeSQLException(ErrorCode.RESULTSET_ALREADY_CLOSED);
       }
     }
 
     @Override
-    public boolean wasNull() throws SQLException
-    {
+    public boolean wasNull() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean next() throws SQLException
-    {
+    public boolean next() throws SQLException {
       return false; // no exception
     }
 
     @Override
-    public void close() throws SQLException
-    {
+    public void close() throws SQLException {
       isClosed = true;
     }
 
     @Override
-    public boolean getBoolean(int columnIndex) throws SQLException
-    {
+    public boolean getBoolean(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public int getInt(int columnIndex) throws SQLException
-    {
+    public int getInt(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public long getLong(int columnIndex) throws SQLException
-    {
+    public long getLong(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0L;
     }
 
     @Override
-    public float getFloat(int columnIndex) throws SQLException
-    {
+    public float getFloat(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return (float) 0;
     }
 
     @Override
-    public double getDouble(int columnIndex) throws SQLException
-    {
+    public double getDouble(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return (double) 0;
     }
 
     @Override
-    public short getShort(int columnIndex) throws SQLException
-    {
+    public short getShort(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return (short) 0;
     }
 
     @Override
-    public byte getByte(int columnIndex) throws SQLException
-    {
+    public byte getByte(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return (byte) 0;
     }
 
     @Override
-    public String getString(int columnIndex) throws SQLException
-    {
+    public String getString(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return "";
     }
 
     @Override
-    public byte[] getBytes(int columnIndex) throws SQLException
-    {
+    public byte[] getBytes(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return new byte[0];
     }
 
     @Override
-    public Date getDate(int columnIndex) throws SQLException
-    {
+    public Date getDate(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(int columnIndex) throws SQLException
-    {
+    public Time getTime(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex) throws SQLException
-    {
+    public Timestamp getTimestamp(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getAsciiStream(int columnIndex) throws SQLException
-    {
+    public InputStream getAsciiStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public InputStream getUnicodeStream(int columnIndex) throws SQLException
-    {
+    public InputStream getUnicodeStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getBinaryStream(int columnIndex) throws SQLException
-    {
+    public InputStream getBinaryStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public String getString(String columnLabel) throws SQLException
-    {
+    public String getString(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean getBoolean(String columnLabel) throws SQLException
-    {
+    public boolean getBoolean(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public byte getByte(String columnLabel) throws SQLException
-    {
+    public byte getByte(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public short getShort(String columnLabel) throws SQLException
-    {
+    public short getShort(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getInt(String columnLabel) throws SQLException
-    {
+    public int getInt(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public long getLong(String columnLabel) throws SQLException
-    {
+    public long getLong(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public float getFloat(String columnLabel) throws SQLException
-    {
+    public float getFloat(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public double getDouble(String columnLabel) throws SQLException
-    {
+    public double getDouble(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Deprecated
     @Override
-    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException
-    {
+    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public byte[] getBytes(String columnLabel) throws SQLException
-    {
+    public byte[] getBytes(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return new byte[0];
     }
 
     @Override
-    public Date getDate(String columnLabel) throws SQLException
-    {
+    public Date getDate(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(String columnLabel) throws SQLException
-    {
+    public Time getTime(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel) throws SQLException
-    {
+    public Timestamp getTimestamp(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public BigDecimal getBigDecimal(int columnIndex) throws SQLException
-    {
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public BigDecimal getBigDecimal(String columnLabel) throws SQLException
-    {
+    public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean isBeforeFirst() throws SQLException
-    {
+    public boolean isBeforeFirst() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isAfterLast() throws SQLException
-    {
+    public boolean isAfterLast() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isFirst() throws SQLException
-    {
+    public boolean isFirst() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isLast() throws SQLException
-    {
+    public boolean isLast() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void beforeFirst() throws SQLException
-    {
+    public void beforeFirst() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void afterLast() throws SQLException
-    {
+    public void afterLast() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public boolean first() throws SQLException
-    {
+    public boolean first() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean last() throws SQLException
-    {
+    public boolean last() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public int getRow() throws SQLException
-    {
+    public int getRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean absolute(int row) throws SQLException
-    {
+    public boolean absolute(int row) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean relative(int rows) throws SQLException
-    {
+    public boolean relative(int rows) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean previous() throws SQLException
-    {
+    public boolean previous() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void setFetchDirection(int direction) throws SQLException
-    {
+    public void setFetchDirection(int direction) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public int getFetchDirection() throws SQLException
-    {
+    public int getFetchDirection() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public void setFetchSize(int rows) throws SQLException
-    {
+    public void setFetchSize(int rows) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public int getFetchSize() throws SQLException
-    {
+    public int getFetchSize() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getType() throws SQLException
-    {
+    public int getType() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getConcurrency() throws SQLException
-    {
+    public int getConcurrency() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean rowUpdated() throws SQLException
-    {
+    public boolean rowUpdated() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean rowInserted() throws SQLException
-    {
+    public boolean rowInserted() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean rowDeleted() throws SQLException
-    {
+    public boolean rowDeleted() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void updateNull(int columnIndex) throws SQLException
-    {
+    public void updateNull(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBoolean(int columnIndex, boolean x) throws SQLException
-    {
+    public void updateBoolean(int columnIndex, boolean x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateByte(int columnIndex, byte x) throws SQLException
-    {
+    public void updateByte(int columnIndex, byte x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateShort(int columnIndex, short x) throws SQLException
-    {
+    public void updateShort(int columnIndex, short x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateInt(int columnIndex, int x) throws SQLException
-    {
+    public void updateInt(int columnIndex, int x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateLong(int columnIndex, long x) throws SQLException
-    {
+    public void updateLong(int columnIndex, long x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateFloat(int columnIndex, float x) throws SQLException
-    {
+    public void updateFloat(int columnIndex, float x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDouble(int columnIndex, double x) throws SQLException
-    {
+    public void updateDouble(int columnIndex, double x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException
-    {
+    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateString(int columnIndex, String x) throws SQLException
-    {
+    public void updateString(int columnIndex, String x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBytes(int columnIndex, byte[] x) throws SQLException
-    {
+    public void updateBytes(int columnIndex, byte[] x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDate(int columnIndex, Date x) throws SQLException
-    {
+    public void updateDate(int columnIndex, Date x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTime(int columnIndex, Time x) throws SQLException
-    {
+    public void updateTime(int columnIndex, Time x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException
-    {
+    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException
-    {
+    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException
-    {
+    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException
-    {
+    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException
-    {
+    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x) throws SQLException
-    {
+    public void updateObject(int columnIndex, Object x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateNull(String columnLabel) throws SQLException
-    {
+    public void updateNull(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBoolean(String columnLabel, boolean x) throws SQLException
-    {
+    public void updateBoolean(String columnLabel, boolean x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateByte(String columnLabel, byte x) throws SQLException
-    {
+    public void updateByte(String columnLabel, byte x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateShort(String columnLabel, short x) throws SQLException
-    {
+    public void updateShort(String columnLabel, short x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateInt(String columnLabel, int x) throws SQLException
-    {
+    public void updateInt(String columnLabel, int x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateLong(String columnLabel, long x) throws SQLException
-    {
+    public void updateLong(String columnLabel, long x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateFloat(String columnLabel, float x) throws SQLException
-    {
+    public void updateFloat(String columnLabel, float x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDouble(String columnLabel, double x) throws SQLException
-    {
+    public void updateDouble(String columnLabel, double x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException
-    {
+    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateString(String columnLabel, String x) throws SQLException
-    {
+    public void updateString(String columnLabel, String x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBytes(String columnLabel, byte[] x) throws SQLException
-    {
+    public void updateBytes(String columnLabel, byte[] x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDate(String columnLabel, Date x) throws SQLException
-    {
+    public void updateDate(String columnLabel, Date x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTime(String columnLabel, Time x) throws SQLException
-    {
+    public void updateTime(String columnLabel, Time x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException
-    {
+    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException
-    {
+    public void updateAsciiStream(String columnLabel, InputStream x, int length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException
-    {
+    public void updateBinaryStream(String columnLabel, InputStream x, int length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException
-    {
+    public void updateCharacterStream(String columnLabel, Reader reader, int length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException
-    {
+    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x) throws SQLException
-    {
+    public void updateObject(String columnLabel, Object x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void insertRow() throws SQLException
-    {
+    public void insertRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateRow() throws SQLException
-    {
+    public void updateRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void deleteRow() throws SQLException
-    {
+    public void deleteRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void refreshRow() throws SQLException
-    {
+    public void refreshRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void cancelRowUpdates() throws SQLException
-    {
+    public void cancelRowUpdates() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void moveToInsertRow() throws SQLException
-    {
+    public void moveToInsertRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void moveToCurrentRow() throws SQLException
-    {
+    public void moveToCurrentRow() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public Statement getStatement() throws SQLException
-    {
+    public Statement getStatement() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException
-    {
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Ref getRef(int columnIndex) throws SQLException
-    {
+    public Ref getRef(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Blob getBlob(int columnIndex) throws SQLException
-    {
+    public Blob getBlob(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Clob getClob(int columnIndex) throws SQLException
-    {
+    public Clob getClob(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Array getArray(int columnIndex) throws SQLException
-    {
+    public Array getArray(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException
-    {
+    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Ref getRef(String columnLabel) throws SQLException
-    {
+    public Ref getRef(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Blob getBlob(String columnLabel) throws SQLException
-    {
+    public Blob getBlob(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Clob getClob(String columnLabel) throws SQLException
-    {
+    public Clob getClob(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Array getArray(String columnLabel) throws SQLException
-    {
+    public Array getArray(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Date getDate(int columnIndex, Calendar cal) throws SQLException
-    {
+    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Date getDate(String columnLabel, Calendar cal) throws SQLException
-    {
+    public Date getDate(String columnLabel, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(int columnIndex, Calendar cal) throws SQLException
-    {
+    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(String columnLabel, Calendar cal) throws SQLException
-    {
+    public Time getTime(String columnLabel, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException
-    {
+    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException
-    {
+    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public URL getURL(int columnIndex) throws SQLException
-    {
+    public URL getURL(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public URL getURL(String columnLabel) throws SQLException
-    {
+    public URL getURL(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateRef(int columnIndex, Ref x) throws SQLException
-    {
+    public void updateRef(int columnIndex, Ref x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateRef(String columnLabel, Ref x) throws SQLException
-    {
+    public void updateRef(String columnLabel, Ref x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(int columnIndex, Blob x) throws SQLException
-    {
+    public void updateBlob(int columnIndex, Blob x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(String columnLabel, Blob x) throws SQLException
-    {
+    public void updateBlob(String columnLabel, Blob x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(int columnIndex, Clob x) throws SQLException
-    {
+    public void updateClob(int columnIndex, Clob x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(String columnLabel, Clob x) throws SQLException
-    {
+    public void updateClob(String columnLabel, Clob x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateArray(int columnIndex, Array x) throws SQLException
-    {
+    public void updateArray(int columnIndex, Array x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateArray(String columnLabel, Array x) throws SQLException
-    {
+    public void updateArray(String columnLabel, Array x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public RowId getRowId(int columnIndex) throws SQLException
-    {
+    public RowId getRowId(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public RowId getRowId(String columnLabel) throws SQLException
-    {
+    public RowId getRowId(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateRowId(int columnIndex, RowId x) throws SQLException
-    {
+    public void updateRowId(int columnIndex, RowId x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateRowId(String columnLabel, RowId x) throws SQLException
-    {
+    public void updateRowId(String columnLabel, RowId x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public int getHoldability() throws SQLException
-    {
+    public int getHoldability() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean isClosed() throws SQLException
-    {
+    public boolean isClosed() throws SQLException {
       return isClosed; // no exception
     }
 
     @Override
-    public void updateNString(int columnIndex, String nString) throws SQLException
-    {
+    public void updateNString(int columnIndex, String nString) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNString(String columnLabel, String nString) throws SQLException
-    {
+    public void updateNString(String columnLabel, String nString) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(int columnIndex, NClob nClob) throws SQLException
-    {
+    public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(String columnLabel, NClob nClob) throws SQLException
-    {
+    public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public NClob getNClob(int columnIndex) throws SQLException
-    {
+    public NClob getNClob(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public NClob getNClob(String columnLabel) throws SQLException
-    {
+    public NClob getNClob(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLXML getSQLXML(int columnIndex) throws SQLException
-    {
+    public SQLXML getSQLXML(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLXML getSQLXML(String columnLabel) throws SQLException
-    {
+    public SQLXML getSQLXML(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException
-    {
+    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException
-    {
+    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public String getNString(int columnIndex) throws SQLException
-    {
+    public String getNString(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public String getNString(String columnLabel) throws SQLException
-    {
+    public String getNString(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getNCharacterStream(int columnIndex) throws SQLException
-    {
+    public Reader getNCharacterStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getNCharacterStream(String columnLabel) throws SQLException
-    {
+    public Reader getNCharacterStream(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException
-    {
+    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
-    {
+    public void updateNCharacterStream(String columnLabel, Reader reader, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException
-    {
+    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException
-    {
+    public void updateBinaryStream(int columnIndex, InputStream x, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException
-    {
+    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException
-    {
+    public void updateAsciiStream(String columnLabel, InputStream x, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException
-    {
+    public void updateBinaryStream(String columnLabel, InputStream x, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
-    {
+    public void updateCharacterStream(String columnLabel, Reader reader, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException
-    {
+    public void updateBlob(int columnIndex, InputStream inputStream, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException
-    {
+    public void updateBlob(String columnLabel, InputStream inputStream, long length)
+        throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException
-    {
+    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException
-    {
+    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException
-    {
+    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException
-    {
+    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException
-    {
+    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException
-    {
+    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException
-    {
+    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException
-    {
+    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException
-    {
+    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException
-    {
+    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException
-    {
+    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException
-    {
+    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException
-    {
+    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException
-    {
+    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(int columnIndex, Reader reader) throws SQLException
-    {
+    public void updateClob(int columnIndex, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateClob(String columnLabel, Reader reader) throws SQLException
-    {
+    public void updateClob(String columnLabel, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(int columnIndex, Reader reader) throws SQLException
-    {
+    public void updateNClob(int columnIndex, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public void updateNClob(String columnLabel, Reader reader) throws SQLException
-    {
+    public void updateNClob(String columnLabel, Reader reader) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException
-    {
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException
-    {
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
-    {
+    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getAsciiStream(String columnIndex) throws SQLException
-    {
+    public InputStream getAsciiStream(String columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public InputStream getUnicodeStream(String columnLabel) throws SQLException
-    {
+    public InputStream getUnicodeStream(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getBinaryStream(String columnLabel) throws SQLException
-    {
+    public InputStream getBinaryStream(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException
-    {
+    public SQLWarning getWarnings() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void clearWarnings() throws SQLException
-    {
+    public void clearWarnings() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
-
     }
 
     @Override
-    public String getCursorName() throws SQLException
-    {
+    public String getCursorName() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException
-    {
+    public ResultSetMetaData getMetaData() throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(int columnIndex) throws SQLException
-    {
+    public Object getObject(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(String columnLabel) throws SQLException
-    {
+    public Object getObject(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public int findColumn(String columnLabel) throws SQLException
-    {
+    public int findColumn(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public Reader getCharacterStream(int columnIndex) throws SQLException
-    {
+    public Reader getCharacterStream(int columnIndex) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getCharacterStream(String columnLabel) throws SQLException
-    {
+    public Reader getCharacterStream(String columnLabel) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public <T> T unwrap(Class<T> iface) throws SQLException
-    {
+    public <T> T unwrap(Class<T> iface) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean isWrapperFor(Class<?> iface) throws SQLException
-    {
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
   }
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -4,6 +4,10 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -28,33 +32,42 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-import net.snowflake.client.core.QueryStatus;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
 
-/** Snowflake ResultSet implementation */
-class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet {
+/**
+ * Snowflake ResultSet implementation
+ */
+class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet
+{
   private final SFBaseResultSet sfBaseResultSet;
 
   /**
-   * Constructor takes an inputstream from the API response that we get from executing a SQL
-   * statement.
-   *
-   * <p>The constructor will fetch the first row (if any) so that it can initialize the
-   * ResultSetMetaData.
+   * Constructor takes an inputstream from the API response that we get from
+   * executing a SQL statement.
+   * <p>
+   * The constructor will fetch the first row (if any) so that it can initialize
+   * the ResultSetMetaData.
+   * </p>
    *
    * @param sfBaseResultSet snowflake core base result rest object
-   * @param statement query statement that generates this result set
+   * @param statement       query statement that generates this result set
    * @throws SQLException if failed to construct snowflake result set metadata
    */
-  SnowflakeResultSetV1(SFBaseResultSet sfBaseResultSet, Statement statement) throws SQLException {
+  SnowflakeResultSetV1(
+      SFBaseResultSet sfBaseResultSet,
+      Statement statement)
+  throws SQLException
+  {
     super(statement);
     this.sfBaseResultSet = sfBaseResultSet;
-    try {
-      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    try
+    {
+      this.resultSetMetaData =
+          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(),
+                                            ex.getSqlState(), ex.getVendorCode(), sfBaseResultSet.getSession(), ex.getParams());
     }
   }
 
@@ -64,30 +77,39 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
    * @return no return value; exception is always thrown
    * @throws SQLFeatureNotSupportedException
    */
-  public QueryStatus getStatus() throws SQLException {
+  public QueryStatus getStatus() throws SQLException
+  {
     throw new SQLFeatureNotSupportedException();
   }
 
   /**
-   * Constructor takes a result set serializable object to create a sessionless result set.
+   * Constructor takes a result set serializable object to create
+   * a sessionless result set.
    *
-   * @param sfBaseResultSet snowflake core base result rest object
-   * @param resultSetSerializable The result set serializable object which includes all metadata to
-   *     create the result set
+   * @param sfBaseResultSet       snowflake core base result rest object
+   * @param resultSetSerializable The result set serializable object which
+   *                              includes all metadata to create the result
+   *                              set
    * @throws SQLException if fails to create the result set object
    */
   public SnowflakeResultSetV1(
-      SFBaseResultSet sfBaseResultSet, SnowflakeResultSetSerializableV1 resultSetSerializable)
-      throws SQLException {
+      SFBaseResultSet sfBaseResultSet,
+      SnowflakeResultSetSerializableV1 resultSetSerializable)
+  throws SQLException
+  {
     super(resultSetSerializable);
 
     this.sfBaseResultSet = sfBaseResultSet;
 
-    try {
-      this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    try
+    {
+      this.resultSetMetaData =
+          new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex.getCause(),
+                                            ex.getSqlState(), ex.getVendorCode(), sfBaseResultSet.getSession(), ex.getParams());
     }
   }
 
@@ -98,234 +120,314 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
    * @throws SQLException if failed to move to the next row
    */
   @Override
-  public boolean next() throws SQLException {
+  public boolean next() throws SQLException
+  {
     // exception
-    try {
+    try
+    {
       return sfBaseResultSet.next();
-    } catch (SFException ex) {
+    }
+    catch (SFException ex)
+    {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void close() throws SQLException {
+  public void close() throws SQLException
+  {
     close(true);
   }
 
-  public void close(boolean removeClosedResultSetFromStatement) throws SQLException {
+  public void close(boolean removeClosedResultSetFromStatement) throws SQLException
+  {
     // no SQLException is raised.
     sfBaseResultSet.close();
-    if (removeClosedResultSetFromStatement && statement.isWrapperFor(SnowflakeStatementV1.class)) {
+    if (removeClosedResultSetFromStatement && statement.isWrapperFor(SnowflakeStatementV1.class))
+    {
       statement.unwrap(SnowflakeStatementV1.class).removeClosedResultSet(this);
     }
   }
 
-  public String getQueryID() {
+  public String getQueryID()
+  {
     return sfBaseResultSet.getQueryId();
   }
 
-  public boolean wasNull() throws SQLException {
+
+  public boolean wasNull() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.wasNull();
   }
 
-  public String getString(int columnIndex) throws SQLException {
+  public String getString(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getString(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public boolean getBoolean(int columnIndex) throws SQLException {
+  public boolean getBoolean(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getBoolean(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public byte getByte(int columnIndex) throws SQLException {
+  public byte getByte(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getByte(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public short getShort(int columnIndex) throws SQLException {
+  public short getShort(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getShort(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public int getInt(int columnIndex) throws SQLException {
+  public int getInt(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getInt(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public long getLong(int columnIndex) throws SQLException {
+  public long getLong(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getLong(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public float getFloat(int columnIndex) throws SQLException {
+  public float getFloat(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getFloat(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+
   }
 
-  public double getDouble(int columnIndex) throws SQLException {
+  public double getDouble(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getDouble(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Date getDate(int columnIndex, TimeZone tz) throws SQLException {
+  public Date getDate(int columnIndex, TimeZone tz) throws SQLException
+  {
     // Note: currently we provide this API but it does not use TimeZone tz.
     // TODO: use the time zone passed from the arguments
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getDate(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Time getTime(int columnIndex) throws SQLException {
+  public Time getTime(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getTime(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public Timestamp getTimestamp(int columnIndex, TimeZone tz) throws SQLException {
+  public Timestamp getTimestamp(int columnIndex, TimeZone tz)
+  throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getTimestamp(columnIndex, tz);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public ResultSetMetaData getMetaData() throws SQLException {
+  public ResultSetMetaData getMetaData() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
 
     return resultSetMetaData;
   }
 
-  public Object getObject(int columnIndex) throws SQLException {
+  public Object getObject(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getObject(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+  public BigDecimal getBigDecimal(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getBigDecimal(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Deprecated
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getBigDecimal(columnIndex, scale);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public byte[] getBytes(int columnIndex) throws SQLException {
+  public byte[] getBytes(int columnIndex) throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
-    try {
+    try
+    {
       return sfBaseResultSet.getBytes(columnIndex);
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  public int getRow() throws SQLException {
+  public int getRow() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
 
     return sfBaseResultSet.getRow();
   }
 
-  public boolean isFirst() throws SQLException {
+  public boolean isFirst() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.isFirst();
   }
 
-  public boolean isClosed() throws SQLException {
+  public boolean isClosed() throws SQLException
+  {
     // no exception is raised.
     return sfBaseResultSet.isClosed();
   }
 
   @Override
-  public boolean isLast() throws SQLException {
+  public boolean isLast() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.isLast();
   }
 
   @Override
-  public boolean isAfterLast() throws SQLException {
+  public boolean isAfterLast() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.isAfterLast();
   }
 
   @Override
-  public boolean isBeforeFirst() throws SQLException {
+  public boolean isBeforeFirst() throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.isBeforeFirst();
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException
+  {
     logger.debug("public boolean isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -333,12 +435,15 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
+  public <T> T unwrap(Class<T> iface) throws SQLException
+  {
     logger.debug("public <T> T unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this)) {
+    if (!iface.isInstance(this))
+    {
       throw new SQLException(
-          this.getClass().getName() + " not unwrappable from " + iface.getName());
+          this.getClass().getName() + " not unwrappable from " + iface
+              .getName());
     }
     return (T) this;
   }
@@ -346,1096 +451,1334 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
   /**
    * Get a list of ResultSetSerializables for the ResultSet in order to parallel processing
    *
-   * @param maxSizeInBytes The expected max data size wrapped in the ResultSetSerializables object.
-   *     NOTE: this parameter is intended to make the data size in each serializable object to be
-   *     less than it. But if user specifies a small value which may be smaller than the data size
-   *     of one result chunk. So the definition can't be guaranteed completely. For this special
-   *     case, one serializable object is used to wrap the data chunk.
+   * @param maxSizeInBytes The expected max data size wrapped in the
+   *                       ResultSetSerializables object.
+   *                       NOTE: this parameter is intended to make the data
+   *                       size in each serializable object to be less than it.
+   *                       But if user specifies a small value which may be
+   *                       smaller than the data size of one result chunk.
+   *                       So the definition can't be guaranteed completely.
+   *                       For this special case, one serializable object is
+   *                       used to wrap the data chunk.
    * @return a list of ResultSetSerializables
    * @throws if fails to get the ResultSetSerializable objects.
    */
   @Override
   public List<SnowflakeResultSetSerializable> getResultSetSerializables(long maxSizeInBytes)
-      throws SQLException {
+  throws SQLException
+  {
     raiseSQLExceptionIfResultSetIsClosed();
     return sfBaseResultSet.getResultSetSerializables(maxSizeInBytes);
   }
 
-  /** Empty result set */
-  static class EmptyResultSet implements ResultSet {
+  /**
+   * Empty result set
+   */
+  static class EmptyResultSet implements ResultSet
+  {
     private boolean isClosed;
 
-    EmptyResultSet() {
+    EmptyResultSet()
+    {
       isClosed = false;
     }
 
-    private void raiseSQLExceptionIfResultSetIsClosed() throws SQLException {
-      if (isClosed()) {
+    private void raiseSQLExceptionIfResultSetIsClosed() throws SQLException
+    {
+      if (isClosed())
+      {
         throw new SnowflakeSQLException(ErrorCode.RESULTSET_ALREADY_CLOSED);
       }
     }
 
     @Override
-    public boolean wasNull() throws SQLException {
+    public boolean wasNull() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean next() throws SQLException {
+    public boolean next() throws SQLException
+    {
       return false; // no exception
     }
 
     @Override
-    public void close() throws SQLException {
+    public void close() throws SQLException
+    {
       isClosed = true;
     }
 
     @Override
-    public boolean getBoolean(int columnIndex) throws SQLException {
+    public boolean getBoolean(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public int getInt(int columnIndex) throws SQLException {
+    public int getInt(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public long getLong(int columnIndex) throws SQLException {
+    public long getLong(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0L;
     }
 
     @Override
-    public float getFloat(int columnIndex) throws SQLException {
+    public float getFloat(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return (float) 0;
     }
 
     @Override
-    public double getDouble(int columnIndex) throws SQLException {
+    public double getDouble(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return (double) 0;
     }
 
     @Override
-    public short getShort(int columnIndex) throws SQLException {
+    public short getShort(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return (short) 0;
     }
 
     @Override
-    public byte getByte(int columnIndex) throws SQLException {
+    public byte getByte(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return (byte) 0;
     }
 
     @Override
-    public String getString(int columnIndex) throws SQLException {
+    public String getString(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return "";
     }
 
     @Override
-    public byte[] getBytes(int columnIndex) throws SQLException {
+    public byte[] getBytes(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return new byte[0];
     }
 
     @Override
-    public Date getDate(int columnIndex) throws SQLException {
+    public Date getDate(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(int columnIndex) throws SQLException {
+    public Time getTime(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex) throws SQLException {
+    public Timestamp getTimestamp(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getAsciiStream(int columnIndex) throws SQLException {
+    public InputStream getAsciiStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+    public InputStream getUnicodeStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getBinaryStream(int columnIndex) throws SQLException {
+    public InputStream getBinaryStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public String getString(String columnLabel) throws SQLException {
+    public String getString(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean getBoolean(String columnLabel) throws SQLException {
+    public boolean getBoolean(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public byte getByte(String columnLabel) throws SQLException {
+    public byte getByte(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public short getShort(String columnLabel) throws SQLException {
+    public short getShort(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getInt(String columnLabel) throws SQLException {
+    public int getInt(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public long getLong(String columnLabel) throws SQLException {
+    public long getLong(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public float getFloat(String columnLabel) throws SQLException {
+    public float getFloat(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public double getDouble(String columnLabel) throws SQLException {
+    public double getDouble(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Deprecated
     @Override
-    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public byte[] getBytes(String columnLabel) throws SQLException {
+    public byte[] getBytes(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return new byte[0];
     }
 
     @Override
-    public Date getDate(String columnLabel) throws SQLException {
+    public Date getDate(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(String columnLabel) throws SQLException {
+    public Time getTime(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel) throws SQLException {
+    public Timestamp getTimestamp(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+    public BigDecimal getBigDecimal(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean isBeforeFirst() throws SQLException {
+    public boolean isBeforeFirst() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isAfterLast() throws SQLException {
+    public boolean isAfterLast() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isFirst() throws SQLException {
+    public boolean isFirst() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean isLast() throws SQLException {
+    public boolean isLast() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void beforeFirst() throws SQLException {
+    public void beforeFirst() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void afterLast() throws SQLException {
+    public void afterLast() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public boolean first() throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return false;
-    }
-
-    @Override
-    public boolean last() throws SQLException {
+    public boolean first() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public int getRow() throws SQLException {
+    public boolean last() throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return false;
+    }
+
+    @Override
+    public int getRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean absolute(int row) throws SQLException {
+    public boolean absolute(int row) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean relative(int rows) throws SQLException {
+    public boolean relative(int rows) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean previous() throws SQLException {
+    public boolean previous() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void setFetchDirection(int direction) throws SQLException {
+    public void setFetchDirection(int direction) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public int getFetchDirection() throws SQLException {
+    public int getFetchDirection() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public void setFetchSize(int rows) throws SQLException {
+    public void setFetchSize(int rows) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public int getFetchSize() throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return 0;
-    }
-
-    @Override
-    public int getType() throws SQLException {
+    public int getFetchSize() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public int getConcurrency() throws SQLException {
+    public int getType() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean rowUpdated() throws SQLException {
+    public int getConcurrency() throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return 0;
+    }
+
+    @Override
+    public boolean rowUpdated() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean rowInserted() throws SQLException {
+    public boolean rowInserted() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public boolean rowDeleted() throws SQLException {
+    public boolean rowDeleted() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
 
     @Override
-    public void updateNull(int columnIndex) throws SQLException {
+    public void updateNull(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBoolean(int columnIndex, boolean x) throws SQLException {
+    public void updateBoolean(int columnIndex, boolean x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateByte(int columnIndex, byte x) throws SQLException {
+    public void updateByte(int columnIndex, byte x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateShort(int columnIndex, short x) throws SQLException {
+    public void updateShort(int columnIndex, short x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateInt(int columnIndex, int x) throws SQLException {
+    public void updateInt(int columnIndex, int x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateLong(int columnIndex, long x) throws SQLException {
+    public void updateLong(int columnIndex, long x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateFloat(int columnIndex, float x) throws SQLException {
+    public void updateFloat(int columnIndex, float x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDouble(int columnIndex, double x) throws SQLException {
+    public void updateDouble(int columnIndex, double x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateString(int columnIndex, String x) throws SQLException {
+    public void updateString(int columnIndex, String x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+    public void updateBytes(int columnIndex, byte[] x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDate(int columnIndex, Date x) throws SQLException {
+    public void updateDate(int columnIndex, Date x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTime(int columnIndex, Time x) throws SQLException {
+    public void updateTime(int columnIndex, Time x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x) throws SQLException {
+    public void updateObject(int columnIndex, Object x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateNull(String columnLabel) throws SQLException {
+    public void updateNull(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBoolean(String columnLabel, boolean x) throws SQLException {
+    public void updateBoolean(String columnLabel, boolean x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateByte(String columnLabel, byte x) throws SQLException {
+    public void updateByte(String columnLabel, byte x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateShort(String columnLabel, short x) throws SQLException {
+    public void updateShort(String columnLabel, short x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateInt(String columnLabel, int x) throws SQLException {
+    public void updateInt(String columnLabel, int x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateLong(String columnLabel, long x) throws SQLException {
+    public void updateLong(String columnLabel, long x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateFloat(String columnLabel, float x) throws SQLException {
+    public void updateFloat(String columnLabel, float x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDouble(String columnLabel, double x) throws SQLException {
+    public void updateDouble(String columnLabel, double x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateString(String columnLabel, String x) throws SQLException {
+    public void updateString(String columnLabel, String x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+    public void updateBytes(String columnLabel, byte[] x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateDate(String columnLabel, Date x) throws SQLException {
+    public void updateDate(String columnLabel, Date x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTime(String columnLabel, Time x) throws SQLException {
+    public void updateTime(String columnLabel, Time x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, int length)
-        throws SQLException {
+    public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, int length)
-        throws SQLException {
+    public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, int length)
-        throws SQLException {
+    public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x) throws SQLException {
+    public void updateObject(String columnLabel, Object x) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void insertRow() throws SQLException {
+    public void insertRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void updateRow() throws SQLException {
+    public void updateRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void deleteRow() throws SQLException {
+    public void deleteRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void refreshRow() throws SQLException {
+    public void refreshRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void cancelRowUpdates() throws SQLException {
+    public void cancelRowUpdates() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void moveToInsertRow() throws SQLException {
+    public void moveToInsertRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public void moveToCurrentRow() throws SQLException {
+    public void moveToCurrentRow() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
     }
 
     @Override
-    public Statement getStatement() throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Ref getRef(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Blob getBlob(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Clob getClob(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Array getArray(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Ref getRef(String columnLabel) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public Blob getBlob(String columnLabel) throws SQLException {
+    public Statement getStatement() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Clob getClob(String columnLabel) throws SQLException {
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Array getArray(String columnLabel) throws SQLException {
+    public Ref getRef(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    public Blob getBlob(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    public Clob getClob(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    public Array getArray(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    public Ref getRef(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    public Blob getBlob(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public URL getURL(int columnIndex) throws SQLException {
+    public Clob getClob(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public URL getURL(String columnLabel) throws SQLException {
+    public Array getArray(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateRef(int columnIndex, Ref x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateRef(String columnLabel, Ref x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(int columnIndex, Blob x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(String columnLabel, Blob x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(int columnIndex, Clob x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(String columnLabel, Clob x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateArray(int columnIndex, Array x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateArray(String columnLabel, Array x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public RowId getRowId(int columnIndex) throws SQLException {
+    public Date getDate(int columnIndex, Calendar cal) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public RowId getRowId(String columnLabel) throws SQLException {
+    public Date getDate(String columnLabel, Calendar cal) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateRowId(int columnIndex, RowId x) throws SQLException {
+    public Time getTime(int columnIndex, Calendar cal) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+      return null;
     }
 
     @Override
-    public void updateRowId(String columnLabel, RowId x) throws SQLException {
+    public Time getTime(String columnLabel, Calendar cal) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+      return null;
     }
 
     @Override
-    public int getHoldability() throws SQLException {
+    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public URL getURL(int columnIndex) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public URL getURL(String columnLabel) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public void updateRef(int columnIndex, Ref x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateRef(String columnLabel, Ref x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, Blob x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, Blob x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Clob x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Clob x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateArray(int columnIndex, Array x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateArray(String columnLabel, Array x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public RowId getRowId(int columnIndex) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public RowId getRowId(String columnLabel) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public void updateRowId(int columnIndex, RowId x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateRowId(String columnLabel, RowId x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public int getHoldability() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public boolean isClosed() throws SQLException {
+    public boolean isClosed() throws SQLException
+    {
       return isClosed; // no exception
     }
 
     @Override
-    public void updateNString(int columnIndex, String nString) throws SQLException {
+    public void updateNString(int columnIndex, String nString) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public void updateNString(String columnLabel, String nString) throws SQLException {
+    public void updateNString(String columnLabel, String nString) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+    public void updateNClob(int columnIndex, NClob nClob) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+    public void updateNClob(String columnLabel, NClob nClob) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public NClob getNClob(int columnIndex) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public NClob getNClob(String columnLabel) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public SQLXML getSQLXML(int columnIndex) throws SQLException {
+    public NClob getNClob(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLXML getSQLXML(String columnLabel) throws SQLException {
+    public NClob getNClob(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public String getNString(int columnIndex) throws SQLException {
+    public SQLXML getSQLXML(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public String getNString(String columnLabel) throws SQLException {
+    public SQLXML getSQLXML(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getNCharacterStream(int columnIndex) throws SQLException {
+    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public String getNString(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getNCharacterStream(String columnLabel) throws SQLException {
+    public String getNString(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(int columnIndex, InputStream inputStream, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(String columnLabel, InputStream inputStream, long length)
-        throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(int columnIndex, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateClob(String columnLabel, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNClob(int columnIndex, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public void updateNClob(String columnLabel, Reader reader) throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-    }
-
-    @Override
-    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+    public Reader getNCharacterStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+    public Reader getNCharacterStream(String columnLabel) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, Reader reader) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+
+    }
+
+    @Override
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getAsciiStream(String columnIndex) throws SQLException {
+    public InputStream getAsciiStream(String columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Deprecated
     @Override
-    public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+    public InputStream getUnicodeStream(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public InputStream getBinaryStream(String columnLabel) throws SQLException {
+    public InputStream getBinaryStream(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException {
+    public SQLWarning getWarnings() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public void clearWarnings() throws SQLException {
+    public void clearWarnings() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
+
     }
 
     @Override
-    public String getCursorName() throws SQLException {
-      raiseSQLExceptionIfResultSetIsClosed();
-      return null;
-    }
-
-    @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public String getCursorName() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(int columnIndex) throws SQLException {
+    public ResultSetMetaData getMetaData() throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Object getObject(String columnLabel) throws SQLException {
+    public Object getObject(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public int findColumn(String columnLabel) throws SQLException {
+    public Object getObject(String columnLabel) throws SQLException
+    {
+      raiseSQLExceptionIfResultSetIsClosed();
+      return null;
+    }
+
+    @Override
+    public int findColumn(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return 0;
     }
 
     @Override
-    public Reader getCharacterStream(int columnIndex) throws SQLException {
+    public Reader getCharacterStream(int columnIndex) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public Reader getCharacterStream(String columnLabel) throws SQLException {
+    public Reader getCharacterStream(String columnLabel) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public <T> T unwrap(Class<T> iface) throws SQLException {
+    public <T> T unwrap(Class<T> iface) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return null;
     }
 
     @Override
-    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    public boolean isWrapperFor(Class<?> iface) throws SQLException
+    {
       raiseSQLExceptionIfResultSetIsClosed();
       return false;
     }
   }
+
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -4,18 +4,7 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.ParameterBindingDTO;
-import net.snowflake.client.core.ResultUtil;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFStatement;
-import net.snowflake.client.core.StmtUtil;
-import net.snowflake.client.log.ArgSupplier;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.util.SecretDetector;
-import net.snowflake.client.util.VariableTypeArray;
-import net.snowflake.common.core.SqlState;
+import static net.snowflake.client.jdbc.ErrorCode.FEATURE_UNSUPPORTED;
 
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
@@ -31,14 +20,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import net.snowflake.client.core.ParameterBindingDTO;
+import net.snowflake.client.core.ResultUtil;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFStatement;
+import net.snowflake.client.core.StmtUtil;
+import net.snowflake.client.log.ArgSupplier;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.util.SecretDetector;
+import net.snowflake.client.util.VariableTypeArray;
+import net.snowflake.common.core.SqlState;
 
-import static net.snowflake.client.jdbc.ErrorCode.FEATURE_UNSUPPORTED;
-
-/**
- * Snowflake statement
- */
-class SnowflakeStatementV1 implements Statement, SnowflakeStatement
-{
+/** Snowflake statement */
+class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementV1.class);
 
   private static final long NO_UPDATES = -1;
@@ -76,19 +72,13 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
 
   private boolean poolable;
 
-  /**
-   * Snowflake query ID from the latest executed query
-   */
+  /** Snowflake query ID from the latest executed query */
   private String queryID;
 
-  /**
-   * Snowflake query IDs from the latest executed batch
-   */
+  /** Snowflake query IDs from the latest executed batch */
   private List<String> batchQueryIDs = new LinkedList<>();
 
-  /**
-   * batch of sql strings added by addBatch
-   */
+  /** batch of sql strings added by addBatch */
   protected final List<BatchEntry> batch = new ArrayList<>();
 
   private SQLWarning sqlWarnings;
@@ -96,8 +86,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
   /**
    * Construct SnowflakeStatementV1
    *
-   * @param connection           connection object
-   * @param resultSetType        result set type: ResultSet.TYPE_FORWARD_ONLY.
+   * @param connection connection object
+   * @param resultSetType result set type: ResultSet.TYPE_FORWARD_ONLY.
    * @param resultSetConcurrency result set concurrency: ResultSet.CONCUR_READ_ONLY.
    * @param resultSetHoldability result set holdability: ResultSet.CLOSE_CURSORS_AT_COMMIT
    * @throws SQLException if any SQL error occurs.
@@ -106,31 +96,27 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
       SnowflakeConnectionV1 connection,
       int resultSetType,
       int resultSetConcurrency,
-      int resultSetHoldability) throws SQLException
-  {
-    logger.debug(
-        " public SnowflakeStatement(SnowflakeConnectionV1 conn)");
+      int resultSetHoldability)
+      throws SQLException {
+    logger.debug(" public SnowflakeStatement(SnowflakeConnectionV1 conn)");
 
     this.connection = connection;
 
-    if (resultSetType != ResultSet.TYPE_FORWARD_ONLY)
-    {
+    if (resultSetType != ResultSet.TYPE_FORWARD_ONLY) {
       throw new SQLFeatureNotSupportedException(
           String.format("ResultSet type %d is not supported.", resultSetType),
           FEATURE_UNSUPPORTED.getSqlState(),
           FEATURE_UNSUPPORTED.getMessageCode());
     }
 
-    if (resultSetConcurrency != ResultSet.CONCUR_READ_ONLY)
-    {
+    if (resultSetConcurrency != ResultSet.CONCUR_READ_ONLY) {
       throw new SQLFeatureNotSupportedException(
           String.format("ResultSet concurrency %d is not supported.", resultSetConcurrency),
           FEATURE_UNSUPPORTED.getSqlState(),
           FEATURE_UNSUPPORTED.getMessageCode());
     }
 
-    if (resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT)
-    {
+    if (resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
       throw new SQLFeatureNotSupportedException(
           String.format("ResultSet holdability %d is not supported.", resultSetHoldability),
           FEATURE_UNSUPPORTED.getSqlState(),
@@ -141,14 +127,11 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
 
-    sfStatement = (connection != null) ?
-                  new SFStatement(connection.getSfSession()) : null;
+    sfStatement = (connection != null) ? new SFStatement(connection.getSfSession()) : null;
   }
 
-  protected void raiseSQLExceptionIfStatementIsClosed() throws SQLException
-  {
-    if (isClosed)
-    {
+  protected void raiseSQLExceptionIfStatementIsClosed() throws SQLException {
+    if (isClosed) {
       throw new SnowflakeSQLException(ErrorCode.STATEMENT_CLOSED);
     }
   }
@@ -161,8 +144,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
    * @throws SQLException if @link{#executeQueryInternal(String, Map)} throws an exception
    */
   @Override
-  public ResultSet executeQuery(String sql) throws SQLException
-  {
+  public ResultSet executeQuery(String sql) throws SQLException {
     raiseSQLExceptionIfStatementIsClosed();
     return executeQueryInternal(sql, false, null);
   }
@@ -174,8 +156,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
    * @return ResultSet
    * @throws SQLException if @link{#executeQueryInternal(String, Map)} throws an exception
    */
-  public ResultSet executeAsyncQuery(String sql) throws SQLException
-  {
+  public ResultSet executeAsyncQuery(String sql) throws SQLException {
     raiseSQLExceptionIfStatementIsClosed();
     return executeQueryInternal(sql, true, null);
   }
@@ -188,8 +169,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
    * @throws SQLException if @link{#executeUpdateInternal(String, Map)} throws exception
    */
   @Override
-  public int executeUpdate(String sql) throws SQLException
-  {
+  public int executeUpdate(String sql) throws SQLException {
     return (int) this.executeLargeUpdate(sql);
   }
 
@@ -201,53 +181,47 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
    * @throws SQLException if @link{#executeUpdateInternal(String, Map)} throws exception
    */
   @Override
-  public long executeLargeUpdate(String sql) throws SQLException
-  {
+  public long executeLargeUpdate(String sql) throws SQLException {
     return executeUpdateInternal(sql, null, true);
   }
 
-  long executeUpdateInternal(String sql,
-                             Map<String, ParameterBindingDTO> parameterBindings,
-                             boolean updateQueryRequired)
-  throws SQLException
-  {
+  long executeUpdateInternal(
+      String sql, Map<String, ParameterBindingDTO> parameterBindings, boolean updateQueryRequired)
+      throws SQLException {
     raiseSQLExceptionIfStatementIsClosed();
 
     /* If sql command is a staging command that has parameter binding, throw an exception because parameter binding
     is not supported for staging commands. */
-    if (StmtUtil.checkStageManageCommand(sql) != null && parameterBindings != null)
-    {
+    if (StmtUtil.checkStageManageCommand(sql) != null && parameterBindings != null) {
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, connection.getSfSession(), StmtUtil.truncateSQL(sql));
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+          connection.getSfSession(),
+          StmtUtil.truncateSQL(sql));
     }
 
     SFBaseResultSet sfResultSet;
-    try
-    {
-      sfResultSet = sfStatement.execute(sql, false, parameterBindings,
-                                        SFStatement.CallingMethod.EXECUTE_UPDATE);
+    try {
+      sfResultSet =
+          sfStatement.execute(
+              sql, false, parameterBindings, SFStatement.CallingMethod.EXECUTE_UPDATE);
       sfResultSet.setSession(this.connection.getSfSession());
       updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       queryID = sfResultSet.getQueryId();
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
-    }
-    finally
-    {
-      if (resultSet != null)
-      {
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } finally {
+      if (resultSet != null) {
         openResultSets.add(resultSet);
       }
       resultSet = null;
     }
 
-    if (updateCount == NO_UPDATES && updateQueryRequired)
-    {
+    if (updateCount == NO_UPDATES && updateQueryRequired) {
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, connection.getSfSession(), StmtUtil.truncateSQL(sql));
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
+          connection.getSfSession(),
+          StmtUtil.truncateSQL(sql));
     }
 
     return updateCount;
@@ -256,41 +230,33 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
   /**
    * Internal method for executing a query with bindings accepted.
    *
-   * @param sql               sql statement
-   * @param asyncExec         execute query asychronously
+   * @param sql sql statement
+   * @param asyncExec execute query asychronously
    * @param parameterBindings parameters bindings
    * @return query result set
    * @throws SQLException if @link{SFStatement.execute(String)} throws exception
    */
   ResultSet executeQueryInternal(
-      String sql, boolean asyncExec,
-      Map<String, ParameterBindingDTO> parameterBindings)
-  throws SQLException
-  {
+      String sql, boolean asyncExec, Map<String, ParameterBindingDTO> parameterBindings)
+      throws SQLException {
     SFBaseResultSet sfResultSet;
-    try
-    {
-      sfResultSet = sfStatement.execute(sql, asyncExec, parameterBindings,
-                                        SFStatement.CallingMethod.EXECUTE_QUERY);
+    try {
+      sfResultSet =
+          sfStatement.execute(
+              sql, asyncExec, parameterBindings, SFStatement.CallingMethod.EXECUTE_QUERY);
       sfResultSet.setSession(this.connection.getSfSession());
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex.getCause(),
-                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(
+          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
 
-    if (resultSet != null)
-    {
+    if (resultSet != null) {
       openResultSets.add(resultSet);
     }
 
-    if (asyncExec)
-    {
+    if (asyncExec) {
       resultSet = new SFAsyncResultSet(sfResultSet, this);
-    }
-    else
-    {
+    } else {
       resultSet = new SnowflakeResultSetV1(sfResultSet, this);
     }
 
@@ -300,39 +266,32 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
   /**
    * Execute sql
    *
-   * @param sql               sql statement
+   * @param sql sql statement
    * @param parameterBindings a map of binds to use for this query
    * @return whether there is result set or not
    * @throws SQLException if @link{#executeQuery(String)} throws exception
    */
-  boolean executeInternal(String sql,
-                          Map<String, ParameterBindingDTO> parameterBindings)
-  throws SQLException
-  {
+  boolean executeInternal(String sql, Map<String, ParameterBindingDTO> parameterBindings)
+      throws SQLException {
     raiseSQLExceptionIfStatementIsClosed();
     connection.injectedDelay();
 
-    logger.debug("execute: {}",
-                 (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
+    logger.debug("execute: {}", (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
 
     String trimmedSql = sql.trim();
 
-    if (trimmedSql.length() >= 20
-        && trimmedSql.toLowerCase().startsWith("set-sf-property"))
-    {
+    if (trimmedSql.length() >= 20 && trimmedSql.toLowerCase().startsWith("set-sf-property")) {
       // deprecated: sfsql
       executeSetProperty(sql);
       return false;
     }
 
     SFBaseResultSet sfResultSet;
-    try
-    {
-      sfResultSet = sfStatement.execute(sql, false, parameterBindings,
-                                        SFStatement.CallingMethod.EXECUTE);
+    try {
+      sfResultSet =
+          sfStatement.execute(sql, false, parameterBindings, SFStatement.CallingMethod.EXECUTE);
       sfResultSet.setSession(this.connection.getSfSession());
-      if (resultSet != null)
-      {
+      if (resultSet != null) {
         openResultSets.add(resultSet);
       }
       resultSet = new SnowflakeResultSetV1(sfResultSet, this);
@@ -342,13 +301,10 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
       // statement execute, so we only treat update counts as update counts
       // if CLIENT_SFSQL is not set, or if a statement
       // is multi-statement
-      if (!sfResultSet.getStatementType().isGenerateResultSet() &&
-          (!connection.getSfSession().isSfSQLMode() ||
-           sfStatement.hasChildren()))
-      {
+      if (!sfResultSet.getStatementType().isGenerateResultSet()
+          && (!connection.getSfSession().isSfSQLMode() || sfStatement.hasChildren())) {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
-        if (resultSet != null)
-        {
+        if (resultSet != null) {
           openResultSets.add(resultSet);
         }
         resultSet = null;
@@ -357,28 +313,20 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
 
       updateCount = NO_UPDATES;
       return true;
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  /**
-   * @return the query ID of the latest executed query
-   */
-  public String getQueryID()
-  {
+  /** @return the query ID of the latest executed query */
+  public String getQueryID() {
     // return the queryID for the query executed last time
     return queryID;
   }
 
-  /**
-   * @return the query IDs of the latest executed batch queries
-   */
-  public List<String> getBatchQueryIDs()
-  {
+  /** @return the query IDs of the latest executed batch queries */
+  public List<String> getBatchQueryIDs() {
     return Collections.unmodifiableList(batchQueryIDs);
   }
 
@@ -390,302 +338,240 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
    * @throws SQLException if @link{#executeQuery(String)} throws exception
    */
   @Override
-  public boolean execute(String sql) throws SQLException
-  {
+  public boolean execute(String sql) throws SQLException {
     return executeInternal(sql, null);
   }
 
-
   @Override
-  public boolean execute(String sql, int autoGeneratedKeys)
-  throws SQLException
-  {
-    logger.debug(
-        "execute(String sql, int autoGeneratedKeys)");
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+    logger.debug("execute(String sql, int autoGeneratedKeys)");
 
-    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS)
-    {
+    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
       return execute(sql);
-    }
-    else
-    {
+    } else {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public boolean execute(String sql, int[] columnIndexes) throws SQLException
-  {
-    logger.debug(
-        "execute(String sql, int[] columnIndexes)");
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+    logger.debug("execute(String sql, int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, String[] columnNames) throws SQLException
-  {
-    logger.debug(
-        "execute(String sql, String[] columnNames)");
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
+    logger.debug("execute(String sql, String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   /**
-   * Batch Execute. If one of the commands in the batch failed, JDBC will
-   * continuing processing and throw BatchUpdateException after all commands
-   * are processed.
+   * Batch Execute. If one of the commands in the batch failed, JDBC will continuing processing and
+   * throw BatchUpdateException after all commands are processed.
    *
    * @return an array of update counts
    * @throws SQLException if any error occurs.
    */
   @Override
-  public int[] executeBatch() throws SQLException
-  {
+  public int[] executeBatch() throws SQLException {
     logger.debug("int[] executeBatch()");
     return executeBatchInternal(false).intArr;
   }
 
   /**
-   * Batch Execute. If one of the commands in the batch failed, JDBC will
-   * continuing processing and throw BatchUpdateException after all commands
-   * are processed.
+   * Batch Execute. If one of the commands in the batch failed, JDBC will continuing processing and
+   * throw BatchUpdateException after all commands are processed.
    *
    * @return an array of update counts
    * @throws SQLException if any error occurs.
    */
   @Override
-  public long[] executeLargeBatch() throws SQLException
-  {
+  public long[] executeLargeBatch() throws SQLException {
     logger.debug("executeBatch()");
     return executeBatchInternal(true).longArr;
   }
 
   /**
-   * This method will iterate through batch and provide sql and bindings to
-   * underlying SFStatement to get result set.
-   * <p>
-   * Note, array binds use a different code path since only one network
-   * roundtrip in the array bind execution case.
+   * This method will iterate through batch and provide sql and bindings to underlying SFStatement
+   * to get result set.
+   *
+   * <p>Note, array binds use a different code path since only one network roundtrip in the array
+   * bind execution case.
    *
    * @return the number of updated rows
    * @throws SQLException raises if statement is closed or any db error occurs
    */
-  VariableTypeArray executeBatchInternal(boolean isLong) throws SQLException
-  {
+  VariableTypeArray executeBatchInternal(boolean isLong) throws SQLException {
     raiseSQLExceptionIfStatementIsClosed();
 
     SQLException exceptionReturned = null;
     VariableTypeArray updateCounts;
-    if (isLong)
-    {
+    if (isLong) {
       long[] arr = new long[batch.size()];
       updateCounts = new VariableTypeArray(null, arr);
-    }
-    else
-    {
+    } else {
       int size = batch.size();
       int[] arr = new int[size];
       updateCounts = new VariableTypeArray(arr, null);
     }
     batchQueryIDs.clear();
-    for (int i = 0; i < batch.size(); i++)
-    {
+    for (int i = 0; i < batch.size(); i++) {
       BatchEntry b = batch.get(i);
-      try
-      {
-        long cnt = this.executeUpdateInternal(
-            b.getSql(), b.getParameterBindings(), false);
-        if (cnt == NO_UPDATES)
-        {
+      try {
+        long cnt = this.executeUpdateInternal(b.getSql(), b.getParameterBindings(), false);
+        if (cnt == NO_UPDATES) {
           // in executeBatch we set updateCount to SUCCESS_NO_INFO
           // for successful query with no updates
           cnt = SUCCESS_NO_INFO;
         }
-        if (isLong)
-        {
+        if (isLong) {
           updateCounts.longArr[i] = cnt;
-        }
-        else if (cnt <= Integer.MAX_VALUE)
-        {
+        } else if (cnt <= Integer.MAX_VALUE) {
           updateCounts.intArr[i] = (int) cnt;
-        }
-        else
-        {
-          throw new SnowflakeSQLLoggedException(SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
-                                                ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(), connection.getSfSession(), i);
+        } else {
+          throw new SnowflakeSQLLoggedException(
+              SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
+              ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(),
+              connection.getSfSession(),
+              i);
         }
         batchQueryIDs.add(queryID);
-      }
-      catch (SQLException e)
-      {
+      } catch (SQLException e) {
         exceptionReturned = exceptionReturned == null ? e : exceptionReturned;
-        if (isLong)
-        {
+        if (isLong) {
           updateCounts.longArr[i] = (long) EXECUTE_FAILED;
-        }
-        else
-        {
+        } else {
           updateCounts.intArr[i] = EXECUTE_FAILED;
         }
       }
     }
 
-    if (exceptionReturned != null && isLong)
-    {
-      throw new BatchUpdateException(exceptionReturned.getLocalizedMessage(),
-                                     exceptionReturned.getSQLState(),
-                                     exceptionReturned.getErrorCode(),
-                                     updateCounts.longArr,
-                                     exceptionReturned);
-    }
-    else if (exceptionReturned != null)
-    {
-      throw new BatchUpdateException(exceptionReturned.getLocalizedMessage(),
-                                     exceptionReturned.getSQLState(),
-                                     exceptionReturned.getErrorCode(),
-                                     updateCounts.intArr,
-                                     exceptionReturned);
+    if (exceptionReturned != null && isLong) {
+      throw new BatchUpdateException(
+          exceptionReturned.getLocalizedMessage(),
+          exceptionReturned.getSQLState(),
+          exceptionReturned.getErrorCode(),
+          updateCounts.longArr,
+          exceptionReturned);
+    } else if (exceptionReturned != null) {
+      throw new BatchUpdateException(
+          exceptionReturned.getLocalizedMessage(),
+          exceptionReturned.getSQLState(),
+          exceptionReturned.getErrorCode(),
+          updateCounts.intArr,
+          exceptionReturned);
     }
 
     return updateCounts;
   }
 
   @Override
-  public int executeUpdate(String sql, int autoGeneratedKeys)
-  throws SQLException
-  {
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
     logger.debug("executeUpdate(String sql, int autoGeneratedKeys)");
 
     return (int) this.executeLargeUpdate(sql, autoGeneratedKeys);
   }
 
   @Override
-  public long executeLargeUpdate(String sql, int autoGeneratedKeys)
-  throws SQLException
-  {
+  public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
     logger.debug("executeUpdate(String sql, int autoGeneratedKeys)");
 
-    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS)
-    {
+    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
       return executeLargeUpdate(sql);
-    }
-    else
-    {
+    } else {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public int executeUpdate(String sql, int[] columnIndexes)
-  throws SQLException
-  {
-    logger.debug(
-        "executeUpdate(String sql, int[] columnIndexes)");
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    logger.debug("executeUpdate(String sql, int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public long executeLargeUpdate(String sql, int[] columnIndexes)
-  throws SQLException
-  {
-    logger.debug(
-        "executeLargeUpdate(String sql, int[] columnIndexes)");
+  public long executeLargeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    logger.debug("executeLargeUpdate(String sql, int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql, String[] columnNames)
-  throws SQLException
-  {
-    logger.debug(
-        "executeUpdate(String sql, String[] columnNames)");
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+    logger.debug("executeUpdate(String sql, String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public long executeLargeUpdate(String sql, String[] columnNames)
-  throws SQLException
-  {
-    logger.debug(
-        "executeUpdate(String sql, String[] columnNames)");
+  public long executeLargeUpdate(String sql, String[] columnNames) throws SQLException {
+    logger.debug("executeUpdate(String sql, String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Connection getConnection() throws SQLException
-  {
+  public Connection getConnection() throws SQLException {
     logger.debug("getConnection()");
     raiseSQLExceptionIfStatementIsClosed();
     return connection;
   }
 
   @Override
-  public int getFetchDirection() throws SQLException
-  {
+  public int getFetchDirection() throws SQLException {
     logger.debug("getFetchDirection()");
     raiseSQLExceptionIfStatementIsClosed();
     return ResultSet.FETCH_FORWARD;
   }
 
   @Override
-  public int getFetchSize() throws SQLException
-  {
+  public int getFetchSize() throws SQLException {
     logger.debug("getFetchSize()");
     raiseSQLExceptionIfStatementIsClosed();
     return fetchSize;
   }
 
   @Override
-  public ResultSet getGeneratedKeys() throws SQLException
-  {
+  public ResultSet getGeneratedKeys() throws SQLException {
     logger.debug("getGeneratedKeys()");
     raiseSQLExceptionIfStatementIsClosed();
     return new SnowflakeResultSetV1.EmptyResultSet();
   }
 
   @Override
-  public int getMaxFieldSize() throws SQLException
-  {
+  public int getMaxFieldSize() throws SQLException {
     logger.debug("getMaxFieldSize()");
     raiseSQLExceptionIfStatementIsClosed();
     return maxFieldSize;
   }
 
   @Override
-  public int getMaxRows() throws SQLException
-  {
+  public int getMaxRows() throws SQLException {
     logger.debug("getMaxRows()");
     raiseSQLExceptionIfStatementIsClosed();
     return maxRows;
   }
 
   @Override
-  public boolean getMoreResults() throws SQLException
-  {
+  public boolean getMoreResults() throws SQLException {
     logger.debug("getMoreResults()");
 
     return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
   }
 
   @Override
-  public boolean getMoreResults(int current) throws SQLException
-  {
+  public boolean getMoreResults(int current) throws SQLException {
     logger.debug("getMoreResults(int current)");
     raiseSQLExceptionIfStatementIsClosed();
 
     // clean up the current result set, if it exists
-    if (resultSet != null &&
-        (current == Statement.CLOSE_CURRENT_RESULT ||
-         current == Statement.CLOSE_ALL_RESULTS))
-    {
+    if (resultSet != null
+        && (current == Statement.CLOSE_CURRENT_RESULT || current == Statement.CLOSE_ALL_RESULTS)) {
       resultSet.close();
     }
-
 
     boolean hasResultSet = sfStatement.getMoreResults(current);
     SFBaseResultSet sfResultSet = sfStatement.getResultSet();
@@ -693,32 +579,25 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
     if (hasResultSet) // result set returned
     {
       sfResultSet.setSession(this.connection.getSfSession());
-      if (resultSet != null)
-      {
+      if (resultSet != null) {
         openResultSets.add(resultSet);
       }
       resultSet = new SnowflakeResultSetV1(sfResultSet, this);
       updateCount = NO_UPDATES;
       return true;
-    }
-    else if (sfResultSet != null) // update count returned
+    } else if (sfResultSet != null) // update count returned
     {
-      if (resultSet != null)
-      {
+      if (resultSet != null) {
         openResultSets.add(resultSet);
       }
       resultSet = null;
-      try
-      {
+      try {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
-      }
-      catch (SFException ex)
-      {
+      } catch (SFException ex) {
         throw new SnowflakeSQLLoggedException(ex, connection.getSfSession());
       }
       return false;
-    }
-    else // no more results
+    } else // no more results
     {
       updateCount = NO_UPDATES;
       return false;
@@ -726,103 +605,89 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
   }
 
   @Override
-  public int getQueryTimeout() throws SQLException
-  {
+  public int getQueryTimeout() throws SQLException {
     logger.debug("getQueryTimeout()");
     raiseSQLExceptionIfStatementIsClosed();
     return this.queryTimeout;
   }
 
   @Override
-  public ResultSet getResultSet() throws SQLException
-  {
+  public ResultSet getResultSet() throws SQLException {
     logger.debug("getResultSet()");
     raiseSQLExceptionIfStatementIsClosed();
     return resultSet;
   }
 
   @Override
-  public int getResultSetConcurrency() throws SQLException
-  {
+  public int getResultSetConcurrency() throws SQLException {
     logger.debug("getResultSetConcurrency()");
     raiseSQLExceptionIfStatementIsClosed();
     return resultSetConcurrency;
   }
 
   @Override
-  public int getResultSetHoldability() throws SQLException
-  {
+  public int getResultSetHoldability() throws SQLException {
     logger.debug("getResultSetHoldability()");
     raiseSQLExceptionIfStatementIsClosed();
     return resultSetHoldability;
   }
 
   @Override
-  public int getResultSetType() throws SQLException
-  {
+  public int getResultSetType() throws SQLException {
     logger.debug("getResultSetType()");
     raiseSQLExceptionIfStatementIsClosed();
     return this.resultSetType;
   }
 
   @Override
-  public int getUpdateCount() throws SQLException
-  {
+  public int getUpdateCount() throws SQLException {
     logger.debug("getUpdateCount()");
     return (int) getUpdateCountIfDML();
   }
 
   @Override
-  public long getLargeUpdateCount() throws SQLException
-  {
+  public long getLargeUpdateCount() throws SQLException {
     logger.debug("getLargeUpdateCount()");
     return getUpdateCountIfDML();
   }
 
-  private long getUpdateCountIfDML() throws SQLException
-  {
+  private long getUpdateCountIfDML() throws SQLException {
     raiseSQLExceptionIfStatementIsClosed();
-    if (updateCount != -1 && sfStatement.getResultSet().getStatementType().isDML())
-    {
+    if (updateCount != -1 && sfStatement.getResultSet().getStatementType().isDML()) {
       return updateCount;
     }
     return -1;
   }
 
   @Override
-  public SQLWarning getWarnings() throws SQLException
-  {
+  public SQLWarning getWarnings() throws SQLException {
     logger.debug("getWarnings()");
     raiseSQLExceptionIfStatementIsClosed();
     return sqlWarnings;
   }
 
   @Override
-  public boolean isClosed() throws SQLException
-  {
+  public boolean isClosed() throws SQLException {
     logger.debug("isClosed()");
     return isClosed; // no exception
   }
 
   @Override
-  public boolean isPoolable() throws SQLException
-  {
+  public boolean isPoolable() throws SQLException {
     logger.debug("isPoolable()");
     raiseSQLExceptionIfStatementIsClosed();
     return poolable;
   }
 
   @Override
-  public void setCursorName(String name) throws SQLException
-  {
+  public void setCursorName(String name) throws SQLException {
     logger.debug("setCursorName(String name)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setEscapeProcessing(boolean enable) throws SQLException
-  {
+  public void setEscapeProcessing(boolean enable) throws SQLException {
     logger.debug("setEscapeProcessing(boolean enable)");
     // NOTE: We could raise an exception here, because not implemented
     // but it may break the existing applications. For now returning nothnig.
@@ -831,62 +696,51 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
   }
 
   @Override
-  public void setFetchDirection(int direction) throws SQLException
-  {
+  public void setFetchDirection(int direction) throws SQLException {
     logger.debug("setFetchDirection(int direction)");
     raiseSQLExceptionIfStatementIsClosed();
-    if (direction != ResultSet.FETCH_FORWARD)
-    {
+    if (direction != ResultSet.FETCH_FORWARD) {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public void setFetchSize(int rows) throws SQLException
-  {
+  public void setFetchSize(int rows) throws SQLException {
     logger.debug("setFetchSize(int rows), rows={}", rows);
     raiseSQLExceptionIfStatementIsClosed();
     fetchSize = rows;
   }
 
   @Override
-  public void setMaxFieldSize(int max) throws SQLException
-  {
+  public void setMaxFieldSize(int max) throws SQLException {
     logger.debug("setMaxFieldSize(int max)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setMaxRows(int max) throws SQLException
-  {
+  public void setMaxRows(int max) throws SQLException {
     logger.debug("setMaxRows(int max)");
 
     raiseSQLExceptionIfStatementIsClosed();
 
     this.maxRows = max;
-    try
-    {
-      if (this.sfStatement != null)
-      {
+    try {
+      if (this.sfStatement != null) {
         this.sfStatement.addProperty("rows_per_resultset", max);
       }
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void setPoolable(boolean poolable) throws SQLException
-  {
+  public void setPoolable(boolean poolable) throws SQLException {
     logger.debug("setPoolable(boolean poolable)");
     raiseSQLExceptionIfStatementIsClosed();
 
-    if (poolable)
-    {
+    if (poolable) {
       throw new SQLFeatureNotSupportedException();
     }
     this.poolable = poolable;
@@ -895,51 +749,40 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
   /**
    * Sets a parameter at the statement level.
    *
-   * @param name  parameter name.
+   * @param name parameter name.
    * @param value parameter value.
    * @throws SQLException if any SQL error occurs.
    */
-  public void setParameter(String name, Object value) throws SQLException
-  {
+  public void setParameter(String name, Object value) throws SQLException {
     logger.debug("setParameter");
 
-    try
-    {
-      if (this.sfStatement != null)
-      {
+    try {
+      if (this.sfStatement != null) {
         this.sfStatement.addProperty(name, value);
       }
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLException(ex);
     }
   }
 
   @Override
-  public void setQueryTimeout(int seconds) throws SQLException
-  {
+  public void setQueryTimeout(int seconds) throws SQLException {
     logger.debug("setQueryTimeout(int seconds)");
     raiseSQLExceptionIfStatementIsClosed();
 
     this.queryTimeout = seconds;
-    try
-    {
-      if (this.sfStatement != null)
-      {
+    try {
+      if (this.sfStatement != null) {
         this.sfStatement.addProperty("query_timeout", seconds);
       }
-    }
-    catch (SFException ex)
-    {
+    } catch (SFException ex) {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException
-  {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
     logger.debug("isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -947,46 +790,38 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException
-  {
+  public <T> T unwrap(Class<T> iface) throws SQLException {
     logger.debug("unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this))
-    {
+    if (!iface.isInstance(this)) {
       throw new SQLException(
-          this.getClass().getName() + " not unwrappable from " + iface
-              .getName());
+          this.getClass().getName() + " not unwrappable from " + iface.getName());
     }
     return (T) this;
   }
 
   @Override
-  public void closeOnCompletion() throws SQLException
-  {
+  public void closeOnCompletion() throws SQLException {
     logger.debug("closeOnCompletion()");
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isCloseOnCompletion() throws SQLException
-  {
+  public boolean isCloseOnCompletion() throws SQLException {
     logger.debug("isCloseOnCompletion()");
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void close() throws SQLException
-  {
+  public void close() throws SQLException {
     close(true);
   }
 
-  public void close(boolean removeClosedStatementFromConnection) throws SQLException
-  {
+  public void close(boolean removeClosedStatementFromConnection) throws SQLException {
     logger.debug("close()");
 
     // No exception is raised even if the statement is closed.
-    if (resultSet != null)
-    {
+    if (resultSet != null) {
       resultSet.close();
       resultSet = null;
     }
@@ -994,56 +829,43 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
     batch.clear();
 
     // also make sure to close all created resultSets from this statement
-    for (ResultSet rs : openResultSets)
-    {
-      if (rs != null && !rs.isClosed())
-      {
-        if (rs.isWrapperFor(SnowflakeResultSetV1.class))
-        {
+    for (ResultSet rs : openResultSets) {
+      if (rs != null && !rs.isClosed()) {
+        if (rs.isWrapperFor(SnowflakeResultSetV1.class)) {
           rs.unwrap(SnowflakeResultSetV1.class).close(false);
-        }
-        else
-        {
+        } else {
           rs.close();
         }
       }
     }
     openResultSets.clear();
     sfStatement.close();
-    if (removeClosedStatementFromConnection)
-    {
+    if (removeClosedStatementFromConnection) {
       connection.removeClosedStatement(this);
     }
   }
 
   @Override
-  public void cancel() throws SQLException
-  {
+  public void cancel() throws SQLException {
     logger.debug("cancel()");
     raiseSQLExceptionIfStatementIsClosed();
 
-    try
-    {
+    try {
       sfStatement.cancel();
-    }
-    catch (SFException ex)
-    {
-      throw new SnowflakeSQLException(ex, ex.getSqlState(),
-                                      ex.getVendorCode(), ex.getParams());
+    } catch (SFException ex) {
+      throw new SnowflakeSQLException(ex, ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void clearWarnings() throws SQLException
-  {
+  public void clearWarnings() throws SQLException {
     logger.debug("clearWarnings()");
     raiseSQLExceptionIfStatementIsClosed();
     sqlWarnings = null;
   }
 
   @Override
-  public void addBatch(String sql) throws SQLException
-  {
+  public void addBatch(String sql) throws SQLException {
     logger.debug("addBatch(String sql)");
 
     raiseSQLExceptionIfStatementIsClosed();
@@ -1052,8 +874,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
   }
 
   @Override
-  public void clearBatch() throws SQLException
-  {
+  public void clearBatch() throws SQLException {
     logger.debug("clearBatch()");
 
     raiseSQLExceptionIfStatementIsClosed();
@@ -1061,22 +882,18 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
     batch.clear();
   }
 
-  private void executeSetProperty(final String sql)
-  {
+  private void executeSetProperty(final String sql) {
     logger.debug("setting property");
 
     // tokenize the sql
     String[] tokens = sql.split("\\s+");
 
-    if (tokens.length < 2)
-    {
+    if (tokens.length < 2) {
       return;
     }
 
-    if ("tracing".equalsIgnoreCase(tokens[1]))
-    {
-      if (tokens.length >= 3)
-      {
+    if ("tracing".equalsIgnoreCase(tokens[1])) {
+      if (tokens.length >= 3) {
         /*connection.tracingLevel = Level.parse(tokens[2].toUpperCase());
         if (connection.tracingLevel != null)
         {
@@ -1084,365 +901,292 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
           snowflakeLogger.setLevel(connection.tracingLevel);
         }*/
       }
-    }
-    else
-    {
+    } else {
       this.sfStatement.executeSetProperty(sql);
     }
   }
 
-  public SFStatement getSfStatement() throws SQLException
-  {
+  public SFStatement getSfStatement() throws SQLException {
     return sfStatement;
   }
 
-  public void removeClosedResultSet(ResultSet rs)
-  {
+  public void removeClosedResultSet(ResultSet rs) {
     openResultSets.remove(rs);
   }
 
-  final class BatchEntry
-  {
+  final class BatchEntry {
     private final String sql;
 
     private final Map<String, ParameterBindingDTO> parameterBindings;
 
-    BatchEntry(String sql,
-               Map<String, ParameterBindingDTO> parameterBindings)
-    {
+    BatchEntry(String sql, Map<String, ParameterBindingDTO> parameterBindings) {
       this.sql = sql;
       this.parameterBindings = parameterBindings;
     }
 
-    public String getSql()
-    {
+    public String getSql() {
       return sql;
     }
 
-    public Map<String, ParameterBindingDTO> getParameterBindings()
-    {
+    public Map<String, ParameterBindingDTO> getParameterBindings() {
       return parameterBindings;
     }
   }
 
   /**
-   * This is a No Operation Statement to avoid null pointer exception for
-   * sessionless result set.
+   * This is a No Operation Statement to avoid null pointer exception for sessionless result set.
    */
-  public static class NoOpSnowflakeStatementV1 extends SnowflakeStatementV1
-  {
-    public NoOpSnowflakeStatementV1() throws SQLException
-    {
-      super(null,
-            ResultSet.TYPE_FORWARD_ONLY,
-            ResultSet.CONCUR_READ_ONLY,
-            ResultSet.CLOSE_CURSORS_AT_COMMIT);
+  public static class NoOpSnowflakeStatementV1 extends SnowflakeStatementV1 {
+    public NoOpSnowflakeStatementV1() throws SQLException {
+      super(
+          null,
+          ResultSet.TYPE_FORWARD_ONLY,
+          ResultSet.CONCUR_READ_ONLY,
+          ResultSet.CLOSE_CURSORS_AT_COMMIT);
     }
 
-    private void throwExceptionAnyway() throws SQLException
-    {
-      throw new SQLException("This is a dummy SnowflakeStatement, " +
-                             "no member function should be called for it.");
+    private void throwExceptionAnyway() throws SQLException {
+      throw new SQLException(
+          "This is a dummy SnowflakeStatement, " + "no member function should be called for it.");
     }
 
     @Override
-    public ResultSet executeQuery(String sql) throws SQLException
-    {
+    public ResultSet executeQuery(String sql) throws SQLException {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public int executeUpdate(String sql) throws SQLException
-    {
+    public int executeUpdate(String sql) throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long executeLargeUpdate(String sql) throws SQLException
-    {
+    public long executeLargeUpdate(String sql) throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public String getQueryID()
-    {
+    public String getQueryID() {
       return "invalid_query_id";
     }
 
     @Override
-    public List<String> getBatchQueryIDs()
-    {
+    public List<String> getBatchQueryIDs() {
       return new ArrayList<>();
     }
 
     @Override
-    public boolean execute(String sql) throws SQLException
-    {
+    public boolean execute(String sql) throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean execute(String sql, int autoGeneratedKeys)
-    throws SQLException
-    {
+    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean execute(String sql, int[] columnIndexes) throws SQLException
-    {
+    public boolean execute(String sql, int[] columnIndexes) throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean execute(String sql, String[] columnNames) throws SQLException
-    {
+    public boolean execute(String sql, String[] columnNames) throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public int[] executeBatch() throws SQLException
-    {
+    public int[] executeBatch() throws SQLException {
       throwExceptionAnyway();
       return new int[1];
     }
 
     @Override
-    public long[] executeLargeBatch() throws SQLException
-    {
+    public long[] executeLargeBatch() throws SQLException {
       throwExceptionAnyway();
       return new long[1];
     }
 
     @Override
-    public int executeUpdate(String sql, int autoGeneratedKeys)
-    throws SQLException
-    {
+    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long executeLargeUpdate(String sql, int autoGeneratedKeys)
-    throws SQLException
-    {
+    public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int executeUpdate(String sql, int[] columnIndexes)
-    throws SQLException
-    {
+    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long executeLargeUpdate(String sql, int[] columnIndexes)
-    throws SQLException
-    {
+    public long executeLargeUpdate(String sql, int[] columnIndexes) throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int executeUpdate(String sql, String[] columnNames)
-    throws SQLException
-    {
+    public int executeUpdate(String sql, String[] columnNames) throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long executeLargeUpdate(String sql, String[] columnNames)
-    throws SQLException
-    {
+    public long executeLargeUpdate(String sql, String[] columnNames) throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public Connection getConnection() throws SQLException
-    {
+    public Connection getConnection() throws SQLException {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public int getFetchDirection() throws SQLException
-    {
+    public int getFetchDirection() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getFetchSize() throws SQLException
-    {
+    public int getFetchSize() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public ResultSet getGeneratedKeys() throws SQLException
-    {
+    public ResultSet getGeneratedKeys() throws SQLException {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public int getMaxFieldSize() throws SQLException
-    {
+    public int getMaxFieldSize() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getMaxRows() throws SQLException
-    {
+    public int getMaxRows() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public boolean getMoreResults() throws SQLException
-    {
+    public boolean getMoreResults() throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean getMoreResults(int current) throws SQLException
-    {
+    public boolean getMoreResults(int current) throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public int getQueryTimeout() throws SQLException
-    {
+    public int getQueryTimeout() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public ResultSet getResultSet() throws SQLException
-    {
+    public ResultSet getResultSet() throws SQLException {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public int getResultSetConcurrency() throws SQLException
-    {
+    public int getResultSetConcurrency() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getResultSetHoldability() throws SQLException
-    {
+    public int getResultSetHoldability() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getResultSetType() throws SQLException
-    {
+    public int getResultSetType() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getUpdateCount() throws SQLException
-    {
+    public int getUpdateCount() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long getLargeUpdateCount() throws SQLException
-    {
+    public long getLargeUpdateCount() throws SQLException {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException
-    {
+    public SQLWarning getWarnings() throws SQLException {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public boolean isClosed() throws SQLException
-    {
+    public boolean isClosed() throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean isPoolable() throws SQLException
-    {
+    public boolean isPoolable() throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public void setCursorName(String name) throws SQLException
-    {
-    }
+    public void setCursorName(String name) throws SQLException {}
 
     @Override
-    public void setEscapeProcessing(boolean enable) throws SQLException
-    {
-    }
+    public void setEscapeProcessing(boolean enable) throws SQLException {}
 
     @Override
-    public void setFetchDirection(int direction) throws SQLException
-    {
-    }
+    public void setFetchDirection(int direction) throws SQLException {}
 
     @Override
-    public void setFetchSize(int rows) throws SQLException
-    {
-    }
+    public void setFetchSize(int rows) throws SQLException {}
 
     @Override
-    public void setMaxFieldSize(int max) throws SQLException
-    {
-    }
+    public void setMaxFieldSize(int max) throws SQLException {}
 
     @Override
-    public void setMaxRows(int max) throws SQLException
-    {
-    }
+    public void setMaxRows(int max) throws SQLException {}
 
     @Override
-    public void setPoolable(boolean poolable) throws SQLException
-    {
-    }
+    public void setPoolable(boolean poolable) throws SQLException {}
 
     @Override
-    public void setParameter(String name, Object value) throws SQLException
-    {
-    }
+    public void setParameter(String name, Object value) throws SQLException {}
 
     @Override
-    public void setQueryTimeout(int seconds) throws SQLException
-    {
-    }
+    public void setQueryTimeout(int seconds) throws SQLException {}
 
     @Override
-    public boolean isWrapperFor(Class<?> iface) throws SQLException
-    {
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
       logger.debug("isWrapperFor(Class<?> iface)");
 
       return iface.isInstance(this);
@@ -1450,71 +1194,50 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T unwrap(Class<T> iface) throws SQLException
-    {
+    public <T> T unwrap(Class<T> iface) throws SQLException {
       logger.debug("unwrap(Class<T> iface)");
 
-      if (!iface.isInstance(this))
-      {
+      if (!iface.isInstance(this)) {
         throw new SQLException(
-            this.getClass().getName() + " not unwrappable from " + iface
-                .getName());
+            this.getClass().getName() + " not unwrappable from " + iface.getName());
       }
       return (T) this;
     }
 
     @Override
-    public void closeOnCompletion() throws SQLException
-    {
-    }
+    public void closeOnCompletion() throws SQLException {}
 
     @Override
-    public boolean isCloseOnCompletion() throws SQLException
-    {
+    public boolean isCloseOnCompletion() throws SQLException {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public void close() throws SQLException
-    {
-    }
+    public void close() throws SQLException {}
 
     @Override
-    public void close(boolean removeClosedStatementFromConnection) throws SQLException
-    {
-    }
+    public void close(boolean removeClosedStatementFromConnection) throws SQLException {}
 
     @Override
-    public void cancel() throws SQLException
-    {
-    }
+    public void cancel() throws SQLException {}
 
     @Override
-    public void clearWarnings() throws SQLException
-    {
-    }
+    public void clearWarnings() throws SQLException {}
 
     @Override
-    public void addBatch(String sql) throws SQLException
-    {
-    }
+    public void addBatch(String sql) throws SQLException {}
 
     @Override
-    public void clearBatch() throws SQLException
-    {
-    }
+    public void clearBatch() throws SQLException {}
 
     @Override
-    public SFStatement getSfStatement() throws SQLException
-    {
+    public SFStatement getSfStatement() throws SQLException {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public void removeClosedResultSet(ResultSet rs)
-    {
-    }
+    public void removeClosedResultSet(ResultSet rs) {}
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -4,7 +4,18 @@
 
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.jdbc.ErrorCode.FEATURE_UNSUPPORTED;
+import net.snowflake.client.core.ParameterBindingDTO;
+import net.snowflake.client.core.ResultUtil;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFStatement;
+import net.snowflake.client.core.StmtUtil;
+import net.snowflake.client.log.ArgSupplier;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.util.SecretDetector;
+import net.snowflake.client.util.VariableTypeArray;
+import net.snowflake.common.core.SqlState;
 
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
@@ -20,21 +31,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import net.snowflake.client.core.ParameterBindingDTO;
-import net.snowflake.client.core.ResultUtil;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFStatement;
-import net.snowflake.client.core.StmtUtil;
-import net.snowflake.client.log.ArgSupplier;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.util.SecretDetector;
-import net.snowflake.client.util.VariableTypeArray;
-import net.snowflake.common.core.SqlState;
 
-/** Snowflake statement */
-class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
+import static net.snowflake.client.jdbc.ErrorCode.FEATURE_UNSUPPORTED;
+
+/**
+ * Snowflake statement
+ */
+class SnowflakeStatementV1 implements Statement, SnowflakeStatement
+{
   static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementV1.class);
 
   private static final long NO_UPDATES = -1;
@@ -72,13 +76,19 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
 
   private boolean poolable;
 
-  /** Snowflake query ID from the latest executed query */
+  /**
+   * Snowflake query ID from the latest executed query
+   */
   private String queryID;
 
-  /** Snowflake query IDs from the latest executed batch */
+  /**
+   * Snowflake query IDs from the latest executed batch
+   */
   private List<String> batchQueryIDs = new LinkedList<>();
 
-  /** batch of sql strings added by addBatch */
+  /**
+   * batch of sql strings added by addBatch
+   */
   protected final List<BatchEntry> batch = new ArrayList<>();
 
   private SQLWarning sqlWarnings;
@@ -86,8 +96,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   /**
    * Construct SnowflakeStatementV1
    *
-   * @param connection connection object
-   * @param resultSetType result set type: ResultSet.TYPE_FORWARD_ONLY.
+   * @param connection           connection object
+   * @param resultSetType        result set type: ResultSet.TYPE_FORWARD_ONLY.
    * @param resultSetConcurrency result set concurrency: ResultSet.CONCUR_READ_ONLY.
    * @param resultSetHoldability result set holdability: ResultSet.CLOSE_CURSORS_AT_COMMIT
    * @throws SQLException if any SQL error occurs.
@@ -96,27 +106,31 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       SnowflakeConnectionV1 connection,
       int resultSetType,
       int resultSetConcurrency,
-      int resultSetHoldability)
-      throws SQLException {
-    logger.debug(" public SnowflakeStatement(SnowflakeConnectionV1 conn)");
+      int resultSetHoldability) throws SQLException
+  {
+    logger.debug(
+        " public SnowflakeStatement(SnowflakeConnectionV1 conn)");
 
     this.connection = connection;
 
-    if (resultSetType != ResultSet.TYPE_FORWARD_ONLY) {
+    if (resultSetType != ResultSet.TYPE_FORWARD_ONLY)
+    {
       throw new SQLFeatureNotSupportedException(
           String.format("ResultSet type %d is not supported.", resultSetType),
           FEATURE_UNSUPPORTED.getSqlState(),
           FEATURE_UNSUPPORTED.getMessageCode());
     }
 
-    if (resultSetConcurrency != ResultSet.CONCUR_READ_ONLY) {
+    if (resultSetConcurrency != ResultSet.CONCUR_READ_ONLY)
+    {
       throw new SQLFeatureNotSupportedException(
           String.format("ResultSet concurrency %d is not supported.", resultSetConcurrency),
           FEATURE_UNSUPPORTED.getSqlState(),
           FEATURE_UNSUPPORTED.getMessageCode());
     }
 
-    if (resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
+    if (resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT)
+    {
       throw new SQLFeatureNotSupportedException(
           String.format("ResultSet holdability %d is not supported.", resultSetHoldability),
           FEATURE_UNSUPPORTED.getSqlState(),
@@ -127,11 +141,14 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
 
-    sfStatement = (connection != null) ? new SFStatement(connection.getSfSession()) : null;
+    sfStatement = (connection != null) ?
+                  new SFStatement(connection.getSfSession()) : null;
   }
 
-  protected void raiseSQLExceptionIfStatementIsClosed() throws SQLException {
-    if (isClosed) {
+  protected void raiseSQLExceptionIfStatementIsClosed() throws SQLException
+  {
+    if (isClosed)
+    {
       throw new SnowflakeSQLException(ErrorCode.STATEMENT_CLOSED);
     }
   }
@@ -144,7 +161,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
    * @throws SQLException if @link{#executeQueryInternal(String, Map)} throws an exception
    */
   @Override
-  public ResultSet executeQuery(String sql) throws SQLException {
+  public ResultSet executeQuery(String sql) throws SQLException
+  {
     raiseSQLExceptionIfStatementIsClosed();
     return executeQueryInternal(sql, false, null);
   }
@@ -156,7 +174,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
    * @return ResultSet
    * @throws SQLException if @link{#executeQueryInternal(String, Map)} throws an exception
    */
-  public ResultSet executeAsyncQuery(String sql) throws SQLException {
+  public ResultSet executeAsyncQuery(String sql) throws SQLException
+  {
     raiseSQLExceptionIfStatementIsClosed();
     return executeQueryInternal(sql, true, null);
   }
@@ -169,7 +188,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
    * @throws SQLException if @link{#executeUpdateInternal(String, Map)} throws exception
    */
   @Override
-  public int executeUpdate(String sql) throws SQLException {
+  public int executeUpdate(String sql) throws SQLException
+  {
     return (int) this.executeLargeUpdate(sql);
   }
 
@@ -181,47 +201,53 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
    * @throws SQLException if @link{#executeUpdateInternal(String, Map)} throws exception
    */
   @Override
-  public long executeLargeUpdate(String sql) throws SQLException {
+  public long executeLargeUpdate(String sql) throws SQLException
+  {
     return executeUpdateInternal(sql, null, true);
   }
 
-  long executeUpdateInternal(
-      String sql, Map<String, ParameterBindingDTO> parameterBindings, boolean updateQueryRequired)
-      throws SQLException {
+  long executeUpdateInternal(String sql,
+                             Map<String, ParameterBindingDTO> parameterBindings,
+                             boolean updateQueryRequired)
+  throws SQLException
+  {
     raiseSQLExceptionIfStatementIsClosed();
 
     /* If sql command is a staging command that has parameter binding, throw an exception because parameter binding
     is not supported for staging commands. */
-    if (StmtUtil.checkStageManageCommand(sql) != null && parameterBindings != null) {
+    if (StmtUtil.checkStageManageCommand(sql) != null && parameterBindings != null)
+    {
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
-          connection.getSfSession(),
-          StmtUtil.truncateSQL(sql));
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, connection.getSfSession(), StmtUtil.truncateSQL(sql));
     }
 
     SFBaseResultSet sfResultSet;
-    try {
-      sfResultSet =
-          sfStatement.execute(
-              sql, false, parameterBindings, SFStatement.CallingMethod.EXECUTE_UPDATE);
+    try
+    {
+      sfResultSet = sfStatement.execute(sql, false, parameterBindings,
+                                        SFStatement.CallingMethod.EXECUTE_UPDATE);
       sfResultSet.setSession(this.connection.getSfSession());
       updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       queryID = sfResultSet.getQueryId();
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
-    } finally {
-      if (resultSet != null) {
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    finally
+    {
+      if (resultSet != null)
+      {
         openResultSets.add(resultSet);
       }
       resultSet = null;
     }
 
-    if (updateCount == NO_UPDATES && updateQueryRequired) {
+    if (updateCount == NO_UPDATES && updateQueryRequired)
+    {
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
-          connection.getSfSession(),
-          StmtUtil.truncateSQL(sql));
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API, connection.getSfSession(), StmtUtil.truncateSQL(sql));
     }
 
     return updateCount;
@@ -230,33 +256,41 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   /**
    * Internal method for executing a query with bindings accepted.
    *
-   * @param sql sql statement
-   * @param asyncExec execute query asychronously
+   * @param sql               sql statement
+   * @param asyncExec         execute query asychronously
    * @param parameterBindings parameters bindings
    * @return query result set
    * @throws SQLException if @link{SFStatement.execute(String)} throws exception
    */
   ResultSet executeQueryInternal(
-      String sql, boolean asyncExec, Map<String, ParameterBindingDTO> parameterBindings)
-      throws SQLException {
+      String sql, boolean asyncExec,
+      Map<String, ParameterBindingDTO> parameterBindings)
+  throws SQLException
+  {
     SFBaseResultSet sfResultSet;
-    try {
-      sfResultSet =
-          sfStatement.execute(
-              sql, asyncExec, parameterBindings, SFStatement.CallingMethod.EXECUTE_QUERY);
+    try
+    {
+      sfResultSet = sfStatement.execute(sql, asyncExec, parameterBindings,
+                                        SFStatement.CallingMethod.EXECUTE_QUERY);
       sfResultSet.setSession(this.connection.getSfSession());
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex.getCause(),
+                                      ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
 
-    if (resultSet != null) {
+    if (resultSet != null)
+    {
       openResultSets.add(resultSet);
     }
 
-    if (asyncExec) {
+    if (asyncExec)
+    {
       resultSet = new SFAsyncResultSet(sfResultSet, this);
-    } else {
+    }
+    else
+    {
       resultSet = new SnowflakeResultSetV1(sfResultSet, this);
     }
 
@@ -266,32 +300,39 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   /**
    * Execute sql
    *
-   * @param sql sql statement
+   * @param sql               sql statement
    * @param parameterBindings a map of binds to use for this query
    * @return whether there is result set or not
    * @throws SQLException if @link{#executeQuery(String)} throws exception
    */
-  boolean executeInternal(String sql, Map<String, ParameterBindingDTO> parameterBindings)
-      throws SQLException {
+  boolean executeInternal(String sql,
+                          Map<String, ParameterBindingDTO> parameterBindings)
+  throws SQLException
+  {
     raiseSQLExceptionIfStatementIsClosed();
     connection.injectedDelay();
 
-    logger.debug("execute: {}", (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
+    logger.debug("execute: {}",
+                 (ArgSupplier) () -> SecretDetector.maskSecrets(sql));
 
     String trimmedSql = sql.trim();
 
-    if (trimmedSql.length() >= 20 && trimmedSql.toLowerCase().startsWith("set-sf-property")) {
+    if (trimmedSql.length() >= 20
+        && trimmedSql.toLowerCase().startsWith("set-sf-property"))
+    {
       // deprecated: sfsql
       executeSetProperty(sql);
       return false;
     }
 
     SFBaseResultSet sfResultSet;
-    try {
-      sfResultSet =
-          sfStatement.execute(sql, false, parameterBindings, SFStatement.CallingMethod.EXECUTE);
+    try
+    {
+      sfResultSet = sfStatement.execute(sql, false, parameterBindings,
+                                        SFStatement.CallingMethod.EXECUTE);
       sfResultSet.setSession(this.connection.getSfSession());
-      if (resultSet != null) {
+      if (resultSet != null)
+      {
         openResultSets.add(resultSet);
       }
       resultSet = new SnowflakeResultSetV1(sfResultSet, this);
@@ -301,10 +342,13 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       // statement execute, so we only treat update counts as update counts
       // if CLIENT_SFSQL is not set, or if a statement
       // is multi-statement
-      if (!sfResultSet.getStatementType().isGenerateResultSet()
-          && (!connection.getSfSession().isSfSQLMode() || sfStatement.hasChildren())) {
+      if (!sfResultSet.getStatementType().isGenerateResultSet() &&
+          (!connection.getSfSession().isSfSQLMode() ||
+           sfStatement.hasChildren()))
+      {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
-        if (resultSet != null) {
+        if (resultSet != null)
+        {
           openResultSets.add(resultSet);
         }
         resultSet = null;
@@ -313,20 +357,28 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
 
       updateCount = NO_UPDATES;
       return true;
-    } catch (SFException ex) {
+    }
+    catch (SFException ex)
+    {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
-  /** @return the query ID of the latest executed query */
-  public String getQueryID() {
+  /**
+   * @return the query ID of the latest executed query
+   */
+  public String getQueryID()
+  {
     // return the queryID for the query executed last time
     return queryID;
   }
 
-  /** @return the query IDs of the latest executed batch queries */
-  public List<String> getBatchQueryIDs() {
+  /**
+   * @return the query IDs of the latest executed batch queries
+   */
+  public List<String> getBatchQueryIDs()
+  {
     return Collections.unmodifiableList(batchQueryIDs);
   }
 
@@ -338,240 +390,302 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
    * @throws SQLException if @link{#executeQuery(String)} throws exception
    */
   @Override
-  public boolean execute(String sql) throws SQLException {
+  public boolean execute(String sql) throws SQLException
+  {
     return executeInternal(sql, null);
   }
 
-  @Override
-  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
-    logger.debug("execute(String sql, int autoGeneratedKeys)");
 
-    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
+  @Override
+  public boolean execute(String sql, int autoGeneratedKeys)
+  throws SQLException
+  {
+    logger.debug(
+        "execute(String sql, int autoGeneratedKeys)");
+
+    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS)
+    {
       return execute(sql);
-    } else {
+    }
+    else
+    {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
-    logger.debug("execute(String sql, int[] columnIndexes)");
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException
+  {
+    logger.debug(
+        "execute(String sql, int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean execute(String sql, String[] columnNames) throws SQLException {
-    logger.debug("execute(String sql, String[] columnNames)");
+  public boolean execute(String sql, String[] columnNames) throws SQLException
+  {
+    logger.debug(
+        "execute(String sql, String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   /**
-   * Batch Execute. If one of the commands in the batch failed, JDBC will continuing processing and
-   * throw BatchUpdateException after all commands are processed.
+   * Batch Execute. If one of the commands in the batch failed, JDBC will
+   * continuing processing and throw BatchUpdateException after all commands
+   * are processed.
    *
    * @return an array of update counts
    * @throws SQLException if any error occurs.
    */
   @Override
-  public int[] executeBatch() throws SQLException {
+  public int[] executeBatch() throws SQLException
+  {
     logger.debug("int[] executeBatch()");
     return executeBatchInternal(false).intArr;
   }
 
   /**
-   * Batch Execute. If one of the commands in the batch failed, JDBC will continuing processing and
-   * throw BatchUpdateException after all commands are processed.
+   * Batch Execute. If one of the commands in the batch failed, JDBC will
+   * continuing processing and throw BatchUpdateException after all commands
+   * are processed.
    *
    * @return an array of update counts
    * @throws SQLException if any error occurs.
    */
   @Override
-  public long[] executeLargeBatch() throws SQLException {
+  public long[] executeLargeBatch() throws SQLException
+  {
     logger.debug("executeBatch()");
     return executeBatchInternal(true).longArr;
   }
 
   /**
-   * This method will iterate through batch and provide sql and bindings to underlying SFStatement
-   * to get result set.
-   *
-   * <p>Note, array binds use a different code path since only one network roundtrip in the array
-   * bind execution case.
+   * This method will iterate through batch and provide sql and bindings to
+   * underlying SFStatement to get result set.
+   * <p>
+   * Note, array binds use a different code path since only one network
+   * roundtrip in the array bind execution case.
    *
    * @return the number of updated rows
    * @throws SQLException raises if statement is closed or any db error occurs
    */
-  VariableTypeArray executeBatchInternal(boolean isLong) throws SQLException {
+  VariableTypeArray executeBatchInternal(boolean isLong) throws SQLException
+  {
     raiseSQLExceptionIfStatementIsClosed();
 
     SQLException exceptionReturned = null;
     VariableTypeArray updateCounts;
-    if (isLong) {
+    if (isLong)
+    {
       long[] arr = new long[batch.size()];
       updateCounts = new VariableTypeArray(null, arr);
-    } else {
+    }
+    else
+    {
       int size = batch.size();
       int[] arr = new int[size];
       updateCounts = new VariableTypeArray(arr, null);
     }
     batchQueryIDs.clear();
-    for (int i = 0; i < batch.size(); i++) {
+    for (int i = 0; i < batch.size(); i++)
+    {
       BatchEntry b = batch.get(i);
-      try {
-        long cnt = this.executeUpdateInternal(b.getSql(), b.getParameterBindings(), false);
-        if (cnt == NO_UPDATES) {
+      try
+      {
+        long cnt = this.executeUpdateInternal(
+            b.getSql(), b.getParameterBindings(), false);
+        if (cnt == NO_UPDATES)
+        {
           // in executeBatch we set updateCount to SUCCESS_NO_INFO
           // for successful query with no updates
           cnt = SUCCESS_NO_INFO;
         }
-        if (isLong) {
+        if (isLong)
+        {
           updateCounts.longArr[i] = cnt;
-        } else if (cnt <= Integer.MAX_VALUE) {
+        }
+        else if (cnt <= Integer.MAX_VALUE)
+        {
           updateCounts.intArr[i] = (int) cnt;
-        } else {
-          throw new SnowflakeSQLLoggedException(
-              SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
-              ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(),
-              connection.getSfSession(),
-              i);
+        }
+        else
+        {
+          throw new SnowflakeSQLLoggedException(SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
+                                                ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(), connection.getSfSession(), i);
         }
         batchQueryIDs.add(queryID);
-      } catch (SQLException e) {
+      }
+      catch (SQLException e)
+      {
         exceptionReturned = exceptionReturned == null ? e : exceptionReturned;
-        if (isLong) {
+        if (isLong)
+        {
           updateCounts.longArr[i] = (long) EXECUTE_FAILED;
-        } else {
+        }
+        else
+        {
           updateCounts.intArr[i] = EXECUTE_FAILED;
         }
       }
     }
 
-    if (exceptionReturned != null && isLong) {
-      throw new BatchUpdateException(
-          exceptionReturned.getLocalizedMessage(),
-          exceptionReturned.getSQLState(),
-          exceptionReturned.getErrorCode(),
-          updateCounts.longArr,
-          exceptionReturned);
-    } else if (exceptionReturned != null) {
-      throw new BatchUpdateException(
-          exceptionReturned.getLocalizedMessage(),
-          exceptionReturned.getSQLState(),
-          exceptionReturned.getErrorCode(),
-          updateCounts.intArr,
-          exceptionReturned);
+    if (exceptionReturned != null && isLong)
+    {
+      throw new BatchUpdateException(exceptionReturned.getLocalizedMessage(),
+                                     exceptionReturned.getSQLState(),
+                                     exceptionReturned.getErrorCode(),
+                                     updateCounts.longArr,
+                                     exceptionReturned);
+    }
+    else if (exceptionReturned != null)
+    {
+      throw new BatchUpdateException(exceptionReturned.getLocalizedMessage(),
+                                     exceptionReturned.getSQLState(),
+                                     exceptionReturned.getErrorCode(),
+                                     updateCounts.intArr,
+                                     exceptionReturned);
     }
 
     return updateCounts;
   }
 
   @Override
-  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+  public int executeUpdate(String sql, int autoGeneratedKeys)
+  throws SQLException
+  {
     logger.debug("executeUpdate(String sql, int autoGeneratedKeys)");
 
     return (int) this.executeLargeUpdate(sql, autoGeneratedKeys);
   }
 
   @Override
-  public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+  public long executeLargeUpdate(String sql, int autoGeneratedKeys)
+  throws SQLException
+  {
     logger.debug("executeUpdate(String sql, int autoGeneratedKeys)");
 
-    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
+    if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS)
+    {
       return executeLargeUpdate(sql);
-    } else {
+    }
+    else
+    {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
-    logger.debug("executeUpdate(String sql, int[] columnIndexes)");
+  public int executeUpdate(String sql, int[] columnIndexes)
+  throws SQLException
+  {
+    logger.debug(
+        "executeUpdate(String sql, int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public long executeLargeUpdate(String sql, int[] columnIndexes) throws SQLException {
-    logger.debug("executeLargeUpdate(String sql, int[] columnIndexes)");
+  public long executeLargeUpdate(String sql, int[] columnIndexes)
+  throws SQLException
+  {
+    logger.debug(
+        "executeLargeUpdate(String sql, int[] columnIndexes)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
-    logger.debug("executeUpdate(String sql, String[] columnNames)");
+  public int executeUpdate(String sql, String[] columnNames)
+  throws SQLException
+  {
+    logger.debug(
+        "executeUpdate(String sql, String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public long executeLargeUpdate(String sql, String[] columnNames) throws SQLException {
-    logger.debug("executeUpdate(String sql, String[] columnNames)");
+  public long executeLargeUpdate(String sql, String[] columnNames)
+  throws SQLException
+  {
+    logger.debug(
+        "executeUpdate(String sql, String[] columnNames)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public Connection getConnection() throws SQLException {
+  public Connection getConnection() throws SQLException
+  {
     logger.debug("getConnection()");
     raiseSQLExceptionIfStatementIsClosed();
     return connection;
   }
 
   @Override
-  public int getFetchDirection() throws SQLException {
+  public int getFetchDirection() throws SQLException
+  {
     logger.debug("getFetchDirection()");
     raiseSQLExceptionIfStatementIsClosed();
     return ResultSet.FETCH_FORWARD;
   }
 
   @Override
-  public int getFetchSize() throws SQLException {
+  public int getFetchSize() throws SQLException
+  {
     logger.debug("getFetchSize()");
     raiseSQLExceptionIfStatementIsClosed();
     return fetchSize;
   }
 
   @Override
-  public ResultSet getGeneratedKeys() throws SQLException {
+  public ResultSet getGeneratedKeys() throws SQLException
+  {
     logger.debug("getGeneratedKeys()");
     raiseSQLExceptionIfStatementIsClosed();
     return new SnowflakeResultSetV1.EmptyResultSet();
   }
 
   @Override
-  public int getMaxFieldSize() throws SQLException {
+  public int getMaxFieldSize() throws SQLException
+  {
     logger.debug("getMaxFieldSize()");
     raiseSQLExceptionIfStatementIsClosed();
     return maxFieldSize;
   }
 
   @Override
-  public int getMaxRows() throws SQLException {
+  public int getMaxRows() throws SQLException
+  {
     logger.debug("getMaxRows()");
     raiseSQLExceptionIfStatementIsClosed();
     return maxRows;
   }
 
   @Override
-  public boolean getMoreResults() throws SQLException {
+  public boolean getMoreResults() throws SQLException
+  {
     logger.debug("getMoreResults()");
 
     return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
   }
 
   @Override
-  public boolean getMoreResults(int current) throws SQLException {
+  public boolean getMoreResults(int current) throws SQLException
+  {
     logger.debug("getMoreResults(int current)");
     raiseSQLExceptionIfStatementIsClosed();
 
     // clean up the current result set, if it exists
-    if (resultSet != null
-        && (current == Statement.CLOSE_CURRENT_RESULT || current == Statement.CLOSE_ALL_RESULTS)) {
+    if (resultSet != null &&
+        (current == Statement.CLOSE_CURRENT_RESULT ||
+         current == Statement.CLOSE_ALL_RESULTS))
+    {
       resultSet.close();
     }
+
 
     boolean hasResultSet = sfStatement.getMoreResults(current);
     SFBaseResultSet sfResultSet = sfStatement.getResultSet();
@@ -579,25 +693,32 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     if (hasResultSet) // result set returned
     {
       sfResultSet.setSession(this.connection.getSfSession());
-      if (resultSet != null) {
+      if (resultSet != null)
+      {
         openResultSets.add(resultSet);
       }
       resultSet = new SnowflakeResultSetV1(sfResultSet, this);
       updateCount = NO_UPDATES;
       return true;
-    } else if (sfResultSet != null) // update count returned
+    }
+    else if (sfResultSet != null) // update count returned
     {
-      if (resultSet != null) {
+      if (resultSet != null)
+      {
         openResultSets.add(resultSet);
       }
       resultSet = null;
-      try {
+      try
+      {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
-      } catch (SFException ex) {
-        throw new SnowflakeSQLException(ex);
+      }
+      catch (SFException ex)
+      {
+        throw new SnowflakeSQLLoggedException(ex, connection.getSfSession());
       }
       return false;
-    } else // no more results
+    }
+    else // no more results
     {
       updateCount = NO_UPDATES;
       return false;
@@ -605,89 +726,103 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   }
 
   @Override
-  public int getQueryTimeout() throws SQLException {
+  public int getQueryTimeout() throws SQLException
+  {
     logger.debug("getQueryTimeout()");
     raiseSQLExceptionIfStatementIsClosed();
     return this.queryTimeout;
   }
 
   @Override
-  public ResultSet getResultSet() throws SQLException {
+  public ResultSet getResultSet() throws SQLException
+  {
     logger.debug("getResultSet()");
     raiseSQLExceptionIfStatementIsClosed();
     return resultSet;
   }
 
   @Override
-  public int getResultSetConcurrency() throws SQLException {
+  public int getResultSetConcurrency() throws SQLException
+  {
     logger.debug("getResultSetConcurrency()");
     raiseSQLExceptionIfStatementIsClosed();
     return resultSetConcurrency;
   }
 
   @Override
-  public int getResultSetHoldability() throws SQLException {
+  public int getResultSetHoldability() throws SQLException
+  {
     logger.debug("getResultSetHoldability()");
     raiseSQLExceptionIfStatementIsClosed();
     return resultSetHoldability;
   }
 
   @Override
-  public int getResultSetType() throws SQLException {
+  public int getResultSetType() throws SQLException
+  {
     logger.debug("getResultSetType()");
     raiseSQLExceptionIfStatementIsClosed();
     return this.resultSetType;
   }
 
   @Override
-  public int getUpdateCount() throws SQLException {
+  public int getUpdateCount() throws SQLException
+  {
     logger.debug("getUpdateCount()");
     return (int) getUpdateCountIfDML();
   }
 
   @Override
-  public long getLargeUpdateCount() throws SQLException {
+  public long getLargeUpdateCount() throws SQLException
+  {
     logger.debug("getLargeUpdateCount()");
     return getUpdateCountIfDML();
   }
 
-  private long getUpdateCountIfDML() throws SQLException {
+  private long getUpdateCountIfDML() throws SQLException
+  {
     raiseSQLExceptionIfStatementIsClosed();
-    if (updateCount != -1 && sfStatement.getResultSet().getStatementType().isDML()) {
+    if (updateCount != -1 && sfStatement.getResultSet().getStatementType().isDML())
+    {
       return updateCount;
     }
     return -1;
   }
 
   @Override
-  public SQLWarning getWarnings() throws SQLException {
+  public SQLWarning getWarnings() throws SQLException
+  {
     logger.debug("getWarnings()");
     raiseSQLExceptionIfStatementIsClosed();
     return sqlWarnings;
   }
 
   @Override
-  public boolean isClosed() throws SQLException {
+  public boolean isClosed() throws SQLException
+  {
     logger.debug("isClosed()");
     return isClosed; // no exception
   }
 
   @Override
-  public boolean isPoolable() throws SQLException {
+  public boolean isPoolable() throws SQLException
+  {
     logger.debug("isPoolable()");
     raiseSQLExceptionIfStatementIsClosed();
     return poolable;
   }
 
   @Override
-  public void setCursorName(String name) throws SQLException {
+  public void setCursorName(String name) throws SQLException
+  {
     logger.debug("setCursorName(String name)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setEscapeProcessing(boolean enable) throws SQLException {
+  public void setEscapeProcessing(boolean enable) throws SQLException
+  {
     logger.debug("setEscapeProcessing(boolean enable)");
     // NOTE: We could raise an exception here, because not implemented
     // but it may break the existing applications. For now returning nothnig.
@@ -696,51 +831,62 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   }
 
   @Override
-  public void setFetchDirection(int direction) throws SQLException {
+  public void setFetchDirection(int direction) throws SQLException
+  {
     logger.debug("setFetchDirection(int direction)");
     raiseSQLExceptionIfStatementIsClosed();
-    if (direction != ResultSet.FETCH_FORWARD) {
+    if (direction != ResultSet.FETCH_FORWARD)
+    {
       throw new SQLFeatureNotSupportedException();
     }
   }
 
   @Override
-  public void setFetchSize(int rows) throws SQLException {
+  public void setFetchSize(int rows) throws SQLException
+  {
     logger.debug("setFetchSize(int rows), rows={}", rows);
     raiseSQLExceptionIfStatementIsClosed();
     fetchSize = rows;
   }
 
   @Override
-  public void setMaxFieldSize(int max) throws SQLException {
+  public void setMaxFieldSize(int max) throws SQLException
+  {
     logger.debug("setMaxFieldSize(int max)");
 
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void setMaxRows(int max) throws SQLException {
+  public void setMaxRows(int max) throws SQLException
+  {
     logger.debug("setMaxRows(int max)");
 
     raiseSQLExceptionIfStatementIsClosed();
 
     this.maxRows = max;
-    try {
-      if (this.sfStatement != null) {
+    try
+    {
+      if (this.sfStatement != null)
+      {
         this.sfStatement.addProperty("rows_per_resultset", max);
       }
-    } catch (SFException ex) {
+    }
+    catch (SFException ex)
+    {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void setPoolable(boolean poolable) throws SQLException {
+  public void setPoolable(boolean poolable) throws SQLException
+  {
     logger.debug("setPoolable(boolean poolable)");
     raiseSQLExceptionIfStatementIsClosed();
 
-    if (poolable) {
+    if (poolable)
+    {
       throw new SQLFeatureNotSupportedException();
     }
     this.poolable = poolable;
@@ -749,40 +895,51 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   /**
    * Sets a parameter at the statement level.
    *
-   * @param name parameter name.
+   * @param name  parameter name.
    * @param value parameter value.
    * @throws SQLException if any SQL error occurs.
    */
-  public void setParameter(String name, Object value) throws SQLException {
+  public void setParameter(String name, Object value) throws SQLException
+  {
     logger.debug("setParameter");
 
-    try {
-      if (this.sfStatement != null) {
+    try
+    {
+      if (this.sfStatement != null)
+      {
         this.sfStatement.addProperty(name, value);
       }
-    } catch (SFException ex) {
+    }
+    catch (SFException ex)
+    {
       throw new SnowflakeSQLException(ex);
     }
   }
 
   @Override
-  public void setQueryTimeout(int seconds) throws SQLException {
+  public void setQueryTimeout(int seconds) throws SQLException
+  {
     logger.debug("setQueryTimeout(int seconds)");
     raiseSQLExceptionIfStatementIsClosed();
 
     this.queryTimeout = seconds;
-    try {
-      if (this.sfStatement != null) {
+    try
+    {
+      if (this.sfStatement != null)
+      {
         this.sfStatement.addProperty("query_timeout", seconds);
       }
-    } catch (SFException ex) {
+    }
+    catch (SFException ex)
+    {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+  public boolean isWrapperFor(Class<?> iface) throws SQLException
+  {
     logger.debug("isWrapperFor(Class<?> iface)");
 
     return iface.isInstance(this);
@@ -790,38 +947,46 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
+  public <T> T unwrap(Class<T> iface) throws SQLException
+  {
     logger.debug("unwrap(Class<T> iface)");
 
-    if (!iface.isInstance(this)) {
+    if (!iface.isInstance(this))
+    {
       throw new SQLException(
-          this.getClass().getName() + " not unwrappable from " + iface.getName());
+          this.getClass().getName() + " not unwrappable from " + iface
+              .getName());
     }
     return (T) this;
   }
 
   @Override
-  public void closeOnCompletion() throws SQLException {
+  public void closeOnCompletion() throws SQLException
+  {
     logger.debug("closeOnCompletion()");
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public boolean isCloseOnCompletion() throws SQLException {
+  public boolean isCloseOnCompletion() throws SQLException
+  {
     logger.debug("isCloseOnCompletion()");
     throw new SQLFeatureNotSupportedException();
   }
 
   @Override
-  public void close() throws SQLException {
+  public void close() throws SQLException
+  {
     close(true);
   }
 
-  public void close(boolean removeClosedStatementFromConnection) throws SQLException {
+  public void close(boolean removeClosedStatementFromConnection) throws SQLException
+  {
     logger.debug("close()");
 
     // No exception is raised even if the statement is closed.
-    if (resultSet != null) {
+    if (resultSet != null)
+    {
       resultSet.close();
       resultSet = null;
     }
@@ -829,43 +994,56 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     batch.clear();
 
     // also make sure to close all created resultSets from this statement
-    for (ResultSet rs : openResultSets) {
-      if (rs != null && !rs.isClosed()) {
-        if (rs.isWrapperFor(SnowflakeResultSetV1.class)) {
+    for (ResultSet rs : openResultSets)
+    {
+      if (rs != null && !rs.isClosed())
+      {
+        if (rs.isWrapperFor(SnowflakeResultSetV1.class))
+        {
           rs.unwrap(SnowflakeResultSetV1.class).close(false);
-        } else {
+        }
+        else
+        {
           rs.close();
         }
       }
     }
     openResultSets.clear();
     sfStatement.close();
-    if (removeClosedStatementFromConnection) {
+    if (removeClosedStatementFromConnection)
+    {
       connection.removeClosedStatement(this);
     }
   }
 
   @Override
-  public void cancel() throws SQLException {
+  public void cancel() throws SQLException
+  {
     logger.debug("cancel()");
     raiseSQLExceptionIfStatementIsClosed();
 
-    try {
+    try
+    {
       sfStatement.cancel();
-    } catch (SFException ex) {
-      throw new SnowflakeSQLException(ex, ex.getSqlState(), ex.getVendorCode(), ex.getParams());
+    }
+    catch (SFException ex)
+    {
+      throw new SnowflakeSQLException(ex, ex.getSqlState(),
+                                      ex.getVendorCode(), ex.getParams());
     }
   }
 
   @Override
-  public void clearWarnings() throws SQLException {
+  public void clearWarnings() throws SQLException
+  {
     logger.debug("clearWarnings()");
     raiseSQLExceptionIfStatementIsClosed();
     sqlWarnings = null;
   }
 
   @Override
-  public void addBatch(String sql) throws SQLException {
+  public void addBatch(String sql) throws SQLException
+  {
     logger.debug("addBatch(String sql)");
 
     raiseSQLExceptionIfStatementIsClosed();
@@ -874,7 +1052,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   }
 
   @Override
-  public void clearBatch() throws SQLException {
+  public void clearBatch() throws SQLException
+  {
     logger.debug("clearBatch()");
 
     raiseSQLExceptionIfStatementIsClosed();
@@ -882,18 +1061,22 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     batch.clear();
   }
 
-  private void executeSetProperty(final String sql) {
+  private void executeSetProperty(final String sql)
+  {
     logger.debug("setting property");
 
     // tokenize the sql
     String[] tokens = sql.split("\\s+");
 
-    if (tokens.length < 2) {
+    if (tokens.length < 2)
+    {
       return;
     }
 
-    if ("tracing".equalsIgnoreCase(tokens[1])) {
-      if (tokens.length >= 3) {
+    if ("tracing".equalsIgnoreCase(tokens[1]))
+    {
+      if (tokens.length >= 3)
+      {
         /*connection.tracingLevel = Level.parse(tokens[2].toUpperCase());
         if (connection.tracingLevel != null)
         {
@@ -901,292 +1084,365 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
           snowflakeLogger.setLevel(connection.tracingLevel);
         }*/
       }
-    } else {
+    }
+    else
+    {
       this.sfStatement.executeSetProperty(sql);
     }
   }
 
-  public SFStatement getSfStatement() throws SQLException {
+  public SFStatement getSfStatement() throws SQLException
+  {
     return sfStatement;
   }
 
-  public void removeClosedResultSet(ResultSet rs) {
+  public void removeClosedResultSet(ResultSet rs)
+  {
     openResultSets.remove(rs);
   }
 
-  final class BatchEntry {
+  final class BatchEntry
+  {
     private final String sql;
 
     private final Map<String, ParameterBindingDTO> parameterBindings;
 
-    BatchEntry(String sql, Map<String, ParameterBindingDTO> parameterBindings) {
+    BatchEntry(String sql,
+               Map<String, ParameterBindingDTO> parameterBindings)
+    {
       this.sql = sql;
       this.parameterBindings = parameterBindings;
     }
 
-    public String getSql() {
+    public String getSql()
+    {
       return sql;
     }
 
-    public Map<String, ParameterBindingDTO> getParameterBindings() {
+    public Map<String, ParameterBindingDTO> getParameterBindings()
+    {
       return parameterBindings;
     }
   }
 
   /**
-   * This is a No Operation Statement to avoid null pointer exception for sessionless result set.
+   * This is a No Operation Statement to avoid null pointer exception for
+   * sessionless result set.
    */
-  public static class NoOpSnowflakeStatementV1 extends SnowflakeStatementV1 {
-    public NoOpSnowflakeStatementV1() throws SQLException {
-      super(
-          null,
-          ResultSet.TYPE_FORWARD_ONLY,
-          ResultSet.CONCUR_READ_ONLY,
-          ResultSet.CLOSE_CURSORS_AT_COMMIT);
+  public static class NoOpSnowflakeStatementV1 extends SnowflakeStatementV1
+  {
+    public NoOpSnowflakeStatementV1() throws SQLException
+    {
+      super(null,
+            ResultSet.TYPE_FORWARD_ONLY,
+            ResultSet.CONCUR_READ_ONLY,
+            ResultSet.CLOSE_CURSORS_AT_COMMIT);
     }
 
-    private void throwExceptionAnyway() throws SQLException {
-      throw new SQLException(
-          "This is a dummy SnowflakeStatement, " + "no member function should be called for it.");
+    private void throwExceptionAnyway() throws SQLException
+    {
+      throw new SQLException("This is a dummy SnowflakeStatement, " +
+                             "no member function should be called for it.");
     }
 
     @Override
-    public ResultSet executeQuery(String sql) throws SQLException {
+    public ResultSet executeQuery(String sql) throws SQLException
+    {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public int executeUpdate(String sql) throws SQLException {
+    public int executeUpdate(String sql) throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long executeLargeUpdate(String sql) throws SQLException {
+    public long executeLargeUpdate(String sql) throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public String getQueryID() {
+    public String getQueryID()
+    {
       return "invalid_query_id";
     }
 
     @Override
-    public List<String> getBatchQueryIDs() {
+    public List<String> getBatchQueryIDs()
+    {
       return new ArrayList<>();
     }
 
     @Override
-    public boolean execute(String sql) throws SQLException {
+    public boolean execute(String sql) throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+    public boolean execute(String sql, int autoGeneratedKeys)
+    throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+    public boolean execute(String sql, int[] columnIndexes) throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean execute(String sql, String[] columnNames) throws SQLException {
+    public boolean execute(String sql, String[] columnNames) throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public int[] executeBatch() throws SQLException {
+    public int[] executeBatch() throws SQLException
+    {
       throwExceptionAnyway();
       return new int[1];
     }
 
     @Override
-    public long[] executeLargeBatch() throws SQLException {
+    public long[] executeLargeBatch() throws SQLException
+    {
       throwExceptionAnyway();
       return new long[1];
     }
 
     @Override
-    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+    public int executeUpdate(String sql, int autoGeneratedKeys)
+    throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+    public long executeLargeUpdate(String sql, int autoGeneratedKeys)
+    throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    public int executeUpdate(String sql, int[] columnIndexes)
+    throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long executeLargeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    public long executeLargeUpdate(String sql, int[] columnIndexes)
+    throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+    public int executeUpdate(String sql, String[] columnNames)
+    throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long executeLargeUpdate(String sql, String[] columnNames) throws SQLException {
+    public long executeLargeUpdate(String sql, String[] columnNames)
+    throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public Connection getConnection() throws SQLException {
+    public Connection getConnection() throws SQLException
+    {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public int getFetchDirection() throws SQLException {
+    public int getFetchDirection() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getFetchSize() throws SQLException {
+    public int getFetchSize() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public ResultSet getGeneratedKeys() throws SQLException {
+    public ResultSet getGeneratedKeys() throws SQLException
+    {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public int getMaxFieldSize() throws SQLException {
+    public int getMaxFieldSize() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getMaxRows() throws SQLException {
+    public int getMaxRows() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public boolean getMoreResults() throws SQLException {
+    public boolean getMoreResults() throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean getMoreResults(int current) throws SQLException {
+    public boolean getMoreResults(int current) throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public int getQueryTimeout() throws SQLException {
+    public int getQueryTimeout() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public ResultSet getResultSet() throws SQLException {
+    public ResultSet getResultSet() throws SQLException
+    {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public int getResultSetConcurrency() throws SQLException {
+    public int getResultSetConcurrency() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getResultSetHoldability() throws SQLException {
+    public int getResultSetHoldability() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getResultSetType() throws SQLException {
+    public int getResultSetType() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public int getUpdateCount() throws SQLException {
+    public int getUpdateCount() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public long getLargeUpdateCount() throws SQLException {
+    public long getLargeUpdateCount() throws SQLException
+    {
       throwExceptionAnyway();
       return 0;
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException {
+    public SQLWarning getWarnings() throws SQLException
+    {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public boolean isClosed() throws SQLException {
+    public boolean isClosed() throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public boolean isPoolable() throws SQLException {
+    public boolean isPoolable() throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public void setCursorName(String name) throws SQLException {}
+    public void setCursorName(String name) throws SQLException
+    {
+    }
 
     @Override
-    public void setEscapeProcessing(boolean enable) throws SQLException {}
+    public void setEscapeProcessing(boolean enable) throws SQLException
+    {
+    }
 
     @Override
-    public void setFetchDirection(int direction) throws SQLException {}
+    public void setFetchDirection(int direction) throws SQLException
+    {
+    }
 
     @Override
-    public void setFetchSize(int rows) throws SQLException {}
+    public void setFetchSize(int rows) throws SQLException
+    {
+    }
 
     @Override
-    public void setMaxFieldSize(int max) throws SQLException {}
+    public void setMaxFieldSize(int max) throws SQLException
+    {
+    }
 
     @Override
-    public void setMaxRows(int max) throws SQLException {}
+    public void setMaxRows(int max) throws SQLException
+    {
+    }
 
     @Override
-    public void setPoolable(boolean poolable) throws SQLException {}
+    public void setPoolable(boolean poolable) throws SQLException
+    {
+    }
 
     @Override
-    public void setParameter(String name, Object value) throws SQLException {}
+    public void setParameter(String name, Object value) throws SQLException
+    {
+    }
 
     @Override
-    public void setQueryTimeout(int seconds) throws SQLException {}
+    public void setQueryTimeout(int seconds) throws SQLException
+    {
+    }
 
     @Override
-    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    public boolean isWrapperFor(Class<?> iface) throws SQLException
+    {
       logger.debug("isWrapperFor(Class<?> iface)");
 
       return iface.isInstance(this);
@@ -1194,50 +1450,71 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T unwrap(Class<T> iface) throws SQLException {
+    public <T> T unwrap(Class<T> iface) throws SQLException
+    {
       logger.debug("unwrap(Class<T> iface)");
 
-      if (!iface.isInstance(this)) {
+      if (!iface.isInstance(this))
+      {
         throw new SQLException(
-            this.getClass().getName() + " not unwrappable from " + iface.getName());
+            this.getClass().getName() + " not unwrappable from " + iface
+                .getName());
       }
       return (T) this;
     }
 
     @Override
-    public void closeOnCompletion() throws SQLException {}
+    public void closeOnCompletion() throws SQLException
+    {
+    }
 
     @Override
-    public boolean isCloseOnCompletion() throws SQLException {
+    public boolean isCloseOnCompletion() throws SQLException
+    {
       throwExceptionAnyway();
       return false;
     }
 
     @Override
-    public void close() throws SQLException {}
+    public void close() throws SQLException
+    {
+    }
 
     @Override
-    public void close(boolean removeClosedStatementFromConnection) throws SQLException {}
+    public void close(boolean removeClosedStatementFromConnection) throws SQLException
+    {
+    }
 
     @Override
-    public void cancel() throws SQLException {}
+    public void cancel() throws SQLException
+    {
+    }
 
     @Override
-    public void clearWarnings() throws SQLException {}
+    public void clearWarnings() throws SQLException
+    {
+    }
 
     @Override
-    public void addBatch(String sql) throws SQLException {}
+    public void addBatch(String sql) throws SQLException
+    {
+    }
 
     @Override
-    public void clearBatch() throws SQLException {}
+    public void clearBatch() throws SQLException
+    {
+    }
 
     @Override
-    public SFStatement getSfStatement() throws SQLException {
+    public SFStatement getSfStatement() throws SQLException
+    {
       throwExceptionAnyway();
       return null;
     }
 
     @Override
-    public void removeClosedResultSet(ResultSet rs) {}
+    public void removeClosedResultSet(ResultSet rs)
+    {
+    }
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -3,31 +3,22 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.storage.*;
-import com.microsoft.azure.storage.blob.*;
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.core.ObjectMapperFactory;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.jdbc.*;
 import com.microsoft.azure.storage.StorageCredentials;
 import com.microsoft.azure.storage.StorageCredentialsAnonymous;
 import com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature;
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.*;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.ListBlobItem;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.client.util.SFPair;
-import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
-import net.snowflake.common.core.SqlState;
-import org.apache.commons.io.IOUtils;
-
 import java.io.*;
 import java.net.SocketTimeoutException;
 import java.net.URI;
@@ -39,35 +30,36 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.ObjectMapperFactory;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.jdbc.*;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.client.util.SFPair;
+import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
+import net.snowflake.common.core.SqlState;
+import org.apache.commons.io.IOUtils;
 
 /**
- * Encapsulates the Azure Storage client
- * and all Azure Storage operations and logic
+ * Encapsulates the Azure Storage client and all Azure Storage operations and logic
  *
  * @author lgiakoumakis
  */
+public class SnowflakeAzureClient implements SnowflakeStorageClient {
 
-public class SnowflakeAzureClient implements SnowflakeStorageClient
-{
-
-  private final static String localFileSep = systemGetProperty("file.separator");
-  private final static String AZ_ENCRYPTIONDATAPROP = "encryptiondata";
+  private static final String localFileSep = systemGetProperty("file.separator");
+  private static final String AZ_ENCRYPTIONDATAPROP = "encryptiondata";
 
   private int encryptionKeySize = 0; // used for PUTs
   private StageInfo stageInfo;
   private RemoteStoreFileEncryptionMaterial encMat;
   private CloudBlobClient azStorageClient;
-  private final static SFLogger logger =
-      SFLoggerFactory.getLogger(SnowflakeAzureClient.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeAzureClient.class);
   private OperationContext opContext = null;
   private SFSession session;
 
-  private SnowflakeAzureClient()
-  {
-  }
-
+  private SnowflakeAzureClient() {}
   ;
 
   /*
@@ -76,11 +68,9 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * @param encMat  The encryption material
    *                required to decrypt/encrypt content in stage
    */
-  public static SnowflakeAzureClient createSnowflakeAzureClient(StageInfo stage,
-                                                                RemoteStoreFileEncryptionMaterial encMat,
-                                                                SFSession sfSession)
-  throws SnowflakeSQLException
-  {
+  public static SnowflakeAzureClient createSnowflakeAzureClient(
+      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession sfSession)
+      throws SnowflakeSQLException {
     SnowflakeAzureClient azureClient = new SnowflakeAzureClient();
     azureClient.setupAzureClient(stage, encMat, sfSession);
 
@@ -97,9 +87,9 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    *                required to decrypt/encrypt content in stage
    * @throws IllegalArgumentException when invalid credentials are used
    */
-  private void setupAzureClient(StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession sfSession)
-  throws IllegalArgumentException, SnowflakeSQLException
-  {
+  private void setupAzureClient(
+      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession sfSession)
+      throws IllegalArgumentException, SnowflakeSQLException {
     // Save the client creation parameters so that we can reuse them,
     // to reset the Azure client.
     this.stageInfo = stage;
@@ -109,83 +99,68 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
     logger.debug("Setting up the Azure client ");
     opContext = new OperationContext();
 
-    try
-    {
-      URI storageEndpoint = buildAzureStorageEndpointURI(stage.getEndPoint(), stage.getStorageAccount());
+    try {
+      URI storageEndpoint =
+          buildAzureStorageEndpointURI(stage.getEndPoint(), stage.getStorageAccount());
 
       StorageCredentials azCreds;
       String sasToken = (String) stage.getCredentials().get("AZURE_SAS_TOKEN");
-      if (sasToken != null)
-      {
+      if (sasToken != null) {
         // We are authenticated with a shared access token.
         azCreds = new StorageCredentialsSharedAccessSignature(sasToken);
-      }
-      else
-      {
+      } else {
         // Use anonymous authentication.
         azCreds = StorageCredentialsAnonymous.ANONYMOUS;
       }
 
-      if (encMat != null)
-      {
+      if (encMat != null) {
         byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
         encryptionKeySize = decodedKey.length * 8;
 
-        if (encryptionKeySize != 128 &&
-            encryptionKeySize != 192 &&
-            encryptionKeySize != 256)
-        {
-          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "unsupported key size", encryptionKeySize);
+        if (encryptionKeySize != 128 && encryptionKeySize != 192 && encryptionKeySize != 256) {
+          throw new SnowflakeSQLLoggedException(
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "unsupported key size",
+              encryptionKeySize);
         }
       }
       HttpUtil.setProxyForAzure(opContext);
       this.azStorageClient = new CloudBlobClient(storageEndpoint, azCreds);
-    }
-    catch (URISyntaxException ex)
-    {
+    } catch (URISyntaxException ex) {
       throw new IllegalArgumentException("invalid_azure_credentials");
     }
   }
 
   // Reurns the Max number of retry attempts
   @Override
-  public int getMaxRetries()
-  {
+  public int getMaxRetries() {
     return 25;
   }
 
   // Returns the max exponent for multiplying backoff with the power of 2, the value
   // of 4 will give us 16secs as the max number of time to sleep before retry
   @Override
-  public int getRetryBackoffMaxExponent()
-  {
+  public int getRetryBackoffMaxExponent() {
     return 4;
   }
 
   // Returns the min number of milliseconds to sleep before retry
   @Override
-  public int getRetryBackoffMin()
-  {
+  public int getRetryBackoffMin() {
     return 1000;
   }
 
-  /**
-   * @return Returns true if encryption is enabled
-   */
+  /** @return Returns true if encryption is enabled */
   @Override
-  public boolean isEncrypting()
-  {
+  public boolean isEncrypting() {
     return encryptionKeySize > 0;
   }
 
-  /**
-   * @return Returns the size of the encryption key
-   */
+  /** @return Returns the size of the encryption key */
   @Override
-  public int getEncryptionKeySize()
-  {
+  public int getEncryptionKeySize() {
     return encryptionKeySize;
   }
 
@@ -194,47 +169,42 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    *
    * @param stageCredentials a Map (as returned by GS) which contains the new credential properties
    * @throws SnowflakeSQLException failure to renew the client
-   **/
+   */
   @Override
-  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException
-  {
+  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException {
     stageInfo.setCredentials(stageCredentials);
     setupAzureClient(stageInfo, encMat, session);
   }
 
-  /**
-   * shuts down the client
-   */
+  /** shuts down the client */
   @Override
-  public void shutdown()
-  { /* Not available */ }
+  public void shutdown() {
+    /* Not available */
+  }
 
   /**
-   * For a set of remote storage objects under a remote location and a given prefix/path
-   * returns their properties wrapped in ObjectSummary objects
+   * For a set of remote storage objects under a remote location and a given prefix/path returns
+   * their properties wrapped in ObjectSummary objects
    *
    * @param remoteStorageLocation location, i.e. container for Azure
-   * @param prefix                the prefix/path to list under
+   * @param prefix the prefix/path to list under
    * @return a collection of storage summary objects
    * @throws StorageProviderException Azure storage exception
    */
   @Override
   public StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
-  throws StorageProviderException
-  {
+      throws StorageProviderException {
     StorageObjectSummaryCollection storageObjectSummaries;
 
-    try
-    {
+    try {
       CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
-      Iterable<ListBlobItem> listBlobItemIterable = container.listBlobs(
-          prefix,       // List the BLOBs under this prefix
-          true          // List the BLOBs as a flat list, i.e. do not list directories
-      );
+      Iterable<ListBlobItem> listBlobItemIterable =
+          container.listBlobs(
+              prefix, // List the BLOBs under this prefix
+              true // List the BLOBs as a flat list, i.e. do not list directories
+              );
       storageObjectSummaries = new StorageObjectSummaryCollection(listBlobItemIterable);
-    }
-    catch (URISyntaxException | StorageException ex)
-    {
+    } catch (URISyntaxException | StorageException ex) {
       logger.debug("Failed to list objects: {}", ex);
       throw new StorageProviderException(ex);
     }
@@ -245,17 +215,15 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * Returns the metadata properties for a remote storage object
    *
    * @param remoteStorageLocation location, i.e. bucket for S3
-   * @param prefix                the prefix/path of the object to retrieve
+   * @param prefix the prefix/path of the object to retrieve
    * @return storage metadata object
    * @throws StorageProviderException azure storage exception
    */
   @Override
   public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
-  throws StorageProviderException
-  {
+      throws StorageProviderException {
     CommonObjectMetadata azureObjectMetadata = null;
-    try
-    {
+    try {
       // Get a reference to the BLOB, to retrieve its metadata
       CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
       CloudBlob blob = container.getBlockBlobReference(prefix);
@@ -270,16 +238,15 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
       String contentEncoding = properties.getContentEncoding();
 
       // Construct an Azure metadata object
-      azureObjectMetadata = new CommonObjectMetadata(contentLength, contentEncoding, userDefinedMetadata);
-    }
-    catch (StorageException ex)
-    {
-      logger.debug("Failed to retrieve BLOB metadata: {} - {}", ex.getErrorCode(),
-                   ex.getExtendedErrorInformation());
+      azureObjectMetadata =
+          new CommonObjectMetadata(contentLength, contentEncoding, userDefinedMetadata);
+    } catch (StorageException ex) {
+      logger.debug(
+          "Failed to retrieve BLOB metadata: {} - {}",
+          ex.getErrorCode(),
+          ex.getExtendedErrorInformation());
       throw new StorageProviderException(ex);
-    }
-    catch (URISyntaxException ex)
-    {
+    } catch (URISyntaxException ex) {
       logger.debug("Cannot retrieve BLOB properties, invalid URI: {}", ex);
       throw new StorageProviderException(ex);
     }
@@ -290,28 +257,32 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
   /**
    * Download a file from remote storage.
    *
-   * @param session               session object
-   * @param command               command to download file
-   * @param localLocation         local file path
-   * @param destFileName          destination file name
-   * @param parallelism           [ not used by the Azure implementation ]
+   * @param session session object
+   * @param command command to download file
+   * @param localLocation local file path
+   * @param destFileName destination file name
+   * @param parallelism [ not used by the Azure implementation ]
    * @param remoteStorageLocation remote storage location, i.e. bucket for S3
-   * @param stageFilePath         stage file path
-   * @param stageRegion           region name where the stage persists
-   * @param presignedUrl          Unused in Azure
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Unused in Azure
    * @throws SnowflakeSQLException download failure
-   **/
+   */
   @Override
-  public void download(SFSession session, String command, String localLocation, String destFileName,
-                       int parallelism, String remoteStorageLocation, String stageFilePath, String stageRegion,
-                       String presignedUrl)
-  throws SnowflakeSQLException
-  {
+  public void download(
+      SFSession session,
+      String command,
+      String localLocation,
+      String destFileName,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
         String localFilePath = localLocation + localFileSep + destFileName;
         File localFile = new File(localFilePath);
         CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
@@ -334,66 +305,65 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
         String key = encryptionData.getKey();
         String iv = encryptionData.getValue();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256)
-        {
-          if (key == null || iv == null)
-          {
-            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                  "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLLoggedException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
+                "File metadata incomplete");
           }
 
           // Decrypt file
-          try
-          {
+          try {
             EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          }
-          catch (Exception ex)
-          {
+          } catch (Exception ex) {
             logger.error("Error decrypting file", ex);
             throw ex;
           }
         }
         return;
 
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
         logger.debug("Download unsuccessful {}", ex);
         handleAzureException(ex, ++retryCount, "download", session, command, this);
       }
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        session,
+        "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Download a file from remote storage
    *
-   * @param session               session object
-   * @param command               command to download file
-   * @param parallelism           number of threads for parallel downloading
+   * @param session session object
+   * @param command command to download file
+   * @param parallelism number of threads for parallel downloading
    * @param remoteStorageLocation remote storage location, i.e. bucket for s3
-   * @param stageFilePath         stage file path
-   * @param stageRegion           region name where the stage persists
-   * @param presignedUrl          Unused in Azure
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Unused in Azure
    * @return input file stream
    * @throws SnowflakeSQLException when download failure
    */
   @Override
-  public InputStream downloadToStream(SFSession session, String command, int parallelism,
-                                      String remoteStorageLocation, String stageFilePath,
-                                      String stageRegion, String presignedUrl) throws SnowflakeSQLException
-  {
+  public InputStream downloadToStream(
+      SFSession session,
+      String command,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
     int retryCount = 0;
 
-    do
-    {
-      try
-      {
+    do {
+      try {
         CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
 
         CloudBlob blob = container.getBlockBlobReference(stageFilePath);
@@ -409,89 +379,93 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
 
         String iv = encryptionData.getValue();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256)
-        {
-          if (key == null || iv == null)
-          {
-            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                  "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLLoggedException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
+                "File metadata incomplete");
           }
 
-          try
-          {
+          try {
 
             return EncryptionProvider.decryptStream(stream, key, iv, encMat);
 
-          }
-          catch (Exception ex)
-          {
+          } catch (Exception ex) {
             logger.error("Error in decrypting file", ex);
             throw ex;
           }
 
-        }
-        else
-        {
+        } else {
           return stream;
         }
 
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
         logger.debug("Downloading unsuccessful {}", ex);
-        handleAzureException(ex, ++retryCount, "download", session, command
-            , this);
+        handleAzureException(ex, ++retryCount, "download", session, command, this);
       }
-    }
-    while (retryCount < getMaxRetries());
+    } while (retryCount < getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        session,
+        "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file/stream to remote storage
    *
-   * @param session                session object
-   * @param command                upload command
-   * @param parallelism            [ not used by the Azure implementation ]
-   * @param uploadFromStream       true if upload source is stream
-   * @param remoteStorageLocation  storage container name
-   * @param srcFile                source file if not uploading from a stream
-   * @param destFileName           file name on remote storage after upload
-   * @param inputStream            stream used for uploading if fileBackedOutputStream is null
+   * @param session session object
+   * @param command upload command
+   * @param parallelism [ not used by the Azure implementation ]
+   * @param uploadFromStream true if upload source is stream
+   * @param remoteStorageLocation storage container name
+   * @param srcFile source file if not uploading from a stream
+   * @param destFileName file name on remote storage after upload
+   * @param inputStream stream used for uploading if fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta                   object meta data
-   * @param stageRegion            region name where the stage persists
-   * @param presignedUrl           Unused in Azure
+   * @param meta object meta data
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Unused in Azure
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   @Override
-  public void upload(SFSession session, String command, int parallelism, boolean uploadFromStream,
-                     String remoteStorageLocation, File srcFile, String destFileName, InputStream inputStream,
-                     FileBackedOutputStream fileBackedOutputStream, StorageObjectMetadata meta, String stageRegion,
-                     String presignedUrl)
-  throws SnowflakeSQLException
-  {
+  public void upload(
+      SFSession session,
+      String command,
+      int parallelism,
+      boolean uploadFromStream,
+      String remoteStorageLocation,
+      File srcFile,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      StorageObjectMetadata meta,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
     final List<FileInputStream> toClose = new ArrayList<>();
     long originalContentLength = meta.getContentLength();
 
-    SFPair<InputStream, Boolean> uploadStreamInfo = createUploadStream(
-        srcFile, uploadFromStream, inputStream, meta, originalContentLength,
-        fileBackedOutputStream, toClose);
+    SFPair<InputStream, Boolean> uploadStreamInfo =
+        createUploadStream(
+            srcFile,
+            uploadFromStream,
+            inputStream,
+            meta,
+            originalContentLength,
+            fileBackedOutputStream,
+            toClose);
 
-    if (!(meta instanceof CommonObjectMetadata))
-    {
+    if (!(meta instanceof CommonObjectMetadata)) {
       throw new IllegalArgumentException("Unexpected metadata object type");
     }
 
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
         logger.debug("Starting upload");
         InputStream fileInputStream = uploadStreamInfo.left;
         CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
@@ -504,61 +478,66 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
         // where the user has control of block size and parallelism
         // we rely on Azure to handle the upload, hence the "parallelism" parameter is ignored
         // in the Azure implementation of the method
-        blob.upload(fileInputStream,  // input stream to upload from
-                    -1                // -1 indicates an unknown stream length
-        );
+        blob.upload(
+            fileInputStream, // input stream to upload from
+            -1 // -1 indicates an unknown stream length
+            );
         logger.debug("Upload successful");
 
         blob.uploadMetadata();
 
         // close any open streams in the "toClose" list and return
-        for (FileInputStream is : toClose)
-          IOUtils.closeQuietly(is);
+        for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
         return;
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
         handleAzureException(ex, ++retryCount, "upload", session, command, this);
 
-        if (uploadFromStream && fileBackedOutputStream == null)
-        {
-          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-                                          ErrorCode.IO_ERROR.getMessageCode(),
-                                          "Encountered exception during upload: " +
-                                          ex.getMessage() + "\nCannot retry upload from stream.");
+        if (uploadFromStream && fileBackedOutputStream == null) {
+          throw new SnowflakeSQLException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              "Encountered exception during upload: "
+                  + ex.getMessage()
+                  + "\nCannot retry upload from stream.");
         }
-        uploadStreamInfo = createUploadStream(srcFile, uploadFromStream,
-                                              inputStream, meta, originalContentLength,
-                                              fileBackedOutputStream, toClose);
+        uploadStreamInfo =
+            createUploadStream(
+                srcFile,
+                uploadFromStream,
+                inputStream,
+                meta,
+                originalContentLength,
+                fileBackedOutputStream,
+                toClose);
       }
 
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    for (FileInputStream is : toClose)
-      IOUtils.closeQuietly(is);
+    for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                    "Unexpected: upload unsuccessful without exception!");
+    throw new SnowflakeSQLException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        "Unexpected: upload unsuccessful without exception!");
   }
 
   /**
    * Handles exceptions thrown by Azure Storage
    *
-   * @param ex         the exception to handle
+   * @param ex the exception to handle
    * @param retryCount current number of retries, incremented by the caller before each call
-   * @param operation  string that indicates the function/operation that was taking place,
-   *                   when the exception was raised, for example "upload"
-   * @param session    the current SFSession object used by the client
-   * @param command    the command attempted at the time of the exception
+   * @param operation string that indicates the function/operation that was taking place, when the
+   *     exception was raised, for example "upload"
+   * @param session the current SFSession object used by the client
+   * @param command the command attempted at the time of the exception
    * @throws SnowflakeSQLException exceptions not handled
    */
   @Override
-  public void handleStorageException(Exception ex, int retryCount, String operation, SFSession session, String command)
-  throws SnowflakeSQLException
-  {
+  public void handleStorageException(
+      Exception ex, int retryCount, String operation, SFSession session, String command)
+      throws SnowflakeSQLException {
     handleAzureException(ex, retryCount, operation, session, command, this);
   }
 
@@ -570,91 +549,91 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
       long originalContentLength,
       FileBackedOutputStream fileBackedOutputStream,
       List<FileInputStream> toClose)
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     logger.debug(
         "createUploadStream({}, {}, {}, {}, {}, {})",
-        this, srcFile, uploadFromStream, inputStream, fileBackedOutputStream, toClose);
+        this,
+        srcFile,
+        uploadFromStream,
+        inputStream,
+        fileBackedOutputStream,
+        toClose);
 
     final InputStream stream;
     FileInputStream srcFileStream = null;
-    try
-    {
-      if (isEncrypting() && getEncryptionKeySize() < 256)
-      {
-        try
-        {
-          final InputStream uploadStream = uploadFromStream ?
-                                           (fileBackedOutputStream != null ?
-                                            fileBackedOutputStream.asByteSource().openStream() :
-                                            inputStream) :
-                                           (srcFileStream = new FileInputStream(srcFile));
+    try {
+      if (isEncrypting() && getEncryptionKeySize() < 256) {
+        try {
+          final InputStream uploadStream =
+              uploadFromStream
+                  ? (fileBackedOutputStream != null
+                      ? fileBackedOutputStream.asByteSource().openStream()
+                      : inputStream)
+                  : (srcFileStream = new FileInputStream(srcFile));
           toClose.add(srcFileStream);
 
           // Encrypt
-          stream = EncryptionProvider.encrypt(meta, originalContentLength,
-                                              uploadStream, this.encMat, this);
+          stream =
+              EncryptionProvider.encrypt(
+                  meta, originalContentLength, uploadStream, this.encMat, this);
           uploadFromStream = true;
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
           logger.error("Failed to encrypt input", ex);
-          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "Failed to encrypt input", ex.getMessage());
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "Failed to encrypt input",
+              ex.getMessage());
         }
-      }
-      else
-      {
-        if (uploadFromStream)
-        {
-          if (fileBackedOutputStream != null)
-          {
+      } else {
+        if (uploadFromStream) {
+          if (fileBackedOutputStream != null) {
             stream = fileBackedOutputStream.asByteSource().openStream();
-          }
-          else
-          {
+          } else {
             stream = inputStream;
           }
-        }
-        else
-        {
+        } else {
           srcFileStream = new FileInputStream(srcFile);
           toClose.add(srcFileStream);
           stream = srcFileStream;
         }
       }
-    }
-    catch (FileNotFoundException ex)
-    {
+    } catch (FileNotFoundException ex) {
       logger.error("Failed to open input file", ex);
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "Failed to open input file", ex.getMessage());
-    }
-    catch (IOException ex)
-    {
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "Failed to open input file",
+          ex.getMessage());
+    } catch (IOException ex) {
       logger.error("Failed to open input stream", ex);
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "Failed to open input stream", ex.getMessage());
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "Failed to open input stream",
+          ex.getMessage());
     }
 
     return SFPair.of(stream, uploadFromStream);
   }
 
   /**
-   * Handles exceptions thrown by Azure Storage
-   * It will retry transient errors as defined by the Azure Client retry policy
-   * It will re-create the client if the SAS token has expired, and re-try
+   * Handles exceptions thrown by Azure Storage It will retry transient errors as defined by the
+   * Azure Client retry policy It will re-create the client if the SAS token has expired, and re-try
    *
-   * @param ex         the exception to handle
+   * @param ex the exception to handle
    * @param retryCount current number of retries, incremented by the caller before each call
-   * @param operation  string that indicates the function/operation that was taking place,
-   *                   when the exception was raised, for example "upload"
-   * @param session    the current SFSession object used by the client
-   * @param command    the command attempted at the time of the exception
-   * @param azClient   the current Snowflake Azure client object
+   * @param operation string that indicates the function/operation that was taking place, when the
+   *     exception was raised, for example "upload"
+   * @param session the current SFSession object used by the client
+   * @param command the command attempted at the time of the exception
+   * @param azClient the current Snowflake Azure client object
    * @throws SnowflakeSQLException exceptions not handled
    */
   private static void handleAzureException(
@@ -664,100 +643,91 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
       SFSession session,
       String command,
       SnowflakeAzureClient azClient)
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
 
     // no need to retry if it is invalid key exception
-    if (ex.getCause() instanceof InvalidKeyException)
-    {
+    if (ex.getCause() instanceof InvalidKeyException) {
       // Most likely cause is that the unlimited strength policy files are not installed
       // Log the error and throw a message that explains the cause
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
-    if (ex instanceof StorageException)
-    {
+    if (ex instanceof StorageException) {
       StorageException se = (StorageException) ex;
 
-      if (((StorageException) ex).getHttpStatusCode() == 403)
-      {
+      if (((StorageException) ex).getHttpStatusCode() == 403) {
         // A 403 indicates that the SAS token has expired,
         // we need to refresh the Azure client with the new token
         SnowflakeFileTransferAgent.renewExpiredToken(session, command, azClient);
       }
       // If we have exceeded the max number of retries, propagate the error
-      if (retryCount > azClient.getMaxRetries())
-      {
-        throw new SnowflakeSQLLoggedException(se, SqlState.SYSTEM_ERROR,
-                                              ErrorCode.AZURE_SERVICE_ERROR.getMessageCode(), session,
-                                              operation,
-                                              se.getErrorCode(),
-                                              se.getHttpStatusCode(),
-                                              se.getMessage(),
-                                              se.getExtendedErrorInformation());
-      }
-      else
-      {
-        logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                     ex.getMessage(), operation, retryCount);
+      if (retryCount > azClient.getMaxRetries()) {
+        throw new SnowflakeSQLLoggedException(
+            se,
+            SqlState.SYSTEM_ERROR,
+            ErrorCode.AZURE_SERVICE_ERROR.getMessageCode(),
+            session,
+            operation,
+            se.getErrorCode(),
+            se.getHttpStatusCode(),
+            se.getMessage(),
+            se.getExtendedErrorInformation());
+      } else {
+        logger.debug(
+            "Encountered exception ({}) during {}, retry count: {}",
+            ex.getMessage(),
+            operation,
+            retryCount);
         logger.debug("Stack trace: ", ex);
 
         // exponential backoff up to a limit
         int backoffInMillis = azClient.getRetryBackoffMin();
 
-        if (retryCount > 1)
-        {
-          backoffInMillis <<= (Math.min(retryCount - 1,
-                                        azClient.getRetryBackoffMaxExponent()));
+        if (retryCount > 1) {
+          backoffInMillis <<= (Math.min(retryCount - 1, azClient.getRetryBackoffMaxExponent()));
         }
 
-        try
-        {
+        try {
           logger.debug("Sleep for {} milliseconds before retry", backoffInMillis);
 
           Thread.sleep(backoffInMillis);
-        }
-        catch (InterruptedException ex1)
-        {
+        } catch (InterruptedException ex1) {
           // ignore
         }
 
-        if (se.getHttpStatusCode() == 403)
-        {
+        if (se.getHttpStatusCode() == 403) {
           // A 403 indicates that the SAS token has expired,
           // we need to refresh the Azure client with the new token
           SnowflakeFileTransferAgent.renewExpiredToken(session, command, azClient);
         }
       }
-    }
-    else
-    {
-      if (ex instanceof InterruptedException ||
-          SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException)
-      {
-        if (retryCount > azClient.getMaxRetries())
-        {
-          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                                ErrorCode.IO_ERROR.getMessageCode(), session,
-                                                "Encountered exception during " + operation + ": " +
-                                                ex.getMessage());
+    } else {
+      if (ex instanceof InterruptedException
+          || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
+        if (retryCount > azClient.getMaxRetries()) {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              session,
+              "Encountered exception during " + operation + ": " + ex.getMessage());
+        } else {
+          logger.debug(
+              "Encountered exception ({}) during {}, retry count: {}",
+              ex.getMessage(),
+              operation,
+              retryCount);
         }
-        else
-        {
-          logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                       ex.getMessage(), operation, retryCount);
-        }
-      }
-      else
-      {
-        throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                              ErrorCode.IO_ERROR.getMessageCode(), session,
-                                              "Encountered exception during " + operation + ": " +
-                                              ex.getMessage());
+      } else {
+        throw new SnowflakeSQLLoggedException(
+            ex,
+            SqlState.SYSTEM_ERROR,
+            ErrorCode.IO_ERROR.getMessageCode(),
+            session,
+            "Encountered exception during " + operation + ": " + ex.getMessage());
       }
     }
   }
-
 
   /*
    * Builds a URI to a Azure Storage account endpoint
@@ -766,11 +736,9 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    *  @param storageAccount    the storage account name
    */
   private static URI buildAzureStorageEndpointURI(String storageEndPoint, String storageAccount)
-  throws URISyntaxException
-  {
-    URI storageEndpoint = new URI(
-        "https", storageAccount + "." + storageEndPoint + "/",
-        null, null);
+      throws URISyntaxException {
+    URI storageEndpoint =
+        new URI("https", storageAccount + "." + storageEndPoint + "/", null, null);
 
     return storageEndpoint;
   }
@@ -780,15 +748,16 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * Takes the base64-encoded iv and key and creates the JSON block to be
    * used as the encryptiondata metadata field on the blob.
    */
-  private String buildEncryptionMetadataJSON(String iv64, String key64)
-  {
-    return String.format("{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
-                         + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
-                         + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
-                         + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
-                         + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
-                         + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
-                         + "\"Java 5.3.0\"}}", key64, iv64);
+  private String buildEncryptionMetadataJSON(String iv64, String key64) {
+    return String.format(
+        "{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
+            + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
+            + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
+            + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
+            + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
+            + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
+            + "\"Java 5.3.0\"}}",
+        key64, iv64);
   }
 
   /*
@@ -797,12 +766,10 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
    * blob and parses out the key and iv. Returns the pair as key = key, iv = value.
    */
   private SimpleEntry<String, String> parseEncryptionData(String jsonEncryptionData)
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
     JsonFactory factory = mapper.getFactory();
-    try
-    {
+    try {
       JsonParser parser = factory.createParser(jsonEncryptionData);
       JsonNode encryptionDataNode = mapper.readTree(parser);
 
@@ -810,63 +777,49 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient
       String key = encryptionDataNode.get("WrappedContentKey").get("EncryptedKey").asText();
 
       return new SimpleEntry<String, String>(key, iv);
-    }
-    catch (Exception ex)
-    {
-      throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                            ErrorCode.IO_ERROR.getMessageCode(), session,
-                                            "Error parsing encryption data as json" + ": " +
-                                            ex.getMessage());
+    } catch (Exception ex) {
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.SYSTEM_ERROR,
+          ErrorCode.IO_ERROR.getMessageCode(),
+          session,
+          "Error parsing encryption data as json" + ": " + ex.getMessage());
     }
   }
 
-  /**
-   * Returns the material descriptor key
-   */
+  /** Returns the material descriptor key */
   @Override
-  public String getMatdescKey()
-  {
+  public String getMatdescKey() {
     return "matdesc";
   }
 
-  /**
-   * Adds encryption metadata to the StorageObjectMetadata object
-   */
+  /** Adds encryption metadata to the StorageObjectMetadata object */
   @Override
-  public void addEncryptionMetadata(StorageObjectMetadata meta,
-                                    MatDesc matDesc,
-                                    byte[] ivData,
-                                    byte[] encKeK,
-                                    long contentLength)
-  {
-    meta.addUserMetadata(getMatdescKey(),
-                         matDesc.toString());
-    meta.addUserMetadata(AZ_ENCRYPTIONDATAPROP, buildEncryptionMetadataJSON(
-        Base64.encodeAsString(ivData),
-        Base64.encodeAsString(encKeK))
-    );
+  public void addEncryptionMetadata(
+      StorageObjectMetadata meta,
+      MatDesc matDesc,
+      byte[] ivData,
+      byte[] encKeK,
+      long contentLength) {
+    meta.addUserMetadata(getMatdescKey(), matDesc.toString());
+    meta.addUserMetadata(
+        AZ_ENCRYPTIONDATAPROP,
+        buildEncryptionMetadataJSON(Base64.encodeAsString(ivData), Base64.encodeAsString(encKeK)));
     meta.setContentLength(contentLength);
   }
 
-  /**
-   * Adds digest metadata to the StorageObjectMetadata object
-   */
+  /** Adds digest metadata to the StorageObjectMetadata object */
   @Override
-  public void addDigestMetadata(StorageObjectMetadata meta, String digest)
-  {
-    if (!SnowflakeUtil.isBlank(digest))
-    {
+  public void addDigestMetadata(StorageObjectMetadata meta, String digest) {
+    if (!SnowflakeUtil.isBlank(digest)) {
       // Azure doesn't allow hyphens in the name of a metadata field.
       meta.addUserMetadata("sfcdigest", digest);
     }
   }
 
-  /**
-   * Gets digest metadata to the StorageObjectMetadata object
-   */
+  /** Gets digest metadata to the StorageObjectMetadata object */
   @Override
-  public String getDigestMetadata(StorageObjectMetadata meta)
-  {
+  public String getDigestMetadata(StorageObjectMetadata meta) {
     return meta.getUserMetadata().get("sfcdigest");
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -3,8 +3,6 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
@@ -12,17 +10,17 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.storage.*;
 import com.microsoft.azure.storage.blob.*;
-import java.io.*;
-import java.net.SocketTimeoutException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.util.*;
-import java.util.AbstractMap.SimpleEntry;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.ObjectMapperFactory;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.jdbc.*;
+import com.microsoft.azure.storage.StorageCredentials;
+import com.microsoft.azure.storage.StorageCredentialsAnonymous;
+import com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.ListBlobItem;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.client.util.SFPair;
@@ -30,25 +28,46 @@ import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 import net.snowflake.common.core.SqlState;
 import org.apache.commons.io.IOUtils;
 
+import java.io.*;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.*;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 /**
- * Encapsulates the Azure Storage client and all Azure Storage operations and logic
+ * Encapsulates the Azure Storage client
+ * and all Azure Storage operations and logic
  *
  * @author lgiakoumakis
  */
-public class SnowflakeAzureClient implements SnowflakeStorageClient {
 
-  private static final String localFileSep = systemGetProperty("file.separator");
-  private static final String AZ_ENCRYPTIONDATAPROP = "encryptiondata";
+public class SnowflakeAzureClient implements SnowflakeStorageClient
+{
+
+  private final static String localFileSep = systemGetProperty("file.separator");
+  private final static String AZ_ENCRYPTIONDATAPROP = "encryptiondata";
 
   private int encryptionKeySize = 0; // used for PUTs
   private StageInfo stageInfo;
   private RemoteStoreFileEncryptionMaterial encMat;
   private CloudBlobClient azStorageClient;
-  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeAzureClient.class);
+  private final static SFLogger logger =
+      SFLoggerFactory.getLogger(SnowflakeAzureClient.class);
   private OperationContext opContext = null;
-  private static SFSession session;
+  private SFSession session;
 
-  private SnowflakeAzureClient() {}
+  private SnowflakeAzureClient()
+  {
+  }
+
   ;
 
   /*
@@ -57,12 +76,13 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
    * @param encMat  The encryption material
    *                required to decrypt/encrypt content in stage
    */
-  public static SnowflakeAzureClient createSnowflakeAzureClient(
-      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession sfSession)
-      throws SnowflakeSQLException {
-    session = sfSession;
+  public static SnowflakeAzureClient createSnowflakeAzureClient(StageInfo stage,
+                                                                RemoteStoreFileEncryptionMaterial encMat,
+                                                                SFSession sfSession)
+  throws SnowflakeSQLException
+  {
     SnowflakeAzureClient azureClient = new SnowflakeAzureClient();
-    azureClient.setupAzureClient(stage, encMat);
+    azureClient.setupAzureClient(stage, encMat, sfSession);
 
     return azureClient;
   }
@@ -77,78 +97,95 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
    *                required to decrypt/encrypt content in stage
    * @throws IllegalArgumentException when invalid credentials are used
    */
-  private void setupAzureClient(StageInfo stage, RemoteStoreFileEncryptionMaterial encMat)
-      throws IllegalArgumentException, SnowflakeSQLException {
+  private void setupAzureClient(StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession sfSession)
+  throws IllegalArgumentException, SnowflakeSQLException
+  {
     // Save the client creation parameters so that we can reuse them,
     // to reset the Azure client.
     this.stageInfo = stage;
     this.encMat = encMat;
+    this.session = sfSession;
 
     logger.debug("Setting up the Azure client ");
     opContext = new OperationContext();
 
-    try {
-      URI storageEndpoint =
-          buildAzureStorageEndpointURI(stage.getEndPoint(), stage.getStorageAccount());
+    try
+    {
+      URI storageEndpoint = buildAzureStorageEndpointURI(stage.getEndPoint(), stage.getStorageAccount());
 
       StorageCredentials azCreds;
       String sasToken = (String) stage.getCredentials().get("AZURE_SAS_TOKEN");
-      if (sasToken != null) {
+      if (sasToken != null)
+      {
         // We are authenticated with a shared access token.
         azCreds = new StorageCredentialsSharedAccessSignature(sasToken);
-      } else {
+      }
+      else
+      {
         // Use anonymous authentication.
         azCreds = StorageCredentialsAnonymous.ANONYMOUS;
       }
 
-      if (encMat != null) {
+      if (encMat != null)
+      {
         byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
         encryptionKeySize = decodedKey.length * 8;
 
-        if (encryptionKeySize != 128 && encryptionKeySize != 192 && encryptionKeySize != 256) {
-          throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              session,
-              "unsupported key size",
-              encryptionKeySize);
+        if (encryptionKeySize != 128 &&
+            encryptionKeySize != 192 &&
+            encryptionKeySize != 256)
+        {
+          throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "unsupported key size", encryptionKeySize);
         }
       }
       HttpUtil.setProxyForAzure(opContext);
       this.azStorageClient = new CloudBlobClient(storageEndpoint, azCreds);
-    } catch (URISyntaxException ex) {
+    }
+    catch (URISyntaxException ex)
+    {
       throw new IllegalArgumentException("invalid_azure_credentials");
     }
   }
 
   // Reurns the Max number of retry attempts
   @Override
-  public int getMaxRetries() {
+  public int getMaxRetries()
+  {
     return 25;
   }
 
   // Returns the max exponent for multiplying backoff with the power of 2, the value
   // of 4 will give us 16secs as the max number of time to sleep before retry
   @Override
-  public int getRetryBackoffMaxExponent() {
+  public int getRetryBackoffMaxExponent()
+  {
     return 4;
   }
 
   // Returns the min number of milliseconds to sleep before retry
   @Override
-  public int getRetryBackoffMin() {
+  public int getRetryBackoffMin()
+  {
     return 1000;
   }
 
-  /** @return Returns true if encryption is enabled */
+  /**
+   * @return Returns true if encryption is enabled
+   */
   @Override
-  public boolean isEncrypting() {
+  public boolean isEncrypting()
+  {
     return encryptionKeySize > 0;
   }
 
-  /** @return Returns the size of the encryption key */
+  /**
+   * @return Returns the size of the encryption key
+   */
   @Override
-  public int getEncryptionKeySize() {
+  public int getEncryptionKeySize()
+  {
     return encryptionKeySize;
   }
 
@@ -157,42 +194,47 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
    *
    * @param stageCredentials a Map (as returned by GS) which contains the new credential properties
    * @throws SnowflakeSQLException failure to renew the client
-   */
+   **/
   @Override
-  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException {
+  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException
+  {
     stageInfo.setCredentials(stageCredentials);
-    setupAzureClient(stageInfo, encMat);
-  }
-
-  /** shuts down the client */
-  @Override
-  public void shutdown() {
-    /* Not available */
+    setupAzureClient(stageInfo, encMat, session);
   }
 
   /**
-   * For a set of remote storage objects under a remote location and a given prefix/path returns
-   * their properties wrapped in ObjectSummary objects
+   * shuts down the client
+   */
+  @Override
+  public void shutdown()
+  { /* Not available */ }
+
+  /**
+   * For a set of remote storage objects under a remote location and a given prefix/path
+   * returns their properties wrapped in ObjectSummary objects
    *
    * @param remoteStorageLocation location, i.e. container for Azure
-   * @param prefix the prefix/path to list under
+   * @param prefix                the prefix/path to list under
    * @return a collection of storage summary objects
    * @throws StorageProviderException Azure storage exception
    */
   @Override
   public StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
-      throws StorageProviderException {
+  throws StorageProviderException
+  {
     StorageObjectSummaryCollection storageObjectSummaries;
 
-    try {
+    try
+    {
       CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
-      Iterable<ListBlobItem> listBlobItemIterable =
-          container.listBlobs(
-              prefix, // List the BLOBs under this prefix
-              true // List the BLOBs as a flat list, i.e. do not list directories
-              );
+      Iterable<ListBlobItem> listBlobItemIterable = container.listBlobs(
+          prefix,       // List the BLOBs under this prefix
+          true          // List the BLOBs as a flat list, i.e. do not list directories
+      );
       storageObjectSummaries = new StorageObjectSummaryCollection(listBlobItemIterable);
-    } catch (URISyntaxException | StorageException ex) {
+    }
+    catch (URISyntaxException | StorageException ex)
+    {
       logger.debug("Failed to list objects: {}", ex);
       throw new StorageProviderException(ex);
     }
@@ -203,15 +245,17 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
    * Returns the metadata properties for a remote storage object
    *
    * @param remoteStorageLocation location, i.e. bucket for S3
-   * @param prefix the prefix/path of the object to retrieve
+   * @param prefix                the prefix/path of the object to retrieve
    * @return storage metadata object
    * @throws StorageProviderException azure storage exception
    */
   @Override
   public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
-      throws StorageProviderException {
+  throws StorageProviderException
+  {
     CommonObjectMetadata azureObjectMetadata = null;
-    try {
+    try
+    {
       // Get a reference to the BLOB, to retrieve its metadata
       CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
       CloudBlob blob = container.getBlockBlobReference(prefix);
@@ -226,15 +270,16 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       String contentEncoding = properties.getContentEncoding();
 
       // Construct an Azure metadata object
-      azureObjectMetadata =
-          new CommonObjectMetadata(contentLength, contentEncoding, userDefinedMetadata);
-    } catch (StorageException ex) {
-      logger.debug(
-          "Failed to retrieve BLOB metadata: {} - {}",
-          ex.getErrorCode(),
-          ex.getExtendedErrorInformation());
+      azureObjectMetadata = new CommonObjectMetadata(contentLength, contentEncoding, userDefinedMetadata);
+    }
+    catch (StorageException ex)
+    {
+      logger.debug("Failed to retrieve BLOB metadata: {} - {}", ex.getErrorCode(),
+                   ex.getExtendedErrorInformation());
       throw new StorageProviderException(ex);
-    } catch (URISyntaxException ex) {
+    }
+    catch (URISyntaxException ex)
+    {
       logger.debug("Cannot retrieve BLOB properties, invalid URI: {}", ex);
       throw new StorageProviderException(ex);
     }
@@ -245,32 +290,28 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
   /**
    * Download a file from remote storage.
    *
-   * @param session session object
-   * @param command command to download file
-   * @param localLocation local file path
-   * @param destFileName destination file name
-   * @param parallelism [ not used by the Azure implementation ]
+   * @param session               session object
+   * @param command               command to download file
+   * @param localLocation         local file path
+   * @param destFileName          destination file name
+   * @param parallelism           [ not used by the Azure implementation ]
    * @param remoteStorageLocation remote storage location, i.e. bucket for S3
-   * @param stageFilePath stage file path
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Unused in Azure
+   * @param stageFilePath         stage file path
+   * @param stageRegion           region name where the stage persists
+   * @param presignedUrl          Unused in Azure
    * @throws SnowflakeSQLException download failure
-   */
+   **/
   @Override
-  public void download(
-      SFSession session,
-      String command,
-      String localLocation,
-      String destFileName,
-      int parallelism,
-      String remoteStorageLocation,
-      String stageFilePath,
-      String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+  public void download(SFSession session, String command, String localLocation, String destFileName,
+                       int parallelism, String remoteStorageLocation, String stageFilePath, String stageRegion,
+                       String presignedUrl)
+  throws SnowflakeSQLException
+  {
     int retryCount = 0;
-    do {
-      try {
+    do
+    {
+      try
+      {
         String localFilePath = localLocation + localFileSep + destFileName;
         File localFile = new File(localFilePath);
         CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
@@ -293,65 +334,66 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
         String key = encryptionData.getKey();
         String iv = encryptionData.getValue();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
-          if (key == null || iv == null) {
-            throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
-                "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256)
+        {
+          if (key == null || iv == null)
+          {
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
           // Decrypt file
-          try {
+          try
+          {
             EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          } catch (Exception ex) {
+          }
+          catch (Exception ex)
+          {
             logger.error("Error decrypting file", ex);
             throw ex;
           }
         }
         return;
 
-      } catch (Exception ex) {
+      }
+      catch (Exception ex)
+      {
         logger.debug("Download unsuccessful {}", ex);
         handleAzureException(ex, ++retryCount, "download", session, command, this);
       }
-    } while (retryCount <= getMaxRetries());
+    }
+    while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        session,
-        "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Download a file from remote storage
    *
-   * @param session session object
-   * @param command command to download file
-   * @param parallelism number of threads for parallel downloading
+   * @param session               session object
+   * @param command               command to download file
+   * @param parallelism           number of threads for parallel downloading
    * @param remoteStorageLocation remote storage location, i.e. bucket for s3
-   * @param stageFilePath stage file path
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Unused in Azure
+   * @param stageFilePath         stage file path
+   * @param stageRegion           region name where the stage persists
+   * @param presignedUrl          Unused in Azure
    * @return input file stream
    * @throws SnowflakeSQLException when download failure
    */
   @Override
-  public InputStream downloadToStream(
-      SFSession session,
-      String command,
-      int parallelism,
-      String remoteStorageLocation,
-      String stageFilePath,
-      String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+  public InputStream downloadToStream(SFSession session, String command, int parallelism,
+                                      String remoteStorageLocation, String stageFilePath,
+                                      String stageRegion, String presignedUrl) throws SnowflakeSQLException
+  {
     int retryCount = 0;
 
-    do {
-      try {
+    do
+    {
+      try
+      {
         CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
 
         CloudBlob blob = container.getBlockBlobReference(stageFilePath);
@@ -367,93 +409,89 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
 
         String iv = encryptionData.getValue();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
-          if (key == null || iv == null) {
-            throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
-                "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256)
+        {
+          if (key == null || iv == null)
+          {
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
-          try {
+          try
+          {
 
             return EncryptionProvider.decryptStream(stream, key, iv, encMat);
 
-          } catch (Exception ex) {
+          }
+          catch (Exception ex)
+          {
             logger.error("Error in decrypting file", ex);
             throw ex;
           }
 
-        } else {
+        }
+        else
+        {
           return stream;
         }
 
-      } catch (Exception ex) {
-        logger.debug("Downloading unsuccessful {}", ex);
-        handleAzureException(ex, ++retryCount, "download", session, command, this);
       }
-    } while (retryCount < getMaxRetries());
+      catch (Exception ex)
+      {
+        logger.debug("Downloading unsuccessful {}", ex);
+        handleAzureException(ex, ++retryCount, "download", session, command
+            , this);
+      }
+    }
+    while (retryCount < getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        session,
-        "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file/stream to remote storage
    *
-   * @param session session object
-   * @param command upload command
-   * @param parallelism [ not used by the Azure implementation ]
-   * @param uploadFromStream true if upload source is stream
-   * @param remoteStorageLocation storage container name
-   * @param srcFile source file if not uploading from a stream
-   * @param destFileName file name on remote storage after upload
-   * @param inputStream stream used for uploading if fileBackedOutputStream is null
+   * @param session                session object
+   * @param command                upload command
+   * @param parallelism            [ not used by the Azure implementation ]
+   * @param uploadFromStream       true if upload source is stream
+   * @param remoteStorageLocation  storage container name
+   * @param srcFile                source file if not uploading from a stream
+   * @param destFileName           file name on remote storage after upload
+   * @param inputStream            stream used for uploading if fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta object meta data
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Unused in Azure
+   * @param meta                   object meta data
+   * @param stageRegion            region name where the stage persists
+   * @param presignedUrl           Unused in Azure
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   @Override
-  public void upload(
-      SFSession session,
-      String command,
-      int parallelism,
-      boolean uploadFromStream,
-      String remoteStorageLocation,
-      File srcFile,
-      String destFileName,
-      InputStream inputStream,
-      FileBackedOutputStream fileBackedOutputStream,
-      StorageObjectMetadata meta,
-      String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+  public void upload(SFSession session, String command, int parallelism, boolean uploadFromStream,
+                     String remoteStorageLocation, File srcFile, String destFileName, InputStream inputStream,
+                     FileBackedOutputStream fileBackedOutputStream, StorageObjectMetadata meta, String stageRegion,
+                     String presignedUrl)
+  throws SnowflakeSQLException
+  {
     final List<FileInputStream> toClose = new ArrayList<>();
     long originalContentLength = meta.getContentLength();
 
-    SFPair<InputStream, Boolean> uploadStreamInfo =
-        createUploadStream(
-            srcFile,
-            uploadFromStream,
-            inputStream,
-            meta,
-            originalContentLength,
-            fileBackedOutputStream,
-            toClose);
+    SFPair<InputStream, Boolean> uploadStreamInfo = createUploadStream(
+        srcFile, uploadFromStream, inputStream, meta, originalContentLength,
+        fileBackedOutputStream, toClose);
 
-    if (!(meta instanceof CommonObjectMetadata)) {
+    if (!(meta instanceof CommonObjectMetadata))
+    {
       throw new IllegalArgumentException("Unexpected metadata object type");
     }
 
     int retryCount = 0;
-    do {
-      try {
+    do
+    {
+      try
+      {
         logger.debug("Starting upload");
         InputStream fileInputStream = uploadStreamInfo.left;
         CloudBlobContainer container = azStorageClient.getContainerReference(remoteStorageLocation);
@@ -466,66 +504,61 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
         // where the user has control of block size and parallelism
         // we rely on Azure to handle the upload, hence the "parallelism" parameter is ignored
         // in the Azure implementation of the method
-        blob.upload(
-            fileInputStream, // input stream to upload from
-            -1 // -1 indicates an unknown stream length
-            );
+        blob.upload(fileInputStream,  // input stream to upload from
+                    -1                // -1 indicates an unknown stream length
+        );
         logger.debug("Upload successful");
 
         blob.uploadMetadata();
 
         // close any open streams in the "toClose" list and return
-        for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
+        for (FileInputStream is : toClose)
+          IOUtils.closeQuietly(is);
 
         return;
-      } catch (Exception ex) {
+      }
+      catch (Exception ex)
+      {
         handleAzureException(ex, ++retryCount, "upload", session, command, this);
 
-        if (uploadFromStream && fileBackedOutputStream == null) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              "Encountered exception during upload: "
-                  + ex.getMessage()
-                  + "\nCannot retry upload from stream.");
+        if (uploadFromStream && fileBackedOutputStream == null)
+        {
+          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
+                                          ErrorCode.IO_ERROR.getMessageCode(),
+                                          "Encountered exception during upload: " +
+                                          ex.getMessage() + "\nCannot retry upload from stream.");
         }
-        uploadStreamInfo =
-            createUploadStream(
-                srcFile,
-                uploadFromStream,
-                inputStream,
-                meta,
-                originalContentLength,
-                fileBackedOutputStream,
-                toClose);
+        uploadStreamInfo = createUploadStream(srcFile, uploadFromStream,
+                                              inputStream, meta, originalContentLength,
+                                              fileBackedOutputStream, toClose);
       }
 
-    } while (retryCount <= getMaxRetries());
+    }
+    while (retryCount <= getMaxRetries());
 
-    for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
+    for (FileInputStream is : toClose)
+      IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        "Unexpected: upload unsuccessful without exception!");
+    throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+                                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                                    "Unexpected: upload unsuccessful without exception!");
   }
 
   /**
    * Handles exceptions thrown by Azure Storage
    *
-   * @param ex the exception to handle
+   * @param ex         the exception to handle
    * @param retryCount current number of retries, incremented by the caller before each call
-   * @param operation string that indicates the function/operation that was taking place, when the
-   *     exception was raised, for example "upload"
-   * @param session the current SFSession object used by the client
-   * @param command the command attempted at the time of the exception
+   * @param operation  string that indicates the function/operation that was taking place,
+   *                   when the exception was raised, for example "upload"
+   * @param session    the current SFSession object used by the client
+   * @param command    the command attempted at the time of the exception
    * @throws SnowflakeSQLException exceptions not handled
    */
   @Override
-  public void handleStorageException(
-      Exception ex, int retryCount, String operation, SFSession session, String command)
-      throws SnowflakeSQLException {
+  public void handleStorageException(Exception ex, int retryCount, String operation, SFSession session, String command)
+  throws SnowflakeSQLException
+  {
     handleAzureException(ex, retryCount, operation, session, command, this);
   }
 
@@ -537,88 +570,91 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       long originalContentLength,
       FileBackedOutputStream fileBackedOutputStream,
       List<FileInputStream> toClose)
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
     logger.debug(
         "createUploadStream({}, {}, {}, {}, {}, {})",
-        this,
-        srcFile,
-        uploadFromStream,
-        inputStream,
-        fileBackedOutputStream,
-        toClose);
+        this, srcFile, uploadFromStream, inputStream, fileBackedOutputStream, toClose);
 
     final InputStream stream;
     FileInputStream srcFileStream = null;
-    try {
-      if (isEncrypting() && getEncryptionKeySize() < 256) {
-        try {
-          final InputStream uploadStream =
-              uploadFromStream
-                  ? (fileBackedOutputStream != null
-                      ? fileBackedOutputStream.asByteSource().openStream()
-                      : inputStream)
-                  : (srcFileStream = new FileInputStream(srcFile));
+    try
+    {
+      if (isEncrypting() && getEncryptionKeySize() < 256)
+      {
+        try
+        {
+          final InputStream uploadStream = uploadFromStream ?
+                                           (fileBackedOutputStream != null ?
+                                            fileBackedOutputStream.asByteSource().openStream() :
+                                            inputStream) :
+                                           (srcFileStream = new FileInputStream(srcFile));
           toClose.add(srcFileStream);
 
           // Encrypt
-          stream =
-              EncryptionProvider.encrypt(
-                  meta, originalContentLength, uploadStream, this.encMat, this);
+          stream = EncryptionProvider.encrypt(meta, originalContentLength,
+                                              uploadStream, this.encMat, this);
           uploadFromStream = true;
-        } catch (Exception ex) {
-          logger.error("Failed to encrypt input", ex);
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Failed to encrypt input",
-              ex.getMessage());
         }
-      } else {
-        if (uploadFromStream) {
-          if (fileBackedOutputStream != null) {
+        catch (Exception ex)
+        {
+          logger.error("Failed to encrypt input", ex);
+          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "Failed to encrypt input", ex.getMessage());
+        }
+      }
+      else
+      {
+        if (uploadFromStream)
+        {
+          if (fileBackedOutputStream != null)
+          {
             stream = fileBackedOutputStream.asByteSource().openStream();
-          } else {
+          }
+          else
+          {
             stream = inputStream;
           }
-        } else {
+        }
+        else
+        {
           srcFileStream = new FileInputStream(srcFile);
           toClose.add(srcFileStream);
           stream = srcFileStream;
         }
       }
-    } catch (FileNotFoundException ex) {
+    }
+    catch (FileNotFoundException ex)
+    {
       logger.error("Failed to open input file", ex);
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Failed to open input file",
-          ex.getMessage());
-    } catch (IOException ex) {
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Failed to open input file", ex.getMessage());
+    }
+    catch (IOException ex)
+    {
       logger.error("Failed to open input stream", ex);
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Failed to open input stream",
-          ex.getMessage());
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Failed to open input stream", ex.getMessage());
     }
 
     return SFPair.of(stream, uploadFromStream);
   }
 
   /**
-   * Handles exceptions thrown by Azure Storage It will retry transient errors as defined by the
-   * Azure Client retry policy It will re-create the client if the SAS token has expired, and re-try
+   * Handles exceptions thrown by Azure Storage
+   * It will retry transient errors as defined by the Azure Client retry policy
+   * It will re-create the client if the SAS token has expired, and re-try
    *
-   * @param ex the exception to handle
+   * @param ex         the exception to handle
    * @param retryCount current number of retries, incremented by the caller before each call
-   * @param operation string that indicates the function/operation that was taking place, when the
-   *     exception was raised, for example "upload"
-   * @param session the current SFSession object used by the client
-   * @param command the command attempted at the time of the exception
-   * @param azClient the current Snowflake Azure client object
+   * @param operation  string that indicates the function/operation that was taking place,
+   *                   when the exception was raised, for example "upload"
+   * @param session    the current SFSession object used by the client
+   * @param command    the command attempted at the time of the exception
+   * @param azClient   the current Snowflake Azure client object
    * @throws SnowflakeSQLException exceptions not handled
    */
   private static void handleAzureException(
@@ -628,88 +664,100 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       SFSession session,
       String command,
       SnowflakeAzureClient azClient)
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
 
     // no need to retry if it is invalid key exception
-    if (ex.getCause() instanceof InvalidKeyException) {
+    if (ex.getCause() instanceof InvalidKeyException)
+    {
       // Most likely cause is that the unlimited strength policy files are not installed
       // Log the error and throw a message that explains the cause
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
-    if (ex instanceof StorageException) {
+    if (ex instanceof StorageException)
+    {
       StorageException se = (StorageException) ex;
 
-      if (((StorageException) ex).getHttpStatusCode() == 403) {
+      if (((StorageException) ex).getHttpStatusCode() == 403)
+      {
         // A 403 indicates that the SAS token has expired,
         // we need to refresh the Azure client with the new token
         SnowflakeFileTransferAgent.renewExpiredToken(session, command, azClient);
       }
       // If we have exceeded the max number of retries, propagate the error
-      if (retryCount > azClient.getMaxRetries()) {
-        throw new SnowflakeSQLException(
-            se,
-            SqlState.SYSTEM_ERROR,
-            ErrorCode.AZURE_SERVICE_ERROR.getMessageCode(),
-            operation,
-            se.getErrorCode(),
-            se.getHttpStatusCode(),
-            se.getMessage(),
-            se.getExtendedErrorInformation());
-      } else {
-        logger.debug(
-            "Encountered exception ({}) during {}, retry count: {}",
-            ex.getMessage(),
-            operation,
-            retryCount);
+      if (retryCount > azClient.getMaxRetries())
+      {
+        throw new SnowflakeSQLLoggedException(se, SqlState.SYSTEM_ERROR,
+                                              ErrorCode.AZURE_SERVICE_ERROR.getMessageCode(), session,
+                                              operation,
+                                              se.getErrorCode(),
+                                              se.getHttpStatusCode(),
+                                              se.getMessage(),
+                                              se.getExtendedErrorInformation());
+      }
+      else
+      {
+        logger.debug("Encountered exception ({}) during {}, retry count: {}",
+                     ex.getMessage(), operation, retryCount);
         logger.debug("Stack trace: ", ex);
 
         // exponential backoff up to a limit
         int backoffInMillis = azClient.getRetryBackoffMin();
 
-        if (retryCount > 1) {
-          backoffInMillis <<= (Math.min(retryCount - 1, azClient.getRetryBackoffMaxExponent()));
+        if (retryCount > 1)
+        {
+          backoffInMillis <<= (Math.min(retryCount - 1,
+                                        azClient.getRetryBackoffMaxExponent()));
         }
 
-        try {
+        try
+        {
           logger.debug("Sleep for {} milliseconds before retry", backoffInMillis);
 
           Thread.sleep(backoffInMillis);
-        } catch (InterruptedException ex1) {
+        }
+        catch (InterruptedException ex1)
+        {
           // ignore
         }
 
-        if (se.getHttpStatusCode() == 403) {
+        if (se.getHttpStatusCode() == 403)
+        {
           // A 403 indicates that the SAS token has expired,
           // we need to refresh the Azure client with the new token
           SnowflakeFileTransferAgent.renewExpiredToken(session, command, azClient);
         }
       }
-    } else {
-      if (ex instanceof InterruptedException
-          || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
-        if (retryCount > azClient.getMaxRetries()) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              "Encountered exception during " + operation + ": " + ex.getMessage());
-        } else {
-          logger.debug(
-              "Encountered exception ({}) during {}, retry count: {}",
-              ex.getMessage(),
-              operation,
-              retryCount);
+    }
+    else
+    {
+      if (ex instanceof InterruptedException ||
+          SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException)
+      {
+        if (retryCount > azClient.getMaxRetries())
+        {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                                ErrorCode.IO_ERROR.getMessageCode(), session,
+                                                "Encountered exception during " + operation + ": " +
+                                                ex.getMessage());
         }
-      } else {
-        throw new SnowflakeSQLException(
-            ex,
-            SqlState.SYSTEM_ERROR,
-            ErrorCode.IO_ERROR.getMessageCode(),
-            "Encountered exception during " + operation + ": " + ex.getMessage());
+        else
+        {
+          logger.debug("Encountered exception ({}) during {}, retry count: {}",
+                       ex.getMessage(), operation, retryCount);
+        }
+      }
+      else
+      {
+        throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                              ErrorCode.IO_ERROR.getMessageCode(), session,
+                                              "Encountered exception during " + operation + ": " +
+                                              ex.getMessage());
       }
     }
   }
+
 
   /*
    * Builds a URI to a Azure Storage account endpoint
@@ -718,9 +766,11 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
    *  @param storageAccount    the storage account name
    */
   private static URI buildAzureStorageEndpointURI(String storageEndPoint, String storageAccount)
-      throws URISyntaxException {
-    URI storageEndpoint =
-        new URI("https", storageAccount + "." + storageEndPoint + "/", null, null);
+  throws URISyntaxException
+  {
+    URI storageEndpoint = new URI(
+        "https", storageAccount + "." + storageEndPoint + "/",
+        null, null);
 
     return storageEndpoint;
   }
@@ -730,16 +780,15 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
    * Takes the base64-encoded iv and key and creates the JSON block to be
    * used as the encryptiondata metadata field on the blob.
    */
-  private String buildEncryptionMetadataJSON(String iv64, String key64) {
-    return String.format(
-        "{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
-            + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
-            + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
-            + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
-            + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
-            + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
-            + "\"Java 5.3.0\"}}",
-        key64, iv64);
+  private String buildEncryptionMetadataJSON(String iv64, String key64)
+  {
+    return String.format("{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
+                         + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
+                         + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
+                         + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
+                         + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
+                         + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
+                         + "\"Java 5.3.0\"}}", key64, iv64);
   }
 
   /*
@@ -748,10 +797,12 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
    * blob and parses out the key and iv. Returns the pair as key = key, iv = value.
    */
   private SimpleEntry<String, String> parseEncryptionData(String jsonEncryptionData)
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
     ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
     JsonFactory factory = mapper.getFactory();
-    try {
+    try
+    {
       JsonParser parser = factory.createParser(jsonEncryptionData);
       JsonNode encryptionDataNode = mapper.readTree(parser);
 
@@ -759,48 +810,63 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       String key = encryptionDataNode.get("WrappedContentKey").get("EncryptedKey").asText();
 
       return new SimpleEntry<String, String>(key, iv);
-    } catch (Exception ex) {
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.SYSTEM_ERROR,
-          ErrorCode.IO_ERROR.getMessageCode(),
-          "Error parsing encryption data as json" + ": " + ex.getMessage());
+    }
+    catch (Exception ex)
+    {
+      throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                            ErrorCode.IO_ERROR.getMessageCode(), session,
+                                            "Error parsing encryption data as json" + ": " +
+                                            ex.getMessage());
     }
   }
 
-  /** Returns the material descriptor key */
+  /**
+   * Returns the material descriptor key
+   */
   @Override
-  public String getMatdescKey() {
+  public String getMatdescKey()
+  {
     return "matdesc";
   }
 
-  /** Adds encryption metadata to the StorageObjectMetadata object */
+  /**
+   * Adds encryption metadata to the StorageObjectMetadata object
+   */
   @Override
-  public void addEncryptionMetadata(
-      StorageObjectMetadata meta,
-      MatDesc matDesc,
-      byte[] ivData,
-      byte[] encKeK,
-      long contentLength) {
-    meta.addUserMetadata(getMatdescKey(), matDesc.toString());
-    meta.addUserMetadata(
-        AZ_ENCRYPTIONDATAPROP,
-        buildEncryptionMetadataJSON(Base64.encodeAsString(ivData), Base64.encodeAsString(encKeK)));
+  public void addEncryptionMetadata(StorageObjectMetadata meta,
+                                    MatDesc matDesc,
+                                    byte[] ivData,
+                                    byte[] encKeK,
+                                    long contentLength)
+  {
+    meta.addUserMetadata(getMatdescKey(),
+                         matDesc.toString());
+    meta.addUserMetadata(AZ_ENCRYPTIONDATAPROP, buildEncryptionMetadataJSON(
+        Base64.encodeAsString(ivData),
+        Base64.encodeAsString(encKeK))
+    );
     meta.setContentLength(contentLength);
   }
 
-  /** Adds digest metadata to the StorageObjectMetadata object */
+  /**
+   * Adds digest metadata to the StorageObjectMetadata object
+   */
   @Override
-  public void addDigestMetadata(StorageObjectMetadata meta, String digest) {
-    if (!SnowflakeUtil.isBlank(digest)) {
+  public void addDigestMetadata(StorageObjectMetadata meta, String digest)
+  {
+    if (!SnowflakeUtil.isBlank(digest))
+    {
       // Azure doesn't allow hyphens in the name of a metadata field.
       meta.addUserMetadata("sfcdigest", digest);
     }
   }
 
-  /** Gets digest metadata to the StorageObjectMetadata object */
+  /**
+   * Gets digest metadata to the StorageObjectMetadata object
+   */
   @Override
-  public String getDigestMetadata(StorageObjectMetadata meta) {
+  public String getDigestMetadata(StorageObjectMetadata meta)
+  {
     return meta.getUserMetadata().get("sfcdigest");
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -3,8 +3,6 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
@@ -16,15 +14,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.*;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.common.base.Strings;
-import java.io.*;
-import java.net.SocketTimeoutException;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.core.ObjectMapperFactory;
@@ -45,24 +34,41 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 
+import java.io.*;
+import java.net.SocketTimeoutException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 /**
  * Encapsulates the GCS Storage client and all GCS operations and logic
  *
  * @author ppaulus
  */
-public class SnowflakeGCSClient implements SnowflakeStorageClient {
-  private static final String GCS_ENCRYPTIONDATAPROP = "encryptiondata";
-  private static final String localFileSep = systemGetProperty("file.separator");
-  private static final String GCS_METADATA_PREFIX = "x-goog-meta-";
+public class SnowflakeGCSClient implements SnowflakeStorageClient
+{
+  private final static String GCS_ENCRYPTIONDATAPROP = "encryptiondata";
+  private final static String localFileSep = systemGetProperty("file.separator");
+  private final static String GCS_METADATA_PREFIX = "x-goog-meta-";
 
   private int encryptionKeySize = 0; // used for PUTs
   private StageInfo stageInfo;
   private RemoteStoreFileEncryptionMaterial encMat;
   private Storage gcsClient = null;
+  private SFSession session = null;
 
-  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeGCSClient.class);
+  private final static SFLogger logger =
+      SFLoggerFactory.getLogger(SnowflakeGCSClient.class);
 
-  private SnowflakeGCSClient() {}
+  private SnowflakeGCSClient()
+  {
+  }
 
   /*
    * Factory method for a SnowflakeGCSClient object
@@ -70,62 +76,78 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
    * @param encMat  The encryption material
    *                required to decrypt/encrypt content in stage
    */
-  public static SnowflakeGCSClient createSnowflakeGCSClient(
-      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat) throws SnowflakeSQLException {
+  public static SnowflakeGCSClient createSnowflakeGCSClient(StageInfo stage,
+                                                            RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+  throws SnowflakeSQLException
+  {
     SnowflakeGCSClient sfGcsClient = new SnowflakeGCSClient();
-    sfGcsClient.setupGCSClient(stage, encMat);
+    sfGcsClient.setupGCSClient(stage, encMat, session);
 
     return sfGcsClient;
   }
 
   // Returns the Max number of retry attempts
   @Override
-  public int getMaxRetries() {
+  public int getMaxRetries()
+  {
     return 25;
   }
 
   // Returns the max exponent for multiplying backoff with the power of 2, the value
   // of 4 will give us 16secs as the max number of time to sleep before retry
   @Override
-  public int getRetryBackoffMaxExponent() {
+  public int getRetryBackoffMaxExponent()
+  {
     return 4;
   }
 
   // Returns the min number of milliseconds to sleep before retry
   @Override
-  public int getRetryBackoffMin() {
+  public int getRetryBackoffMin()
+  {
     return 1000;
   }
 
-  /** @return Returns true if encryption is enabled */
+  /**
+   * @return Returns true if encryption is enabled
+   */
   @Override
-  public boolean isEncrypting() {
+  public boolean isEncrypting()
+  {
     return encryptionKeySize > 0;
   }
 
-  /** @return Returns the size of the encryption key */
+  /**
+   * @return Returns the size of the encryption key
+   */
   @Override
-  public int getEncryptionKeySize() {
+  public int getEncryptionKeySize()
+  {
     return encryptionKeySize;
   }
 
   /**
-   * @return Whether this client requires the use of presigned URLs for upload and download instead
-   *     of credentials that work for all files uploaded/ downloaded to a stage path. True for GCS.
+   * @return Whether this client requires the use of presigned URLs for upload
+   * and download instead of credentials that work for all files uploaded/
+   * downloaded to a stage path. True for GCS.
    */
   @Override
-  public boolean requirePresignedUrl() {
+  public boolean requirePresignedUrl()
+  {
     return true;
   }
 
+
   @Override
-  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException {
+  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException
+  {
     stageInfo.setCredentials(stageCredentials);
-    setupGCSClient(stageInfo, encMat);
+    setupGCSClient(stageInfo, encMat, session);
   }
 
   @Override
-  public void shutdown() {
+  public void shutdown()
+  {
     // nothing to do here
   }
 
@@ -133,26 +155,33 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
    * listObjects gets all the objects in a path
    *
    * @param remoteStorageLocation bucket name
-   * @param prefix Path
+   * @param prefix                Path
    * @return
    * @throws StorageProviderException
    */
   @Override
-  public StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
-      throws StorageProviderException {
-    try {
+  public StorageObjectSummaryCollection listObjects(String remoteStorageLocation,
+                                                    String prefix) throws StorageProviderException
+  {
+    try
+    {
       Page<Blob> blobs = this.gcsClient.list(remoteStorageLocation, BlobListOption.prefix(prefix));
       return new StorageObjectSummaryCollection(blobs);
-    } catch (Exception e) {
+    }
+    catch (Exception e)
+    {
       logger.debug("Failed to list objects");
       throw new StorageProviderException(e);
     }
   }
 
   @Override
-  public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
-      throws StorageProviderException {
-    try {
+  public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation,
+                                                 String prefix)
+  throws StorageProviderException
+  {
+    try
+    {
       BlobId blobId = BlobId.of(remoteStorageLocation, prefix);
       Blob blob = gcsClient.get(blobId);
 
@@ -160,16 +189,22 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
       // By design, our storage platform expects to see a "blob not found" situation
       // as a RemoteStorageProviderException
       // Hence, we throw a RemoteStorageProviderException
-      if (blob == null) {
+      if (blob == null)
+      {
         throw new StorageProviderException(
             new StorageException(
                 404, // because blob not found
-                "Blob" + blobId.getName() + " not found in bucket " + blobId.getBucket()));
+                "Blob" + blobId.getName() + " not found in bucket "
+                + blobId.getBucket())
+        );
       }
 
-      return new CommonObjectMetadata(
-          blob.getSize(), blob.getContentEncoding(), blob.getMetadata());
-    } catch (StorageException ex) {
+      return new CommonObjectMetadata(blob.getSize(),
+                                      blob.getContentEncoding(),
+                                      blob.getMetadata());
+    }
+    catch (StorageException ex)
+    {
       throw new StorageProviderException(ex);
     }
   }
@@ -177,38 +212,40 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
   /**
    * Download a file from remote storage.
    *
-   * @param session session object
-   * @param command command to download file
-   * @param localLocation local file path
-   * @param destFileName destination file name
-   * @param parallelism [ not used by the GCP implementation ]
+   * @param session               session object
+   * @param command               command to download file
+   * @param localLocation         local file path
+   * @param destFileName          destination file name
+   * @param parallelism           [ not used by the GCP implementation ]
    * @param remoteStorageLocation remote storage location, i.e. bucket for S3
-   * @param stageFilePath stage file path
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Credential to use for download
+   * @param stageFilePath         stage file path
+   * @param stageRegion           region name where the stage persists
+   * @param presignedUrl          Credential to use for download
    * @throws SnowflakeSQLException download failure
-   */
+   **/
   @Override
-  public void download(
-      SFSession session,
-      String command,
-      String localLocation,
-      String destFileName,
-      int parallelism,
-      String remoteStorageLocation,
-      String stageFilePath,
-      String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+  public void download(SFSession session,
+                       String command,
+                       String localLocation,
+                       String destFileName,
+                       int parallelism,
+                       String remoteStorageLocation,
+                       String stageFilePath,
+                       String stageRegion,
+                       String presignedUrl) throws SnowflakeSQLException
+  {
     int retryCount = 0;
     String localFilePath = localLocation + localFileSep + destFileName;
     File localFile = new File(localFilePath);
 
-    do {
-      try {
+    do
+    {
+      try
+      {
         String key = null;
         String iv = null;
-        if (!Strings.isNullOrEmpty(presignedUrl)) {
+        if (!Strings.isNullOrEmpty(presignedUrl))
+        {
           logger.debug("Starting download with presigned URL");
           URIBuilder uriBuilder = new URIBuilder(presignedUrl);
 
@@ -217,42 +254,43 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
 
           logger.debug("Fetching result: {}", scrubPresignedUrl(presignedUrl));
 
-          CloseableHttpClient httpClient =
-              HttpUtil.getHttpClientWithoutDecompression(session.getOCSPMode());
+          CloseableHttpClient httpClient = HttpUtil.getHttpClientWithoutDecompression(
+              session.getOCSPMode());
 
           // Put the file on storage using the presigned url
           HttpResponse response =
-              RestRequest.execute(
-                  httpClient,
-                  httpRequest,
-                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
-                  0, // no socketime injection
-                  null, // no canceling
-                  false, // no cookie
-                  false, // no retry
-                  false, // no request_guid
-                  true // retry on HTTP 403
-                  );
+              RestRequest.execute(httpClient,
+                                  httpRequest,
+                                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
+                                  0, // no socketime injection
+                                  null, // no canceling
+                                  false, // no cookie
+                                  false, // no retry
+                                  false, // no request_guid
+                                  true // retry on HTTP 403
+              );
 
-          logger.debug(
-              "Call returned for URL: {}",
-              (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
-          if (response.getStatusLine().getStatusCode() == 200) {
-            try {
+          logger.debug("Call returned for URL: {}",
+                       (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
+          if (response.getStatusLine().getStatusCode() == 200)
+          {
+            try
+            {
               InputStream bodyStream = response.getEntity().getContent();
               byte[] buffer = new byte[8 * 1024];
               int bytesRead;
               OutputStream outStream = new FileOutputStream(localFile);
-              while ((bytesRead = bodyStream.read(buffer)) != -1) {
+              while ((bytesRead = bodyStream.read(buffer)) != -1)
+              {
                 outStream.write(buffer, 0, bytesRead);
               }
               outStream.flush();
               outStream.close();
               bodyStream.close();
-              for (Header header : response.getAllHeaders()) {
-                if (header
-                    .getName()
-                    .equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP)) {
+              for (Header header : response.getAllHeaders())
+              {
+                if (header.getName().equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP))
+                {
                   AbstractMap.SimpleEntry<String, String> encryptionData =
                       parseEncryptionData(header.getValue());
 
@@ -262,19 +300,26 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
                 }
               }
               logger.debug("Download successful");
-            } catch (IOException ex) {
+            }
+            catch (IOException ex)
+            {
               logger.debug("Download unsuccessful {}", ex);
               handleStorageException(ex, ++retryCount, "download", session, command);
             }
           }
-        } else {
+        }
+        else
+        {
           BlobId blobId = BlobId.of(remoteStorageLocation, stageFilePath);
           Blob blob = gcsClient.get(blobId);
-          if (blob == null) {
+          if (blob == null)
+          {
             throw new StorageProviderException(
                 new StorageException(
                     404, // because blob not found
-                    "Blob" + blobId.getName() + " not found in bucket " + blobId.getBucket()));
+                    "Blob" + blobId.getName() + " not found in bucket "
+                    + blobId.getBucket())
+            );
           }
 
           logger.debug("Starting download without presigned URL");
@@ -283,7 +328,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
 
           // Get the user-defined BLOB metadata
           Map<String, String> userDefinedMetadata = blob.getMetadata();
-          if (userDefinedMetadata != null) {
+          if (userDefinedMetadata != null)
+          {
             AbstractMap.SimpleEntry<String, String> encryptionData =
                 parseEncryptionData(userDefinedMetadata.get(GCS_ENCRYPTIONDATAPROP));
 
@@ -292,74 +338,76 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           }
         }
 
-        if (!Strings.isNullOrEmpty(iv)
-            && !Strings.isNullOrEmpty(key)
-            && this.isEncrypting()
-            && this.getEncryptionKeySize() <= 256) {
-          if (key == null || iv == null) {
-            throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
-                "File metadata incomplete");
+        if (!Strings.isNullOrEmpty(iv) && !Strings.isNullOrEmpty(key) &&
+            this.isEncrypting() && this.getEncryptionKeySize() <= 256)
+        {
+          if (key == null || iv == null)
+          {
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
           // Decrypt file
-          try {
+          try
+          {
             EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          } catch (Exception ex) {
+          }
+          catch (Exception ex)
+          {
             logger.error("Error decrypting file", ex);
-            throw new SnowflakeSQLException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                "Cannot decrypt file");
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "Cannot decrypt file");
           }
         }
         return;
-      } catch (Exception ex) {
+      }
+      catch (Exception ex)
+      {
         logger.debug("Download unsuccessful {}", ex);
         handleStorageException(ex, ++retryCount, "download", session, command);
       }
-    } while (retryCount <= getMaxRetries());
+    }
+    while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        session,
-        "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Download a file from remote storage
    *
-   * @param session session object
-   * @param command command to download file
-   * @param parallelism number of threads for parallel downloading
+   * @param session               session object
+   * @param command               command to download file
+   * @param parallelism           number of threads for parallel downloading
    * @param remoteStorageLocation remote storage location, i.e. bucket for s3
-   * @param stageFilePath stage file path
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Signed credential for download
+   * @param stageFilePath         stage file path
+   * @param stageRegion           region name where the stage persists
+   * @param presignedUrl          Signed credential for download
    * @return input file stream
    * @throws SnowflakeSQLException when download failure
    */
   @Override
-  public InputStream downloadToStream(
-      SFSession session,
-      String command,
-      int parallelism,
-      String remoteStorageLocation,
-      String stageFilePath,
-      String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+  public InputStream downloadToStream(SFSession session, String command,
+                                      int parallelism,
+                                      String remoteStorageLocation,
+                                      String stageFilePath, String stageRegion,
+                                      String presignedUrl)
+  throws SnowflakeSQLException
+  {
     int retryCount = 0;
     InputStream inputStream = null;
-    do {
-      try {
+    do
+    {
+      try
+      {
         String key = null;
         String iv = null;
 
-        if (!Strings.isNullOrEmpty(presignedUrl)) {
+        if (!Strings.isNullOrEmpty(presignedUrl))
+        {
           logger.debug("Starting download with presigned URL");
           URIBuilder uriBuilder = new URIBuilder(presignedUrl);
 
@@ -368,34 +416,34 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
 
           logger.debug("Fetching result: {}", scrubPresignedUrl(presignedUrl));
 
-          CloseableHttpClient httpClient =
-              HttpUtil.getHttpClientWithoutDecompression(session.getOCSPMode());
+          CloseableHttpClient httpClient = HttpUtil.getHttpClientWithoutDecompression(
+              session.getOCSPMode());
 
           // Put the file on storage using the presigned url
           HttpResponse response =
-              RestRequest.execute(
-                  httpClient,
-                  httpRequest,
-                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
-                  0, // no socketime injection
-                  null, // no canceling
-                  false, // no cookie
-                  false, // no retry
-                  false, // no request_guid
-                  true // retry on HTTP 403
-                  );
+              RestRequest.execute(httpClient,
+                                  httpRequest,
+                                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
+                                  0, // no socketime injection
+                                  null, // no canceling
+                                  false, // no cookie
+                                  false, // no retry
+                                  false, // no request_guid
+                                  true // retry on HTTP 403
+              );
 
-          logger.debug(
-              "Call returned for URL: {}",
-              (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
-          if (response.getStatusLine().getStatusCode() == 200) {
-            try {
+          logger.debug("Call returned for URL: {}",
+                       (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
+          if (response.getStatusLine().getStatusCode() == 200)
+          {
+            try
+            {
               inputStream = response.getEntity().getContent();
 
-              for (Header header : response.getAllHeaders()) {
-                if (header
-                    .getName()
-                    .equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP)) {
+              for (Header header : response.getAllHeaders())
+              {
+                if (header.getName().equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP))
+                {
                   AbstractMap.SimpleEntry<String, String> encryptionData =
                       parseEncryptionData(header.getValue());
 
@@ -405,19 +453,26 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
                 }
               }
               logger.debug("Download successful");
-            } catch (IOException ex) {
+            }
+            catch (IOException ex)
+            {
               logger.debug("Download unsuccessful {}", ex);
               handleStorageException(ex, ++retryCount, "download", session, command);
             }
           }
-        } else {
+        }
+        else
+        {
           BlobId blobId = BlobId.of(remoteStorageLocation, stageFilePath);
           Blob blob = gcsClient.get(blobId);
-          if (blob == null) {
+          if (blob == null)
+          {
             throw new StorageProviderException(
                 new StorageException(
                     404, // because blob not found
-                    "Blob" + blobId.getName() + " not found in bucket " + blobId.getBucket()));
+                    "Blob" + blobId.getName() + " not found in bucket "
+                    + blobId.getBucket())
+            );
           }
 
           inputStream = new ByteArrayInputStream(blob.getContent());
@@ -431,106 +486,105 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           iv = encryptionData.getValue();
         }
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
-          if (key == null || iv == null) {
-            throw new SnowflakeSQLException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256)
+        {
+          if (key == null || iv == null)
+          {
+            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                                            "File metadata incomplete");
           }
 
           // Decrypt file
-          try {
-            if (inputStream != null) {
+          try
+          {
+            if (inputStream != null)
+            {
               inputStream = EncryptionProvider.decryptStream(inputStream, key, iv, this.encMat);
               return inputStream;
             }
-          } catch (Exception ex) {
+          }
+          catch (Exception ex)
+          {
             logger.error("Error decrypting file", ex);
-            throw new SnowflakeSQLException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                "Cannot decrypt file");
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "Cannot decrypt file");
           }
         }
-      } catch (Exception ex) {
+      }
+      catch (Exception ex)
+      {
         logger.debug("Download unsuccessful {}", ex);
         handleStorageException(ex, ++retryCount, "download", session, command);
       }
-    } while (retryCount <= getMaxRetries());
+    }
+    while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        session,
-        "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
-   * Upload a file (-stream) to remote storage with Pre-signed URL without JDBC session.
+   * Upload a file (-stream) to remote storage with Pre-signed URL without
+   * JDBC session.
    *
-   * @param networkTimeoutInMilli Network timeout for the upload
-   * @param ocspMode OCSP mode for the upload.
-   * @param parallelism number of threads do parallel uploading
-   * @param uploadFromStream true if upload source is stream
-   * @param remoteStorageLocation s3 bucket name
-   * @param srcFile source file if not uploading from a stream
-   * @param destFileName file name on remote storage after upload
-   * @param inputStream stream used for uploading if fileBackedOutputStream is null
+   * @param networkTimeoutInMilli  Network timeout for the upload
+   * @param ocspMode               OCSP mode for the upload.
+   * @param parallelism            number of threads do parallel uploading
+   * @param uploadFromStream       true if upload source is stream
+   * @param remoteStorageLocation  s3 bucket name
+   * @param srcFile                source file if not uploading from a stream
+   * @param destFileName           file name on remote storage after upload
+   * @param inputStream            stream used for uploading if
+   *                               fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta object meta data
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl presigned URL for upload. Used by GCP.
+   * @param meta                   object meta data
+   * @param stageRegion            region name where the stage persists
+   * @param presignedUrl           presigned URL for upload. Used by GCP.
    * @throws SnowflakeSQLException if upload failed
    */
   @Override
   public void uploadWithPresignedUrlWithoutConnection(
-      int networkTimeoutInMilli,
-      OCSPMode ocspMode,
-      int parallelism,
-      boolean uploadFromStream,
-      String remoteStorageLocation,
-      File srcFile,
-      String destFileName,
-      InputStream inputStream,
+      int networkTimeoutInMilli, OCSPMode ocspMode,
+      int parallelism, boolean uploadFromStream,
+      String remoteStorageLocation, File srcFile,
+      String destFileName, InputStream inputStream,
       FileBackedOutputStream fileBackedOutputStream,
-      StorageObjectMetadata meta,
-      String stageRegion,
+      StorageObjectMetadata meta, String stageRegion,
       String presignedUrl)
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
     final List<FileInputStream> toClose = new ArrayList<>();
     long originalContentLength = meta.getContentLength();
 
-    SFPair<InputStream, Boolean> uploadStreamInfo =
-        createUploadStream(
-            srcFile,
-            uploadFromStream,
-            inputStream,
-            meta,
-            originalContentLength,
-            fileBackedOutputStream,
-            toClose);
+    SFPair<InputStream, Boolean> uploadStreamInfo = createUploadStream(
+        srcFile, uploadFromStream, inputStream, meta,
+        originalContentLength, fileBackedOutputStream, toClose);
 
-    if (!(meta instanceof CommonObjectMetadata)) {
+    if (!(meta instanceof CommonObjectMetadata))
+    {
       throw new IllegalArgumentException("Unexpected metadata object type");
     }
 
-    if (Strings.isNullOrEmpty(presignedUrl)) {
+    if (Strings.isNullOrEmpty(presignedUrl))
+    {
       throw new IllegalArgumentException("pre-signed URL has to be specified");
     }
 
     logger.debug("Starting upload");
-    uploadWithPresignedUrl(
-        networkTimeoutInMilli,
-        meta.getContentEncoding(),
-        meta.getUserMetadata(),
-        uploadStreamInfo.left,
-        presignedUrl,
-        ocspMode);
+    uploadWithPresignedUrl(networkTimeoutInMilli,
+                           meta.getContentEncoding(),
+                           meta.getUserMetadata(),
+                           uploadStreamInfo.left,
+                           presignedUrl,
+                           ocspMode);
     logger.debug("Upload successful");
 
     // close any open streams in the "toClose" list and return
-    for (FileInputStream is : toClose) {
+    for (FileInputStream is : toClose)
+    {
       IOUtils.closeQuietly(is);
     }
   }
@@ -538,161 +592,156 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
   /**
    * Upload a file/stream to remote storage
    *
-   * @param session session object
-   * @param command upload command
-   * @param parallelism [ not used by the GCP implementation ]
-   * @param uploadFromStream true if upload source is stream
-   * @param remoteStorageLocation storage container name
-   * @param srcFile source file if not uploading from a stream
-   * @param destFileName file name on remote storage after upload
-   * @param inputStream stream used for uploading if fileBackedOutputStream is null
+   * @param session                session object
+   * @param command                upload command
+   * @param parallelism            [ not used by the GCP implementation ]
+   * @param uploadFromStream       true if upload source is stream
+   * @param remoteStorageLocation  storage container name
+   * @param srcFile                source file if not uploading from a stream
+   * @param destFileName           file name on remote storage after upload
+   * @param inputStream            stream used for uploading if fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta object meta data
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Credential used for upload of a file
+   * @param meta                   object meta data
+   * @param stageRegion            region name where the stage persists
+   * @param presignedUrl           Credential used for upload of a file
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   @Override
-  public void upload(
-      SFSession session,
-      String command,
-      int parallelism,
-      boolean uploadFromStream,
-      String remoteStorageLocation,
-      File srcFile,
-      String destFileName,
-      InputStream inputStream,
-      FileBackedOutputStream fileBackedOutputStream,
-      StorageObjectMetadata meta,
-      String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+  public void upload(SFSession session,
+                     String command,
+                     int parallelism,
+                     boolean uploadFromStream,
+                     String remoteStorageLocation,
+                     File srcFile,
+                     String destFileName,
+                     InputStream inputStream,
+                     FileBackedOutputStream fileBackedOutputStream,
+                     StorageObjectMetadata meta,
+                     String stageRegion,
+                     String presignedUrl) throws SnowflakeSQLException
+  {
     final List<FileInputStream> toClose = new ArrayList<>();
     long originalContentLength = meta.getContentLength();
 
-    SFPair<InputStream, Boolean> uploadStreamInfo =
-        createUploadStream(
-            srcFile,
-            uploadFromStream,
-            inputStream,
-            meta,
-            originalContentLength,
-            fileBackedOutputStream,
-            toClose);
+    SFPair<InputStream, Boolean> uploadStreamInfo = createUploadStream(
+        srcFile, uploadFromStream, inputStream, meta, originalContentLength,
+        fileBackedOutputStream, toClose);
 
-    if (!(meta instanceof CommonObjectMetadata)) {
+    if (!(meta instanceof CommonObjectMetadata))
+    {
       throw new IllegalArgumentException("Unexpected metadata object type");
     }
 
-    if (!Strings.isNullOrEmpty(presignedUrl)) {
+    if (!Strings.isNullOrEmpty(presignedUrl))
+    {
       logger.debug("Starting upload");
-      uploadWithPresignedUrl(
-          session.getNetworkTimeoutInMilli(),
-          meta.getContentEncoding(),
-          meta.getUserMetadata(),
-          uploadStreamInfo.left,
-          presignedUrl,
-          session.getOCSPMode());
+      uploadWithPresignedUrl(session.getNetworkTimeoutInMilli(),
+                             meta.getContentEncoding(),
+                             meta.getUserMetadata(),
+                             uploadStreamInfo.left,
+                             presignedUrl,
+                             session.getOCSPMode());
       logger.debug("Upload successful");
 
       // close any open streams in the "toClose" list and return
-      for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
+      for (FileInputStream is : toClose)
+        IOUtils.closeQuietly(is);
 
       return;
     }
 
     // No presigned URL. This codepath is for when we have a token instead.
     int retryCount = 0;
-    do {
-      try {
+    do
+    {
+      try
+      {
         logger.debug("Starting upload");
         InputStream fileInputStream = uploadStreamInfo.left;
 
         BlobId blobId = BlobId.of(remoteStorageLocation, destFileName);
-        BlobInfo blobInfo =
-            BlobInfo.newBuilder(blobId)
-                .setContentEncoding(meta.getContentEncoding())
-                .setMetadata(meta.getUserMetadata())
-                .build();
+        BlobInfo blobInfo = BlobInfo
+            .newBuilder(blobId)
+            .setContentEncoding(meta.getContentEncoding())
+            .setMetadata(meta.getUserMetadata())
+            .build();
 
         gcsClient.create(blobInfo, fileInputStream);
 
         logger.debug("Upload successful");
 
         // close any open streams in the "toClose" list and return
-        for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
+        for (FileInputStream is : toClose)
+          IOUtils.closeQuietly(is);
 
         return;
-      } catch (Exception ex) {
+      }
+      catch (Exception ex)
+      {
         handleStorageException(ex, ++retryCount, "upload", session, command);
 
-        if (uploadFromStream && fileBackedOutputStream == null) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              "Encountered exception during upload: "
-                  + ex.getMessage()
-                  + "\nCannot retry upload from stream.");
+        if (uploadFromStream && fileBackedOutputStream == null)
+        {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                                ErrorCode.IO_ERROR.getMessageCode(), session,
+                                                "Encountered exception during upload: " +
+                                                ex.getMessage() + "\nCannot retry upload from stream.");
         }
-        uploadStreamInfo =
-            createUploadStream(
-                srcFile,
-                uploadFromStream,
-                inputStream,
-                meta,
-                originalContentLength,
-                fileBackedOutputStream,
-                toClose);
+        uploadStreamInfo = createUploadStream(srcFile, uploadFromStream,
+                                              inputStream, meta, originalContentLength,
+                                              fileBackedOutputStream, toClose);
       }
 
-    } while (retryCount <= getMaxRetries());
+    }
+    while (retryCount <= getMaxRetries());
 
-    for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
+    for (FileInputStream is : toClose)
+      IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        session,
-        "Unexpected: upload unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: upload unsuccessful without exception!");
   }
 
   /**
    * Performs upload using a presigned URL
    *
    * @param networkTimeoutInMilli Network timeout
-   * @param contentEncoding Object's content encoding. We do special things for "gzip"
-   * @param metadata Custom metadata to be uploaded with the object
-   * @param content File content
-   * @param presignedUrl Credential to upload the object
-   * @param ocspMode OCSP mode
+   * @param contentEncoding       Object's content encoding. We do special things for "gzip"
+   * @param metadata              Custom metadata to be uploaded with the object
+   * @param content               File content
+   * @param presignedUrl          Credential to upload the object
+   * @param ocspMode              OCSP mode
    * @throws SnowflakeSQLException
    */
-  private void uploadWithPresignedUrl(
-      int networkTimeoutInMilli,
-      String contentEncoding,
-      Map<String, String> metadata,
-      InputStream content,
-      String presignedUrl,
-      OCSPMode ocspMode)
-      throws SnowflakeSQLException {
-    try {
+  private void uploadWithPresignedUrl(int networkTimeoutInMilli,
+                                      String contentEncoding,
+                                      Map<String, String> metadata,
+                                      InputStream content,
+                                      String presignedUrl,
+                                      OCSPMode ocspMode)
+  throws SnowflakeSQLException
+  {
+    try
+    {
       URIBuilder uriBuilder = new URIBuilder(presignedUrl);
 
       HttpPut httpRequest = new HttpPut(uriBuilder.build());
 
       logger.debug("Fetching result: {}", scrubPresignedUrl(presignedUrl));
 
-      // We set the contentEncoding to blank for GZIP files. We don't want GCS to think
+      // We set the contentEncoding to blank for GZIP files. We don't want GCS to think 
       // our gzip files are gzips because it makes them download uncompressed, and
       // none of the other providers do that. There's essentially no way for us
       // to prevent that behavior. Bad Google.
-      if ("gzip".equals(contentEncoding)) {
+      if ("gzip".equals(contentEncoding))
+      {
         contentEncoding = "";
       }
       httpRequest.addHeader("content-encoding", contentEncoding);
 
-      for (Entry<String, String> entry : metadata.entrySet()) {
+      for (Entry<String, String> entry : metadata.entrySet())
+      {
         httpRequest.addHeader(GCS_METADATA_PREFIX + entry.getKey(), entry.getValue());
       }
 
@@ -703,31 +752,32 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
 
       // Put the file on storage using the presigned url
       HttpResponse response =
-          RestRequest.execute(
-              httpClient,
-              httpRequest,
-              networkTimeoutInMilli / 1000, // retry timeout
-              0, // no socketime injection
-              null, // no canceling
-              false, // no cookie
-              false, // no retry
-              false, // no request_guid
-              true // retry on HTTP 403
-              );
+          RestRequest.execute(httpClient,
+                              httpRequest,
+                              networkTimeoutInMilli / 1000, // retry timeout
+                              0, // no socketime injection
+                              null, // no canceling
+                              false, // no cookie
+                              false, // no retry
+                              false, // no request_guid
+                              true // retry on HTTP 403
+          );
 
-      logger.debug(
-          "Call returned for URL: {}",
-          (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
-    } catch (URISyntaxException e) {
-      throw new SnowflakeSQLException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Unexpected: upload presigned URL invalid");
-    } catch (Exception e) {
-      throw new SnowflakeSQLException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Unexpected: upload with presigned url failed");
+      logger.debug("Call returned for URL: {}",
+                   (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
+    }
+    catch (URISyntaxException e)
+    {
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Unexpected: upload presigned URL invalid");
+    }
+    catch (Exception e)
+    {
+      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Unexpected: upload with presigned url failed");
+
     }
   }
 
@@ -737,12 +787,16 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
    * @param presignedUrl Presigned URL with full signature
    * @return Just the object path
    */
-  private String scrubPresignedUrl(String presignedUrl) {
-    if (Strings.isNullOrEmpty(presignedUrl)) {
+  private String scrubPresignedUrl(String presignedUrl)
+  {
+    if (Strings.isNullOrEmpty(presignedUrl))
+    {
       return "";
     }
     int indexOfQueryString = presignedUrl.lastIndexOf("?");
-    indexOfQueryString = indexOfQueryString > 0 ? indexOfQueryString : presignedUrl.length() - 1;
+    indexOfQueryString = indexOfQueryString > 0 ?
+                         indexOfQueryString :
+                         presignedUrl.length() - 1;
     return presignedUrl.substring(0, indexOfQueryString);
   }
 
@@ -754,180 +808,207 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
       long originalContentLength,
       FileBackedOutputStream fileBackedOutputStream,
       List<FileInputStream> toClose)
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
     logger.debug(
         "createUploadStream({}, {}, {}, {}, {}, {})",
-        this,
-        srcFile,
-        uploadFromStream,
-        inputStream,
-        fileBackedOutputStream,
-        toClose);
+        this, srcFile, uploadFromStream, inputStream, fileBackedOutputStream, toClose);
 
     final InputStream stream;
     FileInputStream srcFileStream = null;
-    try {
-      if (isEncrypting() && getEncryptionKeySize() < 256) {
-        try {
-          final InputStream uploadStream =
-              uploadFromStream
-                  ? (fileBackedOutputStream != null
-                      ? fileBackedOutputStream.asByteSource().openStream()
-                      : inputStream)
-                  : (srcFileStream = new FileInputStream(srcFile));
+    try
+    {
+      if (isEncrypting() && getEncryptionKeySize() < 256)
+      {
+        try
+        {
+          final InputStream uploadStream = uploadFromStream ?
+                                           (fileBackedOutputStream != null ?
+                                            fileBackedOutputStream.asByteSource().openStream() :
+                                            inputStream) :
+                                           (srcFileStream = new FileInputStream(srcFile));
           toClose.add(srcFileStream);
 
           // Encrypt
-          stream =
-              EncryptionProvider.encrypt(
-                  meta, originalContentLength, uploadStream, this.encMat, this);
+          stream = EncryptionProvider.encrypt(meta, originalContentLength,
+                                              uploadStream, this.encMat, this);
           uploadFromStream = true;
-        } catch (Exception ex) {
-          logger.error("Failed to encrypt input", ex);
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "Failed to encrypt input",
-              ex.getMessage());
         }
-      } else {
-        if (uploadFromStream) {
-          if (fileBackedOutputStream != null) {
+        catch (Exception ex)
+        {
+          logger.error("Failed to encrypt input", ex);
+          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                "Failed to encrypt input", ex.getMessage());
+        }
+      }
+      else
+      {
+        if (uploadFromStream)
+        {
+          if (fileBackedOutputStream != null)
+          {
             stream = fileBackedOutputStream.asByteSource().openStream();
-          } else {
+          }
+          else
+          {
             stream = inputStream;
           }
-        } else {
+        }
+        else
+        {
           srcFileStream = new FileInputStream(srcFile);
           toClose.add(srcFileStream);
           stream = srcFileStream;
         }
       }
-    } catch (FileNotFoundException ex) {
+    }
+    catch (FileNotFoundException ex)
+    {
       logger.error("Failed to open input file", ex);
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Failed to open input file",
-          ex.getMessage());
-    } catch (IOException ex) {
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Failed to open input file", ex.getMessage());
+    }
+    catch (IOException ex)
+    {
       logger.error("Failed to open input stream", ex);
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Failed to open input stream",
-          ex.getMessage());
+      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                            "Failed to open input stream", ex.getMessage());
     }
 
     return SFPair.of(stream, uploadFromStream);
   }
 
   @Override
-  public void handleStorageException(
-      Exception ex, int retryCount, String operation, SFSession session, String command)
-      throws SnowflakeSQLException {
+  public void handleStorageException(Exception ex,
+                                     int retryCount,
+                                     String operation,
+                                     SFSession session,
+                                     String command)
+  throws SnowflakeSQLException
+  {
     // no need to retry if it is invalid key exception
-    if (ex.getCause() instanceof InvalidKeyException) {
+    if (ex.getCause() instanceof InvalidKeyException)
+    {
       // Most likely cause is that the unlimited strength policy files are not installed
       // Log the error and throw a message that explains the cause
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
-    if (ex instanceof StorageException) {
+
+    if (ex instanceof StorageException)
+    {
       StorageException se = (StorageException) ex;
 
-      if (se.getCode() == 403 && session != null && command != null) {
+      if (se.getCode() == 403 && session != null && command != null)
+      {
         // A 403 indicates that the access token has expired,
         // we need to refresh the GCS client with the new token
         SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
       }
 
       // If we have exceeded the max number of retries, propagate the error
-      if (retryCount > getMaxRetries()) {
-        throw new SnowflakeSQLException(
-            se,
-            SqlState.SYSTEM_ERROR,
-            ErrorCode.GCP_SERVICE_ERROR.getMessageCode(),
-            operation,
-            se.getCode(),
-            se.getMessage(),
-            se.getReason());
-      } else {
-        logger.debug(
-            "Encountered exception ({}) during {}, retry count: {}",
-            ex.getMessage(),
-            operation,
-            retryCount);
+      if (retryCount > getMaxRetries())
+      {
+        throw new SnowflakeSQLLoggedException(se, SqlState.SYSTEM_ERROR,
+                                              ErrorCode.GCP_SERVICE_ERROR.getMessageCode(),
+                                              session,
+                                              operation,
+                                              se.getCode(),
+                                              se.getMessage(),
+                                              se.getReason());
+      }
+      else
+      {
+        logger.debug("Encountered exception ({}) during {}, retry count: {}",
+                     ex.getMessage(), operation, retryCount);
         logger.debug("Stack trace: ", ex);
 
         // exponential backoff up to a limit
         int backoffInMillis = getRetryBackoffMin();
 
-        if (retryCount > 1) {
-          backoffInMillis <<= (Math.min(retryCount - 1, getRetryBackoffMaxExponent()));
+        if (retryCount > 1)
+        {
+          backoffInMillis <<= (Math.min(retryCount - 1,
+                                        getRetryBackoffMaxExponent()));
         }
 
-        try {
+        try
+        {
           logger.debug("Sleep for {} milliseconds before retry", backoffInMillis);
 
           Thread.sleep(backoffInMillis);
-        } catch (InterruptedException ex1) {
+        }
+        catch (InterruptedException ex1)
+        {
           // ignore
         }
 
-        if (se.getCode() == 403 && session != null && command != null) {
+        if (se.getCode() == 403 && session != null && command != null)
+        {
           // A 403 indicates that the access token has expired,
           // we need to refresh the GCS client with the new token
           SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
         }
       }
-    } else {
-      if (ex instanceof InterruptedException
-          || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
-        if (retryCount > getMaxRetries()) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              "Encountered exception during " + operation + ": " + ex.getMessage());
-        } else {
-          logger.debug(
-              "Encountered exception ({}) during {}, retry count: {}",
-              ex.getMessage(),
-              operation,
-              retryCount);
+    }
+    else
+    {
+      if (ex instanceof InterruptedException ||
+          SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException)
+      {
+        if (retryCount > getMaxRetries())
+        {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                                ErrorCode.IO_ERROR.getMessageCode(),
+                                                session,
+                                                "Encountered exception during " + operation + ": " +
+                                                ex.getMessage());
         }
-      } else {
-        throw new SnowflakeSQLException(
-            ex,
-            SqlState.SYSTEM_ERROR,
-            ErrorCode.IO_ERROR.getMessageCode(),
-            "Encountered exception during " + operation + ": " + ex.getMessage());
+        else
+        {
+          logger.debug("Encountered exception ({}) during {}, retry count: {}",
+                       ex.getMessage(), operation, retryCount);
+        }
+      }
+      else
+      {
+        throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                              ErrorCode.IO_ERROR.getMessageCode(),
+                                              session,
+                                              "Encountered exception during " + operation + ": " +
+                                              ex.getMessage());
       }
     }
   }
 
-  /** Returns the material descriptor key */
+  /**
+   * Returns the material descriptor key
+   */
   @Override
-  public String getMatdescKey() {
+  public String getMatdescKey()
+  {
     return "matdesc";
   }
 
-  /** Adds encryption metadata to the StorageObjectMetadata object */
+  /**
+   * Adds encryption metadata to the StorageObjectMetadata object
+   */
   @Override
-  public void addEncryptionMetadata(
-      StorageObjectMetadata meta,
-      MatDesc matDesc,
-      byte[] ivData,
-      byte[] encKeK,
-      long contentLength) {
-    meta.addUserMetadata(getMatdescKey(), matDesc.toString());
-    meta.addUserMetadata(
-        GCS_ENCRYPTIONDATAPROP,
-        buildEncryptionMetadataJSON(Base64.encodeAsString(ivData), Base64.encodeAsString(encKeK)));
+  public void addEncryptionMetadata(StorageObjectMetadata meta,
+                                    MatDesc matDesc,
+                                    byte[] ivData,
+                                    byte[] encKeK,
+                                    long contentLength)
+  {
+    meta.addUserMetadata(getMatdescKey(),
+                         matDesc.toString());
+    meta.addUserMetadata(GCS_ENCRYPTIONDATAPROP, buildEncryptionMetadataJSON(
+        Base64.encodeAsString(ivData),
+        Base64.encodeAsString(encKeK))
+    );
     meta.setContentLength(contentLength);
   }
 
@@ -936,16 +1017,15 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
    * Takes the base64-encoded iv and key and creates the JSON block to be
    * used as the encryptiondata metadata field on the blob.
    */
-  private String buildEncryptionMetadataJSON(String iv64, String key64) {
-    return String.format(
-        "{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
-            + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
-            + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
-            + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
-            + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
-            + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
-            + "\"Java 5.3.0\"}}",
-        key64, iv64);
+  private String buildEncryptionMetadataJSON(String iv64, String key64)
+  {
+    return String.format("{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
+                         + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
+                         + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
+                         + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
+                         + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
+                         + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
+                         + "\"Java 5.3.0\"}}", key64, iv64);
   }
 
   /*
@@ -954,10 +1034,12 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
    * blob and parses out the key and iv. Returns the pair as key = key, iv = value.
    */
   private AbstractMap.SimpleEntry<String, String> parseEncryptionData(String jsonEncryptionData)
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
     ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
     JsonFactory factory = mapper.getFactory();
-    try {
+    try
+    {
       JsonParser parser = factory.createParser(jsonEncryptionData);
       JsonNode encryptionDataNode = mapper.readTree(parser);
 
@@ -965,26 +1047,34 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
       String key = encryptionDataNode.get("WrappedContentKey").get("EncryptedKey").asText();
 
       return new AbstractMap.SimpleEntry<>(key, iv);
-    } catch (Exception ex) {
-      throw new SnowflakeSQLException(
-          ex,
-          SqlState.SYSTEM_ERROR,
-          ErrorCode.IO_ERROR.getMessageCode(),
-          "Error parsing encryption data as json" + ": " + ex.getMessage());
+    }
+    catch (Exception ex)
+    {
+      throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
+                                      ErrorCode.IO_ERROR.getMessageCode(),
+                                      "Error parsing encryption data as json" + ": " +
+                                      ex.getMessage());
     }
   }
 
-  /** Adds digest metadata to the StorageObjectMetadata object */
+  /**
+   * Adds digest metadata to the StorageObjectMetadata object
+   */
   @Override
-  public void addDigestMetadata(StorageObjectMetadata meta, String digest) {
-    if (!SnowflakeUtil.isBlank(digest)) {
+  public void addDigestMetadata(StorageObjectMetadata meta, String digest)
+  {
+    if (!SnowflakeUtil.isBlank(digest))
+    {
       meta.addUserMetadata("sfc-digest", digest);
     }
   }
 
-  /** Gets digest metadata to the StorageObjectMetadata object */
+  /**
+   * Gets digest metadata to the StorageObjectMetadata object
+   */
   @Override
-  public String getDigestMetadata(StorageObjectMetadata meta) {
+  public String getDigestMetadata(StorageObjectMetadata meta)
+  {
     return meta.getUserMetadata().get("sfc-digest");
   }
 
@@ -998,43 +1088,56 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
    *                required to decrypt/encrypt content in stage
    * @throws IllegalArgumentException when invalid credentials are used
    */
-  private void setupGCSClient(StageInfo stage, RemoteStoreFileEncryptionMaterial encMat)
-      throws IllegalArgumentException, SnowflakeSQLException {
+  private void setupGCSClient(StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+  throws IllegalArgumentException, SnowflakeSQLException
+  {
     // Save the client creation parameters so that we can reuse them,
     // to reset the GCS client.
     this.stageInfo = stage;
     this.encMat = encMat;
+    this.session = session;
 
     logger.debug("Setting up the GCS client ");
 
-    try {
+    try
+    {
       String accessToken = (String) stage.getCredentials().get("GCS_ACCESS_TOKEN");
       GoogleCredentials googleCreds;
-      if (accessToken != null) {
+      if (accessToken != null)
+      {
         AccessToken googleAccessToken = new AccessToken(accessToken, null);
 
         googleCreds = GoogleCredentials.create(googleAccessToken);
         // We are authenticated with an oauth access token.
-        this.gcsClient =
-            StorageOptions.newBuilder().setCredentials(googleCreds).build().getService();
-      } else {
+        this.gcsClient = StorageOptions.newBuilder()
+            .setCredentials(googleCreds)
+            .build()
+            .getService();
+      }
+      else
+      {
         // Use anonymous authentication.
-        this.gcsClient = StorageOptions.getUnauthenticatedInstance().getService();
+        this.gcsClient = StorageOptions.getUnauthenticatedInstance()
+            .getService();
       }
 
-      if (encMat != null) {
+      if (encMat != null)
+      {
         byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
         encryptionKeySize = decodedKey.length * 8;
 
-        if (encryptionKeySize != 128 && encryptionKeySize != 192 && encryptionKeySize != 256) {
-          throw new SnowflakeSQLException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              "unsupported key size",
-              encryptionKeySize);
+        if (encryptionKeySize != 128 &&
+            encryptionKeySize != 192 &&
+            encryptionKeySize != 256)
+        {
+          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                                          "unsupported key size", encryptionKeySize);
         }
       }
-    } catch (Exception ex) {
+    }
+    catch (Exception ex)
+    {
       throw new IllegalArgumentException("invalid_gcs_credentials");
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -3,6 +3,8 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
@@ -14,6 +16,15 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.*;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.common.base.Strings;
+import java.io.*;
+import java.net.SocketTimeoutException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.core.ObjectMapperFactory;
@@ -34,28 +45,15 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 
-import java.io.*;
-import java.net.SocketTimeoutException;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 /**
  * Encapsulates the GCS Storage client and all GCS operations and logic
  *
  * @author ppaulus
  */
-public class SnowflakeGCSClient implements SnowflakeStorageClient
-{
-  private final static String GCS_ENCRYPTIONDATAPROP = "encryptiondata";
-  private final static String localFileSep = systemGetProperty("file.separator");
-  private final static String GCS_METADATA_PREFIX = "x-goog-meta-";
+public class SnowflakeGCSClient implements SnowflakeStorageClient {
+  private static final String GCS_ENCRYPTIONDATAPROP = "encryptiondata";
+  private static final String localFileSep = systemGetProperty("file.separator");
+  private static final String GCS_METADATA_PREFIX = "x-goog-meta-";
 
   private int encryptionKeySize = 0; // used for PUTs
   private StageInfo stageInfo;
@@ -63,12 +61,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
   private Storage gcsClient = null;
   private SFSession session = null;
 
-  private final static SFLogger logger =
-      SFLoggerFactory.getLogger(SnowflakeGCSClient.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeGCSClient.class);
 
-  private SnowflakeGCSClient()
-  {
-  }
+  private SnowflakeGCSClient() {}
 
   /*
    * Factory method for a SnowflakeGCSClient object
@@ -76,10 +71,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * @param encMat  The encryption material
    *                required to decrypt/encrypt content in stage
    */
-  public static SnowflakeGCSClient createSnowflakeGCSClient(StageInfo stage,
-                                                            RemoteStoreFileEncryptionMaterial encMat, SFSession session)
-  throws SnowflakeSQLException
-  {
+  public static SnowflakeGCSClient createSnowflakeGCSClient(
+      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+      throws SnowflakeSQLException {
     SnowflakeGCSClient sfGcsClient = new SnowflakeGCSClient();
     sfGcsClient.setupGCSClient(stage, encMat, session);
 
@@ -88,66 +82,52 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
 
   // Returns the Max number of retry attempts
   @Override
-  public int getMaxRetries()
-  {
+  public int getMaxRetries() {
     return 25;
   }
 
   // Returns the max exponent for multiplying backoff with the power of 2, the value
   // of 4 will give us 16secs as the max number of time to sleep before retry
   @Override
-  public int getRetryBackoffMaxExponent()
-  {
+  public int getRetryBackoffMaxExponent() {
     return 4;
   }
 
   // Returns the min number of milliseconds to sleep before retry
   @Override
-  public int getRetryBackoffMin()
-  {
+  public int getRetryBackoffMin() {
     return 1000;
   }
 
-  /**
-   * @return Returns true if encryption is enabled
-   */
+  /** @return Returns true if encryption is enabled */
   @Override
-  public boolean isEncrypting()
-  {
+  public boolean isEncrypting() {
     return encryptionKeySize > 0;
   }
 
-  /**
-   * @return Returns the size of the encryption key
-   */
+  /** @return Returns the size of the encryption key */
   @Override
-  public int getEncryptionKeySize()
-  {
+  public int getEncryptionKeySize() {
     return encryptionKeySize;
   }
 
   /**
-   * @return Whether this client requires the use of presigned URLs for upload
-   * and download instead of credentials that work for all files uploaded/
-   * downloaded to a stage path. True for GCS.
+   * @return Whether this client requires the use of presigned URLs for upload and download instead
+   *     of credentials that work for all files uploaded/ downloaded to a stage path. True for GCS.
    */
   @Override
-  public boolean requirePresignedUrl()
-  {
+  public boolean requirePresignedUrl() {
     return true;
   }
 
-
   @Override
-  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException
-  {
+  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException {
     stageInfo.setCredentials(stageCredentials);
     setupGCSClient(stageInfo, encMat, session);
   }
 
   @Override
-  public void shutdown()
-  {
+  public void shutdown() {
     // nothing to do here
   }
 
@@ -155,33 +135,26 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * listObjects gets all the objects in a path
    *
    * @param remoteStorageLocation bucket name
-   * @param prefix                Path
+   * @param prefix Path
    * @return
    * @throws StorageProviderException
    */
   @Override
-  public StorageObjectSummaryCollection listObjects(String remoteStorageLocation,
-                                                    String prefix) throws StorageProviderException
-  {
-    try
-    {
+  public StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
+      throws StorageProviderException {
+    try {
       Page<Blob> blobs = this.gcsClient.list(remoteStorageLocation, BlobListOption.prefix(prefix));
       return new StorageObjectSummaryCollection(blobs);
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       logger.debug("Failed to list objects");
       throw new StorageProviderException(e);
     }
   }
 
   @Override
-  public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation,
-                                                 String prefix)
-  throws StorageProviderException
-  {
-    try
-    {
+  public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
+      throws StorageProviderException {
+    try {
       BlobId blobId = BlobId.of(remoteStorageLocation, prefix);
       Blob blob = gcsClient.get(blobId);
 
@@ -189,22 +162,16 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
       // By design, our storage platform expects to see a "blob not found" situation
       // as a RemoteStorageProviderException
       // Hence, we throw a RemoteStorageProviderException
-      if (blob == null)
-      {
+      if (blob == null) {
         throw new StorageProviderException(
             new StorageException(
                 404, // because blob not found
-                "Blob" + blobId.getName() + " not found in bucket "
-                + blobId.getBucket())
-        );
+                "Blob" + blobId.getName() + " not found in bucket " + blobId.getBucket()));
       }
 
-      return new CommonObjectMetadata(blob.getSize(),
-                                      blob.getContentEncoding(),
-                                      blob.getMetadata());
-    }
-    catch (StorageException ex)
-    {
+      return new CommonObjectMetadata(
+          blob.getSize(), blob.getContentEncoding(), blob.getMetadata());
+    } catch (StorageException ex) {
       throw new StorageProviderException(ex);
     }
   }
@@ -212,40 +179,38 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
   /**
    * Download a file from remote storage.
    *
-   * @param session               session object
-   * @param command               command to download file
-   * @param localLocation         local file path
-   * @param destFileName          destination file name
-   * @param parallelism           [ not used by the GCP implementation ]
+   * @param session session object
+   * @param command command to download file
+   * @param localLocation local file path
+   * @param destFileName destination file name
+   * @param parallelism [ not used by the GCP implementation ]
    * @param remoteStorageLocation remote storage location, i.e. bucket for S3
-   * @param stageFilePath         stage file path
-   * @param stageRegion           region name where the stage persists
-   * @param presignedUrl          Credential to use for download
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Credential to use for download
    * @throws SnowflakeSQLException download failure
-   **/
+   */
   @Override
-  public void download(SFSession session,
-                       String command,
-                       String localLocation,
-                       String destFileName,
-                       int parallelism,
-                       String remoteStorageLocation,
-                       String stageFilePath,
-                       String stageRegion,
-                       String presignedUrl) throws SnowflakeSQLException
-  {
+  public void download(
+      SFSession session,
+      String command,
+      String localLocation,
+      String destFileName,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
     int retryCount = 0;
     String localFilePath = localLocation + localFileSep + destFileName;
     File localFile = new File(localFilePath);
 
-    do
-    {
-      try
-      {
+    do {
+      try {
         String key = null;
         String iv = null;
-        if (!Strings.isNullOrEmpty(presignedUrl))
-        {
+        if (!Strings.isNullOrEmpty(presignedUrl)) {
           logger.debug("Starting download with presigned URL");
           URIBuilder uriBuilder = new URIBuilder(presignedUrl);
 
@@ -254,43 +219,42 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
 
           logger.debug("Fetching result: {}", scrubPresignedUrl(presignedUrl));
 
-          CloseableHttpClient httpClient = HttpUtil.getHttpClientWithoutDecompression(
-              session.getOCSPMode());
+          CloseableHttpClient httpClient =
+              HttpUtil.getHttpClientWithoutDecompression(session.getOCSPMode());
 
           // Put the file on storage using the presigned url
           HttpResponse response =
-              RestRequest.execute(httpClient,
-                                  httpRequest,
-                                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
-                                  0, // no socketime injection
-                                  null, // no canceling
-                                  false, // no cookie
-                                  false, // no retry
-                                  false, // no request_guid
-                                  true // retry on HTTP 403
-              );
+              RestRequest.execute(
+                  httpClient,
+                  httpRequest,
+                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
+                  0, // no socketime injection
+                  null, // no canceling
+                  false, // no cookie
+                  false, // no retry
+                  false, // no request_guid
+                  true // retry on HTTP 403
+                  );
 
-          logger.debug("Call returned for URL: {}",
-                       (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
-          if (response.getStatusLine().getStatusCode() == 200)
-          {
-            try
-            {
+          logger.debug(
+              "Call returned for URL: {}",
+              (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
+          if (response.getStatusLine().getStatusCode() == 200) {
+            try {
               InputStream bodyStream = response.getEntity().getContent();
               byte[] buffer = new byte[8 * 1024];
               int bytesRead;
               OutputStream outStream = new FileOutputStream(localFile);
-              while ((bytesRead = bodyStream.read(buffer)) != -1)
-              {
+              while ((bytesRead = bodyStream.read(buffer)) != -1) {
                 outStream.write(buffer, 0, bytesRead);
               }
               outStream.flush();
               outStream.close();
               bodyStream.close();
-              for (Header header : response.getAllHeaders())
-              {
-                if (header.getName().equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP))
-                {
+              for (Header header : response.getAllHeaders()) {
+                if (header
+                    .getName()
+                    .equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP)) {
                   AbstractMap.SimpleEntry<String, String> encryptionData =
                       parseEncryptionData(header.getValue());
 
@@ -300,26 +264,19 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
                 }
               }
               logger.debug("Download successful");
-            }
-            catch (IOException ex)
-            {
+            } catch (IOException ex) {
               logger.debug("Download unsuccessful {}", ex);
               handleStorageException(ex, ++retryCount, "download", session, command);
             }
           }
-        }
-        else
-        {
+        } else {
           BlobId blobId = BlobId.of(remoteStorageLocation, stageFilePath);
           Blob blob = gcsClient.get(blobId);
-          if (blob == null)
-          {
+          if (blob == null) {
             throw new StorageProviderException(
                 new StorageException(
                     404, // because blob not found
-                    "Blob" + blobId.getName() + " not found in bucket "
-                    + blobId.getBucket())
-            );
+                    "Blob" + blobId.getName() + " not found in bucket " + blobId.getBucket()));
           }
 
           logger.debug("Starting download without presigned URL");
@@ -328,8 +285,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
 
           // Get the user-defined BLOB metadata
           Map<String, String> userDefinedMetadata = blob.getMetadata();
-          if (userDefinedMetadata != null)
-          {
+          if (userDefinedMetadata != null) {
             AbstractMap.SimpleEntry<String, String> encryptionData =
                 parseEncryptionData(userDefinedMetadata.get(GCS_ENCRYPTIONDATAPROP));
 
@@ -338,76 +294,75 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
           }
         }
 
-        if (!Strings.isNullOrEmpty(iv) && !Strings.isNullOrEmpty(key) &&
-            this.isEncrypting() && this.getEncryptionKeySize() <= 256)
-        {
-          if (key == null || iv == null)
-          {
-            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                  "File metadata incomplete");
+        if (!Strings.isNullOrEmpty(iv)
+            && !Strings.isNullOrEmpty(key)
+            && this.isEncrypting()
+            && this.getEncryptionKeySize() <= 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLLoggedException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
+                "File metadata incomplete");
           }
 
           // Decrypt file
-          try
-          {
+          try {
             EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          }
-          catch (Exception ex)
-          {
+          } catch (Exception ex) {
             logger.error("Error decrypting file", ex);
-            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                  "Cannot decrypt file");
+            throw new SnowflakeSQLLoggedException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
+                "Cannot decrypt file");
           }
         }
         return;
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
         logger.debug("Download unsuccessful {}", ex);
         handleStorageException(ex, ++retryCount, "download", session, command);
       }
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        session,
+        "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Download a file from remote storage
    *
-   * @param session               session object
-   * @param command               command to download file
-   * @param parallelism           number of threads for parallel downloading
+   * @param session session object
+   * @param command command to download file
+   * @param parallelism number of threads for parallel downloading
    * @param remoteStorageLocation remote storage location, i.e. bucket for s3
-   * @param stageFilePath         stage file path
-   * @param stageRegion           region name where the stage persists
-   * @param presignedUrl          Signed credential for download
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Signed credential for download
    * @return input file stream
    * @throws SnowflakeSQLException when download failure
    */
   @Override
-  public InputStream downloadToStream(SFSession session, String command,
-                                      int parallelism,
-                                      String remoteStorageLocation,
-                                      String stageFilePath, String stageRegion,
-                                      String presignedUrl)
-  throws SnowflakeSQLException
-  {
+  public InputStream downloadToStream(
+      SFSession session,
+      String command,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
     int retryCount = 0;
     InputStream inputStream = null;
-    do
-    {
-      try
-      {
+    do {
+      try {
         String key = null;
         String iv = null;
 
-        if (!Strings.isNullOrEmpty(presignedUrl))
-        {
+        if (!Strings.isNullOrEmpty(presignedUrl)) {
           logger.debug("Starting download with presigned URL");
           URIBuilder uriBuilder = new URIBuilder(presignedUrl);
 
@@ -416,34 +371,34 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
 
           logger.debug("Fetching result: {}", scrubPresignedUrl(presignedUrl));
 
-          CloseableHttpClient httpClient = HttpUtil.getHttpClientWithoutDecompression(
-              session.getOCSPMode());
+          CloseableHttpClient httpClient =
+              HttpUtil.getHttpClientWithoutDecompression(session.getOCSPMode());
 
           // Put the file on storage using the presigned url
           HttpResponse response =
-              RestRequest.execute(httpClient,
-                                  httpRequest,
-                                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
-                                  0, // no socketime injection
-                                  null, // no canceling
-                                  false, // no cookie
-                                  false, // no retry
-                                  false, // no request_guid
-                                  true // retry on HTTP 403
-              );
+              RestRequest.execute(
+                  httpClient,
+                  httpRequest,
+                  session.getNetworkTimeoutInMilli() / 1000, // retry timeout
+                  0, // no socketime injection
+                  null, // no canceling
+                  false, // no cookie
+                  false, // no retry
+                  false, // no request_guid
+                  true // retry on HTTP 403
+                  );
 
-          logger.debug("Call returned for URL: {}",
-                       (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
-          if (response.getStatusLine().getStatusCode() == 200)
-          {
-            try
-            {
+          logger.debug(
+              "Call returned for URL: {}",
+              (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
+          if (response.getStatusLine().getStatusCode() == 200) {
+            try {
               inputStream = response.getEntity().getContent();
 
-              for (Header header : response.getAllHeaders())
-              {
-                if (header.getName().equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP))
-                {
+              for (Header header : response.getAllHeaders()) {
+                if (header
+                    .getName()
+                    .equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP)) {
                   AbstractMap.SimpleEntry<String, String> encryptionData =
                       parseEncryptionData(header.getValue());
 
@@ -453,26 +408,19 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
                 }
               }
               logger.debug("Download successful");
-            }
-            catch (IOException ex)
-            {
+            } catch (IOException ex) {
               logger.debug("Download unsuccessful {}", ex);
               handleStorageException(ex, ++retryCount, "download", session, command);
             }
           }
-        }
-        else
-        {
+        } else {
           BlobId blobId = BlobId.of(remoteStorageLocation, stageFilePath);
           Blob blob = gcsClient.get(blobId);
-          if (blob == null)
-          {
+          if (blob == null) {
             throw new StorageProviderException(
                 new StorageException(
                     404, // because blob not found
-                    "Blob" + blobId.getName() + " not found in bucket "
-                    + blobId.getBucket())
-            );
+                    "Blob" + blobId.getName() + " not found in bucket " + blobId.getBucket()));
           }
 
           inputStream = new ByteArrayInputStream(blob.getContent());
@@ -486,105 +434,107 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
           iv = encryptionData.getValue();
         }
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256)
-        {
-          if (key == null || iv == null)
-          {
-            throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                            "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                "File metadata incomplete");
           }
 
           // Decrypt file
-          try
-          {
-            if (inputStream != null)
-            {
+          try {
+            if (inputStream != null) {
               inputStream = EncryptionProvider.decryptStream(inputStream, key, iv, this.encMat);
               return inputStream;
             }
-          }
-          catch (Exception ex)
-          {
+          } catch (Exception ex) {
             logger.error("Error decrypting file", ex);
-            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                  "Cannot decrypt file");
+            throw new SnowflakeSQLLoggedException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
+                "Cannot decrypt file");
           }
         }
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
         logger.debug("Download unsuccessful {}", ex);
         handleStorageException(ex, ++retryCount, "download", session, command);
       }
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        session,
+        "Unexpected: download unsuccessful without exception!");
   }
 
   /**
-   * Upload a file (-stream) to remote storage with Pre-signed URL without
-   * JDBC session.
+   * Upload a file (-stream) to remote storage with Pre-signed URL without JDBC session.
    *
-   * @param networkTimeoutInMilli  Network timeout for the upload
-   * @param ocspMode               OCSP mode for the upload.
-   * @param parallelism            number of threads do parallel uploading
-   * @param uploadFromStream       true if upload source is stream
-   * @param remoteStorageLocation  s3 bucket name
-   * @param srcFile                source file if not uploading from a stream
-   * @param destFileName           file name on remote storage after upload
-   * @param inputStream            stream used for uploading if
-   *                               fileBackedOutputStream is null
+   * @param networkTimeoutInMilli Network timeout for the upload
+   * @param ocspMode OCSP mode for the upload.
+   * @param parallelism number of threads do parallel uploading
+   * @param uploadFromStream true if upload source is stream
+   * @param remoteStorageLocation s3 bucket name
+   * @param srcFile source file if not uploading from a stream
+   * @param destFileName file name on remote storage after upload
+   * @param inputStream stream used for uploading if fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta                   object meta data
-   * @param stageRegion            region name where the stage persists
-   * @param presignedUrl           presigned URL for upload. Used by GCP.
+   * @param meta object meta data
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl presigned URL for upload. Used by GCP.
    * @throws SnowflakeSQLException if upload failed
    */
   @Override
   public void uploadWithPresignedUrlWithoutConnection(
-      int networkTimeoutInMilli, OCSPMode ocspMode,
-      int parallelism, boolean uploadFromStream,
-      String remoteStorageLocation, File srcFile,
-      String destFileName, InputStream inputStream,
+      int networkTimeoutInMilli,
+      OCSPMode ocspMode,
+      int parallelism,
+      boolean uploadFromStream,
+      String remoteStorageLocation,
+      File srcFile,
+      String destFileName,
+      InputStream inputStream,
       FileBackedOutputStream fileBackedOutputStream,
-      StorageObjectMetadata meta, String stageRegion,
+      StorageObjectMetadata meta,
+      String stageRegion,
       String presignedUrl)
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     final List<FileInputStream> toClose = new ArrayList<>();
     long originalContentLength = meta.getContentLength();
 
-    SFPair<InputStream, Boolean> uploadStreamInfo = createUploadStream(
-        srcFile, uploadFromStream, inputStream, meta,
-        originalContentLength, fileBackedOutputStream, toClose);
+    SFPair<InputStream, Boolean> uploadStreamInfo =
+        createUploadStream(
+            srcFile,
+            uploadFromStream,
+            inputStream,
+            meta,
+            originalContentLength,
+            fileBackedOutputStream,
+            toClose);
 
-    if (!(meta instanceof CommonObjectMetadata))
-    {
+    if (!(meta instanceof CommonObjectMetadata)) {
       throw new IllegalArgumentException("Unexpected metadata object type");
     }
 
-    if (Strings.isNullOrEmpty(presignedUrl))
-    {
+    if (Strings.isNullOrEmpty(presignedUrl)) {
       throw new IllegalArgumentException("pre-signed URL has to be specified");
     }
 
     logger.debug("Starting upload");
-    uploadWithPresignedUrl(networkTimeoutInMilli,
-                           meta.getContentEncoding(),
-                           meta.getUserMetadata(),
-                           uploadStreamInfo.left,
-                           presignedUrl,
-                           ocspMode);
+    uploadWithPresignedUrl(
+        networkTimeoutInMilli,
+        meta.getContentEncoding(),
+        meta.getUserMetadata(),
+        uploadStreamInfo.left,
+        presignedUrl,
+        ocspMode);
     logger.debug("Upload successful");
 
     // close any open streams in the "toClose" list and return
-    for (FileInputStream is : toClose)
-    {
+    for (FileInputStream is : toClose) {
       IOUtils.closeQuietly(is);
     }
   }
@@ -592,156 +542,162 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
   /**
    * Upload a file/stream to remote storage
    *
-   * @param session                session object
-   * @param command                upload command
-   * @param parallelism            [ not used by the GCP implementation ]
-   * @param uploadFromStream       true if upload source is stream
-   * @param remoteStorageLocation  storage container name
-   * @param srcFile                source file if not uploading from a stream
-   * @param destFileName           file name on remote storage after upload
-   * @param inputStream            stream used for uploading if fileBackedOutputStream is null
+   * @param session session object
+   * @param command upload command
+   * @param parallelism [ not used by the GCP implementation ]
+   * @param uploadFromStream true if upload source is stream
+   * @param remoteStorageLocation storage container name
+   * @param srcFile source file if not uploading from a stream
+   * @param destFileName file name on remote storage after upload
+   * @param inputStream stream used for uploading if fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta                   object meta data
-   * @param stageRegion            region name where the stage persists
-   * @param presignedUrl           Credential used for upload of a file
+   * @param meta object meta data
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Credential used for upload of a file
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   @Override
-  public void upload(SFSession session,
-                     String command,
-                     int parallelism,
-                     boolean uploadFromStream,
-                     String remoteStorageLocation,
-                     File srcFile,
-                     String destFileName,
-                     InputStream inputStream,
-                     FileBackedOutputStream fileBackedOutputStream,
-                     StorageObjectMetadata meta,
-                     String stageRegion,
-                     String presignedUrl) throws SnowflakeSQLException
-  {
+  public void upload(
+      SFSession session,
+      String command,
+      int parallelism,
+      boolean uploadFromStream,
+      String remoteStorageLocation,
+      File srcFile,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      StorageObjectMetadata meta,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
     final List<FileInputStream> toClose = new ArrayList<>();
     long originalContentLength = meta.getContentLength();
 
-    SFPair<InputStream, Boolean> uploadStreamInfo = createUploadStream(
-        srcFile, uploadFromStream, inputStream, meta, originalContentLength,
-        fileBackedOutputStream, toClose);
+    SFPair<InputStream, Boolean> uploadStreamInfo =
+        createUploadStream(
+            srcFile,
+            uploadFromStream,
+            inputStream,
+            meta,
+            originalContentLength,
+            fileBackedOutputStream,
+            toClose);
 
-    if (!(meta instanceof CommonObjectMetadata))
-    {
+    if (!(meta instanceof CommonObjectMetadata)) {
       throw new IllegalArgumentException("Unexpected metadata object type");
     }
 
-    if (!Strings.isNullOrEmpty(presignedUrl))
-    {
+    if (!Strings.isNullOrEmpty(presignedUrl)) {
       logger.debug("Starting upload");
-      uploadWithPresignedUrl(session.getNetworkTimeoutInMilli(),
-                             meta.getContentEncoding(),
-                             meta.getUserMetadata(),
-                             uploadStreamInfo.left,
-                             presignedUrl,
-                             session.getOCSPMode());
+      uploadWithPresignedUrl(
+          session.getNetworkTimeoutInMilli(),
+          meta.getContentEncoding(),
+          meta.getUserMetadata(),
+          uploadStreamInfo.left,
+          presignedUrl,
+          session.getOCSPMode());
       logger.debug("Upload successful");
 
       // close any open streams in the "toClose" list and return
-      for (FileInputStream is : toClose)
-        IOUtils.closeQuietly(is);
+      for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
       return;
     }
 
     // No presigned URL. This codepath is for when we have a token instead.
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
         logger.debug("Starting upload");
         InputStream fileInputStream = uploadStreamInfo.left;
 
         BlobId blobId = BlobId.of(remoteStorageLocation, destFileName);
-        BlobInfo blobInfo = BlobInfo
-            .newBuilder(blobId)
-            .setContentEncoding(meta.getContentEncoding())
-            .setMetadata(meta.getUserMetadata())
-            .build();
+        BlobInfo blobInfo =
+            BlobInfo.newBuilder(blobId)
+                .setContentEncoding(meta.getContentEncoding())
+                .setMetadata(meta.getUserMetadata())
+                .build();
 
         gcsClient.create(blobInfo, fileInputStream);
 
         logger.debug("Upload successful");
 
         // close any open streams in the "toClose" list and return
-        for (FileInputStream is : toClose)
-          IOUtils.closeQuietly(is);
+        for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
         return;
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
         handleStorageException(ex, ++retryCount, "upload", session, command);
 
-        if (uploadFromStream && fileBackedOutputStream == null)
-        {
-          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                                ErrorCode.IO_ERROR.getMessageCode(), session,
-                                                "Encountered exception during upload: " +
-                                                ex.getMessage() + "\nCannot retry upload from stream.");
+        if (uploadFromStream && fileBackedOutputStream == null) {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              session,
+              "Encountered exception during upload: "
+                  + ex.getMessage()
+                  + "\nCannot retry upload from stream.");
         }
-        uploadStreamInfo = createUploadStream(srcFile, uploadFromStream,
-                                              inputStream, meta, originalContentLength,
-                                              fileBackedOutputStream, toClose);
+        uploadStreamInfo =
+            createUploadStream(
+                srcFile,
+                uploadFromStream,
+                inputStream,
+                meta,
+                originalContentLength,
+                fileBackedOutputStream,
+                toClose);
       }
 
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    for (FileInputStream is : toClose)
-      IOUtils.closeQuietly(is);
+    for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "Unexpected: upload unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        session,
+        "Unexpected: upload unsuccessful without exception!");
   }
 
   /**
    * Performs upload using a presigned URL
    *
    * @param networkTimeoutInMilli Network timeout
-   * @param contentEncoding       Object's content encoding. We do special things for "gzip"
-   * @param metadata              Custom metadata to be uploaded with the object
-   * @param content               File content
-   * @param presignedUrl          Credential to upload the object
-   * @param ocspMode              OCSP mode
+   * @param contentEncoding Object's content encoding. We do special things for "gzip"
+   * @param metadata Custom metadata to be uploaded with the object
+   * @param content File content
+   * @param presignedUrl Credential to upload the object
+   * @param ocspMode OCSP mode
    * @throws SnowflakeSQLException
    */
-  private void uploadWithPresignedUrl(int networkTimeoutInMilli,
-                                      String contentEncoding,
-                                      Map<String, String> metadata,
-                                      InputStream content,
-                                      String presignedUrl,
-                                      OCSPMode ocspMode)
-  throws SnowflakeSQLException
-  {
-    try
-    {
+  private void uploadWithPresignedUrl(
+      int networkTimeoutInMilli,
+      String contentEncoding,
+      Map<String, String> metadata,
+      InputStream content,
+      String presignedUrl,
+      OCSPMode ocspMode)
+      throws SnowflakeSQLException {
+    try {
       URIBuilder uriBuilder = new URIBuilder(presignedUrl);
 
       HttpPut httpRequest = new HttpPut(uriBuilder.build());
 
       logger.debug("Fetching result: {}", scrubPresignedUrl(presignedUrl));
 
-      // We set the contentEncoding to blank for GZIP files. We don't want GCS to think 
+      // We set the contentEncoding to blank for GZIP files. We don't want GCS to think
       // our gzip files are gzips because it makes them download uncompressed, and
       // none of the other providers do that. There's essentially no way for us
       // to prevent that behavior. Bad Google.
-      if ("gzip".equals(contentEncoding))
-      {
+      if ("gzip".equals(contentEncoding)) {
         contentEncoding = "";
       }
       httpRequest.addHeader("content-encoding", contentEncoding);
 
-      for (Entry<String, String> entry : metadata.entrySet())
-      {
+      for (Entry<String, String> entry : metadata.entrySet()) {
         httpRequest.addHeader(GCS_METADATA_PREFIX + entry.getKey(), entry.getValue());
       }
 
@@ -752,32 +708,33 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
 
       // Put the file on storage using the presigned url
       HttpResponse response =
-          RestRequest.execute(httpClient,
-                              httpRequest,
-                              networkTimeoutInMilli / 1000, // retry timeout
-                              0, // no socketime injection
-                              null, // no canceling
-                              false, // no cookie
-                              false, // no retry
-                              false, // no request_guid
-                              true // retry on HTTP 403
-          );
+          RestRequest.execute(
+              httpClient,
+              httpRequest,
+              networkTimeoutInMilli / 1000, // retry timeout
+              0, // no socketime injection
+              null, // no canceling
+              false, // no cookie
+              false, // no retry
+              false, // no request_guid
+              true // retry on HTTP 403
+              );
 
-      logger.debug("Call returned for URL: {}",
-                   (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
-    }
-    catch (URISyntaxException e)
-    {
-      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "Unexpected: upload presigned URL invalid");
-    }
-    catch (Exception e)
-    {
-      throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "Unexpected: upload with presigned url failed");
-
+      logger.debug(
+          "Call returned for URL: {}",
+          (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
+    } catch (URISyntaxException e) {
+      throw new SnowflakeSQLLoggedException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "Unexpected: upload presigned URL invalid");
+    } catch (Exception e) {
+      throw new SnowflakeSQLLoggedException(
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "Unexpected: upload with presigned url failed");
     }
   }
 
@@ -787,16 +744,12 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * @param presignedUrl Presigned URL with full signature
    * @return Just the object path
    */
-  private String scrubPresignedUrl(String presignedUrl)
-  {
-    if (Strings.isNullOrEmpty(presignedUrl))
-    {
+  private String scrubPresignedUrl(String presignedUrl) {
+    if (Strings.isNullOrEmpty(presignedUrl)) {
       return "";
     }
     int indexOfQueryString = presignedUrl.lastIndexOf("?");
-    indexOfQueryString = indexOfQueryString > 0 ?
-                         indexOfQueryString :
-                         presignedUrl.length() - 1;
+    indexOfQueryString = indexOfQueryString > 0 ? indexOfQueryString : presignedUrl.length() - 1;
     return presignedUrl.substring(0, indexOfQueryString);
   }
 
@@ -808,207 +761,186 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
       long originalContentLength,
       FileBackedOutputStream fileBackedOutputStream,
       List<FileInputStream> toClose)
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     logger.debug(
         "createUploadStream({}, {}, {}, {}, {}, {})",
-        this, srcFile, uploadFromStream, inputStream, fileBackedOutputStream, toClose);
+        this,
+        srcFile,
+        uploadFromStream,
+        inputStream,
+        fileBackedOutputStream,
+        toClose);
 
     final InputStream stream;
     FileInputStream srcFileStream = null;
-    try
-    {
-      if (isEncrypting() && getEncryptionKeySize() < 256)
-      {
-        try
-        {
-          final InputStream uploadStream = uploadFromStream ?
-                                           (fileBackedOutputStream != null ?
-                                            fileBackedOutputStream.asByteSource().openStream() :
-                                            inputStream) :
-                                           (srcFileStream = new FileInputStream(srcFile));
+    try {
+      if (isEncrypting() && getEncryptionKeySize() < 256) {
+        try {
+          final InputStream uploadStream =
+              uploadFromStream
+                  ? (fileBackedOutputStream != null
+                      ? fileBackedOutputStream.asByteSource().openStream()
+                      : inputStream)
+                  : (srcFileStream = new FileInputStream(srcFile));
           toClose.add(srcFileStream);
 
           // Encrypt
-          stream = EncryptionProvider.encrypt(meta, originalContentLength,
-                                              uploadStream, this.encMat, this);
+          stream =
+              EncryptionProvider.encrypt(
+                  meta, originalContentLength, uploadStream, this.encMat, this);
           uploadFromStream = true;
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
           logger.error("Failed to encrypt input", ex);
-          throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                                ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                "Failed to encrypt input", ex.getMessage());
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              session,
+              "Failed to encrypt input",
+              ex.getMessage());
         }
-      }
-      else
-      {
-        if (uploadFromStream)
-        {
-          if (fileBackedOutputStream != null)
-          {
+      } else {
+        if (uploadFromStream) {
+          if (fileBackedOutputStream != null) {
             stream = fileBackedOutputStream.asByteSource().openStream();
-          }
-          else
-          {
+          } else {
             stream = inputStream;
           }
-        }
-        else
-        {
+        } else {
           srcFileStream = new FileInputStream(srcFile);
           toClose.add(srcFileStream);
           stream = srcFileStream;
         }
       }
-    }
-    catch (FileNotFoundException ex)
-    {
+    } catch (FileNotFoundException ex) {
       logger.error("Failed to open input file", ex);
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "Failed to open input file", ex.getMessage());
-    }
-    catch (IOException ex)
-    {
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "Failed to open input file",
+          ex.getMessage());
+    } catch (IOException ex) {
       logger.error("Failed to open input stream", ex);
-      throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                            ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                            "Failed to open input stream", ex.getMessage());
+      throw new SnowflakeSQLLoggedException(
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          session,
+          "Failed to open input stream",
+          ex.getMessage());
     }
 
     return SFPair.of(stream, uploadFromStream);
   }
 
   @Override
-  public void handleStorageException(Exception ex,
-                                     int retryCount,
-                                     String operation,
-                                     SFSession session,
-                                     String command)
-  throws SnowflakeSQLException
-  {
+  public void handleStorageException(
+      Exception ex, int retryCount, String operation, SFSession session, String command)
+      throws SnowflakeSQLException {
     // no need to retry if it is invalid key exception
-    if (ex.getCause() instanceof InvalidKeyException)
-    {
+    if (ex.getCause() instanceof InvalidKeyException) {
       // Most likely cause is that the unlimited strength policy files are not installed
       // Log the error and throw a message that explains the cause
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
-
-    if (ex instanceof StorageException)
-    {
+    if (ex instanceof StorageException) {
       StorageException se = (StorageException) ex;
 
-      if (se.getCode() == 403 && session != null && command != null)
-      {
+      if (se.getCode() == 403 && session != null && command != null) {
         // A 403 indicates that the access token has expired,
         // we need to refresh the GCS client with the new token
         SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
       }
 
       // If we have exceeded the max number of retries, propagate the error
-      if (retryCount > getMaxRetries())
-      {
-        throw new SnowflakeSQLLoggedException(se, SqlState.SYSTEM_ERROR,
-                                              ErrorCode.GCP_SERVICE_ERROR.getMessageCode(),
-                                              session,
-                                              operation,
-                                              se.getCode(),
-                                              se.getMessage(),
-                                              se.getReason());
-      }
-      else
-      {
-        logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                     ex.getMessage(), operation, retryCount);
+      if (retryCount > getMaxRetries()) {
+        throw new SnowflakeSQLLoggedException(
+            se,
+            SqlState.SYSTEM_ERROR,
+            ErrorCode.GCP_SERVICE_ERROR.getMessageCode(),
+            session,
+            operation,
+            se.getCode(),
+            se.getMessage(),
+            se.getReason());
+      } else {
+        logger.debug(
+            "Encountered exception ({}) during {}, retry count: {}",
+            ex.getMessage(),
+            operation,
+            retryCount);
         logger.debug("Stack trace: ", ex);
 
         // exponential backoff up to a limit
         int backoffInMillis = getRetryBackoffMin();
 
-        if (retryCount > 1)
-        {
-          backoffInMillis <<= (Math.min(retryCount - 1,
-                                        getRetryBackoffMaxExponent()));
+        if (retryCount > 1) {
+          backoffInMillis <<= (Math.min(retryCount - 1, getRetryBackoffMaxExponent()));
         }
 
-        try
-        {
+        try {
           logger.debug("Sleep for {} milliseconds before retry", backoffInMillis);
 
           Thread.sleep(backoffInMillis);
-        }
-        catch (InterruptedException ex1)
-        {
+        } catch (InterruptedException ex1) {
           // ignore
         }
 
-        if (se.getCode() == 403 && session != null && command != null)
-        {
+        if (se.getCode() == 403 && session != null && command != null) {
           // A 403 indicates that the access token has expired,
           // we need to refresh the GCS client with the new token
           SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
         }
       }
-    }
-    else
-    {
-      if (ex instanceof InterruptedException ||
-          SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException)
-      {
-        if (retryCount > getMaxRetries())
-        {
-          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                                ErrorCode.IO_ERROR.getMessageCode(),
-                                                session,
-                                                "Encountered exception during " + operation + ": " +
-                                                ex.getMessage());
+    } else {
+      if (ex instanceof InterruptedException
+          || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
+        if (retryCount > getMaxRetries()) {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              session,
+              "Encountered exception during " + operation + ": " + ex.getMessage());
+        } else {
+          logger.debug(
+              "Encountered exception ({}) during {}, retry count: {}",
+              ex.getMessage(),
+              operation,
+              retryCount);
         }
-        else
-        {
-          logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                       ex.getMessage(), operation, retryCount);
-        }
-      }
-      else
-      {
-        throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                              ErrorCode.IO_ERROR.getMessageCode(),
-                                              session,
-                                              "Encountered exception during " + operation + ": " +
-                                              ex.getMessage());
+      } else {
+        throw new SnowflakeSQLLoggedException(
+            ex,
+            SqlState.SYSTEM_ERROR,
+            ErrorCode.IO_ERROR.getMessageCode(),
+            session,
+            "Encountered exception during " + operation + ": " + ex.getMessage());
       }
     }
   }
 
-  /**
-   * Returns the material descriptor key
-   */
+  /** Returns the material descriptor key */
   @Override
-  public String getMatdescKey()
-  {
+  public String getMatdescKey() {
     return "matdesc";
   }
 
-  /**
-   * Adds encryption metadata to the StorageObjectMetadata object
-   */
+  /** Adds encryption metadata to the StorageObjectMetadata object */
   @Override
-  public void addEncryptionMetadata(StorageObjectMetadata meta,
-                                    MatDesc matDesc,
-                                    byte[] ivData,
-                                    byte[] encKeK,
-                                    long contentLength)
-  {
-    meta.addUserMetadata(getMatdescKey(),
-                         matDesc.toString());
-    meta.addUserMetadata(GCS_ENCRYPTIONDATAPROP, buildEncryptionMetadataJSON(
-        Base64.encodeAsString(ivData),
-        Base64.encodeAsString(encKeK))
-    );
+  public void addEncryptionMetadata(
+      StorageObjectMetadata meta,
+      MatDesc matDesc,
+      byte[] ivData,
+      byte[] encKeK,
+      long contentLength) {
+    meta.addUserMetadata(getMatdescKey(), matDesc.toString());
+    meta.addUserMetadata(
+        GCS_ENCRYPTIONDATAPROP,
+        buildEncryptionMetadataJSON(Base64.encodeAsString(ivData), Base64.encodeAsString(encKeK)));
     meta.setContentLength(contentLength);
   }
 
@@ -1017,15 +949,16 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * Takes the base64-encoded iv and key and creates the JSON block to be
    * used as the encryptiondata metadata field on the blob.
    */
-  private String buildEncryptionMetadataJSON(String iv64, String key64)
-  {
-    return String.format("{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
-                         + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
-                         + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
-                         + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
-                         + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
-                         + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
-                         + "\"Java 5.3.0\"}}", key64, iv64);
+  private String buildEncryptionMetadataJSON(String iv64, String key64) {
+    return String.format(
+        "{\"EncryptionMode\":\"FullBlob\",\"WrappedContentKey\""
+            + ":{\"KeyId\":\"symmKey1\",\"EncryptedKey\":\"%s\""
+            + ",\"Algorithm\":\"AES_CBC_256\"},\"EncryptionAgent\":"
+            + "{\"Protocol\":\"1.0\",\"EncryptionAlgorithm\":"
+            + "\"AES_CBC_256\"},\"ContentEncryptionIV\":\"%s\""
+            + ",\"KeyWrappingMetadata\":{\"EncryptionLibrary\":"
+            + "\"Java 5.3.0\"}}",
+        key64, iv64);
   }
 
   /*
@@ -1034,12 +967,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    * blob and parses out the key and iv. Returns the pair as key = key, iv = value.
    */
   private AbstractMap.SimpleEntry<String, String> parseEncryptionData(String jsonEncryptionData)
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
     JsonFactory factory = mapper.getFactory();
-    try
-    {
+    try {
       JsonParser parser = factory.createParser(jsonEncryptionData);
       JsonNode encryptionDataNode = mapper.readTree(parser);
 
@@ -1047,34 +978,26 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
       String key = encryptionDataNode.get("WrappedContentKey").get("EncryptedKey").asText();
 
       return new AbstractMap.SimpleEntry<>(key, iv);
-    }
-    catch (Exception ex)
-    {
-      throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-                                      ErrorCode.IO_ERROR.getMessageCode(),
-                                      "Error parsing encryption data as json" + ": " +
-                                      ex.getMessage());
+    } catch (Exception ex) {
+      throw new SnowflakeSQLException(
+          ex,
+          SqlState.SYSTEM_ERROR,
+          ErrorCode.IO_ERROR.getMessageCode(),
+          "Error parsing encryption data as json" + ": " + ex.getMessage());
     }
   }
 
-  /**
-   * Adds digest metadata to the StorageObjectMetadata object
-   */
+  /** Adds digest metadata to the StorageObjectMetadata object */
   @Override
-  public void addDigestMetadata(StorageObjectMetadata meta, String digest)
-  {
-    if (!SnowflakeUtil.isBlank(digest))
-    {
+  public void addDigestMetadata(StorageObjectMetadata meta, String digest) {
+    if (!SnowflakeUtil.isBlank(digest)) {
       meta.addUserMetadata("sfc-digest", digest);
     }
   }
 
-  /**
-   * Gets digest metadata to the StorageObjectMetadata object
-   */
+  /** Gets digest metadata to the StorageObjectMetadata object */
   @Override
-  public String getDigestMetadata(StorageObjectMetadata meta)
-  {
+  public String getDigestMetadata(StorageObjectMetadata meta) {
     return meta.getUserMetadata().get("sfc-digest");
   }
 
@@ -1088,9 +1011,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
    *                required to decrypt/encrypt content in stage
    * @throws IllegalArgumentException when invalid credentials are used
    */
-  private void setupGCSClient(StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
-  throws IllegalArgumentException, SnowflakeSQLException
-  {
+  private void setupGCSClient(
+      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+      throws IllegalArgumentException, SnowflakeSQLException {
     // Save the client creation parameters so that we can reuse them,
     // to reset the GCS client.
     this.stageInfo = stage;
@@ -1099,45 +1022,34 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient
 
     logger.debug("Setting up the GCS client ");
 
-    try
-    {
+    try {
       String accessToken = (String) stage.getCredentials().get("GCS_ACCESS_TOKEN");
       GoogleCredentials googleCreds;
-      if (accessToken != null)
-      {
+      if (accessToken != null) {
         AccessToken googleAccessToken = new AccessToken(accessToken, null);
 
         googleCreds = GoogleCredentials.create(googleAccessToken);
         // We are authenticated with an oauth access token.
-        this.gcsClient = StorageOptions.newBuilder()
-            .setCredentials(googleCreds)
-            .build()
-            .getService();
-      }
-      else
-      {
+        this.gcsClient =
+            StorageOptions.newBuilder().setCredentials(googleCreds).build().getService();
+      } else {
         // Use anonymous authentication.
-        this.gcsClient = StorageOptions.getUnauthenticatedInstance()
-            .getService();
+        this.gcsClient = StorageOptions.getUnauthenticatedInstance().getService();
       }
 
-      if (encMat != null)
-      {
+      if (encMat != null) {
         byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
         encryptionKeySize = decodedKey.length * 8;
 
-        if (encryptionKeySize != 128 &&
-            encryptionKeySize != 192 &&
-            encryptionKeySize != 256)
-        {
-          throw new SnowflakeSQLException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                                          "unsupported key size", encryptionKeySize);
+        if (encryptionKeySize != 128 && encryptionKeySize != 192 && encryptionKeySize != 256) {
+          throw new SnowflakeSQLException(
+              SqlState.INTERNAL_ERROR,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              "unsupported key size",
+              encryptionKeySize);
         }
       }
-    }
-    catch (Exception ex)
-    {
+    } catch (Exception ex) {
       throw new IllegalArgumentException("invalid_gcs_credentials");
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -4,8 +4,6 @@
 
 package net.snowflake.client.jdbc.cloud.storage;
 
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
@@ -26,17 +24,6 @@ import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.util.Base64;
-import java.io.*;
-import java.net.SocketTimeoutException;
-import java.security.InvalidKeyException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.SFSSLConnectionSocketFactory;
 import net.snowflake.client.core.SFSession;
@@ -50,20 +37,37 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLInitializationException;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.*;
+import java.net.SocketTimeoutException;
+import java.security.InvalidKeyException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 /**
  * Wrapper around AmazonS3Client.
  *
  * @author ffunke
  */
-public class SnowflakeS3Client implements SnowflakeStorageClient {
-  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeS3Client.class);
-  private static final String localFileSep = systemGetProperty("file.separator");
-  private static final String AES = "AES";
-  private static final String AMZ_KEY = "x-amz-key";
-  private static final String AMZ_IV = "x-amz-iv";
+public class SnowflakeS3Client implements SnowflakeStorageClient
+{
+  private final static SFLogger logger =
+      SFLoggerFactory.getLogger(SnowflakeS3Client.class);
+  private final static String localFileSep =
+      systemGetProperty("file.separator");
+  private final static String AES = "AES";
+  private final static String AMZ_KEY = "x-amz-key";
+  private final static String AMZ_IV = "x-amz-iv";
 
   // expired AWS token error code
-  private static final String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
+  private final static String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
 
   private int encryptionKeySize = 0; // used for PUTs
   private AmazonS3 amazonClient = null;
@@ -71,30 +75,30 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
   private ClientConfiguration clientConfig = null;
   private String stageRegion = null;
   private String stageEndPoint = null; // FIPS endpoint, if needed
-  private SFSession session;
+  private SFSession session = null;
 
   // socket factory used by s3 client's http client.
   private static SSLConnectionSocketFactory s3ConnectionSocketFactory = null;
 
-  public SnowflakeS3Client(
-      Map<?, ?> stageCredentials,
-      ClientConfiguration clientConfig,
-      RemoteStoreFileEncryptionMaterial encMat,
-      String stageRegion,
-      String stageEndPoint,
-      SFSession session)
-      throws SnowflakeSQLException {
+  public SnowflakeS3Client(Map<?, ?> stageCredentials,
+                           ClientConfiguration clientConfig,
+                           RemoteStoreFileEncryptionMaterial encMat,
+                           String stageRegion,
+                           String stageEndPoint, SFSession session)
+  throws SnowflakeSQLException
+  {
     this.session = session;
-    setupSnowflakeS3Client(stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint);
+    setupSnowflakeS3Client(stageCredentials, clientConfig,
+                           encMat, stageRegion, stageEndPoint, session);
   }
 
-  private void setupSnowflakeS3Client(
-      Map<?, ?> stageCredentials,
-      ClientConfiguration clientConfig,
-      RemoteStoreFileEncryptionMaterial encMat,
-      String stageRegion,
-      String stageEndPoint)
-      throws SnowflakeSQLException {
+  private void setupSnowflakeS3Client(Map<?, ?> stageCredentials,
+                                      ClientConfiguration clientConfig,
+                                      RemoteStoreFileEncryptionMaterial encMat,
+                                      String stageRegion,
+                                      String stageEndPoint, SFSession session)
+  throws SnowflakeSQLException
+  {
     // Save the client creation parameters so that we can reuse them,
     // to reset the AWS client. We won't save the awsCredentials since
     // we will be refreshing that, every time we reset the AWS client
@@ -102,6 +106,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     this.stageRegion = stageRegion;
     this.encMat = encMat;
     this.stageEndPoint = stageEndPoint; // FIPS endpoint, if needed
+    this.session = session;
 
     logger.debug("Setting up AWS client ");
 
@@ -111,56 +116,66 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     String awsToken = (String) stageCredentials.get("AWS_TOKEN");
 
     // initialize aws credentials
-    AWSCredentials awsCredentials =
-        (awsToken != null)
-            ? new BasicSessionCredentials(awsID, awsKey, awsToken)
-            : new BasicAWSCredentials(awsID, awsKey);
+    AWSCredentials awsCredentials = (awsToken != null) ?
+                                    new BasicSessionCredentials(awsID, awsKey, awsToken)
+                                                       : new BasicAWSCredentials(awsID, awsKey);
+
 
     clientConfig.withSignerOverride("AWSS3V4SignerType");
-    clientConfig.getApacheHttpClientConfig().setSslSocketFactory(getSSLConnectionSocketFactory());
+    clientConfig.getApacheHttpClientConfig().setSslSocketFactory(
+        getSSLConnectionSocketFactory());
     HttpUtil.setProxyForS3(clientConfig);
     AmazonS3Builder<?, ?> amazonS3Builder = AmazonS3Client.builder();
-    if (encMat != null) {
+    if (encMat != null)
+    {
       byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
       encryptionKeySize = decodedKey.length * 8;
 
-      if (encryptionKeySize == 256) {
-        SecretKey queryStageMasterKey = new SecretKeySpec(decodedKey, 0, decodedKey.length, AES);
-        EncryptionMaterials encryptionMaterials = new EncryptionMaterials(queryStageMasterKey);
-        encryptionMaterials.addDescription("queryId", encMat.getQueryId());
-        encryptionMaterials.addDescription("smkId", Long.toString(encMat.getSmkId()));
-        CryptoConfiguration cryptoConfig = new CryptoConfiguration(CryptoMode.EncryptionOnly);
+      if (encryptionKeySize == 256)
+      {
+        SecretKey queryStageMasterKey =
+            new SecretKeySpec(decodedKey, 0, decodedKey.length, AES);
+        EncryptionMaterials encryptionMaterials =
+            new EncryptionMaterials(queryStageMasterKey);
+        encryptionMaterials.addDescription("queryId",
+                                           encMat.getQueryId());
+        encryptionMaterials.addDescription("smkId",
+                                           Long.toString(encMat.getSmkId()));
+        CryptoConfiguration cryptoConfig =
+            new CryptoConfiguration(CryptoMode.EncryptionOnly);
 
-        amazonS3Builder =
-            AmazonS3EncryptionClient.encryptionBuilder()
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .withEncryptionMaterials(new StaticEncryptionMaterialsProvider(encryptionMaterials))
-                .withClientConfiguration(clientConfig)
-                .withCryptoConfiguration(cryptoConfig);
+        amazonS3Builder = AmazonS3EncryptionClient.encryptionBuilder()
+            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+            .withEncryptionMaterials(new StaticEncryptionMaterialsProvider(encryptionMaterials))
+            .withClientConfiguration(clientConfig)
+            .withCryptoConfiguration(cryptoConfig);
 
-      } else if (encryptionKeySize == 128) {
-        amazonS3Builder =
-            AmazonS3Client.builder()
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .withClientConfiguration(clientConfig);
-      } else {
-        throw new SnowflakeSQLLoggedException(
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            session,
-            "unsupported key size",
-            encryptionKeySize);
       }
-    } else {
-      amazonS3Builder =
-          AmazonS3Client.builder()
-              .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-              .withClientConfiguration(clientConfig);
+      else if (encryptionKeySize == 128)
+      {
+        amazonS3Builder = AmazonS3Client.builder()
+            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+            .withClientConfiguration(clientConfig);
+      }
+      else
+      {
+        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                              "unsupported key size", encryptionKeySize);
+      }
+    }
+    else
+    {
+      amazonS3Builder = AmazonS3Client.builder()
+          .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+          .withClientConfiguration(clientConfig);
     }
 
-    if (stageRegion != null) {
+    if (stageRegion != null)
+    {
       Region region = RegionUtils.getRegion(stageRegion);
-      if (region != null) {
+      if (region != null)
+      {
         amazonS3Builder.withRegion(region.getName());
       }
     }
@@ -168,7 +183,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     amazonS3Builder.withPathStyleAccessEnabled(false);
 
     amazonClient = (AmazonS3) amazonS3Builder.build();
-    if (this.stageEndPoint != null && this.stageEndPoint != "") {
+    if (this.stageEndPoint != null && this.stageEndPoint != "")
+    {
       // Set the FIPS endpoint if we need it. GS will tell us if we do by
       // giving us an endpoint to use if required and supported by the region.
       amazonClient.setEndpoint(this.stageEndPoint);
@@ -177,55 +193,63 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
   // Returns the Max number of retry attempts
   @Override
-  public int getMaxRetries() {
+  public int getMaxRetries()
+  {
     return 25;
   }
 
   // Returns the max exponent for multiplying backoff with the power of 2, the value
   // of 4 will give us 16secs as the max number of time to sleep before retry
   @Override
-  public int getRetryBackoffMaxExponent() {
+  public int getRetryBackoffMaxExponent()
+  {
     return 4;
   }
 
   // Returns the min number of milliseconds to sleep before retry
   @Override
-  public int getRetryBackoffMin() {
+  public int getRetryBackoffMin()
+  {
     return 1000;
   }
 
   @Override
-  public boolean isEncrypting() {
+  public boolean isEncrypting()
+  {
     return encryptionKeySize > 0;
   }
 
   @Override
-  public int getEncryptionKeySize() {
+  public int getEncryptionKeySize()
+  {
     return encryptionKeySize;
   }
 
   /**
    * Renew the S3 client with fresh AWS credentials/access token
    *
-   * @param stageCredentials a Map of new AWS credential properties, to refresh the client with (as
-   *     returned by GS)
+   * @param stageCredentials a Map of new AWS credential properties, to refresh the client with (as returned by GS)
    * @throws SnowflakeSQLException if any error occurs
    */
   @Override
-  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException {
+  public void renew(Map<?, ?> stageCredentials)
+  throws SnowflakeSQLException
+  {
     // We renew the client with fresh credentials and with its original parameters
-    setupSnowflakeS3Client(
-        stageCredentials, this.clientConfig, this.encMat, this.stageRegion, this.stageEndPoint);
+    setupSnowflakeS3Client(stageCredentials, this.clientConfig, this.encMat, this.stageRegion,
+                           this.stageEndPoint, this.session);
   }
 
   @Override
-  public void shutdown() {
+  public void shutdown()
+  {
     amazonClient.shutdown();
   }
 
   @Override
   public StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
-      throws StorageProviderException {
+  throws StorageProviderException
+  {
     ObjectListing objListing = amazonClient.listObjects(remoteStorageLocation, prefix);
 
     return new StorageObjectSummaryCollection(objListing.getObjectSummaries());
@@ -233,65 +257,69 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
   @Override
   public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
-      throws StorageProviderException {
+  throws StorageProviderException
+  {
     return new S3ObjectMetadata(amazonClient.getObjectMetadata(remoteStorageLocation, prefix));
   }
 
   /**
    * Download a file from S3.
    *
-   * @param session session object
-   * @param command command to download file
-   * @param localLocation local file path
-   * @param destFileName destination file name
-   * @param parallelism number of threads for parallel downloading
+   * @param session               session object
+   * @param command               command to download file
+   * @param localLocation         local file path
+   * @param destFileName          destination file name
+   * @param parallelism           number of threads for parallel downloading
    * @param remoteStorageLocation s3 bucket name
-   * @param stageFilePath stage file path
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Not used in S3
+   * @param stageFilePath         stage file path
+   * @param stageRegion           region name where the stage persists
+   * @param presignedUrl          Not used in S3
    * @throws SnowflakeSQLException if download failed without an exception
    * @throws SnowflakeSQLException if failed to decrypt downloaded file
    * @throws SnowflakeSQLException if file metadata is incomplete
    */
   @Override
-  public void download(
-      SFSession session,
-      String command,
-      String localLocation,
-      String destFileName,
-      int parallelism,
-      String remoteStorageLocation,
-      String stageFilePath,
-      String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+  public void download(SFSession session,
+                       String command,
+                       String localLocation,
+                       String destFileName,
+                       int parallelism,
+                       String remoteStorageLocation,
+                       String stageFilePath,
+                       String stageRegion,
+                       String presignedUrl) throws SnowflakeSQLException
+  {
     TransferManager tx = null;
     int retryCount = 0;
-    do {
-      try {
+    do
+    {
+      try
+      {
         File localFile = new File(localLocation + localFileSep + destFileName);
 
-        logger.debug(
-            "Creating executor service for transfer" + "manager with {} threads", parallelism);
+        logger.debug("Creating executor service for transfer" +
+                     "manager with {} threads", parallelism);
 
         // download files from s3
-        tx =
-            TransferManagerBuilder.standard()
-                .withS3Client(amazonClient)
-                .withExecutorFactory(
-                    new ExecutorFactory() {
-                      @Override
-                      public ExecutorService newExecutor() {
-                        return SnowflakeUtil.createDefaultExecutorService(
-                            "s3-transfer-manager-downloader-", parallelism);
-                      }
-                    })
-                .build();
+        tx = TransferManagerBuilder.standard()
+            .withS3Client(amazonClient)
+            .withExecutorFactory(new ExecutorFactory()
+            {
+              @Override
+              public ExecutorService newExecutor()
+              {
+                return SnowflakeUtil.createDefaultExecutorService(
+                    "s3-transfer-manager-downloader-", parallelism);
+              }
+            })
+            .build();
 
-        Download myDownload = tx.download(remoteStorageLocation, stageFilePath, localFile);
+        Download myDownload = tx.download(remoteStorageLocation,
+                                          stageFilePath, localFile);
 
         // Pull object metadata from S3
-        ObjectMetadata meta = amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
+        ObjectMetadata meta =
+            amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
 
         Map<String, String> metaMap = meta.getUserMetadata();
         String key = metaMap.get(AMZ_KEY);
@@ -299,19 +327,22 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
         myDownload.waitForCompletion();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() < 256) {
-          if (key == null || iv == null) {
-            throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
-                "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() < 256)
+        {
+          if (key == null || iv == null)
+          {
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
           // Decrypt file
-          try {
+          try
+          {
             EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          } catch (Exception ex) {
+          }
+          catch (Exception ex)
+          {
             logger.error("Error decrypting file", ex);
             throw ex;
           }
@@ -319,52 +350,56 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
         return;
 
-      } catch (Exception ex) {
-        handleS3Exception(ex, ++retryCount, "download", session, command, this);
+      }
+      catch (Exception ex)
+      {
+        handleS3Exception(ex, ++retryCount, "download",
+                          session, command, this);
 
-      } finally {
-        if (tx != null) {
+      }
+      finally
+      {
+        if (tx != null)
+        {
           tx.shutdownNow(false);
         }
       }
-    } while (retryCount <= getMaxRetries());
+    }
+    while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        session,
-        "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Download a file from remote storage
    *
-   * @param session session object
-   * @param command command to download file
-   * @param parallelism number of threads for parallel downloading
+   * @param session               session object
+   * @param command               command to download file
+   * @param parallelism           number of threads for parallel downloading
    * @param remoteStorageLocation remote storage location, i.e. bucket for s3
-   * @param stageFilePath stage file path
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Not used in S3
+   * @param stageFilePath         stage file path
+   * @param stageRegion           region name where the stage persists
+   * @param presignedUrl          Not used in S3
    * @return input file stream
    * @throws SnowflakeSQLException when download failure
    */
   @Override
-  public InputStream downloadToStream(
-      SFSession session,
-      String command,
-      int parallelism,
-      String remoteStorageLocation,
-      String stageFilePath,
-      String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+  public InputStream downloadToStream(SFSession session, String command, int parallelism,
+                                      String remoteStorageLocation, String stageFilePath,
+                                      String stageRegion, String presignedUrl) throws SnowflakeSQLException
+  {
     int retryCount = 0;
-    do {
-      try {
-        S3Object file = amazonClient.getObject(remoteStorageLocation, stageFilePath);
+    do
+    {
+      try
+      {
+        S3Object file =
+            amazonClient.getObject(remoteStorageLocation, stageFilePath);
 
-        ObjectMetadata meta = amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
+        ObjectMetadata meta =
+            amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
 
         InputStream stream = file.getObjectContent();
 
@@ -373,53 +408,59 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         String key = metaMap.get(AMZ_KEY);
         String iv = metaMap.get(AMZ_IV);
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() < 256) {
-          if (key == null || iv == null) {
-            throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
-                "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() < 256)
+        {
+          if (key == null || iv == null)
+          {
+            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                                  "File metadata incomplete");
           }
 
-          try {
+          try
+          {
 
             return EncryptionProvider.decryptStream(stream, key, iv, encMat);
 
-          } catch (Exception ex) {
+          }
+          catch (Exception ex)
+          {
             logger.error("Error in decrypting file", ex);
             throw ex;
           }
-        } else {
+        }
+        else
+        {
           return stream;
         }
-      } catch (Exception ex) {
-        handleS3Exception(ex, ++retryCount, "download", session, command, this);
+      }
+      catch (Exception ex)
+      {
+        handleS3Exception(ex, ++retryCount, "download", session, command,
+                          this);
       }
     } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        session,
-        "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file (-stream) to S3.
    *
-   * @param session session object
-   * @param command upload command
-   * @param parallelism number of threads do parallel uploading
-   * @param uploadFromStream true if upload source is stream
-   * @param remoteStorageLocation s3 bucket name
-   * @param srcFile source file if not uploading from a stream
-   * @param destFileName file name on s3 after upload
-   * @param inputStream stream used for uploading if fileBackedOutputStream is null
+   * @param session                session object
+   * @param command                upload command
+   * @param parallelism            number of threads do parallel uploading
+   * @param uploadFromStream       true if upload source is stream
+   * @param remoteStorageLocation  s3 bucket name
+   * @param srcFile                source file if not uploading from a stream
+   * @param destFileName           file name on s3 after upload
+   * @param inputStream            stream used for uploading if fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta object meta data
-   * @param stageRegion region name where the stage persists
-   * @param presignedUrl Not used in S3
+   * @param meta                   object meta data
+   * @param stageRegion            region name where the stage persists
+   * @param presignedUrl           Not used in S3
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   @Override
@@ -435,54 +476,59 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       FileBackedOutputStream fileBackedOutputStream,
       StorageObjectMetadata meta,
       String stageRegion,
-      String presignedUrl)
-      throws SnowflakeSQLException {
+      String presignedUrl) throws SnowflakeSQLException
+  {
     final long originalContentLength = meta.getContentLength();
     final List<FileInputStream> toClose = new ArrayList<>();
     SFPair<InputStream, Boolean> uploadStreamInfo =
-        createUploadStream(
-            srcFile,
-            uploadFromStream,
-            inputStream,
-            fileBackedOutputStream,
-            ((S3ObjectMetadata) meta).getS3ObjectMetadata(),
-            originalContentLength,
-            toClose);
+        createUploadStream(srcFile, uploadFromStream,
+                           inputStream, fileBackedOutputStream,
+                           ((S3ObjectMetadata) meta).getS3ObjectMetadata(),
+                           originalContentLength, toClose);
 
     ObjectMetadata s3Meta;
-    if (meta instanceof S3ObjectMetadata) {
+    if (meta instanceof S3ObjectMetadata)
+    {
       s3Meta = ((S3ObjectMetadata) meta).getS3ObjectMetadata();
-    } else {
+    }
+    else
+    {
       throw new IllegalArgumentException("Unexpected metadata object type");
     }
 
     TransferManager tx = null;
     int retryCount = 0;
-    do {
-      try {
+    do
+    {
+      try
+      {
 
-        logger.debug(
-            "Creating executor service for transfer" + "manager with {} threads", parallelism);
+        logger.debug("Creating executor service for transfer" +
+                     "manager with {} threads", parallelism);
 
         // upload files to s3
-        tx =
-            TransferManagerBuilder.standard()
-                .withS3Client(amazonClient)
-                .withExecutorFactory(
-                    new ExecutorFactory() {
-                      @Override
-                      public ExecutorService newExecutor() {
-                        return SnowflakeUtil.createDefaultExecutorService(
-                            "s3-transfer-manager-uploader-", parallelism);
-                      }
-                    })
-                .build();
+        tx = TransferManagerBuilder.standard()
+            .withS3Client(amazonClient)
+            .withExecutorFactory(new ExecutorFactory()
+            {
+              @Override
+              public ExecutorService newExecutor()
+              {
+                return SnowflakeUtil.createDefaultExecutorService(
+                    "s3-transfer-manager-uploader-", parallelism);
+              }
+            })
+            .build();
 
         final Upload myUpload;
 
-        if (uploadStreamInfo.right) {
-          myUpload = tx.upload(remoteStorageLocation, destFileName, uploadStreamInfo.left, s3Meta);
-        } else {
+        if (uploadStreamInfo.right)
+        {
+          myUpload = tx.upload(remoteStorageLocation, destFileName,
+                               uploadStreamInfo.left, s3Meta);
+        }
+        else
+        {
           PutObjectRequest putRequest =
               new PutObjectRequest(remoteStorageLocation, destFileName, srcFile);
           putRequest.setMetadata(s3Meta);
@@ -493,126 +539,122 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         myUpload.waitForCompletion();
 
         // get out
-        for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
+        for (FileInputStream is : toClose)
+          IOUtils.closeQuietly(is);
         return;
-      } catch (Exception ex) {
+      }
+      catch (Exception ex)
+      {
 
-        handleS3Exception(ex, ++retryCount, "upload", session, command, this);
-        if (uploadFromStream && fileBackedOutputStream == null) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              "Encountered exception during upload: "
-                  + ex.getMessage()
-                  + "\nCannot retry upload from stream.");
+        handleS3Exception(ex, ++retryCount, "upload",
+                          session, command, this);
+        if (uploadFromStream && fileBackedOutputStream == null)
+        {
+          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
+                                          ErrorCode.IO_ERROR.getMessageCode(),
+                                          "Encountered exception during upload: " +
+                                          ex.getMessage() + "\nCannot retry upload from stream.");
         }
-        uploadStreamInfo =
-            createUploadStream(
-                srcFile,
-                uploadFromStream,
-                inputStream,
-                fileBackedOutputStream,
-                s3Meta,
-                originalContentLength,
-                toClose);
-      } finally {
-        if (tx != null) {
+        uploadStreamInfo = createUploadStream(srcFile, uploadFromStream,
+                                              inputStream, fileBackedOutputStream,
+                                              s3Meta, originalContentLength, toClose);
+      }
+      finally
+      {
+        if (tx != null)
+        {
           tx.shutdownNow(false);
         }
       }
-    } while (retryCount <= getMaxRetries());
+    }
+    while (retryCount <= getMaxRetries());
 
-    for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
+    for (FileInputStream is : toClose)
+      IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
-        session,
-        "Unexpected: upload unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
+                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                          "Unexpected: upload unsuccessful without exception!");
   }
 
-  private SFPair<InputStream, Boolean> createUploadStream(
-      File srcFile,
-      boolean uploadFromStream,
-      InputStream inputStream,
-      FileBackedOutputStream fileBackedOutputStream,
-      ObjectMetadata meta,
-      long originalContentLength,
-      List<FileInputStream> toClose)
-      throws SnowflakeSQLException {
+  private SFPair<InputStream, Boolean>
+  createUploadStream(File srcFile,
+                     boolean uploadFromStream,
+                     InputStream inputStream,
+                     FileBackedOutputStream fileBackedOutputStream,
+                     ObjectMetadata meta,
+                     long originalContentLength,
+                     List<FileInputStream> toClose)
+  throws SnowflakeSQLException
+  {
     logger.debug(
-        "createUploadStream({}, {}, {}, {}, {}, {}, {}) " + "keySize={}",
-        this,
-        srcFile,
-        uploadFromStream,
-        inputStream,
-        fileBackedOutputStream,
-        meta,
-        toClose,
+        "createUploadStream({}, {}, {}, {}, {}, {}, {}) " +
+        "keySize={}",
+        this, srcFile, uploadFromStream, inputStream,
+        fileBackedOutputStream, meta, toClose,
         this.getEncryptionKeySize());
     final InputStream result;
     FileInputStream srcFileStream = null;
-    if (isEncrypting() && getEncryptionKeySize() < 256) {
-      try {
-        final InputStream uploadStream =
-            uploadFromStream
-                ? (fileBackedOutputStream != null
-                    ? fileBackedOutputStream.asByteSource().openStream()
-                    : inputStream)
-                : (srcFileStream = new FileInputStream(srcFile));
+    if (isEncrypting() && getEncryptionKeySize() < 256)
+    {
+      try
+      {
+        final InputStream uploadStream = uploadFromStream ?
+                                         (fileBackedOutputStream != null ?
+                                          fileBackedOutputStream.asByteSource().openStream() :
+                                          inputStream) :
+                                         (srcFileStream = new FileInputStream(srcFile));
         toClose.add(srcFileStream);
 
         // Encrypt
         S3StorageObjectMetadata s3Metadata = new S3StorageObjectMetadata(meta);
-        result =
-            EncryptionProvider.encrypt(
-                s3Metadata, originalContentLength, uploadStream, this.encMat, this);
+        result = EncryptionProvider.encrypt(s3Metadata, originalContentLength,
+                                            uploadStream, this.encMat, this);
         uploadFromStream = true;
-      } catch (Exception ex) {
-        logger.error("Failed to encrypt input", ex);
-        throw new SnowflakeSQLException(
-            ex,
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            "Failed to encrypt input",
-            ex.getMessage());
       }
-    } else {
-      try {
-        result =
-            uploadFromStream
-                ? (fileBackedOutputStream != null
-                    ? fileBackedOutputStream.asByteSource().openStream()
-                    : inputStream)
-                : (srcFileStream = new FileInputStream(srcFile));
+      catch (Exception ex)
+      {
+        logger.error("Failed to encrypt input", ex);
+        throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                              "Failed to encrypt input", ex.getMessage());
+      }
+    }
+    else
+    {
+      try
+      {
+        result = uploadFromStream ?
+                 (fileBackedOutputStream != null ?
+                  fileBackedOutputStream.asByteSource().openStream() :
+                  inputStream) :
+                 (srcFileStream = new FileInputStream(srcFile));
         toClose.add(srcFileStream);
 
-      } catch (FileNotFoundException ex) {
+      }
+      catch (FileNotFoundException ex)
+      {
         logger.error("Failed to open input file", ex);
-        throw new SnowflakeSQLException(
-            ex,
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            "Failed to open input file",
-            ex.getMessage());
-      } catch (IOException ex) {
+        throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                              "Failed to open input file", ex.getMessage());
+      }
+      catch (IOException ex)
+      {
         logger.error("Failed to open input stream", ex);
-        throw new SnowflakeSQLException(
-            ex,
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            "Failed to open input stream",
-            ex.getMessage());
+        throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
+                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
+                                              "Failed to open input stream", ex.getMessage());
       }
     }
     return SFPair.of(result, uploadFromStream);
   }
 
+
   @Override
-  public void handleStorageException(
-      Exception ex, int retryCount, String operation, SFSession session, String command)
-      throws SnowflakeSQLException {
+  public void handleStorageException(Exception ex, int retryCount, String operation, SFSession session, String command)
+  throws SnowflakeSQLException
+  {
     handleS3Exception(ex, retryCount, operation, session, command, this);
   }
 
@@ -623,143 +665,177 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       SFSession session,
       String command,
       SnowflakeS3Client s3Client)
-      throws SnowflakeSQLException {
+  throws SnowflakeSQLException
+  {
     // no need to retry if it is invalid key exception
-    if (ex.getCause() instanceof InvalidKeyException) {
+    if (ex.getCause() instanceof InvalidKeyException)
+    {
       // Most likely cause is that the unlimited strength policy files are not installed
       // Log the error and throw a message that explains the cause
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
-    if (ex instanceof AmazonClientException) {
-      if (retryCount > s3Client.getMaxRetries()) {
+    if (ex instanceof AmazonClientException)
+    {
+      if (retryCount > s3Client.getMaxRetries())
+      {
         String extendedRequestId = "none";
 
-        if (ex instanceof AmazonS3Exception) {
+        if (ex instanceof AmazonS3Exception)
+        {
           AmazonS3Exception ex1 = (AmazonS3Exception) ex;
           extendedRequestId = ex1.getExtendedRequestId();
         }
 
-        if (ex instanceof AmazonServiceException) {
+        if (ex instanceof AmazonServiceException)
+        {
           AmazonServiceException ex1 = (AmazonServiceException) ex;
-          throw new SnowflakeSQLException(
-              ex1,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.S3_OPERATION_ERROR.getMessageCode(),
-              operation,
-              ex1.getErrorType().toString(),
-              ex1.getErrorCode(),
-              ex1.getMessage(),
-              ex1.getRequestId(),
-              extendedRequestId);
-        } else {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.AWS_CLIENT_ERROR.getMessageCode(),
-              operation,
-              ex.getMessage());
+          throw new SnowflakeSQLLoggedException(ex1, SqlState.SYSTEM_ERROR,
+                                                ErrorCode.S3_OPERATION_ERROR.getMessageCode(),
+                                                session,
+                                                operation,
+                                                ex1.getErrorType().toString(),
+                                                ex1.getErrorCode(),
+                                                ex1.getMessage(), ex1.getRequestId(),
+                                                extendedRequestId);
         }
-      } else {
-        logger.debug(
-            "Encountered exception ({}) during {}, retry count: {}",
-            ex.getMessage(),
-            operation,
-            retryCount);
+        else
+        {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                                ErrorCode.AWS_CLIENT_ERROR.getMessageCode(),
+                                                session, operation, ex.getMessage());
+        }
+      }
+      else
+      {
+        logger.debug("Encountered exception ({}) during {}, retry count: {}",
+                     ex.getMessage(), operation, retryCount);
         logger.debug("Stack trace: ", ex);
 
         // exponential backoff up to a limit
         int backoffInMillis = s3Client.getRetryBackoffMin();
 
-        if (retryCount > 1) {
-          backoffInMillis <<= (Math.min(retryCount - 1, s3Client.getRetryBackoffMaxExponent()));
+        if (retryCount > 1)
+        {
+          backoffInMillis <<= (Math.min(retryCount - 1,
+                                        s3Client.getRetryBackoffMaxExponent()));
         }
 
-        try {
-          logger.debug("Sleep for {} milliseconds before retry", backoffInMillis);
+        try
+        {
+          logger.debug("Sleep for {} milliseconds before retry",
+                       backoffInMillis);
 
           Thread.sleep(backoffInMillis);
-        } catch (InterruptedException ex1) {
+        }
+        catch (InterruptedException ex1)
+        {
           // ignore
         }
 
         // If the exception indicates that the AWS token has expired,
         // we need to refresh our S3 client with the new token
-        if (ex instanceof AmazonS3Exception) {
+        if (ex instanceof AmazonS3Exception)
+        {
           AmazonS3Exception s3ex = (AmazonS3Exception) ex;
-          if (s3ex.getErrorCode().equalsIgnoreCase(EXPIRED_AWS_TOKEN_ERROR_CODE)) {
+          if (s3ex.getErrorCode().equalsIgnoreCase(EXPIRED_AWS_TOKEN_ERROR_CODE))
+          {
             SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);
           }
         }
       }
-    } else {
-      if (ex instanceof InterruptedException
-          || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
-        if (retryCount > s3Client.getMaxRetries()) {
-          throw new SnowflakeSQLException(
-              ex,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              "Encountered exception during " + operation + ": " + ex.getMessage());
-        } else {
-          logger.debug(
-              "Encountered exception ({}) during {}, retry count: {}",
-              ex.getMessage(),
-              operation,
-              retryCount);
+    }
+    else
+    {
+      if (ex instanceof InterruptedException ||
+          SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException)
+      {
+        if (retryCount > s3Client.getMaxRetries())
+        {
+          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                                ErrorCode.IO_ERROR.getMessageCode(), session,
+                                                "Encountered exception during " + operation + ": " +
+                                                ex.getMessage());
         }
-      } else {
-        throw new SnowflakeSQLException(
-            ex,
-            SqlState.SYSTEM_ERROR,
-            ErrorCode.IO_ERROR.getMessageCode(),
-            "Encountered exception during " + operation + ": " + ex.getMessage());
+        else
+        {
+          logger.debug("Encountered exception ({}) during {}, retry count: {}",
+                       ex.getMessage(), operation, retryCount);
+        }
+      }
+      else
+      {
+        throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
+                                              ErrorCode.IO_ERROR.getMessageCode(), session,
+                                              "Encountered exception during " + operation + ": " +
+                                              ex.getMessage());
       }
     }
   }
 
-  /** Returns the material descriptor key */
+  /**
+   * Returns the material descriptor key
+   */
   @Override
-  public String getMatdescKey() {
+  public String getMatdescKey()
+  {
     return "x-amz-matdesc";
   }
 
-  /** Adds encryption metadata to the StorageObjectMetadata object */
+  /**
+   * Adds encryption metadata to the StorageObjectMetadata object
+   */
   @Override
-  public void addEncryptionMetadata(
-      StorageObjectMetadata meta,
-      MatDesc matDesc,
-      byte[] ivData,
-      byte[] encKeK,
-      long contentLength) {
-    meta.addUserMetadata(getMatdescKey(), matDesc.toString());
-    meta.addUserMetadata(AMZ_KEY, Base64.encodeAsString(encKeK));
-    meta.addUserMetadata(AMZ_IV, Base64.encodeAsString(ivData));
+  public void addEncryptionMetadata(StorageObjectMetadata meta,
+                                    MatDesc matDesc,
+                                    byte[] ivData,
+                                    byte[] encKeK,
+                                    long contentLength)
+  {
+    meta.addUserMetadata(getMatdescKey(),
+                         matDesc.toString());
+    meta.addUserMetadata(AMZ_KEY,
+                         Base64.encodeAsString(encKeK));
+    meta.addUserMetadata(AMZ_IV,
+                         Base64.encodeAsString(ivData));
     meta.setContentLength(contentLength);
   }
 
-  /** Adds digest metadata to the StorageObjectMetadata object */
+  /**
+   * Adds digest metadata to the StorageObjectMetadata object
+   */
   @Override
-  public void addDigestMetadata(StorageObjectMetadata meta, String digest) {
+  public void addDigestMetadata(StorageObjectMetadata meta, String digest)
+  {
     meta.addUserMetadata("sfc-digest", digest);
   }
 
-  /** Gets digest metadata to the StorageObjectMetadata object */
+  /**
+   * Gets digest metadata to the StorageObjectMetadata object
+   */
   @Override
-  public String getDigestMetadata(StorageObjectMetadata meta) {
+  public String getDigestMetadata(StorageObjectMetadata meta)
+  {
     return meta.getUserMetadata().get("sfc-digest");
   }
 
-  private static SSLConnectionSocketFactory getSSLConnectionSocketFactory() {
-    if (s3ConnectionSocketFactory == null) {
-      synchronized (SnowflakeS3Client.class) {
-        if (s3ConnectionSocketFactory == null) {
-          try {
+  private static SSLConnectionSocketFactory getSSLConnectionSocketFactory()
+  {
+    if (s3ConnectionSocketFactory == null)
+    {
+      synchronized (SnowflakeS3Client.class)
+      {
+        if (s3ConnectionSocketFactory == null)
+        {
+          try
+          {
             // trust manager is set to null, which will use default ones
             // instead of SFTrustManager (which enables ocsp checking)
-            s3ConnectionSocketFactory =
-                new SFSSLConnectionSocketFactory(null, HttpUtil.isSocksProxyDisabled());
-          } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            s3ConnectionSocketFactory = new SFSSLConnectionSocketFactory(null,
+                                                                         HttpUtil.isSocksProxyDisabled());
+          }
+          catch (KeyManagementException | NoSuchAlgorithmException e)
+          {
             throw new SSLInitializationException(e.getMessage(), e);
           }
         }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.jdbc.cloud.storage;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
@@ -24,6 +26,17 @@ import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.util.Base64;
+import java.io.*;
+import java.net.SocketTimeoutException;
+import java.security.InvalidKeyException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.SFSSLConnectionSocketFactory;
 import net.snowflake.client.core.SFSession;
@@ -37,37 +50,20 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLInitializationException;
 
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-import java.io.*;
-import java.net.SocketTimeoutException;
-import java.security.InvalidKeyException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 /**
  * Wrapper around AmazonS3Client.
  *
  * @author ffunke
  */
-public class SnowflakeS3Client implements SnowflakeStorageClient
-{
-  private final static SFLogger logger =
-      SFLoggerFactory.getLogger(SnowflakeS3Client.class);
-  private final static String localFileSep =
-      systemGetProperty("file.separator");
-  private final static String AES = "AES";
-  private final static String AMZ_KEY = "x-amz-key";
-  private final static String AMZ_IV = "x-amz-iv";
+public class SnowflakeS3Client implements SnowflakeStorageClient {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeS3Client.class);
+  private static final String localFileSep = systemGetProperty("file.separator");
+  private static final String AES = "AES";
+  private static final String AMZ_KEY = "x-amz-key";
+  private static final String AMZ_IV = "x-amz-iv";
 
   // expired AWS token error code
-  private final static String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
+  private static final String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
 
   private int encryptionKeySize = 0; // used for PUTs
   private AmazonS3 amazonClient = null;
@@ -80,25 +76,27 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
   // socket factory used by s3 client's http client.
   private static SSLConnectionSocketFactory s3ConnectionSocketFactory = null;
 
-  public SnowflakeS3Client(Map<?, ?> stageCredentials,
-                           ClientConfiguration clientConfig,
-                           RemoteStoreFileEncryptionMaterial encMat,
-                           String stageRegion,
-                           String stageEndPoint, SFSession session)
-  throws SnowflakeSQLException
-  {
+  public SnowflakeS3Client(
+      Map<?, ?> stageCredentials,
+      ClientConfiguration clientConfig,
+      RemoteStoreFileEncryptionMaterial encMat,
+      String stageRegion,
+      String stageEndPoint,
+      SFSession session)
+      throws SnowflakeSQLException {
     this.session = session;
-    setupSnowflakeS3Client(stageCredentials, clientConfig,
-                           encMat, stageRegion, stageEndPoint, session);
+    setupSnowflakeS3Client(
+        stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, session);
   }
 
-  private void setupSnowflakeS3Client(Map<?, ?> stageCredentials,
-                                      ClientConfiguration clientConfig,
-                                      RemoteStoreFileEncryptionMaterial encMat,
-                                      String stageRegion,
-                                      String stageEndPoint, SFSession session)
-  throws SnowflakeSQLException
-  {
+  private void setupSnowflakeS3Client(
+      Map<?, ?> stageCredentials,
+      ClientConfiguration clientConfig,
+      RemoteStoreFileEncryptionMaterial encMat,
+      String stageRegion,
+      String stageEndPoint,
+      SFSession session)
+      throws SnowflakeSQLException {
     // Save the client creation parameters so that we can reuse them,
     // to reset the AWS client. We won't save the awsCredentials since
     // we will be refreshing that, every time we reset the AWS client
@@ -116,66 +114,56 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
     String awsToken = (String) stageCredentials.get("AWS_TOKEN");
 
     // initialize aws credentials
-    AWSCredentials awsCredentials = (awsToken != null) ?
-                                    new BasicSessionCredentials(awsID, awsKey, awsToken)
-                                                       : new BasicAWSCredentials(awsID, awsKey);
-
+    AWSCredentials awsCredentials =
+        (awsToken != null)
+            ? new BasicSessionCredentials(awsID, awsKey, awsToken)
+            : new BasicAWSCredentials(awsID, awsKey);
 
     clientConfig.withSignerOverride("AWSS3V4SignerType");
-    clientConfig.getApacheHttpClientConfig().setSslSocketFactory(
-        getSSLConnectionSocketFactory());
+    clientConfig.getApacheHttpClientConfig().setSslSocketFactory(getSSLConnectionSocketFactory());
     HttpUtil.setProxyForS3(clientConfig);
     AmazonS3Builder<?, ?> amazonS3Builder = AmazonS3Client.builder();
-    if (encMat != null)
-    {
+    if (encMat != null) {
       byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
       encryptionKeySize = decodedKey.length * 8;
 
-      if (encryptionKeySize == 256)
-      {
-        SecretKey queryStageMasterKey =
-            new SecretKeySpec(decodedKey, 0, decodedKey.length, AES);
-        EncryptionMaterials encryptionMaterials =
-            new EncryptionMaterials(queryStageMasterKey);
-        encryptionMaterials.addDescription("queryId",
-                                           encMat.getQueryId());
-        encryptionMaterials.addDescription("smkId",
-                                           Long.toString(encMat.getSmkId()));
-        CryptoConfiguration cryptoConfig =
-            new CryptoConfiguration(CryptoMode.EncryptionOnly);
+      if (encryptionKeySize == 256) {
+        SecretKey queryStageMasterKey = new SecretKeySpec(decodedKey, 0, decodedKey.length, AES);
+        EncryptionMaterials encryptionMaterials = new EncryptionMaterials(queryStageMasterKey);
+        encryptionMaterials.addDescription("queryId", encMat.getQueryId());
+        encryptionMaterials.addDescription("smkId", Long.toString(encMat.getSmkId()));
+        CryptoConfiguration cryptoConfig = new CryptoConfiguration(CryptoMode.EncryptionOnly);
 
-        amazonS3Builder = AmazonS3EncryptionClient.encryptionBuilder()
-            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-            .withEncryptionMaterials(new StaticEncryptionMaterialsProvider(encryptionMaterials))
-            .withClientConfiguration(clientConfig)
-            .withCryptoConfiguration(cryptoConfig);
+        amazonS3Builder =
+            AmazonS3EncryptionClient.encryptionBuilder()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withEncryptionMaterials(new StaticEncryptionMaterialsProvider(encryptionMaterials))
+                .withClientConfiguration(clientConfig)
+                .withCryptoConfiguration(cryptoConfig);
 
+      } else if (encryptionKeySize == 128) {
+        amazonS3Builder =
+            AmazonS3Client.builder()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withClientConfiguration(clientConfig);
+      } else {
+        throw new SnowflakeSQLLoggedException(
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            session,
+            "unsupported key size",
+            encryptionKeySize);
       }
-      else if (encryptionKeySize == 128)
-      {
-        amazonS3Builder = AmazonS3Client.builder()
-            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-            .withClientConfiguration(clientConfig);
-      }
-      else
-      {
-        throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                              "unsupported key size", encryptionKeySize);
-      }
-    }
-    else
-    {
-      amazonS3Builder = AmazonS3Client.builder()
-          .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-          .withClientConfiguration(clientConfig);
+    } else {
+      amazonS3Builder =
+          AmazonS3Client.builder()
+              .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+              .withClientConfiguration(clientConfig);
     }
 
-    if (stageRegion != null)
-    {
+    if (stageRegion != null) {
       Region region = RegionUtils.getRegion(stageRegion);
-      if (region != null)
-      {
+      if (region != null) {
         amazonS3Builder.withRegion(region.getName());
       }
     }
@@ -183,8 +171,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
     amazonS3Builder.withPathStyleAccessEnabled(false);
 
     amazonClient = (AmazonS3) amazonS3Builder.build();
-    if (this.stageEndPoint != null && this.stageEndPoint != "")
-    {
+    if (this.stageEndPoint != null && this.stageEndPoint != "") {
       // Set the FIPS endpoint if we need it. GS will tell us if we do by
       // giving us an endpoint to use if required and supported by the region.
       amazonClient.setEndpoint(this.stageEndPoint);
@@ -193,63 +180,60 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
 
   // Returns the Max number of retry attempts
   @Override
-  public int getMaxRetries()
-  {
+  public int getMaxRetries() {
     return 25;
   }
 
   // Returns the max exponent for multiplying backoff with the power of 2, the value
   // of 4 will give us 16secs as the max number of time to sleep before retry
   @Override
-  public int getRetryBackoffMaxExponent()
-  {
+  public int getRetryBackoffMaxExponent() {
     return 4;
   }
 
   // Returns the min number of milliseconds to sleep before retry
   @Override
-  public int getRetryBackoffMin()
-  {
+  public int getRetryBackoffMin() {
     return 1000;
   }
 
   @Override
-  public boolean isEncrypting()
-  {
+  public boolean isEncrypting() {
     return encryptionKeySize > 0;
   }
 
   @Override
-  public int getEncryptionKeySize()
-  {
+  public int getEncryptionKeySize() {
     return encryptionKeySize;
   }
 
   /**
    * Renew the S3 client with fresh AWS credentials/access token
    *
-   * @param stageCredentials a Map of new AWS credential properties, to refresh the client with (as returned by GS)
+   * @param stageCredentials a Map of new AWS credential properties, to refresh the client with (as
+   *     returned by GS)
    * @throws SnowflakeSQLException if any error occurs
    */
   @Override
-  public void renew(Map<?, ?> stageCredentials)
-  throws SnowflakeSQLException
-  {
+  public void renew(Map<?, ?> stageCredentials) throws SnowflakeSQLException {
     // We renew the client with fresh credentials and with its original parameters
-    setupSnowflakeS3Client(stageCredentials, this.clientConfig, this.encMat, this.stageRegion,
-                           this.stageEndPoint, this.session);
+    setupSnowflakeS3Client(
+        stageCredentials,
+        this.clientConfig,
+        this.encMat,
+        this.stageRegion,
+        this.stageEndPoint,
+        this.session);
   }
 
   @Override
-  public void shutdown()
-  {
+  public void shutdown() {
     amazonClient.shutdown();
   }
 
   @Override
   public StorageObjectSummaryCollection listObjects(String remoteStorageLocation, String prefix)
-  throws StorageProviderException
-  {
+      throws StorageProviderException {
     ObjectListing objListing = amazonClient.listObjects(remoteStorageLocation, prefix);
 
     return new StorageObjectSummaryCollection(objListing.getObjectSummaries());
@@ -257,69 +241,65 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
 
   @Override
   public StorageObjectMetadata getObjectMetadata(String remoteStorageLocation, String prefix)
-  throws StorageProviderException
-  {
+      throws StorageProviderException {
     return new S3ObjectMetadata(amazonClient.getObjectMetadata(remoteStorageLocation, prefix));
   }
 
   /**
    * Download a file from S3.
    *
-   * @param session               session object
-   * @param command               command to download file
-   * @param localLocation         local file path
-   * @param destFileName          destination file name
-   * @param parallelism           number of threads for parallel downloading
+   * @param session session object
+   * @param command command to download file
+   * @param localLocation local file path
+   * @param destFileName destination file name
+   * @param parallelism number of threads for parallel downloading
    * @param remoteStorageLocation s3 bucket name
-   * @param stageFilePath         stage file path
-   * @param stageRegion           region name where the stage persists
-   * @param presignedUrl          Not used in S3
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Not used in S3
    * @throws SnowflakeSQLException if download failed without an exception
    * @throws SnowflakeSQLException if failed to decrypt downloaded file
    * @throws SnowflakeSQLException if file metadata is incomplete
    */
   @Override
-  public void download(SFSession session,
-                       String command,
-                       String localLocation,
-                       String destFileName,
-                       int parallelism,
-                       String remoteStorageLocation,
-                       String stageFilePath,
-                       String stageRegion,
-                       String presignedUrl) throws SnowflakeSQLException
-  {
+  public void download(
+      SFSession session,
+      String command,
+      String localLocation,
+      String destFileName,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
     TransferManager tx = null;
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
         File localFile = new File(localLocation + localFileSep + destFileName);
 
-        logger.debug("Creating executor service for transfer" +
-                     "manager with {} threads", parallelism);
+        logger.debug(
+            "Creating executor service for transfer" + "manager with {} threads", parallelism);
 
         // download files from s3
-        tx = TransferManagerBuilder.standard()
-            .withS3Client(amazonClient)
-            .withExecutorFactory(new ExecutorFactory()
-            {
-              @Override
-              public ExecutorService newExecutor()
-              {
-                return SnowflakeUtil.createDefaultExecutorService(
-                    "s3-transfer-manager-downloader-", parallelism);
-              }
-            })
-            .build();
+        tx =
+            TransferManagerBuilder.standard()
+                .withS3Client(amazonClient)
+                .withExecutorFactory(
+                    new ExecutorFactory() {
+                      @Override
+                      public ExecutorService newExecutor() {
+                        return SnowflakeUtil.createDefaultExecutorService(
+                            "s3-transfer-manager-downloader-", parallelism);
+                      }
+                    })
+                .build();
 
-        Download myDownload = tx.download(remoteStorageLocation,
-                                          stageFilePath, localFile);
+        Download myDownload = tx.download(remoteStorageLocation, stageFilePath, localFile);
 
         // Pull object metadata from S3
-        ObjectMetadata meta =
-            amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
+        ObjectMetadata meta = amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
 
         Map<String, String> metaMap = meta.getUserMetadata();
         String key = metaMap.get(AMZ_KEY);
@@ -327,22 +307,19 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
 
         myDownload.waitForCompletion();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() < 256)
-        {
-          if (key == null || iv == null)
-          {
-            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                  "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() < 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLLoggedException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
+                "File metadata incomplete");
           }
 
           // Decrypt file
-          try
-          {
+          try {
             EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          }
-          catch (Exception ex)
-          {
+          } catch (Exception ex) {
             logger.error("Error decrypting file", ex);
             throw ex;
           }
@@ -350,56 +327,52 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
 
         return;
 
-      }
-      catch (Exception ex)
-      {
-        handleS3Exception(ex, ++retryCount, "download",
-                          session, command, this);
+      } catch (Exception ex) {
+        handleS3Exception(ex, ++retryCount, "download", session, command, this);
 
-      }
-      finally
-      {
-        if (tx != null)
-        {
+      } finally {
+        if (tx != null) {
           tx.shutdownNow(false);
         }
       }
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        session,
+        "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Download a file from remote storage
    *
-   * @param session               session object
-   * @param command               command to download file
-   * @param parallelism           number of threads for parallel downloading
+   * @param session session object
+   * @param command command to download file
+   * @param parallelism number of threads for parallel downloading
    * @param remoteStorageLocation remote storage location, i.e. bucket for s3
-   * @param stageFilePath         stage file path
-   * @param stageRegion           region name where the stage persists
-   * @param presignedUrl          Not used in S3
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Not used in S3
    * @return input file stream
    * @throws SnowflakeSQLException when download failure
    */
   @Override
-  public InputStream downloadToStream(SFSession session, String command, int parallelism,
-                                      String remoteStorageLocation, String stageFilePath,
-                                      String stageRegion, String presignedUrl) throws SnowflakeSQLException
-  {
+  public InputStream downloadToStream(
+      SFSession session,
+      String command,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
     int retryCount = 0;
-    do
-    {
-      try
-      {
-        S3Object file =
-            amazonClient.getObject(remoteStorageLocation, stageFilePath);
+    do {
+      try {
+        S3Object file = amazonClient.getObject(remoteStorageLocation, stageFilePath);
 
-        ObjectMetadata meta =
-            amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
+        ObjectMetadata meta = amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
 
         InputStream stream = file.getObjectContent();
 
@@ -408,59 +381,53 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
         String key = metaMap.get(AMZ_KEY);
         String iv = metaMap.get(AMZ_IV);
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() < 256)
-        {
-          if (key == null || iv == null)
-          {
-            throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                                  ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                                  "File metadata incomplete");
+        if (this.isEncrypting() && this.getEncryptionKeySize() < 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLLoggedException(
+                SqlState.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                session,
+                "File metadata incomplete");
           }
 
-          try
-          {
+          try {
 
             return EncryptionProvider.decryptStream(stream, key, iv, encMat);
 
-          }
-          catch (Exception ex)
-          {
+          } catch (Exception ex) {
             logger.error("Error in decrypting file", ex);
             throw ex;
           }
-        }
-        else
-        {
+        } else {
           return stream;
         }
-      }
-      catch (Exception ex)
-      {
-        handleS3Exception(ex, ++retryCount, "download", session, command,
-                          this);
+      } catch (Exception ex) {
+        handleS3Exception(ex, ++retryCount, "download", session, command, this);
       }
     } while (retryCount <= getMaxRetries());
 
-    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "Unexpected: download unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        session,
+        "Unexpected: download unsuccessful without exception!");
   }
 
   /**
    * Upload a file (-stream) to S3.
    *
-   * @param session                session object
-   * @param command                upload command
-   * @param parallelism            number of threads do parallel uploading
-   * @param uploadFromStream       true if upload source is stream
-   * @param remoteStorageLocation  s3 bucket name
-   * @param srcFile                source file if not uploading from a stream
-   * @param destFileName           file name on s3 after upload
-   * @param inputStream            stream used for uploading if fileBackedOutputStream is null
+   * @param session session object
+   * @param command upload command
+   * @param parallelism number of threads do parallel uploading
+   * @param uploadFromStream true if upload source is stream
+   * @param remoteStorageLocation s3 bucket name
+   * @param srcFile source file if not uploading from a stream
+   * @param destFileName file name on s3 after upload
+   * @param inputStream stream used for uploading if fileBackedOutputStream is null
    * @param fileBackedOutputStream stream used for uploading if not null
-   * @param meta                   object meta data
-   * @param stageRegion            region name where the stage persists
-   * @param presignedUrl           Not used in S3
+   * @param meta object meta data
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl Not used in S3
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   @Override
@@ -476,59 +443,54 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
       FileBackedOutputStream fileBackedOutputStream,
       StorageObjectMetadata meta,
       String stageRegion,
-      String presignedUrl) throws SnowflakeSQLException
-  {
+      String presignedUrl)
+      throws SnowflakeSQLException {
     final long originalContentLength = meta.getContentLength();
     final List<FileInputStream> toClose = new ArrayList<>();
     SFPair<InputStream, Boolean> uploadStreamInfo =
-        createUploadStream(srcFile, uploadFromStream,
-                           inputStream, fileBackedOutputStream,
-                           ((S3ObjectMetadata) meta).getS3ObjectMetadata(),
-                           originalContentLength, toClose);
+        createUploadStream(
+            srcFile,
+            uploadFromStream,
+            inputStream,
+            fileBackedOutputStream,
+            ((S3ObjectMetadata) meta).getS3ObjectMetadata(),
+            originalContentLength,
+            toClose);
 
     ObjectMetadata s3Meta;
-    if (meta instanceof S3ObjectMetadata)
-    {
+    if (meta instanceof S3ObjectMetadata) {
       s3Meta = ((S3ObjectMetadata) meta).getS3ObjectMetadata();
-    }
-    else
-    {
+    } else {
       throw new IllegalArgumentException("Unexpected metadata object type");
     }
 
     TransferManager tx = null;
     int retryCount = 0;
-    do
-    {
-      try
-      {
+    do {
+      try {
 
-        logger.debug("Creating executor service for transfer" +
-                     "manager with {} threads", parallelism);
+        logger.debug(
+            "Creating executor service for transfer" + "manager with {} threads", parallelism);
 
         // upload files to s3
-        tx = TransferManagerBuilder.standard()
-            .withS3Client(amazonClient)
-            .withExecutorFactory(new ExecutorFactory()
-            {
-              @Override
-              public ExecutorService newExecutor()
-              {
-                return SnowflakeUtil.createDefaultExecutorService(
-                    "s3-transfer-manager-uploader-", parallelism);
-              }
-            })
-            .build();
+        tx =
+            TransferManagerBuilder.standard()
+                .withS3Client(amazonClient)
+                .withExecutorFactory(
+                    new ExecutorFactory() {
+                      @Override
+                      public ExecutorService newExecutor() {
+                        return SnowflakeUtil.createDefaultExecutorService(
+                            "s3-transfer-manager-uploader-", parallelism);
+                      }
+                    })
+                .build();
 
         final Upload myUpload;
 
-        if (uploadStreamInfo.right)
-        {
-          myUpload = tx.upload(remoteStorageLocation, destFileName,
-                               uploadStreamInfo.left, s3Meta);
-        }
-        else
-        {
+        if (uploadStreamInfo.right) {
+          myUpload = tx.upload(remoteStorageLocation, destFileName, uploadStreamInfo.left, s3Meta);
+        } else {
           PutObjectRequest putRequest =
               new PutObjectRequest(remoteStorageLocation, destFileName, srcFile);
           putRequest.setMetadata(s3Meta);
@@ -539,122 +501,129 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
         myUpload.waitForCompletion();
 
         // get out
-        for (FileInputStream is : toClose)
-          IOUtils.closeQuietly(is);
+        for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
         return;
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
 
-        handleS3Exception(ex, ++retryCount, "upload",
-                          session, command, this);
-        if (uploadFromStream && fileBackedOutputStream == null)
-        {
-          throw new SnowflakeSQLException(ex, SqlState.SYSTEM_ERROR,
-                                          ErrorCode.IO_ERROR.getMessageCode(),
-                                          "Encountered exception during upload: " +
-                                          ex.getMessage() + "\nCannot retry upload from stream.");
+        handleS3Exception(ex, ++retryCount, "upload", session, command, this);
+        if (uploadFromStream && fileBackedOutputStream == null) {
+          throw new SnowflakeSQLException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              "Encountered exception during upload: "
+                  + ex.getMessage()
+                  + "\nCannot retry upload from stream.");
         }
-        uploadStreamInfo = createUploadStream(srcFile, uploadFromStream,
-                                              inputStream, fileBackedOutputStream,
-                                              s3Meta, originalContentLength, toClose);
-      }
-      finally
-      {
-        if (tx != null)
-        {
+        uploadStreamInfo =
+            createUploadStream(
+                srcFile,
+                uploadFromStream,
+                inputStream,
+                fileBackedOutputStream,
+                s3Meta,
+                originalContentLength,
+                toClose);
+      } finally {
+        if (tx != null) {
           tx.shutdownNow(false);
         }
       }
-    }
-    while (retryCount <= getMaxRetries());
+    } while (retryCount <= getMaxRetries());
 
-    for (FileInputStream is : toClose)
-      IOUtils.closeQuietly(is);
+    for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
-    throw new SnowflakeSQLLoggedException(SqlState.INTERNAL_ERROR,
-                                          ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                          "Unexpected: upload unsuccessful without exception!");
+    throw new SnowflakeSQLLoggedException(
+        SqlState.INTERNAL_ERROR,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        session,
+        "Unexpected: upload unsuccessful without exception!");
   }
 
-  private SFPair<InputStream, Boolean>
-  createUploadStream(File srcFile,
-                     boolean uploadFromStream,
-                     InputStream inputStream,
-                     FileBackedOutputStream fileBackedOutputStream,
-                     ObjectMetadata meta,
-                     long originalContentLength,
-                     List<FileInputStream> toClose)
-  throws SnowflakeSQLException
-  {
+  private SFPair<InputStream, Boolean> createUploadStream(
+      File srcFile,
+      boolean uploadFromStream,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      ObjectMetadata meta,
+      long originalContentLength,
+      List<FileInputStream> toClose)
+      throws SnowflakeSQLException {
     logger.debug(
-        "createUploadStream({}, {}, {}, {}, {}, {}, {}) " +
-        "keySize={}",
-        this, srcFile, uploadFromStream, inputStream,
-        fileBackedOutputStream, meta, toClose,
+        "createUploadStream({}, {}, {}, {}, {}, {}, {}) " + "keySize={}",
+        this,
+        srcFile,
+        uploadFromStream,
+        inputStream,
+        fileBackedOutputStream,
+        meta,
+        toClose,
         this.getEncryptionKeySize());
     final InputStream result;
     FileInputStream srcFileStream = null;
-    if (isEncrypting() && getEncryptionKeySize() < 256)
-    {
-      try
-      {
-        final InputStream uploadStream = uploadFromStream ?
-                                         (fileBackedOutputStream != null ?
-                                          fileBackedOutputStream.asByteSource().openStream() :
-                                          inputStream) :
-                                         (srcFileStream = new FileInputStream(srcFile));
+    if (isEncrypting() && getEncryptionKeySize() < 256) {
+      try {
+        final InputStream uploadStream =
+            uploadFromStream
+                ? (fileBackedOutputStream != null
+                    ? fileBackedOutputStream.asByteSource().openStream()
+                    : inputStream)
+                : (srcFileStream = new FileInputStream(srcFile));
         toClose.add(srcFileStream);
 
         // Encrypt
         S3StorageObjectMetadata s3Metadata = new S3StorageObjectMetadata(meta);
-        result = EncryptionProvider.encrypt(s3Metadata, originalContentLength,
-                                            uploadStream, this.encMat, this);
+        result =
+            EncryptionProvider.encrypt(
+                s3Metadata, originalContentLength, uploadStream, this.encMat, this);
         uploadFromStream = true;
-      }
-      catch (Exception ex)
-      {
+      } catch (Exception ex) {
         logger.error("Failed to encrypt input", ex);
-        throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                              "Failed to encrypt input", ex.getMessage());
+        throw new SnowflakeSQLLoggedException(
+            ex,
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            session,
+            "Failed to encrypt input",
+            ex.getMessage());
       }
-    }
-    else
-    {
-      try
-      {
-        result = uploadFromStream ?
-                 (fileBackedOutputStream != null ?
-                  fileBackedOutputStream.asByteSource().openStream() :
-                  inputStream) :
-                 (srcFileStream = new FileInputStream(srcFile));
+    } else {
+      try {
+        result =
+            uploadFromStream
+                ? (fileBackedOutputStream != null
+                    ? fileBackedOutputStream.asByteSource().openStream()
+                    : inputStream)
+                : (srcFileStream = new FileInputStream(srcFile));
         toClose.add(srcFileStream);
 
-      }
-      catch (FileNotFoundException ex)
-      {
+      } catch (FileNotFoundException ex) {
         logger.error("Failed to open input file", ex);
-        throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                              "Failed to open input file", ex.getMessage());
-      }
-      catch (IOException ex)
-      {
+        throw new SnowflakeSQLLoggedException(
+            ex,
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            session,
+            "Failed to open input file",
+            ex.getMessage());
+      } catch (IOException ex) {
         logger.error("Failed to open input stream", ex);
-        throw new SnowflakeSQLLoggedException(ex, SqlState.INTERNAL_ERROR,
-                                              ErrorCode.INTERNAL_ERROR.getMessageCode(), session,
-                                              "Failed to open input stream", ex.getMessage());
+        throw new SnowflakeSQLLoggedException(
+            ex,
+            SqlState.INTERNAL_ERROR,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            session,
+            "Failed to open input stream",
+            ex.getMessage());
       }
     }
     return SFPair.of(result, uploadFromStream);
   }
 
-
   @Override
-  public void handleStorageException(Exception ex, int retryCount, String operation, SFSession session, String command)
-  throws SnowflakeSQLException
-  {
+  public void handleStorageException(
+      Exception ex, int retryCount, String operation, SFSession session, String command)
+      throws SnowflakeSQLException {
     handleS3Exception(ex, retryCount, operation, session, command, this);
   }
 
@@ -665,177 +634,147 @@ public class SnowflakeS3Client implements SnowflakeStorageClient
       SFSession session,
       String command,
       SnowflakeS3Client s3Client)
-  throws SnowflakeSQLException
-  {
+      throws SnowflakeSQLException {
     // no need to retry if it is invalid key exception
-    if (ex.getCause() instanceof InvalidKeyException)
-    {
+    if (ex.getCause() instanceof InvalidKeyException) {
       // Most likely cause is that the unlimited strength policy files are not installed
       // Log the error and throw a message that explains the cause
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
-    if (ex instanceof AmazonClientException)
-    {
-      if (retryCount > s3Client.getMaxRetries())
-      {
+    if (ex instanceof AmazonClientException) {
+      if (retryCount > s3Client.getMaxRetries()) {
         String extendedRequestId = "none";
 
-        if (ex instanceof AmazonS3Exception)
-        {
+        if (ex instanceof AmazonS3Exception) {
           AmazonS3Exception ex1 = (AmazonS3Exception) ex;
           extendedRequestId = ex1.getExtendedRequestId();
         }
 
-        if (ex instanceof AmazonServiceException)
-        {
+        if (ex instanceof AmazonServiceException) {
           AmazonServiceException ex1 = (AmazonServiceException) ex;
-          throw new SnowflakeSQLLoggedException(ex1, SqlState.SYSTEM_ERROR,
-                                                ErrorCode.S3_OPERATION_ERROR.getMessageCode(),
-                                                session,
-                                                operation,
-                                                ex1.getErrorType().toString(),
-                                                ex1.getErrorCode(),
-                                                ex1.getMessage(), ex1.getRequestId(),
-                                                extendedRequestId);
+          throw new SnowflakeSQLLoggedException(
+              ex1,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.S3_OPERATION_ERROR.getMessageCode(),
+              session,
+              operation,
+              ex1.getErrorType().toString(),
+              ex1.getErrorCode(),
+              ex1.getMessage(),
+              ex1.getRequestId(),
+              extendedRequestId);
+        } else {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.AWS_CLIENT_ERROR.getMessageCode(),
+              session,
+              operation,
+              ex.getMessage());
         }
-        else
-        {
-          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                                ErrorCode.AWS_CLIENT_ERROR.getMessageCode(),
-                                                session, operation, ex.getMessage());
-        }
-      }
-      else
-      {
-        logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                     ex.getMessage(), operation, retryCount);
+      } else {
+        logger.debug(
+            "Encountered exception ({}) during {}, retry count: {}",
+            ex.getMessage(),
+            operation,
+            retryCount);
         logger.debug("Stack trace: ", ex);
 
         // exponential backoff up to a limit
         int backoffInMillis = s3Client.getRetryBackoffMin();
 
-        if (retryCount > 1)
-        {
-          backoffInMillis <<= (Math.min(retryCount - 1,
-                                        s3Client.getRetryBackoffMaxExponent()));
+        if (retryCount > 1) {
+          backoffInMillis <<= (Math.min(retryCount - 1, s3Client.getRetryBackoffMaxExponent()));
         }
 
-        try
-        {
-          logger.debug("Sleep for {} milliseconds before retry",
-                       backoffInMillis);
+        try {
+          logger.debug("Sleep for {} milliseconds before retry", backoffInMillis);
 
           Thread.sleep(backoffInMillis);
-        }
-        catch (InterruptedException ex1)
-        {
+        } catch (InterruptedException ex1) {
           // ignore
         }
 
         // If the exception indicates that the AWS token has expired,
         // we need to refresh our S3 client with the new token
-        if (ex instanceof AmazonS3Exception)
-        {
+        if (ex instanceof AmazonS3Exception) {
           AmazonS3Exception s3ex = (AmazonS3Exception) ex;
-          if (s3ex.getErrorCode().equalsIgnoreCase(EXPIRED_AWS_TOKEN_ERROR_CODE))
-          {
+          if (s3ex.getErrorCode().equalsIgnoreCase(EXPIRED_AWS_TOKEN_ERROR_CODE)) {
             SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);
           }
         }
       }
-    }
-    else
-    {
-      if (ex instanceof InterruptedException ||
-          SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException)
-      {
-        if (retryCount > s3Client.getMaxRetries())
-        {
-          throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                                ErrorCode.IO_ERROR.getMessageCode(), session,
-                                                "Encountered exception during " + operation + ": " +
-                                                ex.getMessage());
+    } else {
+      if (ex instanceof InterruptedException
+          || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
+        if (retryCount > s3Client.getMaxRetries()) {
+          throw new SnowflakeSQLLoggedException(
+              ex,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              session,
+              "Encountered exception during " + operation + ": " + ex.getMessage());
+        } else {
+          logger.debug(
+              "Encountered exception ({}) during {}, retry count: {}",
+              ex.getMessage(),
+              operation,
+              retryCount);
         }
-        else
-        {
-          logger.debug("Encountered exception ({}) during {}, retry count: {}",
-                       ex.getMessage(), operation, retryCount);
-        }
-      }
-      else
-      {
-        throw new SnowflakeSQLLoggedException(ex, SqlState.SYSTEM_ERROR,
-                                              ErrorCode.IO_ERROR.getMessageCode(), session,
-                                              "Encountered exception during " + operation + ": " +
-                                              ex.getMessage());
+      } else {
+        throw new SnowflakeSQLLoggedException(
+            ex,
+            SqlState.SYSTEM_ERROR,
+            ErrorCode.IO_ERROR.getMessageCode(),
+            session,
+            "Encountered exception during " + operation + ": " + ex.getMessage());
       }
     }
   }
 
-  /**
-   * Returns the material descriptor key
-   */
+  /** Returns the material descriptor key */
   @Override
-  public String getMatdescKey()
-  {
+  public String getMatdescKey() {
     return "x-amz-matdesc";
   }
 
-  /**
-   * Adds encryption metadata to the StorageObjectMetadata object
-   */
+  /** Adds encryption metadata to the StorageObjectMetadata object */
   @Override
-  public void addEncryptionMetadata(StorageObjectMetadata meta,
-                                    MatDesc matDesc,
-                                    byte[] ivData,
-                                    byte[] encKeK,
-                                    long contentLength)
-  {
-    meta.addUserMetadata(getMatdescKey(),
-                         matDesc.toString());
-    meta.addUserMetadata(AMZ_KEY,
-                         Base64.encodeAsString(encKeK));
-    meta.addUserMetadata(AMZ_IV,
-                         Base64.encodeAsString(ivData));
+  public void addEncryptionMetadata(
+      StorageObjectMetadata meta,
+      MatDesc matDesc,
+      byte[] ivData,
+      byte[] encKeK,
+      long contentLength) {
+    meta.addUserMetadata(getMatdescKey(), matDesc.toString());
+    meta.addUserMetadata(AMZ_KEY, Base64.encodeAsString(encKeK));
+    meta.addUserMetadata(AMZ_IV, Base64.encodeAsString(ivData));
     meta.setContentLength(contentLength);
   }
 
-  /**
-   * Adds digest metadata to the StorageObjectMetadata object
-   */
+  /** Adds digest metadata to the StorageObjectMetadata object */
   @Override
-  public void addDigestMetadata(StorageObjectMetadata meta, String digest)
-  {
+  public void addDigestMetadata(StorageObjectMetadata meta, String digest) {
     meta.addUserMetadata("sfc-digest", digest);
   }
 
-  /**
-   * Gets digest metadata to the StorageObjectMetadata object
-   */
+  /** Gets digest metadata to the StorageObjectMetadata object */
   @Override
-  public String getDigestMetadata(StorageObjectMetadata meta)
-  {
+  public String getDigestMetadata(StorageObjectMetadata meta) {
     return meta.getUserMetadata().get("sfc-digest");
   }
 
-  private static SSLConnectionSocketFactory getSSLConnectionSocketFactory()
-  {
-    if (s3ConnectionSocketFactory == null)
-    {
-      synchronized (SnowflakeS3Client.class)
-      {
-        if (s3ConnectionSocketFactory == null)
-        {
-          try
-          {
+  private static SSLConnectionSocketFactory getSSLConnectionSocketFactory() {
+    if (s3ConnectionSocketFactory == null) {
+      synchronized (SnowflakeS3Client.class) {
+        if (s3ConnectionSocketFactory == null) {
+          try {
             // trust manager is set to null, which will use default ones
             // instead of SFTrustManager (which enables ocsp checking)
-            s3ConnectionSocketFactory = new SFSSLConnectionSocketFactory(null,
-                                                                         HttpUtil.isSocksProxyDisabled());
-          }
-          catch (KeyManagementException | NoSuchAlgorithmException e)
-          {
+            s3ConnectionSocketFactory =
+                new SFSSLConnectionSocketFactory(null, HttpUtil.isSocksProxyDisabled());
+          } catch (KeyManagementException | NoSuchAlgorithmException e) {
             throw new SSLInitializationException(e.getMessage(), e);
           }
         }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -4,6 +4,7 @@
 package net.snowflake.client.jdbc.cloud.storage;
 
 import com.amazonaws.ClientConfiguration;
+import java.util.Map;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
@@ -11,35 +12,27 @@ import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 
-import java.util.Map;
-
 /**
- * Factory object for abstracting the creation of storage client objects:
- * SnowflakeStorageClient and StorageObjectMetadata
+ * Factory object for abstracting the creation of storage client objects: SnowflakeStorageClient and
+ * StorageObjectMetadata
  *
  * @author lgiakoumakis
  */
-public class StorageClientFactory
-{
+public class StorageClientFactory {
 
-  private final static SFLogger logger =
-      SFLoggerFactory.getLogger(SnowflakeS3Client.class);
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeS3Client.class);
 
   private static StorageClientFactory factory;
 
-  private StorageClientFactory()
-  {
-  }
+  private StorageClientFactory() {}
 
   /**
    * Creates or returns the single instance of the factory object
    *
    * @return the storage client instance
    */
-  public static StorageClientFactory getFactory()
-  {
-    if (factory == null)
-    {
+  public static StorageClientFactory getFactory() {
+    if (factory == null) {
       factory = new StorageClientFactory();
     }
 
@@ -49,23 +42,26 @@ public class StorageClientFactory
   /**
    * Creates a storage client based on the value of stageLocationType
    *
-   * @param stage    the stage properties
+   * @param stage the stage properties
    * @param parallel the degree of parallelism to be used by the client
-   * @param encMat   encryption material for the client
+   * @param encMat encryption material for the client
    * @return a SnowflakeStorageClient interface to the instance created
    * @throws SnowflakeSQLException if any error occurs
    */
-  public SnowflakeStorageClient createClient(StageInfo stage,
-                                             int parallel,
-                                             RemoteStoreFileEncryptionMaterial encMat, SFSession session)
-  throws SnowflakeSQLException
-  {
+  public SnowflakeStorageClient createClient(
+      StageInfo stage, int parallel, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+      throws SnowflakeSQLException {
     logger.debug("createClient client type={}", stage.getStageType().name());
 
-    switch (stage.getStageType())
-    {
+    switch (stage.getStageType()) {
       case S3:
-        return createS3Client(stage.getCredentials(), parallel, encMat, stage.getRegion(), stage.getEndPoint(), session);
+        return createS3Client(
+            stage.getCredentials(),
+            parallel,
+            encMat,
+            stage.getRegion(),
+            stage.getEndPoint(),
+            session);
 
       case AZURE:
         return createAzureClient(stage, encMat, session);
@@ -77,30 +73,30 @@ public class StorageClientFactory
         // We don't create a storage client for FS_LOCAL,
         // so we should only find ourselves here if an unsupported
         // remote storage client type is specified
-        throw new IllegalArgumentException("Unsupported storage client specified: "
-                                           + stage.getStageType().name());
+        throw new IllegalArgumentException(
+            "Unsupported storage client specified: " + stage.getStageType().name());
     }
   }
 
   /**
-   * Creates a SnowflakeS3ClientObject which encapsulates
-   * the Amazon S3 client
+   * Creates a SnowflakeS3ClientObject which encapsulates the Amazon S3 client
    *
    * @param stageCredentials Map of stage credential properties
-   * @param parallel         degree of parallelism
-   * @param encMat           encryption material for the client
-   * @param stageRegion      the region where the stage is located
-   * @param stageEndPoint    the FIPS endpoint for the stage, if needed
-   * @return the SnowflakeS3Client  instance created
+   * @param parallel degree of parallelism
+   * @param encMat encryption material for the client
+   * @param stageRegion the region where the stage is located
+   * @param stageEndPoint the FIPS endpoint for the stage, if needed
+   * @return the SnowflakeS3Client instance created
    * @throws SnowflakeSQLException failure to create the S3 client
    */
-  private SnowflakeS3Client createS3Client(Map<?, ?> stageCredentials,
-                                           int parallel,
-                                           RemoteStoreFileEncryptionMaterial encMat,
-                                           String stageRegion,
-                                           String stageEndPoint, SFSession session)
-  throws SnowflakeSQLException
-  {
+  private SnowflakeS3Client createS3Client(
+      Map<?, ?> stageCredentials,
+      int parallel,
+      RemoteStoreFileEncryptionMaterial encMat,
+      String stageRegion,
+      String stageEndPoint,
+      SFSession session)
+      throws SnowflakeSQLException {
     final int S3_TRANSFER_MAX_RETRIES = 3;
 
     logger.debug("createS3Client encryption={}", (encMat == null ? "no" : "yes"));
@@ -112,19 +108,19 @@ public class StorageClientFactory
     clientConfig.setMaxErrorRetry(S3_TRANSFER_MAX_RETRIES);
     clientConfig.setDisableSocketProxy(HttpUtil.isSocksProxyDisabled());
 
-    logger.debug("s3 client configuration: maxConnection={}, connectionTimeout={}, " +
-                 "socketTimeout={}, maxErrorRetry={}",
-                 clientConfig.getMaxConnections(),
-                 clientConfig.getConnectionTimeout(),
-                 clientConfig.getSocketTimeout(),
-                 clientConfig.getMaxErrorRetry());
+    logger.debug(
+        "s3 client configuration: maxConnection={}, connectionTimeout={}, "
+            + "socketTimeout={}, maxErrorRetry={}",
+        clientConfig.getMaxConnections(),
+        clientConfig.getConnectionTimeout(),
+        clientConfig.getSocketTimeout(),
+        clientConfig.getMaxErrorRetry());
 
-    try
-    {
-      s3Client = new SnowflakeS3Client(stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, session);
-    }
-    catch (Exception ex)
-    {
+    try {
+      s3Client =
+          new SnowflakeS3Client(
+              stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, session);
+    } catch (Exception ex) {
       logger.debug("Exception creating s3 client", ex);
       throw ex;
     }
@@ -134,16 +130,14 @@ public class StorageClientFactory
   }
 
   /**
-   * Creates a storage provider specific metadata object,
-   * accessible via the platform independent interface
+   * Creates a storage provider specific metadata object, accessible via the platform independent
+   * interface
    *
    * @param stageType determines the implementation to be created
    * @return the implementation of StorageObjectMetadata
    */
-  public StorageObjectMetadata createStorageMetadataObj(StageInfo.StageType stageType)
-  {
-    switch (stageType)
-    {
+  public StorageObjectMetadata createStorageMetadataObj(StageInfo.StageType stageType) {
+    switch (stageType) {
       case S3:
         return new S3ObjectMetadata();
 
@@ -157,36 +151,30 @@ public class StorageClientFactory
         // An unsupported remote storage client type was specified
         // We don't create/implement a storage client for FS_LOCAL,
         // so we should never end up here while running on local file system
-        throw new IllegalArgumentException("Unsupported stage type specified: "
-                                           + stageType.name());
+        throw new IllegalArgumentException("Unsupported stage type specified: " + stageType.name());
     }
   }
 
   /**
-   * Creates a SnowflakeAzureClientObject which encapsulates
-   * the Azure Storage client
+   * Creates a SnowflakeAzureClientObject which encapsulates the Azure Storage client
    *
-   * @param stage   Stage information
-   * @param encMat  encryption material for the client
+   * @param stage Stage information
+   * @param encMat encryption material for the client
    * @param session
-   * @return the SnowflakeS3Client  instance created
+   * @return the SnowflakeS3Client instance created
    */
-  private SnowflakeAzureClient createAzureClient(StageInfo stage,
-                                                 RemoteStoreFileEncryptionMaterial encMat, SFSession session)
-  throws SnowflakeSQLException
-  {
+  private SnowflakeAzureClient createAzureClient(
+      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+      throws SnowflakeSQLException {
     logger.debug("createAzureClient encryption={}", (encMat == null ? "no" : "yes"));
 
-    //TODO: implement support for encryption SNOW-33042
+    // TODO: implement support for encryption SNOW-33042
 
     SnowflakeAzureClient azureClient;
 
-    try
-    {
+    try {
       azureClient = SnowflakeAzureClient.createSnowflakeAzureClient(stage, encMat, session);
-    }
-    catch (Exception ex)
-    {
+    } catch (Exception ex) {
       logger.debug("Exception creating Azure Storage client", ex);
       throw ex;
     }
@@ -196,27 +184,22 @@ public class StorageClientFactory
   }
 
   /**
-   * Creates a SnowflakeGCSClient object which encapsulates
-   * the GCS Storage client
+   * Creates a SnowflakeGCSClient object which encapsulates the GCS Storage client
    *
-   * @param stage  Stage information
+   * @param stage Stage information
    * @param encMat encryption material for the client
-   * @return the SnowflakeGCSClient  instance created
+   * @return the SnowflakeGCSClient instance created
    */
-  private SnowflakeGCSClient createGCSClient(StageInfo stage,
-                                             RemoteStoreFileEncryptionMaterial encMat, SFSession session)
-  throws SnowflakeSQLException
-  {
+  private SnowflakeGCSClient createGCSClient(
+      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+      throws SnowflakeSQLException {
     logger.debug("createGCSClient encryption={}", (encMat == null ? "no" : "yes"));
 
     SnowflakeGCSClient gcsClient;
 
-    try
-    {
+    try {
       gcsClient = SnowflakeGCSClient.createSnowflakeGCSClient(stage, encMat, session);
-    }
-    catch (Exception ex)
-    {
+    } catch (Exception ex) {
       logger.debug("Exception creating GCS Storage client", ex);
       throw ex;
     }
@@ -225,4 +208,3 @@ public class StorageClientFactory
     return gcsClient;
   }
 }
-

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -4,7 +4,6 @@
 package net.snowflake.client.jdbc.cloud.storage;
 
 import com.amazonaws.ClientConfiguration;
-import java.util.Map;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
@@ -12,27 +11,35 @@ import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 
+import java.util.Map;
+
 /**
- * Factory object for abstracting the creation of storage client objects: SnowflakeStorageClient and
- * StorageObjectMetadata
+ * Factory object for abstracting the creation of storage client objects:
+ * SnowflakeStorageClient and StorageObjectMetadata
  *
  * @author lgiakoumakis
  */
-public class StorageClientFactory {
+public class StorageClientFactory
+{
 
-  private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeS3Client.class);
+  private final static SFLogger logger =
+      SFLoggerFactory.getLogger(SnowflakeS3Client.class);
 
   private static StorageClientFactory factory;
 
-  private StorageClientFactory() {}
+  private StorageClientFactory()
+  {
+  }
 
   /**
    * Creates or returns the single instance of the factory object
    *
    * @return the storage client instance
    */
-  public static StorageClientFactory getFactory() {
-    if (factory == null) {
+  public static StorageClientFactory getFactory()
+  {
+    if (factory == null)
+    {
       factory = new StorageClientFactory();
     }
 
@@ -42,61 +49,58 @@ public class StorageClientFactory {
   /**
    * Creates a storage client based on the value of stageLocationType
    *
-   * @param stage the stage properties
+   * @param stage    the stage properties
    * @param parallel the degree of parallelism to be used by the client
-   * @param encMat encryption material for the client
+   * @param encMat   encryption material for the client
    * @return a SnowflakeStorageClient interface to the instance created
    * @throws SnowflakeSQLException if any error occurs
    */
-  public SnowflakeStorageClient createClient(
-      StageInfo stage, int parallel, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
-      throws SnowflakeSQLException {
+  public SnowflakeStorageClient createClient(StageInfo stage,
+                                             int parallel,
+                                             RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+  throws SnowflakeSQLException
+  {
     logger.debug("createClient client type={}", stage.getStageType().name());
 
-    switch (stage.getStageType()) {
+    switch (stage.getStageType())
+    {
       case S3:
-        return createS3Client(
-            stage.getCredentials(),
-            parallel,
-            encMat,
-            stage.getRegion(),
-            stage.getEndPoint(),
-            session);
+        return createS3Client(stage.getCredentials(), parallel, encMat, stage.getRegion(), stage.getEndPoint(), session);
 
       case AZURE:
         return createAzureClient(stage, encMat, session);
 
       case GCS:
-        return createGCSClient(stage, encMat);
+        return createGCSClient(stage, encMat, session);
 
       default:
         // We don't create a storage client for FS_LOCAL,
         // so we should only find ourselves here if an unsupported
         // remote storage client type is specified
-        throw new IllegalArgumentException(
-            "Unsupported storage client specified: " + stage.getStageType().name());
+        throw new IllegalArgumentException("Unsupported storage client specified: "
+                                           + stage.getStageType().name());
     }
   }
 
   /**
-   * Creates a SnowflakeS3ClientObject which encapsulates the Amazon S3 client
+   * Creates a SnowflakeS3ClientObject which encapsulates
+   * the Amazon S3 client
    *
    * @param stageCredentials Map of stage credential properties
-   * @param parallel degree of parallelism
-   * @param encMat encryption material for the client
-   * @param stageRegion the region where the stage is located
-   * @param stageEndPoint the FIPS endpoint for the stage, if needed
-   * @return the SnowflakeS3Client instance created
+   * @param parallel         degree of parallelism
+   * @param encMat           encryption material for the client
+   * @param stageRegion      the region where the stage is located
+   * @param stageEndPoint    the FIPS endpoint for the stage, if needed
+   * @return the SnowflakeS3Client  instance created
    * @throws SnowflakeSQLException failure to create the S3 client
    */
-  private SnowflakeS3Client createS3Client(
-      Map<?, ?> stageCredentials,
-      int parallel,
-      RemoteStoreFileEncryptionMaterial encMat,
-      String stageRegion,
-      String stageEndPoint,
-      SFSession session)
-      throws SnowflakeSQLException {
+  private SnowflakeS3Client createS3Client(Map<?, ?> stageCredentials,
+                                           int parallel,
+                                           RemoteStoreFileEncryptionMaterial encMat,
+                                           String stageRegion,
+                                           String stageEndPoint, SFSession session)
+  throws SnowflakeSQLException
+  {
     final int S3_TRANSFER_MAX_RETRIES = 3;
 
     logger.debug("createS3Client encryption={}", (encMat == null ? "no" : "yes"));
@@ -108,19 +112,19 @@ public class StorageClientFactory {
     clientConfig.setMaxErrorRetry(S3_TRANSFER_MAX_RETRIES);
     clientConfig.setDisableSocketProxy(HttpUtil.isSocksProxyDisabled());
 
-    logger.debug(
-        "s3 client configuration: maxConnection={}, connectionTimeout={}, "
-            + "socketTimeout={}, maxErrorRetry={}",
-        clientConfig.getMaxConnections(),
-        clientConfig.getConnectionTimeout(),
-        clientConfig.getSocketTimeout(),
-        clientConfig.getMaxErrorRetry());
+    logger.debug("s3 client configuration: maxConnection={}, connectionTimeout={}, " +
+                 "socketTimeout={}, maxErrorRetry={}",
+                 clientConfig.getMaxConnections(),
+                 clientConfig.getConnectionTimeout(),
+                 clientConfig.getSocketTimeout(),
+                 clientConfig.getMaxErrorRetry());
 
-    try {
-      s3Client =
-          new SnowflakeS3Client(
-              stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, session);
-    } catch (Exception ex) {
+    try
+    {
+      s3Client = new SnowflakeS3Client(stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, session);
+    }
+    catch (Exception ex)
+    {
       logger.debug("Exception creating s3 client", ex);
       throw ex;
     }
@@ -130,14 +134,16 @@ public class StorageClientFactory {
   }
 
   /**
-   * Creates a storage provider specific metadata object, accessible via the platform independent
-   * interface
+   * Creates a storage provider specific metadata object,
+   * accessible via the platform independent interface
    *
    * @param stageType determines the implementation to be created
    * @return the implementation of StorageObjectMetadata
    */
-  public StorageObjectMetadata createStorageMetadataObj(StageInfo.StageType stageType) {
-    switch (stageType) {
+  public StorageObjectMetadata createStorageMetadataObj(StageInfo.StageType stageType)
+  {
+    switch (stageType)
+    {
       case S3:
         return new S3ObjectMetadata();
 
@@ -151,30 +157,36 @@ public class StorageClientFactory {
         // An unsupported remote storage client type was specified
         // We don't create/implement a storage client for FS_LOCAL,
         // so we should never end up here while running on local file system
-        throw new IllegalArgumentException("Unsupported stage type specified: " + stageType.name());
+        throw new IllegalArgumentException("Unsupported stage type specified: "
+                                           + stageType.name());
     }
   }
 
   /**
-   * Creates a SnowflakeAzureClientObject which encapsulates the Azure Storage client
+   * Creates a SnowflakeAzureClientObject which encapsulates
+   * the Azure Storage client
    *
-   * @param stage Stage information
-   * @param encMat encryption material for the client
+   * @param stage   Stage information
+   * @param encMat  encryption material for the client
    * @param session
-   * @return the SnowflakeS3Client instance created
+   * @return the SnowflakeS3Client  instance created
    */
-  private SnowflakeAzureClient createAzureClient(
-      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
-      throws SnowflakeSQLException {
+  private SnowflakeAzureClient createAzureClient(StageInfo stage,
+                                                 RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+  throws SnowflakeSQLException
+  {
     logger.debug("createAzureClient encryption={}", (encMat == null ? "no" : "yes"));
 
-    // TODO: implement support for encryption SNOW-33042
+    //TODO: implement support for encryption SNOW-33042
 
     SnowflakeAzureClient azureClient;
 
-    try {
+    try
+    {
       azureClient = SnowflakeAzureClient.createSnowflakeAzureClient(stage, encMat, session);
-    } catch (Exception ex) {
+    }
+    catch (Exception ex)
+    {
       logger.debug("Exception creating Azure Storage client", ex);
       throw ex;
     }
@@ -184,21 +196,27 @@ public class StorageClientFactory {
   }
 
   /**
-   * Creates a SnowflakeGCSClient object which encapsulates the GCS Storage client
+   * Creates a SnowflakeGCSClient object which encapsulates
+   * the GCS Storage client
    *
-   * @param stage Stage information
+   * @param stage  Stage information
    * @param encMat encryption material for the client
-   * @return the SnowflakeGCSClient instance created
+   * @return the SnowflakeGCSClient  instance created
    */
-  private SnowflakeGCSClient createGCSClient(
-      StageInfo stage, RemoteStoreFileEncryptionMaterial encMat) throws SnowflakeSQLException {
+  private SnowflakeGCSClient createGCSClient(StageInfo stage,
+                                             RemoteStoreFileEncryptionMaterial encMat, SFSession session)
+  throws SnowflakeSQLException
+  {
     logger.debug("createGCSClient encryption={}", (encMat == null ? "no" : "yes"));
 
     SnowflakeGCSClient gcsClient;
 
-    try {
-      gcsClient = SnowflakeGCSClient.createSnowflakeGCSClient(stage, encMat);
-    } catch (Exception ex) {
+    try
+    {
+      gcsClient = SnowflakeGCSClient.createSnowflakeGCSClient(stage, encMat, session);
+    }
+    catch (Exception ex)
+    {
       logger.debug("Exception creating GCS Storage client", ex);
       throw ex;
     }
@@ -207,3 +225,4 @@ public class StorageClientFactory {
     return gcsClient;
   }
 }
+


### PR DESCRIPTION
Several types of exceptions are caught by JDBC driver functions due to external errors, and then these errors are caught and re-thrown as SQLExceptions, usually classified with the SQLState of "Internal Error." These have been refactored so that the exceptions are logged with telemetry.