### PR TITLE
SNOW-194437 Time values can now be uploaded via stage bind

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -73,10 +73,6 @@ public class SFStatement {
   /** id used in combine describe and execute */
   private String describeJobUUID;
 
-  // when uploading binds to stage, we use a table scan which cannot parse times from ms
-  // so, if the user binds time values, we don't upload to stage
-  private boolean hasUnsupportedStageBind = false;
-
   // list of child result objects for queries called by the current query, if any
   private List<SFChildResult> childResults = null;
 
@@ -384,7 +380,6 @@ public class SFStatement {
       if (0 < session.getArrayBindStageThreshold()
           && session.getArrayBindStageThreshold() <= numBinds
           && !describeOnly
-          && !hasUnsupportedStageBind
           && BindUploader.isArrayBind(bindValues)) {
         try (BindUploader uploader = BindUploader.newInstance(session, requestId)) {
           uploader.upload(bindValues);
@@ -880,10 +875,6 @@ public class SFStatement {
 
   protected SFSession getSession() {
     return session;
-  }
-
-  public void setHasUnsupportedStageBind(boolean hasUnsupportedStageBind) {
-    this.hasUnsupportedStageBind = hasUnsupportedStageBind;
   }
 
   // *NOTE* this new SQL format is incomplete. It should only be used under certain circumstances.

--- a/src/main/java/net/snowflake/client/core/bind/BindUploader.java
+++ b/src/main/java/net/snowflake/client/core/bind/BindUploader.java
@@ -125,8 +125,8 @@ public class BindUploader implements Closeable {
 
     Time v1 = new Time(sec * 1000);
     String formatWithDate = timestampFormat.format(v1) + String.format("%09d", nano);
+    // Take out the Date portion of the formatted string. Only time data is needed.
     return formatWithDate.substring(11);
-    // return timeFormat.format(new java.sql.Date(Long.parseLong(o)));
   }
 
   private synchronized String synchronizedTimestampFormat(String o) {

--- a/src/main/java/net/snowflake/client/core/bind/BindUploader.java
+++ b/src/main/java/net/snowflake/client/core/bind/BindUploader.java
@@ -122,7 +122,7 @@ public class BindUploader implements Closeable {
     return formatWithDate.substring(11);
   }
 
-  private synchronized SFPair<Long, Integer> getNanosAndSecs(String o, boolean isNegative) {
+  private SFPair<Long, Integer> getNanosAndSecs(String o, boolean isNegative) {
     String inpString = o;
     if (isNegative) {
       inpString = o.substring(1);

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -309,7 +309,6 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
               String.valueOf(nanosSinceMidnight));
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
-      sfStatement.setHasUnsupportedStageBind(true);
     }
   }
 
@@ -356,9 +355,6 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   @Override
   public void clearParameters() throws SQLException {
     parameterBindings.clear();
-    if (batchParameterBindings.isEmpty()) {
-      sfStatement.setHasUnsupportedStageBind(false);
-    }
   }
 
   @Override
@@ -768,7 +764,6 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     parameterBindings.clear();
     wasPrevValueNull.clear();
     batchSize = 0;
-    sfStatement.setHasUnsupportedStageBind(false);
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -298,6 +298,12 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       // Convert to nanoseconds since midnight using the input time mod 24 hours.
       final long MS_IN_DAY = 86400 * 1000;
       long msSinceEpoch = x.getTime();
+      if (msSinceEpoch < 0) {
+        throw new SnowflakeSQLLoggedException(
+            connection.getSfSession(),
+            SqlState.INVALID_PARAMETER_VALUE,
+            "Invalid bind value " + msSinceEpoch + " for type TIME");
+      }
       // Use % + % instead of just % to get the nonnegative remainder.
       // TODO(mkember): Change to use Math.floorMod when Client is on Java 8.
       long msSinceMidnight = (msSinceEpoch % MS_IN_DAY + MS_IN_DAY) % MS_IN_DAY;

--- a/src/test/java/net/snowflake/client/jdbc/BindUploaderIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/BindUploaderIT.java
@@ -13,19 +13,9 @@ import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.sql.Connection;
+import java.sql.*;
 import java.sql.Date;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.zip.GZIPInputStream;
 import net.snowflake.client.category.TestCategoryOthers;
 import net.snowflake.client.core.ParameterBindingDTO;
@@ -80,9 +70,9 @@ public class BindUploaderIT extends BaseJDBCTest {
   };
 
   private static final String csv1 =
-      "42,1234,12.34,12.34,42,row1,807F,1970-01-01,0,1970-01-01 00:00:00.000000000 +00:00";
+      "42,1234,12.34,12.34,42,row1,807F,1970-01-01,00:00:00.000000000,1970-01-01 00:00:00.000000000 +00:00";
   private static final String csv2 =
-      "420,12340,120.34,120.34,420,row2,7F80,1970-01-01,1000000,1970-01-01 00:00:00.001000000 +00:00";
+      "420,12340,120.34,120.34,420,row2,7F80,1970-01-01,00:00:00.001000000,1970-01-01 00:00:00.001000000 +00:00";
 
   private static final String STAGE_DIR = "binduploaderit";
   private static final String SELECT_FROM_STAGE =

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
@@ -84,9 +84,13 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
    * Test to ensure it's possible to upload Time values via stage array binding and get proper
    * values back (SNOW-194437)
    *
+   * <p>Ignored on GitHub Action because CLIENT_STAGE_ARRAY_BINDING_THRESHOLD parameter is not
+   * available to customers so cannot be set when running on Github Action
+   *
    * @throws SQLException
    */
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testInsertStageArrayBindWithTime() throws SQLException {
     try (Connection connection = init()) {
       Statement statement = connection.createStatement();

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
@@ -3,23 +3,23 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.jdbc.ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryStatement;
+import net.snowflake.common.core.SqlState;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import java.sql.*;
-import java.util.Map;
-import java.util.Properties;
-
-import static net.snowflake.client.jdbc.ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
 @Category(TestCategoryStatement.class)
 public class PreparedStatement1IT extends PreparedStatement0IT {
@@ -98,13 +98,13 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
       statement.execute("alter session set CLIENT_STAGE_ARRAY_BINDING_THRESHOLD=2");
       statement.execute("create or replace table testStageBindTime (c1 time, c2 time)");
       PreparedStatement prepSt =
-          connection.prepareStatement("insert into testStageBindTime values (?, ?), (?, ?)");
-      Time[][] timeValues = {{new Time(0), new Time(1)},
-              {new Time(100), new Time(-100)},
-              {new Time(-456782), new Time(123456)},
-              {new Time(Integer.MIN_VALUE), new Time(Integer.MAX_VALUE)}};
-      for (int i = 0; i < timeValues.length; i++)
-      {
+          connection.prepareStatement("insert into testStageBindTime values (?, ?)");
+      Time[][] timeValues = {
+        {new Time(0), new Time(1)},
+        {new Time(1000), new Time(Integer.MAX_VALUE)},
+        {new Time(123456), new Time(55555)}
+      };
+      for (int i = 0; i < timeValues.length; i++) {
         prepSt.setTime(1, timeValues[i][0]);
         prepSt.setTime(2, timeValues[i][1]);
         prepSt.addBatch();
@@ -112,15 +112,19 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
       prepSt.executeBatch();
       // check results
       ResultSet rs = statement.executeQuery("select * from testStageBindTime");
-      for (int i = 0; i < timeValues.length; i++)
-      {
+      for (int i = 0; i < timeValues.length; i++) {
         rs.next();
-        System.out.println(rs.getTime(1).toString());
-        System.out.println(rs.getTime(2).toString());
-        assertEquals(timeValues[i][0], rs.getTime(1));
-        assertEquals(timeValues[i][1], rs.getTime(2));
+        assertEquals(timeValues[i][0].toString(), rs.getTime(1).toString());
+        assertEquals(timeValues[i][1].toString(), rs.getTime(2).toString());
       }
       rs.close();
+      // test that negative time values results in an error
+      try {
+        prepSt.setTime(1, new Time(-100));
+        fail("Exception should have been thrown for negative setTime() value.");
+      } catch (SnowflakeSQLException e) {
+        assertEquals(e.getSQLState(), SqlState.INVALID_PARAMETER_VALUE);
+      }
       statement.execute("drop table if exists testStageBindTime");
       statement.execute("alter session unset CLIENT_STAGE_ARRAY_BINDING_THRESHOLD");
       statement.close();
@@ -493,11 +497,10 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
   public void testStageBatchTimes() throws SQLException {
     try (Connection connection = init()) {
       Time tMidnight = new Time(0);
-      Time tNeg = new Time(-1);
       Time tPos = new Time(1);
       Time tNow = new Time(System.currentTimeMillis());
       Time tNoon = new Time(12 * 60 * 60 * 1000);
-      Time[] times = new Time[] {tMidnight, tNeg, tPos, tNow, tNoon, null};
+      Time[] times = new Time[] {tMidnight, tPos, tNow, tNoon, null};
       int[] countResult;
       try {
         connection

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
@@ -110,6 +110,7 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
       assertEquals(new Time(100), rs.getTime(1));
       assertEquals(new Date(100).toString(), rs.getDate(2).toString());
       rs.close();
+      statement.execute("drop table if exists testStageBindTime");
       statement.execute("alter session unset CLIENT_STAGE_ARRAY_BINDING_THRESHOLD");
       statement.close();
     }

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
@@ -82,7 +82,7 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
 
   /**
    * Test to ensure it's possible to upload Time values via stage array binding and get proper
-   * values back
+   * values back (SNOW-194437)
    *
    * @throws SQLException
    */


### PR DESCRIPTION
Currently, java Time objects can only be uploaded individually with insert statements, even if there are enough bind parameters to trigger bulk uploading via stage. This change allows time objects to be uploaded via stage by changing their serialization format.

Now the format is in HH:MM:SS.sssssssss instead of milliseconds.