### PR TITLE
SNOW-164505 Refactor FEATURE_NOT_SUPPORTED exceptions into SnowflakeSQLLoggedExceptions

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -173,9 +173,10 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
       if (sortResult) {
         // we don't support sort result when there are offline chunks
         if (resultSetSerializable.getChunkFileCount() > 0) {
-          throw new SnowflakeSQLException(
+          throw new SnowflakeSQLLoggedException(
               SqlState.FEATURE_NOT_SUPPORTED,
-              ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
+              ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode(),
+              session);
         }
 
         this.currentChunkIterator =

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -156,9 +156,10 @@ public class SFResultSet extends SFJsonResultSet {
     if (sortResult) {
       // we don't support sort result when there are offline chunks
       if (chunkCount > 0) {
-        throw new SnowflakeSQLException(
+        throw new SnowflakeSQLLoggedException(
             SqlState.FEATURE_NOT_SUPPORTED,
-            ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode());
+            ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode(),
+            session);
       }
 
       sortResultSet();

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -2578,17 +2578,19 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       Optional<FileCompressionType> foundCompType =
           FileCompressionType.lookupByMimeSubType(sourceCompression.toLowerCase());
       if (!foundCompType.isPresent()) {
-        throw new SnowflakeSQLException(
+        throw new SnowflakeSQLLoggedException(
             SqlState.FEATURE_NOT_SUPPORTED,
             ErrorCode.COMPRESSION_TYPE_NOT_KNOWN.getMessageCode(),
+            session,
             sourceCompression);
       }
       userSpecifiedSourceCompression = foundCompType.get();
 
       if (!userSpecifiedSourceCompression.isSupported()) {
-        throw new SnowflakeSQLException(
+        throw new SnowflakeSQLLoggedException(
             SqlState.FEATURE_NOT_SUPPORTED,
             ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
+            session,
             sourceCompression);
       }
 
@@ -2670,9 +2672,10 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
                   srcFile);
             } else {
               // error if not supported
-              throw new SnowflakeSQLException(
+              throw new SnowflakeSQLLoggedException(
                   SqlState.FEATURE_NOT_SUPPORTED,
                   ErrorCode.COMPRESSION_TYPE_NOT_SUPPORTED.getMessageCode(),
+                  session,
                   currentFileCompressionType.name());
             }
           } else {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -163,7 +163,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     logger.debug("setBoolean(parameterIndex: {}, boolean x)", parameterIndex);
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN), String.valueOf(x));
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN, connection.getSfSession()),
+            String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -172,7 +173,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     logger.debug("setByte(parameterIndex: {}, byte x)", parameterIndex);
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.TINYINT), String.valueOf(x));
+            SnowflakeUtil.javaTypeToSFTypeString(Types.TINYINT, connection.getSfSession()),
+            String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -182,7 +184,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.SMALLINT), String.valueOf(x));
+            SnowflakeUtil.javaTypeToSFTypeString(Types.SMALLINT, connection.getSfSession()),
+            String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -192,7 +195,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.INTEGER), String.valueOf(x));
+            SnowflakeUtil.javaTypeToSFTypeString(Types.INTEGER, connection.getSfSession()),
+            String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -202,7 +206,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT), String.valueOf(x));
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT, connection.getSfSession()),
+            String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -212,7 +217,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT), String.valueOf(x));
+            SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT, connection.getSfSession()),
+            String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -222,7 +228,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE), String.valueOf(x));
+            SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE, connection.getSfSession()),
+            String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -235,7 +242,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     } else {
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL), String.valueOf(x));
+              SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL, connection.getSfSession()),
+              String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
@@ -245,7 +253,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     logger.debug("setString(parameterIndex: {}, String x)", parameterIndex);
 
     ParameterBindingDTO binding =
-        new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR), x);
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR, connection.getSfSession()), x);
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -255,7 +264,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BINARY), new SFBinary(x).toHex());
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BINARY, connection.getSfSession()),
+            new SFBinary(x).toHex());
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -268,7 +278,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     } else {
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.DATE),
+              SnowflakeUtil.javaTypeToSFTypeString(Types.DATE, connection.getSfSession()),
               String.valueOf(
                   x.getTime()
                       + TimeZone.getDefault().getOffset(x.getTime())
@@ -295,7 +305,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.TIME), String.valueOf(nanosSinceMidnight));
+              SnowflakeUtil.javaTypeToSFTypeString(Types.TIME, connection.getSfSession()),
+              String.valueOf(nanosSinceMidnight));
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
       sfStatement.setHasUnsupportedStageBind(true);
@@ -315,7 +326,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
                     .scaleByPowerOfTen(9)
                     .add(BigDecimal.valueOf(x.getNanos())));
 
-    SnowflakeType sfType = SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP);
+    SnowflakeType sfType =
+        SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP, connection.getSfSession());
 
     if (sfType == SnowflakeType.TIMESTAMP) {
       sfType = connection.getSfSession().getTimestampMappedType();
@@ -367,7 +379,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(targetSqlType), String.valueOf(x));
+              SnowflakeUtil.javaTypeToSFTypeString(targetSqlType, connection.getSfSession()),
+              String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
@@ -544,7 +557,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
                   - ResultUtil.msDiffJulianToGregorian(x));
 
       ParameterBindingDTO binding =
