### PR TITLE
SNOW-164505 change SnowflakeSQLLoggedException constructor to take session parameter first

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -174,9 +174,9 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
         // we don't support sort result when there are offline chunks
         if (resultSetSerializable.getChunkFileCount() > 0) {
           throw new SnowflakeSQLLoggedException(
-              SqlState.FEATURE_NOT_SUPPORTED,
+              session,
               ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode(),
-              session);
+              SqlState.FEATURE_NOT_SUPPORTED);
         }
 
         this.currentChunkIterator =
@@ -220,9 +220,9 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
 
           if (nextChunk == null) {
             throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
                 session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                SqlState.INTERNAL_ERROR,
                 "Expect chunk but got null for chunk index " + nextChunkIndex);
           }
 
@@ -240,7 +240,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
           }
         } catch (InterruptedException ex) {
           throw new SnowflakeSQLLoggedException(
-              SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
+              session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
         }
       } else {
         // always free current chunk
@@ -253,7 +253,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
           }
         } catch (InterruptedException e) {
           throw new SnowflakeSQLLoggedException(
-              SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
+              session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
         }
       }
 
@@ -278,8 +278,8 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
       resultChunk.readArrowStream(inputStream);
     } catch (IOException e) {
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.INTERNAL_ERROR,
           session,
+          ErrorCode.INTERNAL_ERROR,
           "Failed to " + "load data in first chunk into arrow vector ex: " + e.getMessage());
     }
 
@@ -502,7 +502,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
       }
     } catch (InterruptedException ex) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
+          session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
@@ -45,10 +45,10 @@ public class SFFixedViewResultSet extends SFJsonResultSet {
 
     } catch (Exception ex) {
       throw new SnowflakeSQLLoggedException(
-          ex,
+          session,
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
+          ex,
           "Failed to describe fixed view: " + fixedView.getClass().getName());
     }
   }

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -157,9 +157,9 @@ public class SFResultSet extends SFJsonResultSet {
       // we don't support sort result when there are offline chunks
       if (chunkCount > 0) {
         throw new SnowflakeSQLLoggedException(
-            SqlState.FEATURE_NOT_SUPPORTED,
+            session,
             ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode(),
-            session);
+            SqlState.FEATURE_NOT_SUPPORTED);
       }
 
       sortResultSet();
@@ -208,9 +208,9 @@ public class SFResultSet extends SFJsonResultSet {
 
         if (nextChunk == null) {
           throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
               session,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              SqlState.INTERNAL_ERROR,
               "Expect chunk but got null for chunk index " + nextChunkIndex);
         }
 
@@ -226,7 +226,7 @@ public class SFResultSet extends SFJsonResultSet {
         return true;
       } catch (InterruptedException ex) {
         throw new SnowflakeSQLLoggedException(
-            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
+            session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
       }
     } else if (chunkCount > 0) {
       try {
@@ -235,7 +235,7 @@ public class SFResultSet extends SFJsonResultSet {
         logChunkDownloaderMetrics(metrics);
       } catch (InterruptedException ex) {
         throw new SnowflakeSQLLoggedException(
-            SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
+            session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
       }
     }
 
@@ -390,7 +390,7 @@ public class SFResultSet extends SFJsonResultSet {
       }
     } catch (InterruptedException ex) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.QUERY_CANCELED, ErrorCode.INTERRUPTED.getMessageCode(), session);
+          session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
@@ -34,8 +34,8 @@ class SFResultSetFactory {
         return new SFResultSet(resultSetSerializable, statement, sortResult);
       default:
         throw new SnowflakeSQLLoggedException(
-            ErrorCode.INTERNAL_ERROR,
             statement.getSession(),
+            ErrorCode.INTERNAL_ERROR,
             "Unsupported query result format: "
                 + resultSetSerializable.getQueryResultFormat().name());
     }

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -274,7 +274,7 @@ public class SFSession {
       jsonNode = OBJECT_MAPPER.readTree(response);
     } catch (Exception e) {
       throw new SnowflakeSQLLoggedException(
-          "No response or invalid response from GET request. Error: {}", e.getMessage(), this);
+          this, e.getMessage(), "No response or invalid response from GET request. Error: {}");
     }
     // Get response as JSON and parse it to get the query status
     // check the success field first

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -235,9 +235,9 @@ public class SFStatement {
 
     if (result == null) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           session,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "got null result");
     }
 
@@ -264,10 +264,10 @@ public class SFStatement {
         // ensure first query type matches the calling JDBC method, if exists
         if (caller == CallingMethod.EXECUTE_QUERY && !type.isGenerateResultSet()) {
           throw new SnowflakeSQLLoggedException(
-              ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET, session);
+              session, ErrorCode.QUERY_FIRST_RESULT_NOT_RESULT_SET);
         } else if (caller == CallingMethod.EXECUTE_UPDATE && type.isGenerateResultSet()) {
           throw new SnowflakeSQLLoggedException(
-              ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT, session);
+              session, ErrorCode.UPDATE_FIRST_RESULT_NOT_UPDATE_COUNT);
         }
 
         // this will update resultSet to point to the first child result before we return it
@@ -317,7 +317,7 @@ public class SFStatement {
           statement.cancel();
         } catch (SFException ex) {
           throw new SnowflakeSQLLoggedException(
-              ex, ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
+              session, ex.getSqlState(), ex.getVendorCode(), ex, ex.getParams());
         }
         return null;
       }
