### PR TITLE
SNOW-175899: Username pwd mfa token cache

### DIFF
--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>net.snowflake</groupId>
       <artifactId>snowflake-common</artifactId>
-      <version>3.1.44</version>
+      <version>5.1.0</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <dependency>
       <groupId>net.snowflake</groupId>
       <artifactId>snowflake-common</artifactId>
-      <version>4.0.1</version>
+      <version>5.0.1</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <dependency>
       <groupId>net.snowflake</groupId>
       <artifactId>snowflake-common</artifactId>
-      <version>5.0.1</version>
+      <version>5.1.0</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -100,7 +100,6 @@ public class CredentialManager {
 
   synchronized void writeMfaToken(SFLoginInput loginInput, SFLoginOutput loginOutput)
       throws SFException {
-    // WUFAN TODO:
     String mfaToken = loginOutput.getMfaToken();
     if (Strings.isNullOrEmpty(mfaToken)) {
       logger.debug("no username_pwd_mfa token is given.");

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -5,11 +5,12 @@
 package net.snowflake.client.core;
 
 import com.google.common.base.Strings;
-import java.net.MalformedURLException;
-import java.net.URL;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 public class CredentialManager {
   private static final SFLogger logger = SFLoggerFactory.getLogger(CredentialManager.class);
@@ -101,7 +102,7 @@ public class CredentialManager {
       }
 
     secureStorageManager.setCredential(
-        extractHostFromServerUtl(loginInput.getServerUrl()), loginInput.getUserName(), MFA_TOKEN, mfaToken);
+        extractHostFromServerUrl(loginInput.getServerUrl()), loginInput.getUserName(), MFA_TOKEN, mfaToken);
   }
 
   /** Delete the id token cache */

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -132,7 +132,7 @@ public class CredentialManager {
   }
 
   /** Delete the mfa token cache */
-  void deleteMfaTokenCache(String host, String user) {
+  public void deleteMfaTokenCache(String host, String user) {
     secureStorageManager.deleteCredential(host, user, MFA_TOKEN);
   }
 

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -5,12 +5,11 @@
 package net.snowflake.client.core;
 
 import com.google.common.base.Strings;
+import java.net.MalformedURLException;
+import java.net.URL;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
-
-import java.net.MalformedURLException;
-import java.net.URL;
 
 public class CredentialManager {
   private static final SFLogger logger = SFLoggerFactory.getLogger(CredentialManager.class);
@@ -48,7 +47,9 @@ public class CredentialManager {
   synchronized void fillCachedIdToken(SFLoginInput loginInput) throws SFException {
     String idToken =
         secureStorageManager.getCredential(
-            extractHostFromServerUrl(loginInput.getServerUrl()), loginInput.getUserName(), ID_TOKEN);
+            extractHostFromServerUrl(loginInput.getServerUrl()),
+            loginInput.getUserName(),
+            ID_TOKEN);
 
     if (idToken == null) {
       logger.debug("retrieved idToken is null");
@@ -65,7 +66,9 @@ public class CredentialManager {
   synchronized void fillCachedMfaToken(SFLoginInput loginInput) throws SFException {
     String mfaToken =
         secureStorageManager.getCredential(
-            extractHostFromServerUrl(loginInput.getServerUrl()), loginInput.getUserName(), MFA_TOKEN);
+            extractHostFromServerUrl(loginInput.getServerUrl()),
+            loginInput.getUserName(),
+            MFA_TOKEN);
 
     if (mfaToken == null) {
       logger.debug("retrieved mfaToken is null");
@@ -89,20 +92,26 @@ public class CredentialManager {
     }
 
     secureStorageManager.setCredential(
-        extractHostFromServerUrl(loginInput.getServerUrl()), loginInput.getUserName(), ID_TOKEN, idToken);
+        extractHostFromServerUrl(loginInput.getServerUrl()),
+        loginInput.getUserName(),
+        ID_TOKEN,
+        idToken);
   }
 
   synchronized void writeMfaToken(SFLoginInput loginInput, SFLoginOutput loginOutput)
       throws SFException {
-      // WUFAN TODO:
-      String mfaToken = loginOutput.getMfaToken();
-      if (Strings.isNullOrEmpty(mfaToken)) {
-        logger.debug("no username_pwd_mfa token is given.");
-        return; // no mfa token
-      }
+    // WUFAN TODO:
+    String mfaToken = loginOutput.getMfaToken();
+    if (Strings.isNullOrEmpty(mfaToken)) {
+      logger.debug("no username_pwd_mfa token is given.");
+      return; // no mfa token
+    }
 
     secureStorageManager.setCredential(
-        extractHostFromServerUrl(loginInput.getServerUrl()), loginInput.getUserName(), MFA_TOKEN, mfaToken);
+        extractHostFromServerUrl(loginInput.getServerUrl()),
+        loginInput.getUserName(),
+        MFA_TOKEN,
+        mfaToken);
   }
 
   /** Delete the id token cache */

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -5,9 +5,6 @@
 package net.snowflake.client.core;
 
 import com.google.common.base.Strings;
-import java.net.MalformedURLException;
-import java.net.URL;
-import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
@@ -67,9 +64,7 @@ public class CredentialManager {
       throws SFException {
     String cred =
         secureStorageManager.getCredential(
-            extractHostFromServerUrl(loginInput.getServerUrl()),
-            loginInput.getUserName(),
-            credType);
+            loginInput.getHostFromServerUrl(), loginInput.getUserName(), credType);
     if (cred == null) {
       logger.debug("retrieved %s is null", credType);
     }
@@ -120,10 +115,7 @@ public class CredentialManager {
     }
 
     secureStorageManager.setCredential(
-        extractHostFromServerUrl(loginInput.getServerUrl()),
-        loginInput.getUserName(),
-        credType,
-        cred);
+        loginInput.getHostFromServerUrl(), loginInput.getUserName(), credType, cred);
   }
 
   /** Delete the id token cache */
@@ -132,22 +124,7 @@ public class CredentialManager {
   }
 
   /** Delete the mfa token cache */
-  public void deleteMfaTokenCache(String host, String user) {
+  void deleteMfaTokenCache(String host, String user) {
     secureStorageManager.deleteCredential(host, user, MFA_TOKEN);
-  }
-
-  /**
-   * Used to extract host name from a well formated internal serverUrl, e.g., serverUrl in
-   * SFLoginInput.
-   */
-  private String extractHostFromServerUrl(String serverUrl) throws SFException {
-    URL url = null;
-    try {
-      url = new URL(serverUrl);
-    } catch (MalformedURLException e) {
-      logger.error("Invalid serverUrl for retrieving host name");
-      throw new SFException(ErrorCode.INTERNAL_ERROR, "Invalid serverUrl for retrieving host name");
-    }
-    return url.getHost();
   }
 }

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -25,7 +25,7 @@ public class CredentialManager {
     } else if (Constants.getOS() == Constants.OS.WINDOWS) {
       secureStorageManager = SecureStorageWindowsManager.builder();
     } else if (Constants.getOS() == Constants.OS.LINUX) {
-      secureStorageManager = SecureStorageLinuxManager.builder();
+      secureStorageManager = SecureStorageLinuxManager.getInstance();
     } else {
       logger.error("Unsupported Operating System. Expected: OSX, Windows, Linux");
     }

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -17,6 +17,10 @@ public class CredentialManager {
   private static final String MFA_TOKEN = "MFATOKEN";
 
   private CredentialManager() {
+    initSecureStorageManager();
+  }
+
+  private void initSecureStorageManager() {
     if (Constants.getOS() == Constants.OS.MAC) {
       secureStorageManager = SecureStorageAppleManager.builder();
     } else if (Constants.getOS() == Constants.OS.WINDOWS) {
@@ -26,6 +30,20 @@ public class CredentialManager {
     } else {
       logger.error("Unsupported Operating System. Expected: OSX, Windows, Linux");
     }
+  }
+
+  /** Helper function for tests to go back to normal settings. */
+  void resetSecureStorageManager() {
+    initSecureStorageManager();
+  }
+
+  /**
+   * Testing purpose. Inject a mock manager.
+   *
+   * @param manager
+   */
+  void injectSecureStorageManager(SecureStorageManager manager) {
+    secureStorageManager = manager;
   }
 
   private static class CredentialManagerHolder {

--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -37,6 +37,7 @@ public class SFLoginInput {
   private PrivateKey privateKey;
   private String application;
   private String idToken;
+  private String mfaToken;
   private String serviceName;
   private OCSPMode ocspMode;
   private String privateKeyFile;
@@ -239,6 +240,15 @@ public class SFLoginInput {
 
   SFLoginInput setIdToken(String idToken) {
     this.idToken = idToken;
+    return this;
+  }
+
+  String getMfaToken() {
+    return mfaToken;
+  }
+
+  SFLoginInput setMfaToken(String mfaToken) {
+    this.mfaToken = mfaToken;
     return this;
   }
 

--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -4,8 +4,11 @@
 
 package net.snowflake.client.core;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.security.PrivateKey;
 import java.util.Map;
+import net.snowflake.client.jdbc.ErrorCode;
 
 /** A class for holding all information required for login */
 public class SFLoginInput {
@@ -325,5 +328,16 @@ public class SFLoginInput {
               || "on".equalsIgnoreCase((String) v));
     }
     return false;
+  }
+
+  String getHostFromServerUrl() throws SFException {
+    URL url;
+    try {
+      url = new URL(serverUrl);
+    } catch (MalformedURLException e) {
+      throw new SFException(
+          e, ErrorCode.INTERNAL_ERROR, "Invalid serverUrl for retrieving host name");
+    }
+    return url.getHost();
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFLoginOutput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginOutput.java
@@ -12,6 +12,7 @@ public class SFLoginOutput {
   private String masterToken;
   private long masterTokenValidityInSeconds;
   private String idToken;
+  private String mfaToken;
   private String databaseVersion;
   private int databaseMajorVersion;
   private int databaseMinorVersion;
@@ -31,6 +32,7 @@ public class SFLoginOutput {
       String masterToken,
       long masterTokenValidityInSeconds,
       String idToken,
+      String mfaToken,
       String databaseVersion,
       int databaseMajorVersion,
       int databaseMinorVersion,
@@ -44,6 +46,7 @@ public class SFLoginOutput {
     this.sessionToken = sessionToken;
     this.masterToken = masterToken;
     this.idToken = idToken;
+    this.mfaToken = mfaToken;
     this.databaseVersion = databaseVersion;
     this.databaseMajorVersion = databaseMajorVersion;
     this.databaseMinorVersion = databaseMinorVersion;
@@ -89,6 +92,15 @@ public class SFLoginOutput {
 
   SFLoginOutput setIdToken(String idToken) {
     this.idToken = idToken;
+    return this;
+  }
+
+  String getMfaToken() {
+    return mfaToken;
+  }
+
+  SFLoginOutput setMfaToken(String mfaToken) {
+    this.mfaToken = mfaToken;
     return this;
   }
 

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -506,7 +506,9 @@ public class SFSession {
    */
   boolean isUsernamePasswordMFAAuthenticator() {
     String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
-    return ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA.name().equalsIgnoreCase(authenticator);
+    return ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA
+        .name()
+        .equalsIgnoreCase(authenticator);
   }
 
   /**
@@ -709,7 +711,9 @@ public class SFSession {
       }
     }
 
-    if (isSnowflakeAuthenticator() || isOKTAAuthenticator() || isUsernamePasswordMFAAuthenticator()) {
+    if (isSnowflakeAuthenticator()
+        || isOKTAAuthenticator()
+        || isUsernamePasswordMFAAuthenticator()) {
       // userName and password are expected for both Snowflake and Okta.
       String userName = (String) connectionPropertiesMap.get(SFSessionProperty.USER);
       if (Strings.isNullOrEmpty(userName)) {

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -66,6 +66,7 @@ public class SFSession {
   private String sessionId;
 
   private String idToken;
+  private String mfaToken;
   private String privateKeyFileLocation;
   private String privateKeyPassword;
   private PrivateKey privateKey;
@@ -499,6 +500,16 @@ public class SFSession {
   }
 
   /**
+   * Returns true if authenticator is UsernamePasswordMFA native
+   *
+   * @return true or false
+   */
+  boolean isUsernamePasswordMFAAuthenticator() {
+    String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
+    return ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA.name().equalsIgnoreCase(authenticator);
+  }
+
+  /**
    * Open a new database session
    *
    * @throws SFException this is a runtime exception
@@ -578,6 +589,7 @@ public class SFSession {
         .setPassword((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
         .setToken((String) connectionPropertiesMap.get(SFSessionProperty.TOKEN))
         .setIdToken((String) connectionPropertiesMap.get(SFSessionProperty.ID_TOKEN))
+        .setMfaToken((String) connectionPropertiesMap.get(SFSessionProperty.MFA_TOKEN))
         .setPasscodeInPassword(passcodeInPassword)
         .setPasscode((String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE))
         .setConnectionTimeout(httpClientConnectionTimeout)
@@ -602,6 +614,7 @@ public class SFSession {
     sessionToken = loginOutput.getSessionToken();
     masterToken = loginOutput.getMasterToken();
     idToken = loginOutput.getIdToken();
+    mfaToken = loginOutput.getMfaToken();
     databaseVersion = loginOutput.getDatabaseVersion();
     databaseMajorVersion = loginOutput.getDatabaseMajorVersion();
     databaseMinorVersion = loginOutput.getDatabaseMinorVersion();
@@ -696,7 +709,7 @@ public class SFSession {
       }
     }
 
-    if (isSnowflakeAuthenticator() || isOKTAAuthenticator()) {
+    if (isSnowflakeAuthenticator() || isOKTAAuthenticator() || isUsernamePasswordMFAAuthenticator()) {
       // userName and password are expected for both Snowflake and Okta.
       String userName = (String) connectionPropertiesMap.get(SFSessionProperty.USER);
       if (Strings.isNullOrEmpty(userName)) {
@@ -806,6 +819,7 @@ public class SFSession {
         .setSessionToken(sessionToken)
         .setMasterToken(masterToken)
         .setIdToken(idToken)
+        .setMfaToken(mfaToken)
         .setLoginTimeout(loginTimeout)
         .setDatabaseName(this.getDatabase())
         .setSchemaName(this.getSchema())
@@ -1270,6 +1284,10 @@ public class SFSession {
 
   public String getIdToken() {
     return idToken;
+  }
+
+  public String getMfaToken() {
+    return mfaToken;
   }
 
   public boolean isStoreTemporaryCredential() {

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -590,8 +590,6 @@ public class SFSession {
         .setUserName((String) connectionPropertiesMap.get(SFSessionProperty.USER))
         .setPassword((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
         .setToken((String) connectionPropertiesMap.get(SFSessionProperty.TOKEN))
-        .setIdToken((String) connectionPropertiesMap.get(SFSessionProperty.ID_TOKEN))
-        .setMfaToken((String) connectionPropertiesMap.get(SFSessionProperty.MFA_TOKEN))
         .setPasscodeInPassword(passcodeInPassword)
         .setPasscode((String) connectionPropertiesMap.get(SFSessionProperty.PASSCODE))
         .setConnectionTimeout(httpClientConnectionTimeout)

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -25,6 +25,7 @@ public enum SFSessionProperty {
   PASSCODE("passcode", false, String.class),
   TOKEN("token", false, String.class),
   ID_TOKEN("id_token", false, String.class),
+  MFA_TOKEN("mfa_token", false, String.class),
   ID_TOKEN_PASSWORD("id_token_password", false, String.class),
   ROLE("role", false, String.class),
   AUTHENTICATOR("authenticator", false, String.class),

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -24,8 +24,6 @@ public enum SFSessionProperty {
   PASSCODE_IN_PASSWORD("passcodeInPassword", false, Boolean.class),
   PASSCODE("passcode", false, String.class),
   TOKEN("token", false, String.class),
-  ID_TOKEN("id_token", false, String.class),
-  MFA_TOKEN("mfa_token", false, String.class),
   ID_TOKEN_PASSWORD("id_token_password", false, String.class),
   ROLE("role", false, String.class),
   AUTHENTICATOR("authenticator", false, String.class),

--- a/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
@@ -25,13 +25,13 @@ public class SecureStorageAppleManager implements SecureStorageManager {
     return new SecureStorageAppleManager();
   }
 
-  public SecureStorageStatus setCredential(String host, String user, String cred) {
+  public SecureStorageStatus setCredential(String host, String user, String type, String cred) {
     if (Strings.isNullOrEmpty(cred)) {
       logger.info("No credential provided");
       return SecureStorageStatus.SUCCESS;
     }
 
-    String target = SecureStorageManager.convertTarget(host, user);
+    String target = SecureStorageManager.convertTarget(host, user, type);
     byte[] targetBytes = target.getBytes(StandardCharsets.UTF_8);
     byte[] userBytes = user.toUpperCase().getBytes(StandardCharsets.UTF_8);
     byte[] credBytes = cred.getBytes(StandardCharsets.UTF_8);
@@ -90,8 +90,8 @@ public class SecureStorageAppleManager implements SecureStorageManager {
     return SecureStorageStatus.SUCCESS;
   }
 
-  public String getCredential(String host, String user) {
-    String target = SecureStorageManager.convertTarget(host, user);
+  public String getCredential(String host, String user, String type) {
+    String target = SecureStorageManager.convertTarget(host, user, type);
     byte[] targetBytes = target.getBytes(StandardCharsets.UTF_8);
     byte[] userBytes = user.toUpperCase().getBytes(StandardCharsets.UTF_8);
 
@@ -139,8 +139,8 @@ public class SecureStorageAppleManager implements SecureStorageManager {
     }
   }
 
-  public SecureStorageStatus deleteCredential(String host, String user) {
-    String target = SecureStorageManager.convertTarget(host, user);
+  public SecureStorageStatus deleteCredential(String host, String user, String type) {
+    String target = SecureStorageManager.convertTarget(host, user, type);
     byte[] targetBytes = target.getBytes(StandardCharsets.UTF_8);
     byte[] userBytes = user.toUpperCase().getBytes(StandardCharsets.UTF_8);
 

--- a/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
@@ -8,10 +8,9 @@ import com.google.common.base.Strings;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
+import java.nio.charset.StandardCharsets;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
-
-import java.nio.charset.StandardCharsets;
 
 public class SecureStorageAppleManager implements SecureStorageManager {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SecureStorageAppleManager.class);

--- a/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
@@ -8,9 +8,10 @@ import com.google.common.base.Strings;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import java.nio.charset.StandardCharsets;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
+
+import java.nio.charset.StandardCharsets;
 
 public class SecureStorageAppleManager implements SecureStorageManager {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SecureStorageAppleManager.class);

--- a/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
@@ -202,6 +202,13 @@ public class SecureStorageAppleManager implements SecureStorageManager {
     public static void setInstance(SecurityLib instance) {
       INSTANCE = instance;
     }
+
+    /** This function is a helper function for testing */
+    public static void resetInstance() {
+      if (Constants.getOS() == Constants.OS.MAC) {
+        INSTANCE = ResourceHolder.INSTANCE;
+      }
+    }
   }
 
   /** the java mapping of OS X Security Library */

--- a/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
@@ -47,7 +47,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
     return new SecureStorageLinuxManager();
   }
 
-  public SecureStorageStatus setCredential(String host, String user, String token) {
+  public SecureStorageStatus setCredential(String host, String user, String type, String token) {
     if (Strings.isNullOrEmpty(token)) {
       logger.info("No token provided");
       return SecureStorageStatus.SUCCESS;
@@ -73,7 +73,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
     return SecureStorageStatus.SUCCESS;
   }
 
-  public String getCredential(String host, String user) {
+  public String getCredential(String host, String user, String type) {
     JsonNode res = fileCacheManager.readCacheFile();
     readJsonStoreCache(res);
 
@@ -92,7 +92,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
    * the future, deletion for a specific credential is needed, we can change this function to
    * satisfy it."
    */
-  public SecureStorageStatus deleteCredential(String host, String user) {
+  public SecureStorageStatus deleteCredential(String host, String user, String type) {
     fileCacheManager.deleteCacheFile();
     idTokenCache.clear();
     return SecureStorageStatus.SUCCESS;

--- a/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
@@ -26,6 +26,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
   private static final String CACHE_FILE_NAME = "temporary_credential.json";
   private static final String CACHE_DIR_PROP = "net.snowflake.jdbc.temporaryCredentialCacheDir";
   private static final String CACHE_DIR_ENV = "SF_TEMPORARY_CREDENTIAL_CACHE_DIR";
+  private static final String DRIVER_NAME = "SNOWFLAKE-JDBC-DRIVER";
   private static final long CACHE_EXPIRATION_IN_SECONDS = 86400L;
   private static final long CACHE_FILE_LOCK_EXPIRATION_IN_SECONDS = 60L;
   private FileCacheManager fileCacheManager;
@@ -56,7 +57,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
     idTokenCache.computeIfAbsent(host.toUpperCase(), newMap -> new HashMap<>());
 
     Map<String, String> currentUserMap = idTokenCache.get(host.toUpperCase());
-    currentUserMap.put(user.toUpperCase(), token);
+    currentUserMap.put(buildCredName(user, type), token);
 
     ObjectNode out = mapper.createObjectNode();
     for (Map.Entry<String, Map<String, String>> elem : idTokenCache.entrySet()) {
@@ -83,7 +84,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
       return null;
     }
 
-    return userMap.get(user.toUpperCase());
+    return userMap.get(buildCredName(user, type));
   }
 
   /**
@@ -115,5 +116,9 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
         idTokenCache.get(host).put(userMap.getKey(), userMap.getValue().asText());
       }
     }
+  }
+
+  private String buildCredName(String user, String type) {
+    return user.toUpperCase() + ":" + DRIVER_NAME + ":" + type.toUpperCase();
   }
 }

--- a/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
@@ -99,6 +99,9 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
     Map<String, String> hostMap = localCredCache.get(host.toUpperCase());
     if (hostMap != null) {
       hostMap.remove(SecureStorageManager.convertTarget(host, user, type));
+      if (hostMap.isEmpty()) {
+        localCredCache.remove(host.toUpperCase());
+      }
     }
     fileCacheManager.writeCacheFile(localCacheToJson());
     return SecureStorageStatus.SUCCESS;

--- a/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
@@ -31,7 +31,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
   private static final long CACHE_FILE_LOCK_EXPIRATION_IN_SECONDS = 60L;
   private FileCacheManager fileCacheManager;
 
-  private final Map<String, Map<String, String>> idTokenCache = new HashMap<>();
+  private final Map<String, Map<String, String>> localCredCache = new HashMap<>();
 
   private SecureStorageLinuxManager() {
     fileCacheManager =
@@ -44,58 +44,64 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
             .build();
   }
 
-  public static SecureStorageLinuxManager builder() {
-    return new SecureStorageLinuxManager();
+  private static class SecureStorageLinuxManagerHolder {
+    private static final SecureStorageLinuxManager INSTANCE = new SecureStorageLinuxManager();
   }
 
-  public SecureStorageStatus setCredential(String host, String user, String type, String token) {
+  public static SecureStorageLinuxManager getInstance() {
+    return SecureStorageLinuxManagerHolder.INSTANCE;
+  }
+
+  private ObjectNode localCacheToJson() {
+    ObjectNode res = mapper.createObjectNode();
+    for (Map.Entry<String, Map<String, String>> elem : localCredCache.entrySet()) {
+      String elemHost = elem.getKey();
+      Map<String, String> hostMap = elem.getValue();
+      ObjectNode hostNode = mapper.createObjectNode();
+      for (Map.Entry<String, String> elem0 : hostMap.entrySet()) {
+        hostNode.put(elem0.getKey(), elem0.getValue());
+      }
+      res.set(elemHost, hostNode);
+    }
+    return res;
+  }
+
+  public synchronized SecureStorageStatus setCredential(
+      String host, String user, String type, String token) {
     if (Strings.isNullOrEmpty(token)) {
       logger.info("No token provided");
       return SecureStorageStatus.SUCCESS;
     }
 
-    idTokenCache.computeIfAbsent(host.toUpperCase(), newMap -> new HashMap<>());
+    localCredCache.computeIfAbsent(host.toUpperCase(), newMap -> new HashMap<>());
 
-    Map<String, String> currentUserMap = idTokenCache.get(host.toUpperCase());
-    currentUserMap.put(buildCredName(user, type), token);
+    Map<String, String> hostMap = localCredCache.get(host.toUpperCase());
+    hostMap.put(buildCredName(user, type), token);
 
-    ObjectNode out = mapper.createObjectNode();
-    for (Map.Entry<String, Map<String, String>> elem : idTokenCache.entrySet()) {
-      String elemHost = elem.getKey();
-      Map<String, String> userMap = elem.getValue();
-      ObjectNode userNode = mapper.createObjectNode();
-      for (Map.Entry<String, String> elem0 : userMap.entrySet()) {
-        userNode.put(elem0.getKey(), elem0.getValue());
-      }
-      out.set(elemHost, userNode);
-    }
-    fileCacheManager.writeCacheFile(out);
-
+    fileCacheManager.writeCacheFile(localCacheToJson());
     return SecureStorageStatus.SUCCESS;
   }
 
-  public String getCredential(String host, String user, String type) {
+  public synchronized String getCredential(String host, String user, String type) {
     JsonNode res = fileCacheManager.readCacheFile();
     readJsonStoreCache(res);
 
-    Map<String, String> userMap = idTokenCache.get(host.toUpperCase());
+    Map<String, String> hostMap = localCredCache.get(host.toUpperCase());
 
-    if (userMap == null) {
+    if (hostMap == null) {
       return null;
     }
 
-    return userMap.get(buildCredName(user, type));
+    return hostMap.get(buildCredName(user, type));
   }
 
-  /**
-   * Since Linux doesn't have secure local storage right now, this function's input parameters are
-   * only here to be consistent with Mac/Win platform. We don't really use these parameters. If in
-   * the future, deletion for a specific credential is needed, we can change this function to
-   * satisfy it."
-   */
-  public SecureStorageStatus deleteCredential(String host, String user, String type) {
-    fileCacheManager.deleteCacheFile();
-    idTokenCache.clear();
+  /** May delete credentials which doesn't belong to this process */
+  public synchronized SecureStorageStatus deleteCredential(String host, String user, String type) {
+    Map<String, String> hostMap = localCredCache.get(host.toUpperCase());
+    if (hostMap != null) {
+      hostMap.remove(buildCredName(user, type));
+      fileCacheManager.writeCacheFile(localCacheToJson());
+    }
     return SecureStorageStatus.SUCCESS;
   }
 
@@ -107,13 +113,13 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
     for (Iterator<Map.Entry<String, JsonNode>> itr = m.fields(); itr.hasNext(); ) {
       Map.Entry<String, JsonNode> hostMap = itr.next();
       String host = hostMap.getKey();
-      if (!idTokenCache.containsKey(host)) {
-        idTokenCache.put(host, new HashMap<>());
+      if (!localCredCache.containsKey(host)) {
+        localCredCache.put(host, new HashMap<>());
       }
       JsonNode userJsonNode = hostMap.getValue();
       for (Iterator<Map.Entry<String, JsonNode>> itr0 = userJsonNode.fields(); itr0.hasNext(); ) {
         Map.Entry<String, JsonNode> userMap = itr0.next();
-        idTokenCache.get(host).put(userMap.getKey(), userMap.getValue().asText());
+        localCredCache.get(host).put(userMap.getKey(), userMap.getValue().asText());
       }
     }
   }

--- a/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageLinuxManager.java
@@ -100,8 +100,8 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
     Map<String, String> hostMap = localCredCache.get(host.toUpperCase());
     if (hostMap != null) {
       hostMap.remove(buildCredName(user, type));
-      fileCacheManager.writeCacheFile(localCacheToJson());
     }
+    fileCacheManager.writeCacheFile(localCacheToJson());
     return SecureStorageStatus.SUCCESS;
   }
 

--- a/src/main/java/net/snowflake/client/core/SecureStorageManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageManager.java
@@ -21,7 +21,11 @@ interface SecureStorageManager {
   static String convertTarget(String host, String user, String type) {
     StringBuilder target =
         new StringBuilder(
-            host.length() + user.length() + DRIVER_NAME.length() + type.length() + 3 * COLON_CHAR_LENGTH);
+            host.length()
+                + user.length()
+                + DRIVER_NAME.length()
+                + type.length()
+                + 3 * COLON_CHAR_LENGTH);
 
     target.append(host.toUpperCase());
     target.append(":");

--- a/src/main/java/net/snowflake/client/core/SecureStorageManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageManager.java
@@ -12,22 +12,24 @@ interface SecureStorageManager {
   String DRIVER_NAME = "SNOWFLAKE-JDBC-DRIVER";
   int COLON_CHAR_LENGTH = 1;
 
-  SecureStorageStatus setCredential(String host, String user, String token);
+  SecureStorageStatus setCredential(String host, String user, String type, String token);
 
-  public String getCredential(String host, String user);
+  public String getCredential(String host, String user, String type);
 
-  SecureStorageStatus deleteCredential(String host, String user);
+  SecureStorageStatus deleteCredential(String host, String user, String type);
 
-  static String convertTarget(String host, String user) {
+  static String convertTarget(String host, String user, String type) {
     StringBuilder target =
         new StringBuilder(
-            host.length() + user.length() + DRIVER_NAME.length() + 2 * COLON_CHAR_LENGTH);
+            host.length() + user.length() + DRIVER_NAME.length() + type.length() + 3 * COLON_CHAR_LENGTH);
 
     target.append(host.toUpperCase());
     target.append(":");
     target.append(user.toUpperCase());
     target.append(":");
     target.append(DRIVER_NAME);
+    target.append(":");
+    target.append(type.toUpperCase());
 
     return target.toString();
   }

--- a/src/main/java/net/snowflake/client/core/SecureStorageManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageManager.java
@@ -14,7 +14,7 @@ interface SecureStorageManager {
 
   SecureStorageStatus setCredential(String host, String user, String type, String token);
 
-  public String getCredential(String host, String user, String type);
+  String getCredential(String host, String user, String type);
 
   SecureStorageStatus deleteCredential(String host, String user, String type);
 

--- a/src/main/java/net/snowflake/client/core/SecureStorageWindowsManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageWindowsManager.java
@@ -36,7 +36,7 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     return new SecureStorageWindowsManager();
   }
 
-  public SecureStorageStatus setCredential(String host, String user, String token) {
+  public SecureStorageStatus setCredential(String host, String user, String type, String token) {
     if (Strings.isNullOrEmpty(token)) {
       logger.info("No token provided");
       return SecureStorageStatus.SUCCESS;
@@ -46,7 +46,7 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     Memory credBlobMem = new Memory(credBlob.length);
     credBlobMem.write(0, credBlob, 0, credBlob.length);
 
-    String target = SecureStorageManager.convertTarget(host, user);
+    String target = SecureStorageManager.convertTarget(host, user, type);
 
     SecureStorageWindowsCredential cred = new SecureStorageWindowsCredential();
     cred.Type = SecureStorageWindowsCredentialType.CRED_TYPE_GENERIC.getType();
@@ -73,9 +73,9 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     return SecureStorageStatus.SUCCESS;
   }
 
-  public String getCredential(String host, String user) {
+  public String getCredential(String host, String user, String type) {
     PointerByReference pCredential = new PointerByReference();
-    String target = SecureStorageManager.convertTarget(host, user);
+    String target = SecureStorageManager.convertTarget(host, user, type);
 
     try {
       boolean ret = false;
@@ -125,8 +125,8 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     }
   }
 
-  public SecureStorageStatus deleteCredential(String host, String user) {
-    String target = SecureStorageManager.convertTarget(host, user);
+  public SecureStorageStatus deleteCredential(String host, String user, String type) {
+    String target = SecureStorageManager.convertTarget(host, user, type);
 
     boolean ret = false;
     synchronized (advapi32Lib) {

--- a/src/main/java/net/snowflake/client/core/SecureStorageWindowsManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageWindowsManager.java
@@ -5,11 +5,7 @@
 package net.snowflake.client.core;
 
 import com.google.common.base.Strings;
-import com.sun.jna.Memory;
-import com.sun.jna.Native;
-import com.sun.jna.Pointer;
-import com.sun.jna.Structure;
-import com.sun.jna.WString;
+import com.sun.jna.*;
 import com.sun.jna.platform.win32.WinBase.FILETIME;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.StdCallLibrary;
@@ -209,7 +205,7 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     private static Map<Integer, SecureStorageWindowsCredentialType> map =
         new HashMap<Integer, SecureStorageWindowsCredentialType>();
 
-    private SecureStorageWindowsCredentialType(int type) {
+    SecureStorageWindowsCredentialType(int type) {
       this.type = type;
     }
 
@@ -239,7 +235,7 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     private static Map<Integer, SecureStorageWindowsCredentialPersistType> map =
         new HashMap<Integer, SecureStorageWindowsCredentialPersistType>();
 
-    private SecureStorageWindowsCredentialPersistType(int type) {
+    SecureStorageWindowsCredentialPersistType(int type) {
       this.type = type;
     }
 
@@ -259,6 +255,7 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     private static Advapi32Lib INSTANCE = null;
 
     private static class ResourceHolder {
+      // map Windows advapi32.dll to Interface Advapi32Lib
       private static final Advapi32Lib INSTANCE =
           (Advapi32Lib)
               Native.loadLibrary("advapi32", Advapi32Lib.class, W32APIOptions.UNICODE_OPTIONS);
@@ -275,14 +272,16 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     public static void setInstance(Advapi32Lib instance) {
       INSTANCE = instance;
     }
+
+    /** This function is a helper function for testing */
+    public static void resetInstance() {
+      if (Constants.getOS() == Constants.OS.WINDOWS) {
+        INSTANCE = ResourceHolder.INSTANCE;
+      }
+    }
   }
 
   interface Advapi32Lib extends StdCallLibrary {
-    // map Windows advapi32.dll to Interface Advapi32Lib
-    // Advapi32Lib INSTANCE =
-    //   (Advapi32Lib) Native.loadLibrary("advapi32", Advapi32Lib.class,
-    // W32APIOptions.UNICODE_OPTIONS);
-
     /** BOOL CredReadW( LPCWSTR TargetName, DWORD Type, DWORD Flags, PCREDENTIALW *Credential ); */
     boolean CredReadW(String targetName, int type, int flags, PointerByReference pcred);
 

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -612,7 +612,6 @@ public class SessionUtil {
       sessionToken = jsonNode.path("data").path("token").asText();
       masterToken = jsonNode.path("data").path("masterToken").asText();
       idToken = nullStringAsEmptyString(jsonNode.path("data").path("idToken").asText());
-      // WUFAN TODO, checkout whether mfa token is given as field `mfaToken`:
       mfaToken = nullStringAsEmptyString(jsonNode.path("data").path("mfaToken").asText());
       masterTokenValidityInSeconds = jsonNode.path("data").path("masterValidityInSeconds").asLong();
       String serverVersion = jsonNode.path("data").path("serverVersion").asText();

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -725,7 +725,7 @@ public class SessionUtil {
             commonParams);
 
     if (consentCacheIdToken) {
-      CredentialManager.getInstance().writeTemporaryCredential(loginInput, ret);
+      CredentialManager.getInstance().writeIdToken(loginInput, ret);
     }
 
     if (asBoolean(loginInput.getSessionParameters().get(CLIENT_REQUEST_MFA_TOKEN))) {

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -4,9 +4,21 @@
 
 package net.snowflake.client.core;
 
+import static net.snowflake.client.core.SFTrustManager.resetOCSPResponseCacherServerURL;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.log.ArgSupplier;
@@ -27,19 +39,6 @@ import org.apache.http.message.HeaderGroup;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static net.snowflake.client.core.SFTrustManager.resetOCSPResponseCacherServerURL;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 /** Low level session util */
 public class SessionUtil {
@@ -66,8 +65,7 @@ public class SessionUtil {
   private static final String SF_HEADER_TOKEN_TAG = "Token";
   private static final String CLIENT_STORE_TEMPORARY_CREDENTIAL =
       "CLIENT_STORE_TEMPORARY_CREDENTIAL";
-  private static final String CLIENT_ALLOW_MFA_CACHING =
-      "CLIENT_ALLOW_MFA_CACHING";
+  private static final String CLIENT_ALLOW_MFA_CACHING = "CLIENT_ALLOW_MFA_CACHING";
   private static final String SERVICE_NAME = "SERVICE_NAME";
   private static final String CLIENT_IN_BAND_TELEMETRY_ENABLED = "CLIENT_TELEMETRY_ENABLED";
   private static final String CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED =
@@ -289,10 +287,10 @@ public class SessionUtil {
     }
   }
 
-  static private void preNewSession(SFLoginInput loginInput) throws SFException {
+  private static void preNewSession(SFLoginInput loginInput) throws SFException {
     if (asBoolean(loginInput.getSessionParameters().get(CLIENT_STORE_TEMPORARY_CREDENTIAL))) {
       CredentialManager.getInstance().fillCachedIdToken(loginInput);
-    } 
+    }
 
     if (asBoolean(loginInput.getSessionParameters().get(CLIENT_ALLOW_MFA_CACHING))) {
       CredentialManager.getInstance().fillCachedMfaToken(loginInput);

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -4,21 +4,9 @@
 
 package net.snowflake.client.core;
 
-import static net.snowflake.client.core.SFTrustManager.resetOCSPResponseCacherServerURL;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.log.ArgSupplier;
@@ -39,6 +27,19 @@ import org.apache.http.message.HeaderGroup;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static net.snowflake.client.core.SFTrustManager.resetOCSPResponseCacherServerURL;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 /** Low level session util */
 public class SessionUtil {
@@ -205,7 +206,7 @@ public class SessionUtil {
         return ClientAuthnDTO.AuthenticatorType.OKTA;
       } else if (!loginInput
           .getAuthenticator()
-          .equalsIgnoreCase(ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA())) {
+          .equalsIgnoreCase(ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA.name())) {
         return ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA;
       }
     }

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -65,7 +65,7 @@ public class SessionUtil {
   private static final String SF_HEADER_TOKEN_TAG = "Token";
   private static final String CLIENT_STORE_TEMPORARY_CREDENTIAL =
       "CLIENT_STORE_TEMPORARY_CREDENTIAL";
-  private static final String CLIENT_ALLOW_MFA_CACHING = "CLIENT_ALLOW_MFA_CACHING";
+  private static final String CLIENT_REQUEST_MFA_TOKEN = "CLIENT_REQUEST_MFA_TOKEN";
   private static final String SERVICE_NAME = "SERVICE_NAME";
   private static final String CLIENT_IN_BAND_TELEMETRY_ENABLED = "CLIENT_TELEMETRY_ENABLED";
   private static final String CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED =
@@ -160,7 +160,7 @@ public class SessionUtil {
               CLIENT_IN_BAND_TELEMETRY_ENABLED,
               CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED,
               CLIENT_STORE_TEMPORARY_CREDENTIAL,
-              CLIENT_ALLOW_MFA_CACHING,
+              CLIENT_REQUEST_MFA_TOKEN,
               "JDBC_USE_JSON_PARSER",
               "AUTOCOMMIT",
               "JDBC_EFFICIENT_CHUNK_STORAGE",
@@ -267,11 +267,11 @@ public class SessionUtil {
 
     if (authenticator.equals(ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA)) {
       if (Constants.getOS() == Constants.OS.MAC || Constants.getOS() == Constants.OS.WINDOWS) {
-        loginInput.getSessionParameters().put(CLIENT_ALLOW_MFA_CACHING, true);
+        loginInput.getSessionParameters().put(CLIENT_REQUEST_MFA_TOKEN, true);
       } else {
-        if (!loginInput.getSessionParameters().containsKey(CLIENT_ALLOW_MFA_CACHING)) {
+        if (!loginInput.getSessionParameters().containsKey(CLIENT_REQUEST_MFA_TOKEN)) {
           // for testing purpose
-          loginInput.getSessionParameters().put(CLIENT_ALLOW_MFA_CACHING, false);
+          loginInput.getSessionParameters().put(CLIENT_REQUEST_MFA_TOKEN, false);
         }
       }
     }
@@ -292,7 +292,7 @@ public class SessionUtil {
       CredentialManager.getInstance().fillCachedIdToken(loginInput);
     }
 
-    if (asBoolean(loginInput.getSessionParameters().get(CLIENT_ALLOW_MFA_CACHING))) {
+    if (asBoolean(loginInput.getSessionParameters().get(CLIENT_REQUEST_MFA_TOKEN))) {
       CredentialManager.getInstance().fillCachedMfaToken(loginInput);
     }
   }
@@ -728,7 +728,7 @@ public class SessionUtil {
       CredentialManager.getInstance().writeTemporaryCredential(loginInput, ret);
     }
 
-    if (asBoolean(loginInput.getSessionParameters().get(CLIENT_ALLOW_MFA_CACHING))) {
+    if (asBoolean(loginInput.getSessionParameters().get(CLIENT_REQUEST_MFA_TOKEN))) {
       CredentialManager.getInstance().writeMfaToken(loginInput, ret);
     }
 

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -199,15 +199,15 @@ public class SessionUtil {
           .getAuthenticator()
           .equalsIgnoreCase(ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT.name())) {
         return ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT;
+      } else if (loginInput
+          .getAuthenticator()
+          .equalsIgnoreCase(ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA.name())) {
+        return ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA;
       } else if (!loginInput
           .getAuthenticator()
           .equalsIgnoreCase(ClientAuthnDTO.AuthenticatorType.SNOWFLAKE.name())) {
         // OKTA authenticator v1.
         return ClientAuthnDTO.AuthenticatorType.OKTA;
-      } else if (!loginInput
-          .getAuthenticator()
-          .equalsIgnoreCase(ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA.name())) {
-        return ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA;
       }
     }
 
@@ -271,7 +271,10 @@ public class SessionUtil {
       if (Constants.getOS() == Constants.OS.MAC || Constants.getOS() == Constants.OS.WINDOWS) {
         loginInput.getSessionParameters().put(CLIENT_ALLOW_MFA_CACHING, true);
       } else {
-        loginInput.getSessionParameters().put(CLIENT_ALLOW_MFA_CACHING, false);
+        if (!loginInput.getSessionParameters().containsKey(CLIENT_ALLOW_MFA_CACHING)) {
+          // for testing purpose
+          loginInput.getSessionParameters().put(CLIENT_ALLOW_MFA_CACHING, false);
+        }
       }
     }
 

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -268,11 +268,6 @@ public class SessionUtil {
     if (authenticator.equals(ClientAuthnDTO.AuthenticatorType.USERNAME_PASSWORD_MFA)) {
       if (Constants.getOS() == Constants.OS.MAC || Constants.getOS() == Constants.OS.WINDOWS) {
         loginInput.getSessionParameters().put(CLIENT_REQUEST_MFA_TOKEN, true);
-      } else {
-        if (!loginInput.getSessionParameters().containsKey(CLIENT_REQUEST_MFA_TOKEN)) {
-          // for testing purpose
-          loginInput.getSessionParameters().put(CLIENT_REQUEST_MFA_TOKEN, false);
-        }
       }
     }
 

--- a/src/test/java/net/snowflake/client/RunningNotOnLinux.java
+++ b/src/test/java/net/snowflake/client/RunningNotOnLinux.java
@@ -1,0 +1,9 @@
+package net.snowflake.client;
+
+import net.snowflake.client.core.Constants;
+
+public class RunningNotOnLinux implements ConditionalIgnoreRule.IgnoreCondition {
+  public boolean isSatisfied() {
+    return Constants.getOS() != Constants.OS.LINUX;
+  }
+}

--- a/src/test/java/net/snowflake/client/core/SecureStorageManagerTest.java
+++ b/src/test/java/net/snowflake/client/core/SecureStorageManagerTest.java
@@ -10,8 +10,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;

--- a/src/test/java/net/snowflake/client/core/SecureStorageManagerTest.java
+++ b/src/test/java/net/snowflake/client/core/SecureStorageManagerTest.java
@@ -10,6 +10,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -216,6 +218,7 @@ public class SecureStorageManagerTest {
   private static final String user = "fakeUser";
   private static final String idToken = "fakeIdToken";
   private static final String idToken0 = "fakeIdToken0";
+  private static final String ID_TOKEN = "ID_TOKEN";
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningNotOnWinMac.class)
@@ -256,28 +259,28 @@ public class SecureStorageManagerTest {
   private void testBody(SecureStorageManager manager) {
     // first delete possible old credential
     assertThat(
-        manager.deleteCredential(host, user),
+        manager.deleteCredential(host, user, ID_TOKEN),
         equalTo(SecureStorageManager.SecureStorageStatus.SUCCESS));
 
     // ensure no old credential exists
-    assertThat(manager.getCredential(host, user), is(nullValue()));
+    assertThat(manager.getCredential(host, user, ID_TOKEN), is(nullValue()));
 
     // set token
     assertThat(
-        manager.setCredential(host, user, idToken),
+        manager.setCredential(host, user, ID_TOKEN, idToken),
         equalTo(SecureStorageManager.SecureStorageStatus.SUCCESS));
-    assertThat(manager.getCredential(host, user), equalTo(idToken));
+    assertThat(manager.getCredential(host, user, ID_TOKEN), equalTo(idToken));
 
     // update token
     assertThat(
-        manager.setCredential(host, user, idToken0),
+        manager.setCredential(host, user, ID_TOKEN, idToken0),
         equalTo(SecureStorageManager.SecureStorageStatus.SUCCESS));
-    assertThat(manager.getCredential(host, user), equalTo(idToken0));
+    assertThat(manager.getCredential(host, user, ID_TOKEN), equalTo(idToken0));
 
     // delete token
     assertThat(
-        manager.deleteCredential(host, user),
+        manager.deleteCredential(host, user, ID_TOKEN),
         equalTo(SecureStorageManager.SecureStorageStatus.SUCCESS));
-    assertThat(manager.getCredential(host, user), is(nullValue()));
+    assertThat(manager.getCredential(host, user, ID_TOKEN), is(nullValue()));
   }
 }

--- a/src/test/java/net/snowflake/client/core/SecureStorageManagerTest.java
+++ b/src/test/java/net/snowflake/client/core/SecureStorageManagerTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import net.snowflake.client.ConditionalIgnoreRule;
+import net.snowflake.client.RunningNotOnLinux;
 import net.snowflake.client.RunningNotOnWinMac;
 import org.junit.Rule;
 import org.junit.Test;
@@ -241,6 +242,7 @@ public class SecureStorageManagerTest {
     SecureStorageManager manager = SecureStorageWindowsManager.builder();
 
     testBody(manager);
+    SecureStorageWindowsManager.Advapi32LibManager.resetInstance();
   }
 
   @Test
@@ -249,9 +251,11 @@ public class SecureStorageManagerTest {
     SecureStorageManager manager = SecureStorageAppleManager.builder();
 
     testBody(manager);
+    SecureStorageAppleManager.SecurityLibManager.resetInstance();
   }
 
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningNotOnLinux.class)
   public void testLinuxManager() {
     SecureStorageManager manager = SecureStorageLinuxManager.getInstance();
 

--- a/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
@@ -327,5 +327,4 @@ public class SSOConnectionTest {
       // we won't get a new id_token here
       assertThat("idToken", sfcon.getSfSession().getIdToken(), equalTo(MOCK_ID_TOKEN));
     }
-  // }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
@@ -318,7 +318,6 @@ public class SSOConnectionTest {
       assertThat("token", sfcon.getSfSession().getSessionToken(), equalTo(MOCK_SESSION_TOKEN));
       assertThat("idToken", sfcon.getSfSession().getIdToken(), equalTo(MOCK_ID_TOKEN));
 
-      // To be changed
       // second connection reads the cache and use the id token to get the
       // session token.
       Connection conSecond = DriverManager.getConnection(url, properties);
@@ -328,6 +327,5 @@ public class SSOConnectionTest {
       // we won't get a new id_token here
       assertThat("idToken", sfcon.getSfSession().getIdToken(), equalTo(MOCK_ID_TOKEN));
     }
-  }
   // }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
@@ -24,7 +24,6 @@ import net.snowflake.client.core.*;
 import net.snowflake.common.core.ClientAuthnDTO;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.HttpPost;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -115,11 +114,6 @@ public class SSOConnectionTest {
   private static final String MOCK_NEW_MASTER_TOKEN = "MOCK_NEW_MASTER_TOKEN";
   private static final String ID_TOKEN_AUTHENTICATOR = "ID_TOKEN";
   private static ObjectMapper mapper = new ObjectMapper();
-
-  @BeforeClass
-  public static void setUpClass() throws Throwable {
-    Class.forName("net.snowflake.client.jdbc.SnowflakeDriver");
-  }
 
   class HttpUtilResponseDataSSODTO {
     public String proofKey;

--- a/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
@@ -327,4 +327,5 @@ public class SSOConnectionTest {
       // we won't get a new id_token here
       assertThat("idToken", sfcon.getSfSession().getIdToken(), equalTo(MOCK_ID_TOKEN));
     }
+  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
@@ -24,7 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 
 class Buddy {
-  static String name(int x) {
+  static String name() {
     return "John";
   }
 }
@@ -56,12 +56,16 @@ public class SnowflakeMFACacheTest extends BaseJDBCTest {
   @Test
   public void testNormalConnection() throws SQLException, IOException {
     String ret = getMockedHttpResponse().toString();
-    try (MockedStatic<HttpUtil> theMock = Mockito.mockStatic(HttpUtil.class)) {
+    assertTrue(Buddy.name() == "John");
+    try (MockedStatic<HttpUtil> theMock = Mockito.mockStatic(HttpUtil.class); MockedStatic<Buddy> mockBuddy = Mockito.mockStatic(Buddy.class)) {
       theMock.when(() -> HttpUtil.executeGeneralRequest(any(HttpPost.class), anyInt(), any(OCSPMode.class))).thenReturn(ret);
+      mockBuddy.when(Buddy::name).thenReturn("Daddy");
+      assertTrue(Buddy.name() == "Daddy");
       Connection con = getConnection();
       assertFalse(con.isClosed());
       con.close();
       assertTrue(con.isClosed());
+      assertFalse(Buddy.name() == "John");
     }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
@@ -62,7 +62,6 @@ public class SnowflakeMFACacheTest {
 
     respNode.set("data", dataNode);
     respNode.put("success", success);
-    // respNode.put("success", false);
     respNode.put("message", "msg");
 
     return respNode;

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.client.jdbc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.OCSPMode;
+import net.snowflake.client.core.ObjectMapperFactory;
+import org.apache.http.client.methods.HttpPost;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+
+class Buddy {
+  static String name(int x) {
+    return "John";
+  }
+}
+
+public class SnowflakeMFACacheTest extends BaseJDBCTest {
+  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+
+  private ObjectNode getMockedHttpResponse() {
+    ObjectNode respNode = mapper.createObjectNode();
+    ObjectNode dataNode = mapper.createObjectNode();
+    ArrayNode paraArray = mapper.createArrayNode();
+    ObjectNode autocommit = mapper.createObjectNode();
+
+    autocommit.put("name", "AUTOCOMMIT");
+    autocommit.put("value", true);
+    paraArray.add(autocommit);
+
+    dataNode.set("parameters", paraArray);
+    dataNode.put("masterToken", "mockedMasterToken");
+    dataNode.put("token", "mockedToken");
+
+    respNode.set("data", dataNode);
+    respNode.put("success", true);
+    respNode.put("message", "msg");
+
+    return respNode;
+  }
+
+  @Test
+  public void testNormalConnection() throws SQLException, IOException {
+    String ret = getMockedHttpResponse().toString();
+    try (MockedStatic<HttpUtil> theMock = Mockito.mockStatic(HttpUtil.class)) {
+      theMock.when(() -> HttpUtil.executeGeneralRequest(any(HttpPost.class), anyInt(), any(OCSPMode.class))).thenReturn(ret);
+      Connection con = getConnection();
+      assertFalse(con.isClosed());
+      con.close();
+      assertTrue(con.isClosed());
+    }
+  }
+}

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
@@ -4,20 +4,27 @@
 
 package net.snowflake.client.jdbc;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.core.ObjectMapperFactory;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.HttpPost;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,8 +38,9 @@ class Buddy {
 
 public class SnowflakeMFACacheTest extends BaseJDBCTest {
   private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+  private static final String[] mockedMfaToken = {"mockedMfaToken0", "mockedMfaToken1"};
 
-  private ObjectNode getMockedHttpResponse() {
+  private ObjectNode getNormalMockedHttpResponse(boolean success, int mfaTokenIdx) {
     ObjectNode respNode = mapper.createObjectNode();
     ObjectNode dataNode = mapper.createObjectNode();
     ArrayNode paraArray = mapper.createArrayNode();
@@ -45,17 +53,38 @@ public class SnowflakeMFACacheTest extends BaseJDBCTest {
     dataNode.set("parameters", paraArray);
     dataNode.put("masterToken", "mockedMasterToken");
     dataNode.put("token", "mockedToken");
+    if (mfaTokenIdx >= 0) {
+      dataNode.put("mfaToken", mockedMfaToken[mfaTokenIdx]);
+    }
 
     respNode.set("data", dataNode);
-    respNode.put("success", true);
+    respNode.put("success", success);
+    //respNode.put("success", false);
     respNode.put("message", "msg");
 
     return respNode;
   }
 
+  private JsonNode parseRequest(HttpPost post) throws IOException {
+    StringWriter writer = null;
+    String theString;
+    try {
+      writer = new StringWriter();
+      try (InputStream ins = post.getEntity().getContent()) {
+        IOUtils.copy(ins, writer, "UTF-8");
+      }
+      theString = writer.toString();
+    } finally {
+      IOUtils.closeQuietly(writer);
+    }
+
+    JsonNode jsonNode = mapper.readTree(theString);
+    return jsonNode;
+  }
+
   @Test
   public void testNormalConnection() throws SQLException, IOException {
-    String ret = getMockedHttpResponse().toString();
+    String ret = getNormalMockedHttpResponse(true, 0).toString();
     assertTrue(Buddy.name() == "John");
     try (MockedStatic<HttpUtil> theMock = Mockito.mockStatic(HttpUtil.class); MockedStatic<Buddy> mockBuddy = Mockito.mockStatic(Buddy.class)) {
       theMock.when(() -> HttpUtil.executeGeneralRequest(any(HttpPost.class), anyInt(), any(OCSPMode.class))).thenReturn(ret);
@@ -66,6 +95,64 @@ public class SnowflakeMFACacheTest extends BaseJDBCTest {
       con.close();
       assertTrue(con.isClosed());
       assertFalse(Buddy.name() == "John");
+    }
+  }
+
+  @Test
+  public void testMFAFunctionality() throws SQLException {
+    try (MockedStatic<HttpUtil> mockedHttpUtil = Mockito.mockStatic(HttpUtil.class);) {
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequest(
+                      any(HttpPost.class), anyInt(), any(OCSPMode.class)))
+          .thenAnswer(
+              new Answer<String>() {
+                int callCount = 0;
+                @Override
+                public String answer(InvocationOnMock invocation) throws Throwable {
+                  String res;
+                  JsonNode jsonNode;
+                  final Object[] args = invocation.getArguments();
+
+                  if (callCount == 0) {
+                    jsonNode = parseRequest((HttpPost) args[0]);
+                    assertTrue(jsonNode.path("data").path("SESSION_PARAMETERS").path("CLIENT_ALLOW_MFA_CACHING").asBoolean());
+                    res = getNormalMockedHttpResponse(true, 0).toString();
+                  } else if (callCount == 1) {
+                    res = getNormalMockedHttpResponse(true, -1).toString();
+                  } else if (callCount == 2) {
+                    jsonNode = parseRequest((HttpPost) args[0]);
+                    assertTrue(jsonNode.path("data").path("SESSION_PARAMETERS").path("CLIENT_ALLOW_MFA_CACHING").asBoolean());
+                    assertEquals(jsonNode.path("data").path("TOKEN").asText(), mockedMfaToken[0]);
+                    res = getNormalMockedHttpResponse(true, 1).toString();
+                  } else if (callCount == 3) {
+                    res = getNormalMockedHttpResponse(true, -1).toString();
+                  } else if (callCount == 4) {
+                    jsonNode = parseRequest((HttpPost) args[0]);
+                    assertTrue(jsonNode.path("data").path("SESSION_PARAMETERS").path("CLIENT_ALLOW_MFA_CACHING").asBoolean());
+                    assertEquals(jsonNode.path("data").path("TOKEN").asText(), mockedMfaToken[1]);
+                    res = getNormalMockedHttpResponse(true, -1).toString();
+                  } else if (callCount == 5) {
+                    res = getNormalMockedHttpResponse(true, -1).toString();
+                  } else {
+                    res = getNormalMockedHttpResponse(false, -1).toString();
+                  }
+
+                  callCount += 1; // this will be incremented on both connecting and closing
+                  return res;
+                }
+              });
+
+      Properties properties = new Properties();
+      properties.put("authenticator", "username_password_mfa");
+      properties.put("CLIENT_ALLOW_MFA_CACHING", true);
+      Connection con = getConnection(properties);
+      con.close();
+      Connection con1 = getConnection(properties);
+      con1.close();
+      Connection con2 = getConnection(properties);
+      con2.close();
     }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
@@ -90,7 +90,7 @@ public class SnowflakeMFACacheTest {
     prop.put("user", "testuser");
     prop.put("password", "testpassword");
     prop.put("authenticator", "username_password_mfa");
-    prop.put("CLIENT_ALLOW_MFA_CACHING", true);
+    prop.put("CLIENT_REQUEST_MFA_TOKEN", true);
     return prop;
   }
 
@@ -144,7 +144,7 @@ public class SnowflakeMFACacheTest {
                         jsonNode
                             .path("data")
                             .path("SESSION_PARAMETERS")
-                            .path("CLIENT_ALLOW_MFA_CACHING")
+                            .path("CLIENT_REQUEST_MFA_TOKEN")
                             .asBoolean());
                     res = getNormalMockedHttpResponse(true, 0).toString();
                   } else if (callCount == 1) {
@@ -155,7 +155,7 @@ public class SnowflakeMFACacheTest {
                         jsonNode
                             .path("data")
                             .path("SESSION_PARAMETERS")
-                            .path("CLIENT_ALLOW_MFA_CACHING")
+                            .path("CLIENT_REQUEST_MFA_TOKEN")
                             .asBoolean());
                     assertEquals(jsonNode.path("data").path("TOKEN").asText(), mockedMfaToken[0]);
                     res = getNormalMockedHttpResponse(true, 1).toString();
@@ -167,7 +167,7 @@ public class SnowflakeMFACacheTest {
                         jsonNode
                             .path("data")
                             .path("SESSION_PARAMETERS")
-                            .path("CLIENT_ALLOW_MFA_CACHING")
+                            .path("CLIENT_REQUEST_MFA_TOKEN")
                             .asBoolean());
                     assertEquals(jsonNode.path("data").path("TOKEN").asText(), mockedMfaToken[1]);
                     res = getNormalMockedHttpResponse(true, -1).toString();

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java
@@ -19,14 +19,12 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
-import net.snowflake.client.category.TestCategoryConnection;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.core.ObjectMapperFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.HttpPost;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -38,7 +36,6 @@ class Buddy {
   }
 }
 
-@Category(TestCategoryConnection.class)
 public class SnowflakeMFACacheTest {
   private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
   private static final String[] mockedMfaToken = {"mockedMfaToken0", "mockedMfaToken1"};


### PR DESCRIPTION
**_NOTE!_**
    This pr won't be merged until a thorough test with backend changes is done.

The whole context:
> For users who are using username-pwd plus MFA authentication, we plan to add a temporary mfa token cache. This mfa token cache helps prevent multiple MFA authentication with a short perioud of time, which is similar to previous ID_TOKEN. In other words, if user's connection request is sent with a correct pwd (yes, pwd is still needed) and a valid mfa token, then users don't need to do mfa authentication again.

What this pr does:

1. Add a new authenticator USERNAME_PASSWORD_MFA. CLIENT_REQUEST_MFA_TOKEN parameter is added.
2. Support both ID_TOKEN and MFATOKEN in Local Secure Storage.
3. Change the way we name local cache of ID_TOKEN
4. Change the SecureStorageLinuxManager to singleton pattern which helps avoid some potential problems.
5. For Linux local file cache, support partially deletion of temporary credential file.

`src/test/java/net/snowflake/client/jdbc/SnowflakeMFACacheTest.java` can be a good start for learning use cases.