### PR TITLE
SNOW-180954 make jna lib optional dep

### DIFF
--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -294,11 +294,13 @@
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
       <version>${jna.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
       <version>${jna.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/FIPS/public_pom.xml
+++ b/FIPS/public_pom.xml
@@ -31,6 +31,10 @@
       <url>http://github.com/snowflakedb/snowflake-jdbc/tree/master</url>
     </scm>
 
+    <properties>
+      <jna.version>5.5.0</jna.version>
+    </properties>
+
     <dependencies>
       <dependency>
         <groupId>org.bouncycastle</groupId>
@@ -43,6 +47,18 @@
         <artifactId>bcpkix-fips</artifactId>
         <version>1.0.3</version>
         <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>${jna.version}</version>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>${jna.version}</version>
+        <optional>true</optional>
       </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -311,17 +311,17 @@
       <artifactId>google-http-client</artifactId>
       <version>${google.http.client.version}</version>
     </dependency>
-    <!-- http://mvnrepository.com/artifact/net.java.dev.jna/jna -->
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
       <version>${jna.version}</version>
+      <scope>provided</scope>
     </dependency>
-    <!-- http://mvnrepository.com/artifact/net.java.dev.jna/jna-platform -->
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
       <version>${jna.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/public_pom.xml
+++ b/public_pom.xml
@@ -31,4 +31,22 @@
       <url>http://github.com/snowflakedb/snowflake-jdbc/tree/master</url>
     </scm>
 
+    <properties>
+      <jna.version>5.5.0</jna.version>
+    </properties>
+
+    <dependencies>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>${jna.version}</version>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>${jna.version}</version>
+        <optional>true</optional>
+      </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -168,6 +168,22 @@ public class CredentialManager {
 
   /** Delete the id token cache */
   void deleteIdTokenCache(String host, String user) {
+    deleteTemporaryCredential(host, user, ID_TOKEN);
+  }
+
+  /** Delete the mfa token cache */
+  void deleteMfaTokenCache(String host, String user) {
+    deleteTemporaryCredential(host, user, MFA_TOKEN);
+  }
+
+  /**
+   * Delete the temporary credential
+   *
+   * @param host host name
+   * @param user user name
+   * @param credType type of the credential
+   */
+  synchronized void deleteTemporaryCredential(String host, String user, String credType) {
     if (secureStorageManager == null) {
       logger.info(
           "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
@@ -175,15 +191,10 @@ public class CredentialManager {
     }
 
     try {
-      secureStorageManager.deleteCredential(host, user, ID_TOKEN);
+      secureStorageManager.deleteCredential(host, user, credType);
     } catch (NoClassDefFoundError error) {
       logger.info(
           "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
     }
-  }
-
-  /** Delete the mfa token cache */
-  void deleteMfaTokenCache(String host, String user) {
-    secureStorageManager.deleteCredential(host, user, MFA_TOKEN);
   }
 }

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -21,14 +21,19 @@ public class CredentialManager {
   }
 
   private void initSecureStorageManager() {
-    if (Constants.getOS() == Constants.OS.MAC) {
-      secureStorageManager = SecureStorageAppleManager.builder();
-    } else if (Constants.getOS() == Constants.OS.WINDOWS) {
-      secureStorageManager = SecureStorageWindowsManager.builder();
-    } else if (Constants.getOS() == Constants.OS.LINUX) {
-      secureStorageManager = SecureStorageLinuxManager.getInstance();
-    } else {
-      logger.error("Unsupported Operating System. Expected: OSX, Windows, Linux");
+    try {
+      if (Constants.getOS() == Constants.OS.MAC) {
+        secureStorageManager = SecureStorageAppleManager.builder();
+      } else if (Constants.getOS() == Constants.OS.WINDOWS) {
+        secureStorageManager = SecureStorageWindowsManager.builder();
+      } else if (Constants.getOS() == Constants.OS.LINUX) {
+        secureStorageManager = SecureStorageLinuxManager.getInstance();
+      } else {
+        logger.error("Unsupported Operating System. Expected: OSX, Windows, Linux");
+      }
+    } catch (NoClassDefFoundError error) {
+      logger.info(
+          "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
     }
   }
 
@@ -80,9 +85,23 @@ public class CredentialManager {
    */
   synchronized void fillCachedCredential(SFLoginInput loginInput, String credType)
       throws SFException {
-    String cred =
-        secureStorageManager.getCredential(
-            loginInput.getHostFromServerUrl(), loginInput.getUserName(), credType);
+    if (secureStorageManager == null) {
+      logger.info(
+          "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
+      return;
+    }
+
+    String cred = null;
+    try {
+      cred =
+          secureStorageManager.getCredential(
+              loginInput.getHostFromServerUrl(), loginInput.getUserName(), credType);
+    } catch (NoClassDefFoundError error) {
+      logger.info(
+          "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
+      return;
+    }
+
     if (cred == null) {
       logger.debug("retrieved %s is null", credType);
     }
@@ -132,13 +151,35 @@ public class CredentialManager {
       return; // no credential
     }
 
-    secureStorageManager.setCredential(
-        loginInput.getHostFromServerUrl(), loginInput.getUserName(), credType, cred);
+    if (secureStorageManager == null) {
+      logger.info(
+          "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
+      return;
+    }
+
+    try {
+      secureStorageManager.setCredential(
+          loginInput.getHostFromServerUrl(), loginInput.getUserName(), credType, cred);
+    } catch (NoClassDefFoundError error) {
+      logger.info(
+          "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
+    }
   }
 
   /** Delete the id token cache */
   void deleteIdTokenCache(String host, String user) {
-    secureStorageManager.deleteCredential(host, user, ID_TOKEN);
+    if (secureStorageManager == null) {
+      logger.info(
+          "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
+      return;
+    }
+
+    try {
+      secureStorageManager.deleteCredential(host, user, ID_TOKEN);
+    } catch (NoClassDefFoundError error) {
+      logger.info(
+          "JNA jar files are needed for Secure Local Storage service. Please follow the Snowflake JDBC instruction for Secure Local Storage feature. Fall back to normal process.");
+    }
   }
 
   /** Delete the mfa token cache */

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -720,7 +720,8 @@ public class SessionUtil {
             sessionId,
             commonParams);
 
-    if (consentCacheIdToken) {
+    if (consentCacheIdToken
+        && asBoolean(loginInput.getSessionParameters().get(CLIENT_STORE_TEMPORARY_CREDENTIAL))) {
       CredentialManager.getInstance().writeIdToken(loginInput, ret);
     }
 


### PR DESCRIPTION
[Latest Update]
Now we will catch the `NoClassDefFoundError` and use `logger.info` to send out the msg. If the error is catched, then we fall back to normal process.


[Original description]
Make JNA as an optional dependency.

Question, how do we want to deal with FIPS version?