@@ -362,9 +362,9 @@ public class SFStatement {
 
         if (this.requestId != null) {
           throw new SnowflakeSQLLoggedException(
-              SqlState.FEATURE_NOT_SUPPORTED,
+              session,
               ErrorCode.STATEMENT_ALREADY_RUNNING_QUERY.getMessageCode(),
-              session);
+              SqlState.FEATURE_NOT_SUPPORTED);
         }
 
         this.requestId = UUID.randomUUID().toString();

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -963,9 +963,10 @@ public class SessionUtil {
         // Session is in process of getting created, so exception constructor takes in null session
         // value
         throw new SnowflakeSQLLoggedException(
-            SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
+            null,
             ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(),
-            /* session = */ null);
+            SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION
+            /* session = */ );
       }
     } catch (IOException | URISyntaxException ex) {
       handleFederatedFlowError(loginInput, ex);
@@ -1047,9 +1048,10 @@ public class SessionUtil {
         // Session is in process of getting created, so exception constructor takes in null session
         // value
         throw new SnowflakeSQLLoggedException(
-            SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
+            null,
             ErrorCode.IDP_CONNECTION_ERROR.getMessageCode(),
-            /* session = */ null);
+            SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION
+            /* session = */ );
       }
     } catch (MalformedURLException ex) {
       handleFederatedFlowError(loginInput, ex);

--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -231,9 +231,9 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
                 break;
               default:
                 throw new SnowflakeSQLLoggedException(
-                    SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
                     session,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    SqlState.INTERNAL_ERROR,
                     "Unexpected Arrow Field for ",
                     st.name());
             }
@@ -249,9 +249,9 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
               converters.add(new TwoFieldStructToTimestampLTZConverter(vector, i, context));
             } else {
               throw new SnowflakeSQLLoggedException(
-                  SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
                   session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  SqlState.INTERNAL_ERROR,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
@@ -266,9 +266,9 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
               converters.add(new TwoFieldStructToTimestampNTZConverter(vector, i, context));
             } else {
               throw new SnowflakeSQLLoggedException(
-                  SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
                   session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  SqlState.INTERNAL_ERROR,
                   "Unexpected Arrow Field for ",
                   st.name());
             }
@@ -284,9 +284,9 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
               converters.add(new ThreeFieldStructToTimestampTZConverter(vector, i, context));
             } else {
               throw new SnowflakeSQLLoggedException(
-                  SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
                   session,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  SqlState.INTERNAL_ERROR,
                   "Unexpected SnowflakeType ",
                   st.name());
             }
@@ -294,17 +294,17 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
 
           default:
             throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
                 session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                SqlState.INTERNAL_ERROR,
                 "Unexpected Arrow Field for ",
                 st.name());
         }
       } else {
         throw new SnowflakeSQLLoggedException(
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
             session,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            SqlState.INTERNAL_ERROR,
             "Unexpected Arrow Field for ",
             type.toString());
       }
@@ -454,10 +454,10 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
       batchOfVectors.add(first);
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex,
+          session,
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
+          ex,
           "Failed to merge first result chunk: " + ex.getLocalizedMessage());
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
@@ -68,9 +68,9 @@ public class JsonResultChunk extends SnowflakeResultChunk {
   public final void addRow(Object[] row) throws SnowflakeSQLException {
     if (row.length != colCount) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           this.session,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "Exception: expected " + colCount + " columns and received " + row.length);
     }
 
@@ -84,9 +84,9 @@ public class JsonResultChunk extends SnowflakeResultChunk {
           data.add((boolean) cell ? "1" : "0");
         } else {
           throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
               this.session,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              SqlState.INTERNAL_ERROR,
               "unknown data type in JSON row " + cell.getClass().toString());
         }
       }
@@ -348,9 +348,9 @@ public class JsonResultChunk extends SnowflakeResultChunk {
     @Override
     public void add(String string) throws SnowflakeSQLException {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           this.session,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "Unimplemented");
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -163,7 +163,7 @@ public class RestRequest {
         // because of closing of connection, stop retrying
         if (ex instanceof IllegalStateException) {
           throw new SnowflakeSQLLoggedException(
-              ex, ErrorCode.INVALID_STATE, /* session = */ null, ex.getMessage());
+              null, ErrorCode.INVALID_STATE, ex, /* session = */ ex.getMessage());
         }
         savedEx = ex;
         // if the request took more than 5 min (socket timeout) log an error

--- a/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
+++ b/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
@@ -42,9 +42,9 @@ public class ResultJsonParserV2 {
     this.resultChunk = resultChunk;
     if (state != State.UNINITIALIZED) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           session,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "Json parser is already used!");
     }
     state = State.NEXT_ROW;
@@ -74,9 +74,9 @@ public class ResultJsonParserV2 {
 
     if (state != State.ROW_FINISHED) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           session,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "SFResultJsonParser2Failed: Chunk is truncated!");
     }
     currentColumn = 0;
@@ -92,9 +92,9 @@ public class ResultJsonParserV2 {
   public void continueParsing(ByteBuffer in, SFSession session) throws SnowflakeSQLException {
     if (state == State.UNINITIALIZED) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           session,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "Json parser hasn't been initialized!");
     }
 
