### PR TITLE
SNOW-161456 Support for unencrypted stages in JDBC

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -977,7 +977,8 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     boolean isClientSideEncrypted = true;
     if (!jsonNode.path("data").path("stageInfo").path("isClientSideEncrypted").isMissingNode()) {
-      isClientSideEncrypted = jsonNode.path("data").path("stageInfo").path("isClientSideEncrypted").asBoolean(true);
+      isClientSideEncrypted =
+          jsonNode.path("data").path("stageInfo").path("isClientSideEncrypted").asBoolean(true);
     }
 
     // endPoint and storageAccount are only available in Azure stages. Value
@@ -1058,7 +1059,13 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     stageInfo =
         StageInfo.createStageInfo(
-            stageLocationType, stageLocation, stageCredentials, stageRegion, endPoint, stgAcct, isClientSideEncrypted);
+            stageLocationType,
+            stageLocation,
+            stageCredentials,
+            stageRegion,
+            endPoint,
+            stgAcct,
+            isClientSideEncrypted);
 
     // Setup pre-signed URL into stage info if pre-signed URL is returned.
     if (stageInfo.getStageType() == StageInfo.StageType.GCS) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -975,6 +975,11 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
       stageRegion = jsonNode.path("data").path("stageInfo").path("region").asText();
     }
 
+    boolean isClientSideEncrypted = true;
+    if (!jsonNode.path("data").path("stageInfo").path("isClientSideEncrypted").isMissingNode()) {
+      isClientSideEncrypted = jsonNode.path("data").path("stageInfo").path("isClientSideEncrypted").asBoolean(true);
+    }
+
     // endPoint and storageAccount are only available in Azure stages. Value
     // will be present but null in other platforms.
     String endPoint = null;
@@ -1053,7 +1058,7 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
 
     stageInfo =
         StageInfo.createStageInfo(
-            stageLocationType, stageLocation, stageCredentials, stageRegion, endPoint, stgAcct);
+            stageLocationType, stageLocation, stageCredentials, stageRegion, endPoint, stgAcct, isClientSideEncrypted);
 
     // Setup pre-signed URL into stage info if pre-signed URL is returned.
     if (stageInfo.getStageType() == StageInfo.StageType.GCS) {

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -113,7 +113,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
         azCreds = StorageCredentialsAnonymous.ANONYMOUS;
       }
 