-          new ParameterBindingDTO(SnowflakeUtil.javaTypeToSFTypeString(Types.DATE), value);
+          new ParameterBindingDTO(
+              SnowflakeUtil.javaTypeToSFTypeString(Types.DATE, connection.getSfSession()), value);
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
   }
@@ -563,7 +577,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
     // convert the time from being in UTC to be in local time zone
     String value = null;
-    SnowflakeType sfType = SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP);
+    SnowflakeType sfType =
+        SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP, connection.getSfSession());
     if (x != null) {
       long milliSecSinceEpoch = x.getTime();
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -8,38 +8,10 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.URL;
-import java.sql.Array;
-import java.sql.Blob;
-import java.sql.Clob;
+import java.sql.*;
 import java.sql.Date;
-import java.sql.NClob;
-import java.sql.ParameterMetaData;
-import java.sql.PreparedStatement;
-import java.sql.Ref;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.RowId;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.SQLXML;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-import net.snowflake.client.core.ParameterBindingDTO;
-import net.snowflake.client.core.ResultUtil;
-import net.snowflake.client.core.SFException;
-import net.snowflake.client.core.SFStatementMetaData;
-import net.snowflake.client.core.StmtUtil;
+import java.util.*;
+import net.snowflake.client.core.*;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SFBinary;
@@ -427,9 +399,10 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     } else if (x instanceof Boolean) {
       setBoolean(parameterIndex, (Boolean) x);
     } else {
-      throw new SnowflakeSQLException(
+      throw new SnowflakeSQLLoggedException(
           SqlState.FEATURE_NOT_SUPPORTED,
           ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
+          connection.getSfSession(),
           "Object type: " + x.getClass());
     }
   }
@@ -493,9 +466,10 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
               values = typeCheckedList;
               row = Integer.toString(values.size() + 1);
             }
-            throw new SnowflakeSQLException(
+            throw new SnowflakeSQLLoggedException(
                 SqlState.FEATURE_NOT_SUPPORTED,
                 ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
+                connection.getSfSession(),
                 SnowflakeType.getJavaType(SnowflakeType.fromString(prevType)).name(),
                 SnowflakeType.getJavaType(SnowflakeType.fromString(newType)).name(),
                 binding.getKey(),

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.jdbc;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -4,15 +4,16 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.SFSession;
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SqlState;
+
 import java.math.BigDecimal;
 import java.sql.*;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SqlState;
 
 /** Type converters */
 public enum SnowflakeType {
@@ -425,7 +426,7 @@ public enum SnowflakeType {
         throw new SnowflakeSQLLoggedException(
             SqlState.FEATURE_NOT_SUPPORTED,
             ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
-            /* session = */ null,
+            session,
             javaType);
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -4,15 +4,15 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SqlState;
-
 import java.math.BigDecimal;
 import java.sql.*;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SqlState;
 
 /** Type converters */
 public enum SnowflakeType {
@@ -383,7 +383,8 @@ public enum SnowflakeType {
     }
   }
 
-  public static SnowflakeType javaTypeToSFType(int javaType) throws SnowflakeSQLException {
+  public static SnowflakeType javaTypeToSFType(int javaType, SFSession session)
+      throws SnowflakeSQLException {
 
     switch (javaType) {
       case Types.INTEGER:

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -4,18 +4,15 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SqlState;
+
 import java.math.BigDecimal;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.sql.Types;
+import java.sql.*;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SqlState;
 
 /** Type converters */
 public enum SnowflakeType {
@@ -424,9 +421,10 @@ public enum SnowflakeType {
         return ANY;
 
       default:
-        throw new SnowflakeSQLException(
+        throw new SnowflakeSQLLoggedException(
             SqlState.FEATURE_NOT_SUPPORTED,
             ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
+            /* session = */ null,
             javaType);
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -4,16 +4,15 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.SFSession;
-import net.snowflake.common.core.SFBinary;
-import net.snowflake.common.core.SqlState;
-
 import java.math.BigDecimal;
 import java.sql.*;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.common.core.SFBinary;
+import net.snowflake.common.core.SqlState;
 
 /** Type converters */
 public enum SnowflakeType {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -249,12 +249,14 @@ public class SnowflakeUtil {
         colSrcTable);
   }
 
-  static String javaTypeToSFTypeString(int javaType) throws SnowflakeSQLException {
-    return SnowflakeType.javaTypeToSFType(javaType).name();
+  static String javaTypeToSFTypeString(int javaType, SFSession session)
+      throws SnowflakeSQLException {
+    return SnowflakeType.javaTypeToSFType(javaType, session).name();
   }
 
-  static SnowflakeType javaTypeToSFType(int javaType) throws SnowflakeSQLException {
-    return SnowflakeType.javaTypeToSFType(javaType);
+  static SnowflakeType javaTypeToSFType(int javaType, SFSession session)
+      throws SnowflakeSQLException {
+    return SnowflakeType.javaTypeToSFType(javaType, session);
   }
 
   /**


### PR DESCRIPTION
There is a set of exceptions raised when a user tries to call on a JDBC driver feature or function that is not supported. We want to gather metrics on when these exceptions are raised and these features are attempted to be used. These exceptions have been refactored so that a telemetry message is sent when they are raised by changing them to SnowflakeSQLLoggedExceptions.