@@ -158,17 +158,17 @@ public class ResultJsonParserV2 {
     while (in.hasRemaining()) {
       if (outputPosition >= outputDataLength) {
         throw new SnowflakeSQLLoggedException(
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
             session,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            SqlState.INTERNAL_ERROR,
             "column chunk longer than expected");
       }
       switch (state) {
         case UNINITIALIZED:
           throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
               session,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              SqlState.INTERNAL_ERROR,
               "parser is in inconsistent state");
         case NEXT_ROW:
           switch (in.get()) {
@@ -185,9 +185,9 @@ public class ResultJsonParserV2 {
             default:
               {
                 throw new SnowflakeSQLLoggedException(
-                    SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
                     session,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    SqlState.INTERNAL_ERROR,
                     String.format(
                         "encountered unexpected character 0x%x between rows",
                         in.get(((Buffer) in).position() - 1)));
@@ -208,9 +208,9 @@ public class ResultJsonParserV2 {
             default:
               {
                 throw new SnowflakeSQLLoggedException(
-                    SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
                     session,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    SqlState.INTERNAL_ERROR,
                     String.format(
                         "encountered unexpected character 0x%x after array",
                         in.get(((Buffer) in).position() - 1)));
@@ -362,9 +362,9 @@ public class ResultJsonParserV2 {
               if (in.remaining() >= 9 || (lastData && in.remaining() >= 3)) {
                 if (!parseCodepoint(in)) {
                   throw new SnowflakeSQLLoggedException(
-                      SqlState.INTERNAL_ERROR,
-                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
                       session,
+                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                      SqlState.INTERNAL_ERROR,
                       "SFResultJsonParser2Failed: invalid escaped unicode character");
                 }
                 state = State.IN_STRING;
@@ -387,9 +387,9 @@ public class ResultJsonParserV2 {
             default:
               {
                 throw new SnowflakeSQLLoggedException(
-                    SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
                     session,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    SqlState.INTERNAL_ERROR,
                     "SFResultJsonParser2Failed: encountered unexpected escape character " + "0x%x",
                     in.get(((Buffer) in).position() - 1));
               }
@@ -402,9 +402,9 @@ public class ResultJsonParserV2 {
               resultChunk.nextIndex();
               if (currentColumn >= resultChunk.getColCount()) {
                 throw new SnowflakeSQLLoggedException(
-                    SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
                     session,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    SqlState.INTERNAL_ERROR,
                     "SFResultJsonParser2Failed: Too many columns!");
               }
               state = State.WAIT_FOR_VALUE;
@@ -423,9 +423,9 @@ public class ResultJsonParserV2 {
             default:
               {
                 throw new SnowflakeSQLLoggedException(
-                    SqlState.INTERNAL_ERROR,
-                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
                     session,
+                    ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                    SqlState.INTERNAL_ERROR,
                     String.format(
                         "encountered unexpected character 0x%x between columns",
                         in.get(((Buffer) in).position() - 1)));

--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -66,7 +66,7 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
       this.resultSetMetaData.setQueryType(SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), this.session, ex.getParams());
+          this.session, ex.getSqlState(), ex.getVendorCode(), ex.getCause(), ex.getParams());
     }
   }
 
@@ -91,7 +91,7 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
       this.resultSetMetaData.setQueryType(SnowflakeResultSetMetaDataV1.QueryType.ASYNC);
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), this.session, ex.getParams());
+          this.session, ex.getSqlState(), ex.getVendorCode(), ex.getCause(), ex.getParams());
     }
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -211,8 +211,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
 
     if (resultSetSerializable.getChunkFileCount() < 1) {
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.INTERNAL_ERROR,
           this.session,
+          ErrorCode.INTERNAL_ERROR,
           "Incorrect chunk count: " + resultSetSerializable.getChunkFileCount());
     }
 
@@ -245,8 +245,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
 
         default:
           throw new SnowflakeSQLLoggedException(
-              ErrorCode.INTERNAL_ERROR,
               this.session,
+              ErrorCode.INTERNAL_ERROR,
               "Invalid result format: " + queryResultFormat.name());
       }
 
@@ -284,7 +284,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
       StringWriter errors = new StringWriter();
       outOfMemoryError.printStackTrace(new PrintWriter(errors));
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session, errors);
+          this.session, ErrorCode.INTERNAL_ERROR.getMessageCode(), SqlState.INTERNAL_ERROR, errors);
     }
   }
 
@@ -486,7 +486,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
       StringWriter errors = new StringWriter();
       outOfMemoryError.printStackTrace(new PrintWriter(errors));
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode(), this.session, errors);
+          this.session, ErrorCode.INTERNAL_ERROR.getMessageCode(), SqlState.INTERNAL_ERROR, errors);
     }
 
     SnowflakeResultChunk currentChunk = this.chunks.get(nextChunkToConsume);
@@ -520,9 +520,9 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
           }
 
           throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
               this.session,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              SqlState.INTERNAL_ERROR,
               currentChunk.getDownloadError());
         }
 
@@ -784,9 +784,9 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
           response = getResultChunk(resultChunk.getUrl());
         } catch (URISyntaxException | IOException ex) {
           throw new SnowflakeSQLLoggedException(
-              SqlState.IO_ERROR,
-              ErrorCode.NETWORK_ERROR.getMessageCode(),
               session,
+              ErrorCode.NETWORK_ERROR.getMessageCode(),
+              SqlState.IO_ERROR,
               "Error encountered when request a result chunk URL: "
                   + resultChunk.getUrl()
                   + " "
@@ -821,9 +821,9 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
           logger.error("Failed to decompress data: {}", response);
 
           throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
               session,
+              ErrorCode.INTERNAL_ERROR.getMessageCode(),
+              SqlState.INTERNAL_ERROR,
               "Failed to decompress data: " + response.toString());
         }
 
