### PR TITLE
SNOW-182763 Fix displaying GEOGRAPHY type in JDBC driver 

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -33,7 +33,7 @@ public enum SnowflakeType {
   TIMESTAMP_NTZ,
   TIMESTAMP_TZ,
   VARIANT,
-  USER_DEFINED_TYPE;
+  GEOGRAPHY;
 
   public static final String DATE_OR_TIME_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
   public static final String TIMESTAMP_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.";
@@ -76,8 +76,6 @@ public enum SnowflakeType {
         return JavaDataType.JAVA_BYTES;
       case ANY:
         return JavaDataType.JAVA_OBJECT;
-      case USER_DEFINED_TYPE:
-        return JavaDataType.JAVA_STRING;
       default:
         // Those are not supported, but no reason to panic
         return JavaDataType.JAVA_STRING;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -32,7 +32,8 @@ public enum SnowflakeType {
   TIMESTAMP_LTZ,
   TIMESTAMP_NTZ,
   TIMESTAMP_TZ,
-  VARIANT;
+  VARIANT,
+  USER_DEFINED_TYPE;
 
   public static final String DATE_OR_TIME_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
   public static final String TIMESTAMP_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.";
@@ -75,6 +76,8 @@ public enum SnowflakeType {
         return JavaDataType.JAVA_BYTES;
       case ANY:
         return JavaDataType.JAVA_OBJECT;
+      case USER_DEFINED_TYPE:
+        return JavaDataType.JAVA_STRING;
       default:
         // Those are not supported, but no reason to panic
         return JavaDataType.JAVA_STRING;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -243,8 +243,7 @@ public class SnowflakeUtil {
     }
 
     JsonNode extColTypeNameNode = colNode.path("extTypeName");
-    if (!extColTypeNameNode.isMissingNode())
-    {
+    if (!extColTypeNameNode.isMissingNode()) {
       extColTypeName = extColTypeNameNode.asText();
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -217,13 +217,20 @@ public class SnowflakeUtil {
         extColTypeName = "BINARY";
         break;
 
-      case USER_DEFINED_TYPE:
+      case GEOGRAPHY:
         colType = Types.VARCHAR;
-        JsonNode extColTypeNameNode = colNode.path("gludt");
-        if (!extColTypeNameNode.isMissingNode()) {
-          extColTypeName = extColTypeNameNode.asText();
-        } else {
-          extColTypeName = "USER_DEFINED_TYPE";
+        extColTypeName = "GEOGRAPHY";
+        JsonNode udtOutputType = colNode.path("outputType");
+        if (!udtOutputType.isMissingNode()) {
+          SnowflakeType outputType = SnowflakeType.fromString(udtOutputType.asText());
+          switch (outputType) {
+            case OBJECT:
+            case TEXT:
+              colType = Types.VARCHAR;
+              break;
+            case BINARY:
+              colType = Types.BINARY;
+          }
         }
         break;
 
@@ -233,6 +240,12 @@ public class SnowflakeUtil {
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
             SqlState.INTERNAL_ERROR,
             "Unknown column type: " + internalColTypeName);
+    }
+
+    JsonNode extColTypeNameNode = colNode.path("extTypeName");
+    if (!extColTypeNameNode.isMissingNode())
+    {
+      extColTypeName = extColTypeNameNode.asText();
     }
 
     String colSrcDatabase = colNode.path("database").asText();

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -217,17 +217,22 @@ public class SnowflakeUtil {
         extColTypeName = "BINARY";
         break;
 
+      case USER_DEFINED_TYPE:
+        colType = Types.VARCHAR;
+        JsonNode extColTypeNameNode = colNode.path("gludt");
+        if (!extColTypeNameNode.isMissingNode()) {
+          extColTypeName = extColTypeNameNode.asText();
+        } else {
+          extColTypeName = "USER_DEFINED_TYPE";
+        }
+        break;
+
       default:
         throw new SnowflakeSQLLoggedException(
             session,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
             SqlState.INTERNAL_ERROR,
             "Unknown column type: " + internalColTypeName);
-    }
-
-    JsonNode extColTypeNameNode = colNode.path("extTypeName");
-    if (!extColTypeNameNode.isMissingNode()) {
-      extColTypeName = extColTypeNameNode.asText();
     }
 
     String colSrcDatabase = colNode.path("database").asText();

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -2878,7 +2878,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
       statement = connection.createStatement();
 
       String sql =
-          "SELECT random()||random(), randstr(1000, random()) FROM table(generator(rowcount => 10000))";
+          "SELECT random()||random(), randstr(1000, random()) FROM table(generator(rowcount =>"
+              + " 10000))";
       ResultSet result = statement.executeQuery(sql);
 
       int cnt = 0;
@@ -2944,7 +2945,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
       preparedStatement =
           snowflakeConnection.prepareStatement(
-              "select bv:\"1\":\"value\"::string, bv:\"2\":\"value\"::string from (select parse_json(system$get_bind_values(?)) bv)");
+              "select bv:\"1\":\"value\"::string, bv:\"2\":\"value\"::string from (select"
+                  + " parse_json(system$get_bind_values(?)) bv)");
       preparedStatement.setString(1, queryId);
       resultSet = preparedStatement.executeQuery();
       resultSet.next();
@@ -3420,11 +3422,11 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
   }
 
   private void testGeoMetadataSingle(
-          Connection connection,
-          Statement regularStatement,
-          String outputFormat,
-          int expectedColumnType)
-          throws Throwable {
+      Connection connection,
+      Statement regularStatement,
+      String outputFormat,
+      int expectedColumnType)
+      throws Throwable {
     ResultSet resultSet = null;
 
     try {
@@ -3745,7 +3747,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
       preparedStatement =
           connection.prepareStatement(
-              "select 3 where to_timestamp_ltz(?, 3) = '1970-01-01 00:00:12.345 +000'::timestamp_ltz");
+              "select 3 where to_timestamp_ltz(?, 3) = '1970-01-01 00:00:12.345"
+                  + " +000'::timestamp_ltz");
 
       // First test, normal usage.
       preparedStatement.setInt(1, 12345);


### PR DESCRIPTION
Description
When we parse the snowflake type, we got an exception because we never declared GEOGRAPHY as a type in the enum. Might need to add USER_DEFINED_TYPE later on if we allow users to create their own udts.

See https://github.com/snowflakedb/snowflake/pull/11930 for GS changes to `show columns`

Testing
Added test