-      if (encMat != null) {
+      if (stage.getIsClientSideEncrypted() && encMat != null) {
         byte[] decodedKey = Base64.decode(encMat.getQueryStageMasterKey());
         encryptionKeySize = decodedKey.length * 8;
 
@@ -155,7 +155,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
   /** @return Returns true if encryption is enabled */
   @Override
   public boolean isEncrypting() {
-    return encryptionKeySize > 0;
+    return encryptionKeySize > 0 && this.stageInfo.getIsClientSideEncrypted();
   }
 
   /** @return Returns the size of the encryption key */
@@ -299,27 +299,29 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
 
         // Get the user-defined BLOB metadata
         Map<String, String> userDefinedMetadata = blob.getMetadata();
-        AbstractMap.SimpleEntry<String, String> encryptionData =
-            parseEncryptionData(userDefinedMetadata.get(AZ_ENCRYPTIONDATAPROP));
+        if (isEncrypting()) {
+          AbstractMap.SimpleEntry<String, String> encryptionData =
+                  parseEncryptionData(userDefinedMetadata.get(AZ_ENCRYPTIONDATAPROP));
 
-        String key = encryptionData.getKey();
-        String iv = encryptionData.getValue();
+          String key = encryptionData.getKey();
+          String iv = encryptionData.getValue();
 
-        if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
-          if (key == null || iv == null) {
-            throw new SnowflakeSQLLoggedException(
-                SqlState.INTERNAL_ERROR,
-                ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                session,
-                "File metadata incomplete");
-          }
+          if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
+            if (key == null || iv == null) {
+              throw new SnowflakeSQLLoggedException(
+                      SqlState.INTERNAL_ERROR,
+                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                      session,
+                      "File metadata incomplete");
+            }
 
-          // Decrypt file
-          try {
-            EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
-          } catch (Exception ex) {
-            logger.error("Error decrypting file", ex);
-            throw ex;
+            // Decrypt file
+            try {
+              EncryptionProvider.decrypt(localFile, key, iv, this.encMat);
+            } catch (Exception ex) {
+              logger.error("Error decrypting file", ex);
+              throw ex;
+            }
           }
         }
         return;

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -301,7 +301,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
         Map<String, String> userDefinedMetadata = blob.getMetadata();
         if (isEncrypting()) {
           AbstractMap.SimpleEntry<String, String> encryptionData =
-                  parseEncryptionData(userDefinedMetadata.get(AZ_ENCRYPTIONDATAPROP));
+              parseEncryptionData(userDefinedMetadata.get(AZ_ENCRYPTIONDATAPROP));
 
           String key = encryptionData.getKey();
           String iv = encryptionData.getValue();
@@ -309,10 +309,10 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
           if (this.isEncrypting() && this.getEncryptionKeySize() <= 256) {
             if (key == null || iv == null) {
               throw new SnowflakeSQLLoggedException(
-                      SqlState.INTERNAL_ERROR,
-                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                      session,
-                      "File metadata incomplete");
+                  SqlState.INTERNAL_ERROR,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  session,
+                  "File metadata incomplete");
             }
 
             // Decrypt file

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -254,10 +254,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
               if (isEncrypting()) {
                 for (Header header : response.getAllHeaders()) {
                   if (header
-                          .getName()
-                          .equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP)) {
+                      .getName()
+                      .equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP)) {
                     AbstractMap.SimpleEntry<String, String> encryptionData =
-                            parseEncryptionData(header.getValue());
+                        parseEncryptionData(header.getValue());
 
                     key = encryptionData.getKey();
                     iv = encryptionData.getValue();
@@ -290,7 +290,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           if (isEncrypting()) {
             if (userDefinedMetadata != null) {
               AbstractMap.SimpleEntry<String, String> encryptionData =
-                      parseEncryptionData(userDefinedMetadata.get(GCS_ENCRYPTIONDATAPROP));
+                  parseEncryptionData(userDefinedMetadata.get(GCS_ENCRYPTIONDATAPROP));
 
               key = encryptionData.getKey();
               iv = encryptionData.getValue();
@@ -305,10 +305,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
               && this.getEncryptionKeySize() <= 256) {
             if (key == null || iv == null) {
               throw new SnowflakeSQLLoggedException(
-                      SqlState.INTERNAL_ERROR,
-                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                      session,
-                      "File metadata incomplete");
+                  SqlState.INTERNAL_ERROR,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  session,
+                  "File metadata incomplete");
             }
 
             // Decrypt file
@@ -317,10 +317,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
             } catch (Exception ex) {
               logger.error("Error decrypting file", ex);
               throw new SnowflakeSQLLoggedException(
-                      SqlState.INTERNAL_ERROR,
-                      ErrorCode.INTERNAL_ERROR.getMessageCode(),
-                      session,
-                      "Cannot decrypt file");
+                  SqlState.INTERNAL_ERROR,
+                  ErrorCode.INTERNAL_ERROR.getMessageCode(),
+                  session,
+                  "Cannot decrypt file");
             }
           }
         }
@@ -404,10 +404,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
               if (isEncrypting()) {
                 for (Header header : response.getAllHeaders()) {
                   if (header
-                          .getName()
-                          .equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP)) {
+                      .getName()
+                      .equalsIgnoreCase(GCS_METADATA_PREFIX + GCS_ENCRYPTIONDATAPROP)) {
                     AbstractMap.SimpleEntry<String, String> encryptionData =
-                            parseEncryptionData(header.getValue());
+                        parseEncryptionData(header.getValue());
 
                     key = encryptionData.getKey();
                     iv = encryptionData.getValue();
@@ -437,7 +437,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
             // Get the user-defined BLOB metadata
             Map<String, String> userDefinedMetadata = blob.getMetadata();
             AbstractMap.SimpleEntry<String, String> encryptionData =
-                    parseEncryptionData(userDefinedMetadata.get(GCS_ENCRYPTIONDATAPROP));
+                parseEncryptionData(userDefinedMetadata.get(GCS_ENCRYPTIONDATAPROP));
 
             key = encryptionData.getKey();
             iv = encryptionData.getValue();

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -88,7 +88,13 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       throws SnowflakeSQLException {
     this.session = session;
     setupSnowflakeS3Client(
-        stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, isClientSideEncrypted, session);
+        stageCredentials,
+        clientConfig,
+        encMat,
+        stageRegion,
+        stageEndPoint,
+        isClientSideEncrypted,
+        session);
   }
 
   private void setupSnowflakeS3Client(
@@ -494,7 +500,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         final Upload myUpload;
 
         if (!this.isClientSideEncrypted) {
-          // since we're not client-side encrypting, make sure we're server-side encrypting with SSE-S3
+          // since we're not client-side encrypting, make sure we're server-side encrypting with
+          // SSE-S3
           s3Meta.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
         }
 
@@ -600,7 +607,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     } else {
       try {
         if (!isClientSideEncrypted) {
-          // since we're not client-side encrypting, make sure we're server-side encrypting with SSE-S3
+          // since we're not client-side encrypting, make sure we're server-side encrypting with
+          // SSE-S3
           meta.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
         }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
@@ -81,7 +81,8 @@ public class StageInfo implements Serializable {
       default:
         throw new IllegalArgumentException("Invalid stage type: " + locationType);
     }
-    return new StageInfo(stageType, location, credentials, region, endPoint, storageAccount, isClientSideEncrypted);
+    return new StageInfo(
+        stageType, location, credentials, region, endPoint, storageAccount, isClientSideEncrypted);
   }
 
   /*
@@ -150,7 +151,9 @@ public class StageInfo implements Serializable {
     this.presignedUrl = presignedUrl;
   }
 
-  public boolean getIsClientSideEncrypted() { return isClientSideEncrypted; }
+  public boolean getIsClientSideEncrypted() {
+    return isClientSideEncrypted;
+  }
 
   private static boolean isSpecified(String arg) {
     return !(arg == null || arg.equalsIgnoreCase(""));

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
@@ -20,6 +20,7 @@ public class StageInfo implements Serializable {
   private String endPoint; // The Azure Storage endpoint (Azure only)
   private String storageAccount; // The Azure Storage account (Azure only)
   private String presignedUrl; // GCS gives us back a presigned URL instead of a cred
+  private boolean isClientSideEncrypted; // whether to encrypt/decrypt files on the stage
 
   /*
    * Creates a StageInfo object
@@ -31,6 +32,7 @@ public class StageInfo implements Serializable {
    * @param region The geographic region where the stage is located (S3 only)
    * @param endPoint The Azure Storage end point (Azure only)
    * @param storageAccount The Azure Storage account (azure only)
+   * @param isClientSideEncrypted Whether the stage should use client-side encryption
    * @throws IllegalArgumentException one or more parameters required were missing
    */
   public static StageInfo createStageInfo(
@@ -39,7 +41,8 @@ public class StageInfo implements Serializable {
       Map<?, ?> credentials,
       String region,
       String endPoint,
-      String storageAccount)
+      String storageAccount,
+      boolean isClientSideEncrypted)
       throws IllegalArgumentException {
     StageType stageType;
     // Ensure that all the required parameters are specified
@@ -78,7 +81,7 @@ public class StageInfo implements Serializable {
       default:
         throw new IllegalArgumentException("Invalid stage type: " + locationType);
     }
-    return new StageInfo(stageType, location, credentials, region, endPoint, storageAccount);
+    return new StageInfo(stageType, location, credentials, region, endPoint, storageAccount, isClientSideEncrypted);
   }
 
   /*
@@ -92,6 +95,7 @@ public class StageInfo implements Serializable {
    * @param region The geographic region where the stage is located (S3 only)
    * @param endPoint The Azure Storage end point (Azure only)
    * @param storageAccount The Azure Storage account (azure only)
+   * @param isClientSideEncrypted Whether the stage uses client-side encryption
    */
   private StageInfo(
       StageType stageType,
@@ -99,13 +103,15 @@ public class StageInfo implements Serializable {
       Map<?, ?> credentials,
       String region,
       String endPoint,
-      String storageAccount) {
+      String storageAccount,
+      boolean isClientSideEncrypted) {
     this.stageType = stageType;
     this.location = location;
     this.credentials = credentials;
     this.region = region;
     this.endPoint = endPoint;
     this.storageAccount = storageAccount;
+    this.isClientSideEncrypted = isClientSideEncrypted;
   }
 
   public StageType getStageType() {
@@ -143,6 +149,8 @@ public class StageInfo implements Serializable {
   public void setPresignedUrl(String presignedUrl) {
     this.presignedUrl = presignedUrl;
   }
+
+  public boolean getIsClientSideEncrypted() { return isClientSideEncrypted; }
 
   private static boolean isSpecified(String arg) {
     return !(arg == null || arg.equalsIgnoreCase(""));

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -123,7 +123,13 @@ public class StorageClientFactory {
     try {
       s3Client =
           new SnowflakeS3Client(
-              stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, isClientSideEncrypted, session);
+              stageCredentials,
+              clientConfig,
+              encMat,
+              stageRegion,
+              stageEndPoint,
+              isClientSideEncrypted,
+              session);
     } catch (Exception ex) {
       logger.debug("Exception creating s3 client", ex);
       throw ex;

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -61,6 +61,7 @@ public class StorageClientFactory {
             encMat,
             stage.getRegion(),
             stage.getEndPoint(),
+            stage.getIsClientSideEncrypted(),
             session);
 
       case AZURE:
@@ -86,6 +87,8 @@ public class StorageClientFactory {
    * @param encMat encryption material for the client
    * @param stageRegion the region where the stage is located
    * @param stageEndPoint the FIPS endpoint for the stage, if needed
+   * @param isClientSideEncrypted whether client-side encryption should be used
+   * @param session the active session
    * @return the SnowflakeS3Client instance created
    * @throws SnowflakeSQLException failure to create the S3 client
    */
@@ -95,6 +98,7 @@ public class StorageClientFactory {
       RemoteStoreFileEncryptionMaterial encMat,
       String stageRegion,
       String stageEndPoint,
+      boolean isClientSideEncrypted,
       SFSession session)
       throws SnowflakeSQLException {
     final int S3_TRANSFER_MAX_RETRIES = 3;
@@ -119,7 +123,7 @@ public class StorageClientFactory {
     try {
       s3Client =
           new SnowflakeS3Client(
-              stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, session);
+              stageCredentials, clientConfig, encMat, stageRegion, stageEndPoint, isClientSideEncrypted, session);
     } catch (Exception ex) {
       logger.debug("Exception creating s3 client", ex);
       throw ex;
@@ -167,8 +171,6 @@ public class StorageClientFactory {
       StageInfo stage, RemoteStoreFileEncryptionMaterial encMat, SFSession session)
       throws SnowflakeSQLException {
     logger.debug("createAzureClient encryption={}", (encMat == null ? "no" : "yes"));
-
-    // TODO: implement support for encryption SNOW-33042
 
     SnowflakeAzureClient azureClient;
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -3312,6 +3312,67 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     }
   }
 
+  /** Tests unencrypted named stages, which don't use client-side encryption to enable data lake
+   * scenarios. Unencrypted named stages are specified with encryption=(TYPE='SNOWFLAKE_SSE').
+   * @throws Throwable
+   */
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testPutGetToUnencryptedStage() throws Throwable {
+
+    Connection connection = null;
+    Statement statement = null;
+    List<String> accounts = Arrays.asList(null, "s3testaccount", "azureaccount", "gcpaccount");
+    for (int i = 0; i < accounts.size(); i++) {
+      try {
+        connection = getConnection(accounts.get(i));
+
+        statement = connection.createStatement();
+
+        String sourceFilePath = getFullPathFileInResource(TEST_DATA_FILE);
+
+        File destFolder = tmpFolder.newFolder();
+        String destFolderCanonicalPath = destFolder.getCanonicalPath();
+        String destFolderCanonicalPathWithSeparator = destFolderCanonicalPath + File.separator;
+
+        try {
+          statement.execute("alter session set ENABLE_UNENCRYPTED_INTERNAL_STAGES=true");
+          statement.execute("CREATE OR REPLACE STAGE testPutGet_unencstage encryption=(TYPE='SNOWFLAKE_SSE')");
+
+          assertTrue(
+                  "Failed to put a file",
+                  statement.execute("PUT file://" + sourceFilePath + " @testPutGet_unencstage"));
+
+          findFile(statement, "ls @testPutGet_unencstage/");
+
+          // download the file we just uploaded to stage
+          assertTrue(
+                  "Failed to get a file",
+                  statement.execute(
+                          "GET @testPutGet_unencstage 'file://" + destFolderCanonicalPath + "' parallel=8"));
+
+          // Make sure that the downloaded file exists, it should be gzip compressed
+          File downloaded = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
+          assert (downloaded.exists());
+
+          Process p =
+                  Runtime.getRuntime()
+                          .exec("gzip -d " + destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
+          p.waitFor();
+
+          File original = new File(sourceFilePath);
+          File unzipped = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE);
+          assert (original.length() == unzipped.length());
+        } finally {
+          statement.execute("DROP STAGE IF EXISTS testPutGet_unencstage");
+          statement.close();
+        }
+      } finally {
+        closeSQLObjects(null, statement, connection);
+      }
+    }
+  }
+
   /**
    * Tests that result columns of type GEOGRAPHY appear as VARCHAR / VARIANT / BINARY to the client,
    * depending on the value of GEOGRAPHY_OUTPUT_FORMAT

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -3312,8 +3312,10 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     }
   }
 
-  /** Tests unencrypted named stages, which don't use client-side encryption to enable data lake
+  /**
+   * Tests unencrypted named stages, which don't use client-side encryption to enable data lake
    * scenarios. Unencrypted named stages are specified with encryption=(TYPE='SNOWFLAKE_SSE').
+   *
    * @throws Throwable
    */
   @Test
@@ -3337,27 +3339,30 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
         try {
           statement.execute("alter session set ENABLE_UNENCRYPTED_INTERNAL_STAGES=true");
-          statement.execute("CREATE OR REPLACE STAGE testPutGet_unencstage encryption=(TYPE='SNOWFLAKE_SSE')");
+          statement.execute(
+              "CREATE OR REPLACE STAGE testPutGet_unencstage encryption=(TYPE='SNOWFLAKE_SSE')");
 
           assertTrue(
-                  "Failed to put a file",
-                  statement.execute("PUT file://" + sourceFilePath + " @testPutGet_unencstage"));
+              "Failed to put a file",
+              statement.execute("PUT file://" + sourceFilePath + " @testPutGet_unencstage"));
 
           findFile(statement, "ls @testPutGet_unencstage/");
 
           // download the file we just uploaded to stage
           assertTrue(
-                  "Failed to get a file",
-                  statement.execute(
-                          "GET @testPutGet_unencstage 'file://" + destFolderCanonicalPath + "' parallel=8"));
+              "Failed to get a file",
+              statement.execute(
+                  "GET @testPutGet_unencstage 'file://"
+                      + destFolderCanonicalPath
+                      + "' parallel=8"));
 
           // Make sure that the downloaded file exists, it should be gzip compressed
           File downloaded = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
           assert (downloaded.exists());
 
           Process p =
-                  Runtime.getRuntime()
-                          .exec("gzip -d " + destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
+              Runtime.getRuntime()
+                  .exec("gzip -d " + destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
           p.waitFor();
 
           File original = new File(sourceFilePath);


### PR DESCRIPTION
This checkin adds support for named stages that don't use client-side encryption for data lake scenarios. You can create a stage that doesn't use client-side encryption like this:
CREATE OR REPLACE STAGE testPutGet_unencstage encryption=(TYPE='SNOWFLAKE_SSE');

Unencrypted stages allow data lake users to create stand-alone presigned URLs to objects on internal stages so that other parts of the data lake pipeline can use the object without encryption/decryption (which only Snowflake can do). This enables customers to use their objects in image processing pipelines, unstructured data scenarios, and other things that Snowflake can't do directly on these objects.

To ensure there is server-side encryption on these objects, S3 objects without CSE are uploaded with SSE-S3 encryption specified. We need to do this because our buckets don't have default SSE policies on them. Azure and GCP do this by default on all objects, so we don't need to do anything special for them to have SSE.

Test added. We will need to make the same changes to Python (SNOW-174787).