@@ -896,10 +896,10 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
               ex.getLocalizedMessage());
 
           throw new SnowflakeSQLLoggedException(
-              ex,
+              session,
               SqlState.INTERNAL_ERROR,
               ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              session,
+              ex,
               "Exception: " + ex.getLocalizedMessage());
         } finally {
           // close the buffer reader will close underlying stream
@@ -911,10 +911,10 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
             inputStream.close();
           } catch (IOException ex) {
             throw new SnowflakeSQLLoggedException(
-                ex,
+                session,
                 SqlState.INTERNAL_ERROR,
                 ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
+                ex,
                 "Exception: " + ex.getLocalizedMessage());
           }
         }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -126,7 +126,7 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
       missingProperties = sfSession.checkProperties();
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), sfSession, ex.getParams());
+          sfSession, ex.getSqlState(), ex.getVendorCode(), ex.getCause(), ex.getParams());
     }
 
     isClosed = false;
@@ -157,7 +157,7 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
       showStatementParameters = sfSession.getPreparedStatementLogging();
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), sfSession, ex.getParams());
+          sfSession, ex.getSqlState(), ex.getVendorCode(), ex.getCause(), ex.getParams());
     }
 
     appendWarnings(sfSession.getSqlWarnings());
@@ -313,7 +313,7 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), sfSession, ex.getParams());
+          sfSession, ex.getSqlState(), ex.getVendorCode(), ex.getCause(), ex.getParams());
     }
   }
 
@@ -920,17 +920,17 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
     if (stageName == null) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "stage name is null");
     }
 
     if (destFileName == null) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "stage name is null");
     }
 
@@ -986,17 +986,17 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
     if (Strings.isNullOrEmpty(stageName)) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "stage name is null or empty");
     }
 
     if (Strings.isNullOrEmpty(sourceFileName)) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           sfSession,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "source file name is null or empty");
     }
 
@@ -1039,9 +1039,9 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
         return new GZIPInputStream(stream);
       } catch (IOException ex) {
         throw new SnowflakeSQLLoggedException(
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
             sfSession,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            SqlState.INTERNAL_ERROR,
             ex.getMessage());
       }
     } else {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -83,10 +83,10 @@ public class SnowflakeDriver implements Driver {
           patchVersion = Long.parseLong(versionBreakdown[2]);
         } else {
           throw new SnowflakeSQLLoggedException(
-              SqlState.INTERNAL_ERROR,
+              null,
               ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              /*session = */ null,
-              "Invalid Snowflake JDBC Version: " + implementVersion);
+              SqlState.INTERNAL_ERROR,
+              /*session = */ "Invalid Snowflake JDBC Version: " + implementVersion);
         }
       } else {
         throw new SnowflakeSQLException(

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -12,6 +14,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
 import net.snowflake.client.core.*;
 import net.snowflake.client.jdbc.cloud.storage.*;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
@@ -27,22 +42,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.DigestOutputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.GZIPOutputStream;
-
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 /**
  * Class for uploading/downloading files

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -95,7 +95,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       try {
         this.statementMetaData = sfStatement.describe(sql);
       } catch (SFException e) {
-        throw new SnowflakeSQLLoggedException(e, connection.getSfSession());
+        throw new SnowflakeSQLLoggedException(connection.getSfSession(), e);
       } catch (SnowflakeSQLException e) {
         if (!errorCodesIgnoredInDescribeMode.contains(e.getErrorCode())) {
           throw e;
@@ -413,9 +413,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       setBoolean(parameterIndex, (Boolean) x);
     } else {
       throw new SnowflakeSQLLoggedException(
-          SqlState.FEATURE_NOT_SUPPORTED,
-          ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
           connection.getSfSession(),
+          ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
+          SqlState.FEATURE_NOT_SUPPORTED,
           "Object type: " + x.getClass());
     }
   }
@@ -480,9 +480,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
               row = Integer.toString(values.size() + 1);
             }
             throw new SnowflakeSQLLoggedException(
-                SqlState.FEATURE_NOT_SUPPORTED,
-                ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
                 connection.getSfSession(),
+                ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
+                SqlState.FEATURE_NOT_SUPPORTED,
                 SnowflakeType.getJavaType(SnowflakeType.fromString(prevType)).name(),
                 SnowflakeType.getJavaType(SnowflakeType.fromString(newType)).name(),
                 binding.getKey(),

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaDataV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetMetaDataV1.java
@@ -67,7 +67,7 @@ class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResult
       return resultSetMetaData.getInternalColumnType(column);
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
+          session, ex.getSqlState(), ex.getVendorCode(), ex.getCause(), ex.getParams());
     }
   }
 
@@ -173,7 +173,7 @@ class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResult
       return resultSetMetaData.getColumnType(column);
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
+          session, ex.getSqlState(), ex.getVendorCode(), ex.getCause(), ex.getParams());
     }
   }
 
@@ -183,7 +183,7 @@ class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, SnowflakeResult
       return resultSetMetaData.getColumnTypeName(column);
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(), ex.getSqlState(), ex.getVendorCode(), session, ex.getParams());
+          session, ex.getSqlState(), ex.getVendorCode(), ex.getCause(), ex.getParams());
     }
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -815,8 +815,8 @@ public class SnowflakeResultSetSerializableV1
             (this.firstChunkStringData != null) ? mapper.readTree(this.firstChunkStringData) : null;
       } catch (IOException ex) {
         throw new SnowflakeSQLLoggedException(
-            "The JSON data is invalid. The error is: " + ex.getMessage(),
-            possibleSession.orElse(/* session = */ null));
+            possibleSession.orElse(/* session = */ null),
+            "The JSON data is invalid. The error is: " + ex.getMessage());
       }
     }
 
