### PR TITLE
SNOW-190589 Support private link for Spark Connector

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -374,7 +374,7 @@ public class SessionUtil {
       // Adjust OCSP cache server if it is private link
       resetOCSPUrlIfNecessary(loginInput.getServerUrl());
     } catch (IOException ex) {
-      throw new SFException(ex, ErrorCode.INTERNAL_ERROR, "unexpected URL syntax exception");
+      throw new SFException(ex, ErrorCode.IO_ERROR, "unexpected URL syntax exception");
     }
 
     HttpPost postRequest = null;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializable.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializable.java
@@ -13,11 +13,64 @@ import java.util.Properties;
  * serializable object.
  */
 public interface SnowflakeResultSetSerializable {
+  // This wraps the required info for retrieving ResultSet
+  class ResultSetRetrieveConfig {
+    private Properties proxyProperties;
+    private String sfFullURL;
+
+    public ResultSetRetrieveConfig(Builder builder) {
+      this.proxyProperties = builder.proxyProperties;
+      this.sfFullURL = builder.sfFullURL;
+    }
+
+    public Properties getProxyProperties() {
+      return proxyProperties;
+    }
+
+    public String getSfFullURL() {
+      return sfFullURL;
+    }
+
+    // The inner builder class for ResultSetRetrieveConfig
+    public static class Builder {
+      private Builder() {}
+
+      private Properties proxyProperties = null;
+      private String sfFullURL = null;
+
+      public static Builder newInstance() {
+        return new Builder();
+      }
+
+      public ResultSetRetrieveConfig build() throws IllegalArgumentException {
+        // The SFURL must include protocol like https or http
+        if (sfFullURL == null || !sfFullURL.toLowerCase().startsWith("http")) {
+          throw new IllegalArgumentException(
+              "The SF URL must include protocol. The invalid is: " + sfFullURL);
+        }
+
+        return new ResultSetRetrieveConfig(this);
+      }
+
+      public Builder setProxyProperties(Properties proxyProperties) {
+        this.proxyProperties = proxyProperties;
+        return this;
+      }
+
+      public Builder setSfFullURL(String sfFullURL) {
+        this.sfFullURL = sfFullURL;
+        return this;
+      }
+    }
+  }
+
   /**
    * Get ResultSet from the ResultSet Serializable object so that the user can access the data.
    *
    * @return a ResultSet which represents for the data wrapped in the object
+   * @deprecated Please use new interface function getResultSet(ResultSetRetrieveConfig)
    */
+  @Deprecated
   ResultSet getResultSet() throws SQLException;
 
   /**
@@ -25,8 +78,18 @@ public interface SnowflakeResultSetSerializable {
    *
    * @param info The proxy server information if proxy is necessary.
    * @return a ResultSet which represents for the data wrapped in the object
+   * @deprecated Please use new interface function getResultSet(ResultSetRetrieveConfig)
    */
+  @Deprecated
   ResultSet getResultSet(Properties info) throws SQLException;
+
+  /**
+   * Get ResultSet from the ResultSet Serializable object so that the user can access the data.
+   *
+   * @param resultSetRetrieveConfig The extra info to retrieve the result set.
+   * @return a ResultSet which represents for the data wrapped in the object
+   */
+  ResultSet getResultSet(ResultSetRetrieveConfig resultSetRetrieveConfig) throws SQLException;
 
   /**
    * Retrieve total row count included in the the ResultSet Serializable object.

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializable.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializable.java
@@ -67,14 +67,8 @@ public interface SnowflakeResultSetSerializable {
   /**
    * Get ResultSet from the ResultSet Serializable object so that the user can access the data.
    *
-   * @return a ResultSet which represents for the data wrapped in the object
-   * @deprecated Please use new interface function getResultSet(ResultSetRetrieveConfig)
-   */
-  @Deprecated
-  ResultSet getResultSet() throws SQLException;
-
-  /**
-   * Get ResultSet from the ResultSet Serializable object so that the user can access the data.
+   * <p>This API is used by spark spark connector from 2.6.0 to 2.8.1. It is deprecated from
+   * sc:2.8.2/jdbc:3.12.12 since Sept 2020. It is safe to remove it after Sept 2022.
    *
    * @param info The proxy server information if proxy is necessary.
    * @return a ResultSet which represents for the data wrapped in the object

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -899,18 +899,6 @@ public class SnowflakeResultSetSerializableV1
   }
 
   /**
-   * Get ResultSet from the ResultSet Serializable object so that the user can access the data. The
-   * ResultSet is sessionless.
-   *
-   * @return a ResultSet which represents for the data wrapped in the object
-   * @deprecated Please use new interface function getResultSet(ResultSetRetrieveConfig)
-   */
-  @Deprecated
-  public ResultSet getResultSet() throws SQLException {
-    return getResultSetInternal(null);
-  }
-
-  /**
    * Get ResultSet from the ResultSet Serializable object so that the user can access the data.
    *
    * @param resultSetRetrieveConfig The extra info to retrieve the result set.
@@ -934,6 +922,9 @@ public class SnowflakeResultSetSerializableV1
 
   /**
    * Get ResultSet from the ResultSet Serializable object so that the user can access the data.
+   *
+   * <p>This API is used by spark spark connector from 2.6.0 to 2.8.1. It is deprecated from
+   * sc:2.8.2/jdbc:3.12.12 since Sept 2020. It is safe to remove it after Sept 2022.
    *
    * @param info The proxy sever information if proxy is necessary.
    * @return a ResultSet which represents for the data wrapped in the object

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
@@ -179,7 +179,14 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
       }
 
       // Read data from object
-      ResultSet rs = resultSetChunk.getResultSet(props);
+      // sfFullURL is used to support private link URL.
+      // This test case is not for private link env, so just use a valid URL for testing purpose.
+      ResultSet rs =
+          resultSetChunk.getResultSet(
+              SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder.newInstance()
+                  .setProxyProperties(props)
+                  .setSfFullURL("https://sfctest0.snowflakecomputing.com")
+                  .build());
 
       // print result set meta data
       ResultSetMetaData metadata = rs.getMetaData();
@@ -920,5 +927,22 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
         && actualRowCountFromMetadata == expectedTotalRowCount
         && actualTotalCompressedSize == expectedTotalCompressedSize
         && expectedTotalUncompressedSize == actualTotalUncompressedSize;
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testResultSetRetrieveConfig() throws Throwable {
+    SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder builder =
+        SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder.newInstance();
+
+    boolean hitExpectedException = false;
+    try {
+      builder.setSfFullURL("sfctest0.snowflakecomputing.com");
+      // The URL is invalid because it doesn't include protocol, it should raise exception
+      builder.build();
+    } catch (Exception ex) {
+      hitExpectedException = true;
+    }
+    assertTrue(hitExpectedException);
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
@@ -35,6 +35,10 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
 
   private String queryResultFormat;
 
+  // sfFullURL is used to support private link URL.
+  // This test case is not for private link env, so just use a valid URL for testing purpose.
+  private String sfFullURL = "https://sfctest0.snowflakecomputing.com";
+
   public SnowflakeResultSetSerializableIT() {
     this("json");
   }
@@ -179,13 +183,11 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
       }
 
       // Read data from object
-      // sfFullURL is used to support private link URL.
-      // This test case is not for private link env, so just use a valid URL for testing purpose.
       ResultSet rs =
           resultSetChunk.getResultSet(
               SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder.newInstance()
                   .setProxyProperties(props)
-                  .setSfFullURL("https://sfctest0.snowflakecomputing.com")
+                  .setSfFullURL(sfFullURL)
                   .build());
 
       // print result set meta data
@@ -474,7 +476,12 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
       fi.close();
 
       // Get ResultSet from object
-      ResultSet rs = resultSetChunk.getResultSet();
+      ResultSet rs =
+          resultSetChunk.getResultSet(
+              SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder.newInstance()
+                  .setProxyProperties(new Properties())
+                  .setSfFullURL(sfFullURL)
+                  .build());
 
       String[] filePathParts = filename.split(File.separator);
       String appendix = filePathParts[filePathParts.length - 1];
@@ -621,7 +628,13 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
       try {
         SnowflakeResultSetSerializable resultSetSerializable = resultSetSerializables.get(0);
 
-        ResultSet resultSet = resultSetSerializable.getResultSet();
+        ResultSet resultSet =
+            resultSetSerializable.getResultSet(
+                SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder.newInstance()
+                    .setProxyProperties(new Properties())
+                    .setSfFullURL(sfFullURL)
+                    .build());
+
         while (resultSet.next()) {
           resultSet.getString(1);
         }
@@ -893,7 +906,14 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
       chunkFileCount += resultSetChunk.chunkFileCount;
 
       // Get actual row count from result set.
-      ResultSet rs = resultSetChunk.getResultSet(props);
+      // sfFullURL is used to support private link URL.
+      // This test case is not for private link env, so just use a valid URL for testing purpose.
+      ResultSet rs =
+          resultSetChunk.getResultSet(
+              SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder.newInstance()
+                  .setProxyProperties(props)
+                  .setSfFullURL(sfFullURL)
+                  .build());
 
       // Accumulate the actual row count from result set.
       while (rs.next()) {
@@ -930,7 +950,6 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
   }
 
   @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testResultSetRetrieveConfig() throws Throwable {
     SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder builder =
         SnowflakeResultSetSerializable.ResultSetRetrieveConfig.Builder.newInstance();


### PR DESCRIPTION
Enhance SnowflakeResultSetSerializable.getResultSet() to support private link.

SNOW-190589

When JDBC connects to snowflake, the OCSP cache server is adjusted if the URL
is for private link. But the spark connector executors try to get the
ResultSet without connection. So the OCSP cache server adjusting is
skipped.

The fix proposal is:
1. Spark Connector needs to pass the snowflake URL into JDBC
2. JDBC adjusts the OCSP cache server if the URL is private link.

This PR is for item #2.