### PR TITLE
SNOW-186894 Ignore all PUT tests until GCP issue is solved

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
@@ -30,6 +30,7 @@ import net.snowflake.common.core.SFBinary;
 import org.apache.arrow.vector.Float8Vector;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -886,6 +887,7 @@ public class ResultSetIT extends BaseJDBCTest {
     assertFalse(resultSet.next());
   }
 
+  @Ignore
   @Test
   public void testReleaseDownloaderCurrentMemoryUsage() throws SQLException {
     Connection connection = getConnection();

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -5,42 +5,16 @@ package net.snowflake.client.jdbc;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.*;
 import java.math.BigDecimal;
 import java.nio.channels.FileChannel;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.DriverPropertyInfo;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.sql.Types;
+import java.sql.*;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Properties;
-import java.util.TimeZone;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -57,11 +31,7 @@ import net.snowflake.client.core.SFStatement;
 import net.snowflake.common.core.SqlState;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
@@ -824,6 +794,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     }
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPutWithWildcardGCP() throws Throwable {
@@ -902,6 +873,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     fIn.close();
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPutGetLargeFileGCP() throws Throwable {
@@ -979,6 +951,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     }
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPutOverwrite() throws Throwable {
@@ -1052,6 +1025,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     }
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPutOverwriteFalseNoDigest() throws Throwable {
@@ -1126,6 +1100,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     }
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPut() throws Throwable {
@@ -3258,6 +3233,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     }
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPutGet() throws Throwable {
@@ -3320,6 +3296,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
    *
    * @throws Throwable
    */
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPutGetToUnencryptedStage() throws Throwable {
@@ -3566,6 +3543,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
   }
 
   /** Test API for Spark connector for FileTransferMetadata */
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testGCPFileTransferMetadataWithOneFile() throws Throwable {
@@ -3649,6 +3627,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
   }
 
   /** Negative test for FileTransferMetadata. It is only supported for GCP. */
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testGCPFileTransferMetadataNegativeOnlySupportGCP() throws Throwable {
@@ -3689,6 +3668,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
   }
 
   /** Negative test for FileTransferMetadata. It is only supported for PUT. */
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testGCPFileTransferMetadataNetativeOnlySupportPut() throws Throwable {

--- a/src/test/java/net/snowflake/client/jdbc/StatementIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/StatementIT.java
@@ -7,22 +7,11 @@ import static net.snowflake.client.jdbc.ErrorCode.ROW_DOES_NOT_EXIST;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.net.URL;
-import java.sql.BatchUpdateException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.Arrays;
 import java.util.List;
 import net.snowflake.client.AbstractDriverIT;
@@ -350,6 +339,7 @@ public class StatementIT extends BaseJDBCTest {
     connection.close();
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testCopyAndUpload() throws Exception {
@@ -428,6 +418,7 @@ public class StatementIT extends BaseJDBCTest {
     connection.close();
   }
 
+  @Ignore
   @Test
   public void testExecuteBatch() throws Exception {
     Connection connection = getConnection();


### PR DESCRIPTION
We are having an issue where PUT statements are returning a 400 Bad Response and all tests that test whether a file is uploaded with PUT are now failing. The BPTP team has requested that we disable the failing tests temporarily until we can find the GCP issue. A ticket has been opened with GCS. This relates to SNOW-186503. See Slack exchange https://snowflake.slack.com/archives/CUND9L30C/p1598288860026900