@@ -854,8 +854,8 @@ public class SnowflakeResultSetSerializableV1
 
     if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null) {
       throw new SnowflakeSQLLoggedException(
-          "The Result Set serializable is invalid.",
-          this.possibleSession.orElse(/* session = */ null));
+          this.possibleSession.orElse(/* session = */ null),
+          "The Result Set serializable is invalid.");
     }
 
     // In the beginning, only the first data chunk is included in the result
@@ -940,8 +940,8 @@ public class SnowflakeResultSetSerializableV1
         }
       default:
         throw new SnowflakeSQLLoggedException(
-            ErrorCode.INTERNAL_ERROR,
             this.possibleSession.orElse(/*session = */ null),
+            ErrorCode.INTERNAL_ERROR,
             "Unsupported query result format: " + getQueryResultFormat().name());
     }
 
@@ -976,8 +976,8 @@ public class SnowflakeResultSetSerializableV1
         }
       } catch (Exception ex) {
         throw new SnowflakeSQLLoggedException(
-            ErrorCode.INTERNAL_ERROR,
             possibleSession.orElse(/* session = */ null),
+            ErrorCode.INTERNAL_ERROR,
             "Fail to retrieve row count for first arrow chunk: " + ex.getCause());
       } finally {
         if (root != null) {
@@ -987,8 +987,8 @@ public class SnowflakeResultSetSerializableV1
     } else {
       // This shouldn't happen
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.INTERNAL_ERROR,
           this.possibleSession.orElse(/*session = */ null),
+          ErrorCode.INTERNAL_ERROR,
           "setFirstChunkRowCountForArrow() should only be called for Arrow.");
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -54,10 +54,10 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
       this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(),
+          sfBaseResultSet.getSession(),
           ex.getSqlState(),
           ex.getVendorCode(),
-          sfBaseResultSet.getSession(),
+          ex.getCause(),
           ex.getParams());
     }
   }
@@ -91,10 +91,10 @@ class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeRe
       this.resultSetMetaData = new SnowflakeResultSetMetaDataV1(sfBaseResultSet.getMetaData());
     } catch (SFException ex) {
       throw new SnowflakeSQLLoggedException(
-          ex.getCause(),
+          sfBaseResultSet.getSession(),
           ex.getSqlState(),
           ex.getVendorCode(),
-          sfBaseResultSet.getSession(),
+          ex.getCause(),
           ex.getParams());
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -9,7 +9,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.util.Strings;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import net.minidev.json.JSONObject;
 import net.snowflake.client.core.ObjectMapperFactory;
 import net.snowflake.client.core.SFException;
@@ -184,23 +187,23 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
   }
 
   public SnowflakeSQLLoggedException(
-      String queryId, String reason, String SQLState, int vendorCode, SFSession session) {
+      SFSession session, String reason, String SQLState, int vendorCode, String queryId) {
     super(queryId, reason, SQLState, vendorCode);
     sendTelemetryData(queryId, reason, SQLState, vendorCode, null, session);
   }
 
-  public SnowflakeSQLLoggedException(String SQLState, int vendorCode, SFSession session) {
+  public SnowflakeSQLLoggedException(SFSession session, int vendorCode, String SQLState) {
     super(SQLState, vendorCode);
     sendTelemetryData(null, null, SQLState, vendorCode, null, session);
   }
 
-  public SnowflakeSQLLoggedException(String reason, String SQLState, SFSession session) {
+  public SnowflakeSQLLoggedException(SFSession session, String SQLState, String reason) {
     super(reason, SQLState);
     sendTelemetryData(null, reason, SQLState, -1, null, session);
   }
 
   public SnowflakeSQLLoggedException(
-      String SQLState, int vendorCode, SFSession session, Object... params) {
+      SFSession session, int vendorCode, String SQLState, Object... params) {
     super(SQLState, vendorCode, params);
     String reason =
         errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
@@ -208,7 +211,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
   }
 
   public SnowflakeSQLLoggedException(
-      Throwable ex, ErrorCode errorCode, SFSession session, Object... params) {
+      SFSession session, ErrorCode errorCode, Throwable ex, Object... params) {
     super(ex, errorCode, params);
     // add telemetry
     String reason =
@@ -219,7 +222,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
   }
 
   public SnowflakeSQLLoggedException(
-      Throwable ex, String SQLState, int vendorCode, SFSession session, Object... params) {
+      SFSession session, String SQLState, int vendorCode, Throwable ex, Object... params) {
     super(ex, SQLState, vendorCode, params);
     // add telemetry
     String reason =
@@ -227,7 +230,7 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     sendTelemetryData(null, reason, SQLState, vendorCode, null, session);
   }
 
-  public SnowflakeSQLLoggedException(ErrorCode errorCode, SFSession session, Object... params) {
+  public SnowflakeSQLLoggedException(SFSession session, ErrorCode errorCode, Object... params) {
     super(errorCode, params);
     // add telemetry
     String reason =
@@ -236,13 +239,13 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     sendTelemetryData(null, reason, null, -1, errorCode, session);
   }
 
-  public SnowflakeSQLLoggedException(SFException e, SFSession session) {
+  public SnowflakeSQLLoggedException(SFSession session, SFException e) {
     super(e);
     // add telemetry
     sendTelemetryData(null, null, null, -1, null, session);
   }
 
-  public SnowflakeSQLLoggedException(String reason, SFSession session) {
+  public SnowflakeSQLLoggedException(SFSession session, String reason) {
     super(reason);
     sendTelemetryData(null, reason, null, -1, null, session);
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -194,8 +194,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     is not supported for staging commands. */
     if (StmtUtil.checkStageManageCommand(sql) != null && parameterBindings != null) {
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
           connection.getSfSession(),
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
           StmtUtil.truncateSQL(sql));
     }
 
@@ -219,8 +219,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
 
     if (updateCount == NO_UPDATES && updateQueryRequired) {
       throw new SnowflakeSQLLoggedException(
-          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
           connection.getSfSession(),
+          ErrorCode.UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API,
           StmtUtil.truncateSQL(sql));
     }
 
@@ -432,9 +432,9 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
           updateCounts.intArr[i] = (int) cnt;
         } else {
           throw new SnowflakeSQLLoggedException(
-              SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
-              ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(),
               connection.getSfSession(),
+              ErrorCode.EXECUTE_BATCH_INTEGER_OVERFLOW.getMessageCode(),
+              SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
               i);
         }
         batchQueryIDs.add(queryID);
@@ -594,7 +594,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       try {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       } catch (SFException ex) {
-        throw new SnowflakeSQLLoggedException(ex, connection.getSfSession());
+        throw new SnowflakeSQLLoggedException(connection.getSfSession(), ex);
       }
       return false;
     } else // no more results

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -423,9 +423,9 @@ public enum SnowflakeType {
 
       default:
         throw new SnowflakeSQLLoggedException(
-            SqlState.FEATURE_NOT_SUPPORTED,
-            ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
             session,
+            ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
+            SqlState.FEATURE_NOT_SUPPORTED,
             javaType);
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -219,9 +219,9 @@ public class SnowflakeUtil {
 
       default:
         throw new SnowflakeSQLLoggedException(
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
             session,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            SqlState.INTERNAL_ERROR,
             "Unknown column type: " + internalColTypeName);
     }
 
@@ -342,9 +342,9 @@ public class SnowflakeUtil {
         stype = SnowflakeType.TEXT;
       } else {
         throw new SnowflakeSQLLoggedException(
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
             session,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            SqlState.INTERNAL_ERROR,
             "Unsupported column type: " + type.getName());
       }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -298,30 +298,28 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           }
         }
 
-        if (isEncrypting()) {
-          if (!Strings.isNullOrEmpty(iv)
-              && !Strings.isNullOrEmpty(key)
-              && this.isEncrypting()
-              && this.getEncryptionKeySize() <= 256) {
-            if (key == null || iv == null) {
-              throw new SnowflakeSQLLoggedException(
-                  SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  session,
-                  "File metadata incomplete");
-            }
+        if (!Strings.isNullOrEmpty(iv)
+            && !Strings.isNullOrEmpty(key)
+            && this.isEncrypting()
+            && this.getEncryptionKeySize() <= 256) {
+          if (key == null || iv == null) {
+            throw new SnowflakeSQLLoggedException(
+                session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                SqlState.INTERNAL_ERROR,
+                "File metadata incomplete");
+          }
 
-            // Decrypt file
-            try {
-              EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-            } catch (Exception ex) {
-              logger.error("Error decrypting file", ex);
-              throw new SnowflakeSQLLoggedException(
-                  SqlState.INTERNAL_ERROR,
-                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                  session,
-                  "Cannot decrypt file");
-            }
+          // Decrypt file
+          try {
+            EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
+          } catch (Exception ex) {
+            logger.error("Error decrypting file", ex);
+            throw new SnowflakeSQLLoggedException(
+                session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                SqlState.INTERNAL_ERROR,
+                "Cannot decrypt file");
           }
         }
         return;
@@ -332,9 +330,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
     } while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
         session,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        SqlState.INTERNAL_ERROR,
         "Unexpected: download unsuccessful without exception!");
   }
 
@@ -461,9 +459,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           } catch (Exception ex) {
             logger.error("Error decrypting file", ex);
             throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
                 session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                SqlState.INTERNAL_ERROR,
                 "Cannot decrypt file");
           }
         }
@@ -474,9 +472,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
     } while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
         session,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        SqlState.INTERNAL_ERROR,
         "Unexpected: download unsuccessful without exception!");
   }
 
@@ -642,10 +640,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
 
         if (uploadFromStream && fileBackedOutputStream == null) {
           throw new SnowflakeSQLLoggedException(
-              ex,
+              session,
               SqlState.SYSTEM_ERROR,
               ErrorCode.IO_ERROR.getMessageCode(),
-              session,
+              ex,
               "Encountered exception during upload: "
                   + ex.getMessage()
                   + "\nCannot retry upload from stream.");
@@ -666,9 +664,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
     for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
     throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
         session,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        SqlState.INTERNAL_ERROR,
         "Unexpected: upload unsuccessful without exception!");
   }
 
@@ -735,15 +733,15 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           (ArgSupplier) () -> scrubPresignedUrl(this.stageInfo.getPresignedUrl()));
     } catch (URISyntaxException e) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           session,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "Unexpected: upload presigned URL invalid");
     } catch (Exception e) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           session,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          SqlState.INTERNAL_ERROR,
           "Unexpected: upload with presigned url failed");
     }
   }
@@ -802,10 +800,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
         } catch (Exception ex) {
           logger.error("Failed to encrypt input", ex);
           throw new SnowflakeSQLLoggedException(
-              ex,
+              session,
               SqlState.INTERNAL_ERROR,
               ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              session,
+              ex,
               "Failed to encrypt input",
               ex.getMessage());
         }
@@ -825,19 +823,19 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
     } catch (FileNotFoundException ex) {
       logger.error("Failed to open input file", ex);
       throw new SnowflakeSQLLoggedException(
-          ex,
+          session,
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
+          ex,
           "Failed to open input file",
           ex.getMessage());
     } catch (IOException ex) {
       logger.error("Failed to open input stream", ex);
       throw new SnowflakeSQLLoggedException(
-          ex,
+          session,
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          session,
+          ex,
           "Failed to open input stream",
           ex.getMessage());
     }
@@ -868,10 +866,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
       // If we have exceeded the max number of retries, propagate the error
       if (retryCount > getMaxRetries()) {
         throw new SnowflakeSQLLoggedException(
-            se,
+            session,
             SqlState.SYSTEM_ERROR,
             ErrorCode.GCP_SERVICE_ERROR.getMessageCode(),
-            session,
+            se,
             operation,
             se.getCode(),
             se.getMessage(),
@@ -910,10 +908,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
         if (retryCount > getMaxRetries()) {
           throw new SnowflakeSQLLoggedException(
-              ex,
+              session,
               SqlState.SYSTEM_ERROR,
               ErrorCode.IO_ERROR.getMessageCode(),
-              session,
+              ex,
               "Encountered exception during " + operation + ": " + ex.getMessage());
         } else {
           logger.debug(
@@ -924,10 +922,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
         }
       } else {
         throw new SnowflakeSQLLoggedException(
-            ex,
+            session,
             SqlState.SYSTEM_ERROR,
             ErrorCode.IO_ERROR.getMessageCode(),
-            session,
+            ex,
             "Encountered exception during " + operation + ": " + ex.getMessage());
       }
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -158,9 +158,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
                 .withClientConfiguration(clientConfig);
       } else {
         throw new SnowflakeSQLLoggedException(
-            SqlState.INTERNAL_ERROR,
-            ErrorCode.INTERNAL_ERROR.getMessageCode(),
             session,
+            ErrorCode.INTERNAL_ERROR.getMessageCode(),
+            SqlState.INTERNAL_ERROR,
             "unsupported key size",
             encryptionKeySize);
       }
@@ -321,9 +321,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         if (this.isEncrypting() && this.getEncryptionKeySize() < 256) {
           if (key == null || iv == null) {
             throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
                 session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                SqlState.INTERNAL_ERROR,
                 "File metadata incomplete");
           }
 
@@ -349,9 +349,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     } while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
         session,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        SqlState.INTERNAL_ERROR,
         "Unexpected: download unsuccessful without exception!");
   }
 
@@ -395,9 +395,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         if (this.isEncrypting() && this.getEncryptionKeySize() < 256) {
           if (key == null || iv == null) {
             throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
                 session,
+                ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                SqlState.INTERNAL_ERROR,
                 "File metadata incomplete");
           }
 
@@ -418,9 +418,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     } while (retryCount <= getMaxRetries());
 
     throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
         session,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        SqlState.INTERNAL_ERROR,
         "Unexpected: download unsuccessful without exception!");
   }
 
@@ -551,9 +551,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     for (FileInputStream is : toClose) IOUtils.closeQuietly(is);
 
     throw new SnowflakeSQLLoggedException(
-        SqlState.INTERNAL_ERROR,
-        ErrorCode.INTERNAL_ERROR.getMessageCode(),
         session,
+        ErrorCode.INTERNAL_ERROR.getMessageCode(),
+        SqlState.INTERNAL_ERROR,
         "Unexpected: upload unsuccessful without exception!");
   }
 
@@ -597,10 +597,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       } catch (Exception ex) {
         logger.error("Failed to encrypt input", ex);
         throw new SnowflakeSQLLoggedException(
-            ex,
+            session,
             SqlState.INTERNAL_ERROR,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            session,
+            ex,
             "Failed to encrypt input",
             ex.getMessage());
       }
@@ -623,19 +623,19 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       } catch (FileNotFoundException ex) {
         logger.error("Failed to open input file", ex);
         throw new SnowflakeSQLLoggedException(
-            ex,
+            session,
             SqlState.INTERNAL_ERROR,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            session,
+            ex,
             "Failed to open input file",
             ex.getMessage());
       } catch (IOException ex) {
         logger.error("Failed to open input stream", ex);
         throw new SnowflakeSQLLoggedException(
-            ex,
+            session,
             SqlState.INTERNAL_ERROR,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
-            session,
+            ex,
             "Failed to open input stream",
             ex.getMessage());
       }
@@ -677,10 +677,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         if (ex instanceof AmazonServiceException) {
           AmazonServiceException ex1 = (AmazonServiceException) ex;
           throw new SnowflakeSQLLoggedException(
-              ex1,
+              session,
               SqlState.SYSTEM_ERROR,
               ErrorCode.S3_OPERATION_ERROR.getMessageCode(),
-              session,
+              ex1,
               operation,
               ex1.getErrorType().toString(),
               ex1.getErrorCode(),
@@ -689,10 +689,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
               extendedRequestId);
         } else {
           throw new SnowflakeSQLLoggedException(
-              ex,
+              session,
               SqlState.SYSTEM_ERROR,
               ErrorCode.AWS_CLIENT_ERROR.getMessageCode(),
-              session,
+              ex,
               operation,
               ex.getMessage());
         }
@@ -733,10 +733,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
           || SnowflakeUtil.getRootCause(ex) instanceof SocketTimeoutException) {
         if (retryCount > s3Client.getMaxRetries()) {
           throw new SnowflakeSQLLoggedException(
-              ex,
+              session,
               SqlState.SYSTEM_ERROR,
               ErrorCode.IO_ERROR.getMessageCode(),
-              session,
+              ex,
               "Encountered exception during " + operation + ": " + ex.getMessage());
         } else {
           logger.debug(
@@ -747,10 +747,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         }
       } else {
         throw new SnowflakeSQLLoggedException(
-            ex,
+            session,
             SqlState.SYSTEM_ERROR,
             ErrorCode.IO_ERROR.getMessageCode(),
-            session,
+            ex,
             "Encountered exception during " + operation + ": " + ex.getMessage());
       }
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
@@ -195,10 +195,11 @@ public interface SnowflakeStorageClient {
       throws SnowflakeSQLException {
     if (!requirePresignedUrl()) {
       throw new SnowflakeSQLLoggedException(
-          SqlState.INTERNAL_ERROR,
+          null,
           ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          /*session = */ null,
-          "uploadWithPresignedUrlWithoutConnection" + " only works for pre-signed URL.");
+          SqlState.INTERNAL_ERROR,
+          /*session = */ "uploadWithPresignedUrlWithoutConnection"
+              + " only works for pre-signed URL.");
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -3,17 +3,12 @@
  */
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.ConditionalIgnoreRule.ConditionalIgnore;
-import net.snowflake.client.RunningNotOnTestaccount;
-import net.snowflake.client.RunningOnGithubAction;
-import net.snowflake.client.category.TestCategoryConnection;
-import net.snowflake.client.core.QueryStatus;
-import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
-import net.snowflake.common.core.SqlState;
-import org.apache.commons.codec.binary.Base64;
-import org.junit.*;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
+import static net.snowflake.client.core.QueryStatus.RUNNING;
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -27,13 +22,17 @@ import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import static net.snowflake.client.core.QueryStatus.RUNNING;
-import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import net.snowflake.client.ConditionalIgnoreRule.ConditionalIgnore;
+import net.snowflake.client.RunningNotOnTestaccount;
+import net.snowflake.client.RunningOnGithubAction;
+import net.snowflake.client.category.TestCategoryConnection;
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
+import net.snowflake.common.core.SqlState;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 
 /** Connection integration tests */
 @Category(TestCategoryConnection.class)

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -3,44 +3,6 @@
  */
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.core.QueryStatus.RUNNING;
-import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.SecureRandom;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLClientInfoException;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.Statement;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import net.snowflake.client.ConditionalIgnoreRule.ConditionalIgnore;
 import net.snowflake.client.RunningNotOnTestaccount;
 import net.snowflake.client.RunningOnGithubAction;
@@ -49,14 +11,29 @@ import net.snowflake.client.core.QueryStatus;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.common.core.SqlState;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.*;
+import java.sql.*;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static net.snowflake.client.core.QueryStatus.RUNNING;
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 /** Connection integration tests */
 @Category(TestCategoryConnection.class)
@@ -108,6 +85,25 @@ public class ConnectionIT extends BaseJDBCTest {
     con.close();
     assertTrue(con.isClosed());
     con.close(); // ensure no exception
+  }
+
+  @Test
+  public void testMultiStmtTransaction() throws SQLException {
+    Connection connection = getConnection();
+    Statement statement = connection.createStatement();
+    statement.execute("alter session set enable_fix_175547 = false");
+
+    statement.execute(
+        "create or replace table test_multi_txn(c1 number, c2 string)" + " as select 10, 'z'");
+
+    statement.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 4);
+    String multiStmtQuery =
+        "begin;\n"
+            + "delete from test_multi_txn;\n"
+            + "insert into test_multi_txn values (1, 'a'), (2, 'b');\n"
+            + "commit";
+
+    boolean hasResultSet = statement.execute(multiStmtQuery);
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -88,25 +88,6 @@ public class ConnectionIT extends BaseJDBCTest {
   }
 
   @Test
-  public void testMultiStmtTransaction() throws SQLException {
-    Connection connection = getConnection();
-    Statement statement = connection.createStatement();
-    statement.execute("alter session set enable_fix_175547 = false");
-
-    statement.execute(
-        "create or replace table test_multi_txn(c1 number, c2 string)" + " as select 10, 'z'");
-
-    statement.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 4);
-    String multiStmtQuery =
-        "begin;\n"
-            + "delete from test_multi_txn;\n"
-            + "insert into test_multi_txn values (1, 'a'), (2, 'b');\n"
-            + "commit";
-
-    boolean hasResultSet = statement.execute(multiStmtQuery);
-  }
-
-  @Test
   @Ignore
   public void test300ConnectionsWithSingleClientInstance() throws SQLException {
     // concurrent testing

--- a/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
@@ -204,7 +204,7 @@ public class TelemetryServiceIT extends BaseJDBCTest {
     String queryID = "01234567-1234-1234-1234-00001abcdefg";
     String reason = "This is a test exception.";
     String sqlState = SqlState.NO_DATA;
-    throw new SnowflakeSQLLoggedException(queryID, reason, sqlState, vendorCode, session);
+    throw new SnowflakeSQLLoggedException(session, reason, sqlState, vendorCode, queryID);
   }
 
   /**


### PR DESCRIPTION
Change signatures from:

`public SnowflakeSQLLoggedException(int vendorCode, String SQLState, SFSession session, Object... params)`

to 

`public SnowflakeSQLLoggedException(SFSession, int vendorCode, String SQLState, Object... params)`

This will cause compilation error if someone tries to insert a session into a SnowflakeSQLException, which will make it easier to tell the 2 types of constructors apart.