### PR TITLE
SNOW-187546 Remove Unused Code from JDBC driver

### DIFF
--- a/src/main/java/net/snowflake/client/core/BasicEvent.java
+++ b/src/main/java/net/snowflake/client/core/BasicEvent.java
@@ -38,10 +38,6 @@ public class BasicEvent extends Event {
       this.argString = argString;
     }
 
-    public int getId() {
-      return id;
-    }
-
     public String getDescription() {
       return description;
     }

--- a/src/main/java/net/snowflake/client/core/Event.java
+++ b/src/main/java/net/snowflake/client/core/Event.java
@@ -5,12 +5,6 @@
 package net.snowflake.client.core;
 
 import com.google.common.base.Preconditions;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.util.zip.GZIPOutputStream;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
@@ -21,9 +15,6 @@ import net.snowflake.client.log.SFLoggerFactory;
  */
 public abstract class Event {
   private static final SFLogger logger = SFLoggerFactory.getLogger(Event.class);
-
-  private static final String EVENT_DUMP_FILE_NAME = "sf_event_";
-  private static final String EVENT_DUMP_FILE_EXT = ".dmp.gz";
 
   // need to check if directory exists, if not try to create it
   // need to check file size, see if it exceeds maximum (need parameter for this)
@@ -69,46 +60,6 @@ public abstract class Event {
 
   public EventType getType() {
     return this.type;
-  }
-
-  public void setType(EventType type) {
-    this.type = type;
-  }
-
-  public String getMessage() {
-    return this.message;
-  }
-
-  public void setMessage(String message) {
-    this.message = message;
-  }
-
-  protected void writeEventDumpLine(String message) {
-    final String eventDumpPath =
-        EventUtil.getDumpPathPrefix()
-            + "/"
-            + EVENT_DUMP_FILE_NAME
-            + EventUtil.getDumpFileId()
-            + EVENT_DUMP_FILE_EXT;
-
-    // If the event dump file is too large, truncate
-    if (new File(eventDumpPath).length() < EventUtil.getmaxDumpFileSizeBytes()) {
-      try {
-        final OutputStream outStream =
-            new GZIPOutputStream(new FileOutputStream(eventDumpPath, true));
-        PrintWriter eventDumper = new PrintWriter(outStream, true);
-        eventDumper.println(message);
-        eventDumper.flush();
-        eventDumper.close();
-      } catch (IOException ex) {
-        logger.error(
-            "Could not open Event dump file {}, exception:{}", eventDumpPath, ex.getMessage());
-      }
-    } else {
-      logger.error(
-          "Failed to dump Event because dump file is "
-              + "too large. Delete dump file or increase maximum dump file size.");
-    }
   }
 
   /*

--- a/src/main/java/net/snowflake/client/core/HostSpecSSD.java
+++ b/src/main/java/net/snowflake/client/core/HostSpecSSD.java
@@ -9,10 +9,6 @@ class HostSpecSSD {
     this.hostSpecDirective = null;
   }
 
-  String getHostname() {
-    return this.hostname;
-  }
-
   String getHostSpecDirective() {
     return this.hostSpecDirective;
   }

--- a/src/main/java/net/snowflake/client/core/IncidentUtil.java
+++ b/src/main/java/net/snowflake/client/core/IncidentUtil.java
@@ -30,7 +30,6 @@ public class IncidentUtil {
 
   // Json message variables
   public static final String TIMESTAMP = "timestamp";
-  public static final String INCIDENT_INFO = "incidentInfo";
 
   // Determines name of dump file.
   public static final String INC_DUMP_FILE_NAME = "sf_incident_";

--- a/src/main/java/net/snowflake/client/core/MetaDataOfBinds.java
+++ b/src/main/java/net/snowflake/client/core/MetaDataOfBinds.java
@@ -50,18 +50,6 @@ public class MetaDataOfBinds implements Serializable {
     return this.scale;
   }
 
-  public int getByteLength() {
-    return this.byteLength;
-  }
-
-  public int getLength() {
-    return this.length;
-  }
-
-  public String getName() {
-    return this.name;
-  }
-
   public String getTypeName() {
     return this.type;
   }

--- a/src/main/java/net/snowflake/client/core/OCSPMode.java
+++ b/src/main/java/net/snowflake/client/core/OCSPMode.java
@@ -23,8 +23,4 @@ public enum OCSPMode {
   OCSPMode(int value) {
     this.value = value;
   }
-
-  public int getValue() {
-    return this.value;
-  }
 }

--- a/src/main/java/net/snowflake/client/core/SFLoginOutput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginOutput.java
@@ -21,7 +21,6 @@ public class SFLoginOutput {
   private String sessionRole;
   private String sessionWarehouse;
   private Map<String, Object> commonParams;
-  private boolean updatedByTokenRequest;
   private String sessionId;
 
   SFLoginOutput() {}

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -66,10 +66,6 @@ public class SFResultSet extends SFJsonResultSet {
 
   private Telemetry telemetryClient;
 
-  // If customer wants Timestamp_NTZ values to be stored in UTC time
-  // instead of a local/session timezone, set to true
-  private boolean treatNTZAsUTC;
-
   /**
    * Constructor takes a result from the API response that we get from executing a SQL statement.
    *
@@ -93,7 +89,6 @@ public class SFResultSet extends SFJsonResultSet {
     session.setSchema(resultSetSerializable.getFinalSchemaName());
     session.setRole(resultSetSerializable.getFinalRoleName());
     session.setWarehouse(resultSetSerializable.getFinalWarehouseName());
-    this.treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
 
     // update the driver/session with common parameters from GS
     SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSession());
@@ -150,7 +145,6 @@ public class SFResultSet extends SFJsonResultSet {
     this.arrayBindSupported = resultSetSerializable.isArrayBindSupported();
     this.metaDataOfBinds = resultSetSerializable.getMetaDataOfBinds();
     this.resultSetMetaData = resultSetSerializable.getSFResultSetMetaData();
-    this.treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
 
     // sort result set if needed
     if (sortResult) {

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -1013,10 +1013,6 @@ public class SFSession {
     return injectSocketTimeout;
   }
 
-  public void setInjectSocketTimeout(int injectSocketTimeout) {
-    this.injectSocketTimeout = injectSocketTimeout;
-  }
-
   public void setInjectFileUploadFailure(String fileToFail) {
     this.injectFileUploadFailure = fileToFail;
   }
@@ -1037,18 +1033,6 @@ public class SFSession {
     return injectClientPause;
   }
 
-  public void setInjectClientPause(int injectClientPause) {
-    this.injectClientPause = injectClientPause;
-  }
-
-  protected int getHttpClientConnectionTimeout() {
-    return httpClientConnectionTimeout;
-  }
-
-  protected int getHttpClientSocketTimeout() {
-    return httpClientSocketTimeout;
-  }
-
   protected int getAndIncrementSequenceId() {
     return sequenceId.getAndIncrement();
   }
@@ -1061,20 +1045,8 @@ public class SFSession {
     return this.sfSQLMode;
   }
 
-  public boolean isEnableHeartbeat() {
-    return enableHeartbeat;
-  }
-
   public void setEnableHeartbeat(boolean enableHeartbeat) {
     this.enableHeartbeat = enableHeartbeat;
-  }
-
-  public void setHeartbeatFrequency(int frequency) {
-    this.heartbeatFrequency = frequency;
-  }
-
-  public long getHeartbeatFrequency() {
-    return this.heartbeatFrequency;
   }
 
   public boolean getAutoCommit() {
@@ -1257,14 +1229,6 @@ public class SFSession {
         String.format("%s.%s.%s", this.getDatabase(), this.getSchema(), arrayBindStage);
   }
 
-  public String getIdToken() {
-    return idToken;
-  }
-
-  public boolean isStoreTemporaryCredential() {
-    return this.storeTemporaryCredential;
-  }
-
   public void setStoreTemporaryCredential(boolean storeTemporaryCredential) {
     this.storeTemporaryCredential = storeTemporaryCredential;
   }
@@ -1378,10 +1342,6 @@ public class SFSession {
 
   public int getClientPrefetchThreads() {
     return clientPrefetchThreads;
-  }
-
-  public boolean isValidateDefaultParameters() {
-    return validateDefaultParameters;
   }
 
   public void setValidateDefaultParameters(boolean v) {

--- a/src/main/java/net/snowflake/client/core/SFStatementMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFStatementMetaData.java
@@ -52,10 +52,6 @@ public class SFStatementMetaData {
     return resultSetMetaData;
   }
 
-  public void setResultSetMetaData(SFResultSetMetaData resultSetMetaData) {
-    this.resultSetMetaData = resultSetMetaData;
-  }
-
   public int getNumberOfBinds() {
     return numberOfBinds;
   }
@@ -72,10 +68,6 @@ public class SFStatementMetaData {
       throw new SnowflakeSQLException(SqlState.NO_DATA, ErrorCode.NO_VALID_DATA.getMessageCode());
     }
     return metaDataOfBinds.get(param - 1);
-  }
-
-  public void setNumberOfBinds(int numberOfBinds) {
-    this.numberOfBinds = numberOfBinds;
   }
 
   /**

--- a/src/main/java/net/snowflake/client/core/SFStatementType.java
+++ b/src/main/java/net/snowflake/client/core/SFStatementType.java
@@ -97,21 +97,9 @@ public enum SFStatementType {
     return statementTypeId;
   }
 
-  public boolean isDDL() {
-    return this == DDL;
-  }
-
   public boolean isDML() {
     return statementTypeId >= DML.getStatementTypeId()
         && statementTypeId < DML.getStatementTypeId() + LEVEL_3_RANGE;
-  }
-
-  public boolean isTCL() {
-    return this == TCL;
-  }
-
-  public boolean isSCL() {
-    return this == SCL;
   }
 
   public boolean isGenerateResultSet() {

--- a/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
@@ -44,8 +44,6 @@ class SessionUtilKeyPair {
 
   private Provider SecurityProvider = null;
 
-  private SecretKeyFactory secretKeyFactory = null;
-
   private static final String ISSUER_FMT = "%s.%s.%s";
 
   private static final String SUBJECT_FMT = "%s.%s";

--- a/src/main/java/net/snowflake/client/core/arrow/BigIntToTimeConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BigIntToTimeConverter.java
@@ -3,7 +3,6 @@
  */
 package net.snowflake.client.core.arrow;
 
-import java.nio.ByteBuffer;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.TimeZone;
@@ -20,7 +19,6 @@ import org.apache.arrow.vector.ValueVector;
 
 public class BigIntToTimeConverter extends AbstractArrowVectorConverter {
   private BigIntVector bigIntVector;
-  protected ByteBuffer byteBuf = ByteBuffer.allocate(BigIntVector.TYPE_WIDTH);
 
   public BigIntToTimeConverter(
       ValueVector fieldVector, int columnIndex, DataConversionContext context) {

--- a/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/JsonResultChunk.java
@@ -17,7 +17,6 @@ import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 
 public class JsonResultChunk extends SnowflakeResultChunk {
-  private static final int NULL_VALUE = Integer.MIN_VALUE;
 
   private static final SFLogger logger = SFLoggerFactory.getLogger(JsonResultChunk.class);
 
@@ -63,50 +62,6 @@ public class JsonResultChunk extends SnowflakeResultChunk {
    */
   public final Object getCell(int rowIdx, int colIdx) {
     return data.get(colCount * rowIdx + colIdx);
-  }
-
-  public final void addRow(Object[] row) throws SnowflakeSQLException {
-    if (row.length != colCount) {
-      throw new SnowflakeSQLLoggedException(
-          this.session,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          SqlState.INTERNAL_ERROR,
-          "Exception: expected " + colCount + " columns and received " + row.length);
-    }
-
-    for (Object cell : row) {
-      if (cell == null) {
-        data.add(null);
-      } else {
-        if (cell instanceof String) {
-          data.add((String) cell);
-        } else if (cell instanceof Boolean) {
-          data.add((boolean) cell ? "1" : "0");
-        } else {
-          throw new SnowflakeSQLLoggedException(
-              this.session,
-              ErrorCode.INTERNAL_ERROR.getMessageCode(),
-              SqlState.INTERNAL_ERROR,
-              "unknown data type in JSON row " + cell.getClass().toString());
-        }
-      }
-    }
-    currentRow++;
-  }
-
-  /**
-   * Checks that all data has been added after parsing.
-   *
-   * @throws SnowflakeSQLException when rows are not all downloaded
-   */
-  public final void ensureRowsComplete() throws SnowflakeSQLException {
-    // Check that all the rows have been decoded, raise an error if not
-    if (rowCount != currentRow) {
-      throw new SnowflakeSQLException(
-          SqlState.INTERNAL_ERROR,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
-          "Exception: expected " + rowCount + " rows and received " + currentRow);
-    }
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/jdbc/MatDesc.java
+++ b/src/main/java/net/snowflake/client/jdbc/MatDesc.java
@@ -49,18 +49,6 @@ public class MatDesc {
     this(smkId, queryId, DEFAULT_KEY_SIZE);
   }
 
-  public long getSmkId() {
-    return this.smkId;
-  }
-
-  public String getQueryId() {
-    return this.queryId;
-  }
-
-  public int getKeySize() {
-    return this.keySize;
-  }
-
   /**
    * Try to parse the material descriptor string.
    *

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -6,29 +6,11 @@ package net.snowflake.client.jdbc;
 
 import static net.snowflake.client.core.Constants.MB;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.MappingJsonFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.PushbackInputStream;
-import java.io.StringWriter;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPInputStream;
@@ -62,11 +44,6 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
 
   // SSE-C algorithm value
   private static final String SSE_C_AES = "AES256";
-
-  // object mapper for deserialize JSON
-  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
-  /** a shared JSON parser factory. */
-  private static final JsonFactory jsonFactory = new MappingJsonFactory();
 
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeChunkDownloader.class);
   private static final int STREAM_BUFFER_SIZE = MB;

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageProviderException.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageProviderException.java
@@ -24,15 +24,6 @@ public class StorageProviderException extends RuntimeException {
   }
 
   /**
-   * Method to obtain the original provider exception that led to this exception being thrown.
-   *
-   * @return The original provider exception that led to this exception.
-   */
-  public Exception getOriginalProviderException() {
-    return (Exception) (super.getCause());
-  }
-
-  /**
    * Returns true if this is an exception corresponding to a HTTP 404 error returned by the storage
    * provider
    *

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryData.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryData.java
@@ -21,10 +21,6 @@ public class TelemetryData {
     this.timeStamp = timeStamp;
   }
 
-  public long getTimeStamp() {
-    return timeStamp;
-  }
-
   public ObjectNode getMessage() {
     return message;
   }

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -187,10 +187,6 @@ public class TelemetryService {
     return this.connStr;
   }
 
-  public SnowflakeConnectString getSnowflakeConnectionString() {
-    return sfConnStr;
-  }
-
   private enum TELEMETRY_API {
     SFCTEST(
         "https://sfctest.client-telemetry.snowflakecomputing.com/enqueue",
@@ -275,14 +271,6 @@ public class TelemetryService {
    */
   public int getClientFailureCount() {
     return clientFailureCnt.get();
-  }
-
-  /**
-   * @return the number of times an event was attempted to be reported but failed due to a
-   *     server-side error
-   */
-  public int getServerFailureCount() {
-    return serverFailureCnt.get();
   }
 
   /** @return the string containing the most recent failed response */

--- a/src/main/java/net/snowflake/client/loader/BufferStage.java
+++ b/src/main/java/net/snowflake/client/loader/BufferStage.java
@@ -6,11 +6,7 @@ package net.snowflake.client.loader;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -269,14 +265,6 @@ public class BufferStage {
 
   public String getId() {
     return _id;
-  }
-
-  public void setId(String _id) {
-    this._id = _id;
-  }
-
-  public State state() {
-    return _state;
   }
 
   public void setState(State state) {

--- a/src/main/java/net/snowflake/client/loader/LoadResultListener.java
+++ b/src/main/java/net/snowflake/client/loader/LoadResultListener.java
@@ -44,9 +44,6 @@ public interface LoadResultListener {
    */
   void addErrorCount(int number);
 
-  /** Method to reset the error count back to zero */
-  void resetErrorCount();
-
   /**
    * method to get the total number of errors
    *
@@ -61,18 +58,12 @@ public interface LoadResultListener {
    */
   void addErrorRecordCount(int number);
 
-  /** Method to reset the errorRecordCount back to zero */
-  void resetErrorRecordCount();
-
   /**
    * method to get the total number of error records
    *
    * @return the number of rows in errors
    */
   int getErrorRecordCount();
-
-  /** Resets submitted row count */
-  void resetSubmittedRowCount();
 
   /**
    * Adds the number of submitted rows

--- a/src/main/java/net/snowflake/client/loader/Loader.java
+++ b/src/main/java/net/snowflake/client/loader/Loader.java
@@ -38,13 +38,6 @@ public interface Loader {
   void submitRow(Object[] data);
 
   /**
-   * If operation is changed, previous data is committed
-   *
-   * @param op operation will be reset
-   */
-  void resetOperation(Operation op);
-
-  /**
    * Rollback uncommitted changes. If no transaction was initialized, indeterminate fraction of rows
    * could have been committed.
    */

--- a/src/main/java/net/snowflake/client/loader/LoadingError.java
+++ b/src/main/java/net/snowflake/client/loader/LoadingError.java
@@ -70,28 +70,8 @@ public class LoadingError {
     }
   }
 
-  public String getStage() {
-    return _stage;
-  }
-
-  public String getPrefix() {
-    return _prefix;
-  }
-
-  public String getFile() {
-    return _file;
-  }
-
   public String getTarget() {
     return _target;
-  }
-
-  public String getProperty(ErrorProperty p) {
-    return this._properties.get(p);
-  }
-
-  public void setProperty(ErrorProperty p, String value) {
-    this._properties.put(p, value);
   }
 
   public String toString() {

--- a/src/main/java/net/snowflake/client/loader/StreamLoader.java
+++ b/src/main/java/net/snowflake/client/loader/StreamLoader.java
@@ -703,30 +703,6 @@ public class StreamLoader implements Loader, Runnable {
     LOGGER.debug("Snowflake loader terminating");
   }
 
-  // If operation changes, existing stage needs to be scheduled for processing.
-  @Override
-  public void resetOperation(Operation op) {
-    LOGGER.debug("Reset Loader");
-
-    if (op.equals(_op)) {
-      // no-op
-      return;
-    }
-
-    LOGGER.debug("Operation is changing from {} to {}", _op, op);
-    _op = op;
-
-    if (_stage != null) {
-      try {
-        queuePut(_stage);
-      } catch (InterruptedException ex) {
-        LOGGER.error(_stage.getId(), ex);
-      }
-    }
-
-    _stage = new BufferStage(this, _op, _csvFileBucketSize, _csvFileSize);
-  }
-
   String getTable() {
     return _table;
   }
@@ -871,16 +847,6 @@ public class StreamLoader implements Loader, Runnable {
         }
 
         @Override
-        public void resetErrorCount() {
-          errorCount.set(0);
-        }
-
-        @Override
-        public void resetErrorRecordCount() {
-          errorRecordCount.set(0);
-        }
-
-        @Override
         public void addErrorCount(int count) {
           errorCount.addAndGet(count);
         }
@@ -888,11 +854,6 @@ public class StreamLoader implements Loader, Runnable {
         @Override
         public void addErrorRecordCount(int count) {
           errorRecordCount.addAndGet(count);
-        }
-
-        @Override
-        public void resetSubmittedRowCount() {
-          submittedRowCount.set(0);
         }
 
         @Override

--- a/src/main/java/net/snowflake/client/log/SLF4JJCLWrapper.java
+++ b/src/main/java/net/snowflake/client/log/SLF4JJCLWrapper.java
@@ -6,7 +6,6 @@ package net.snowflake.client.log;
 import org.apache.commons.logging.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.spi.LocationAwareLogger;
 
 /* Although this class doesn't really include SLF4J, this class play the role of
  * a wrapper class of snowflake SLF4JLogger for apache Jakarta Commons
@@ -20,13 +19,8 @@ import org.slf4j.spi.LocationAwareLogger;
 public class SLF4JJCLWrapper implements Log {
   private Logger slf4jLogger;
 
-  private boolean isLocationAwareLogger;
-
-  private static final String FQCN = SLF4JJCLWrapper.class.getName();
-
   public SLF4JJCLWrapper(String name) {
     slf4jLogger = LoggerFactory.getLogger(name);
-    isLocationAwareLogger = slf4jLogger instanceof LocationAwareLogger;
   }
 
   public void debug(Object message) {

--- a/src/main/java/net/snowflake/client/util/SecretDetector.java
+++ b/src/main/java/net/snowflake/client/util/SecretDetector.java
@@ -15,8 +15,6 @@ import java.util.regex.Pattern;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONStyle;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
 
 /** Search for credentials in sql and/or other text */
 public class SecretDetector {
@@ -72,12 +70,8 @@ public class SecretDetector {
           "(token|assertion content)" + "(['\"\\s:=]+)" + "([a-z0-9=/_\\-+]{8,})",
           Pattern.CASE_INSENSITIVE);
 
-  private static final int LOOK_AHEAD = 10;
-
   // only attempt to find secrets in its leading 100Kb SNOW-30961
   private static final int MAX_LENGTH = 100 * 1000;
-
-  private static final SFLogger LOGGER = SFLoggerFactory.getLogger(SecretDetector.class);
 
   private static String[] SENSITIVE_NAMES = {
     "access_key_id",
@@ -144,17 +138,6 @@ public class SecretDetector {
 
     if (matcher.find()) {
       return matcher.replaceAll("$1$2'****'");
-    }
-    return text;
-  }
-
-  private static String filterGenericSecret(String text) {
-    Matcher matcher =
-        GENERIC_CREDS_PATTERN.matcher(
-            text.length() <= MAX_LENGTH ? text : text.substring(0, MAX_LENGTH));
-
-    if (matcher.find()) {
-      return matcher.replaceAll("****");
     }
     return text;
   }

--- a/src/test/java/net/snowflake/client/loader/FlatfileReadMultithreadIT.java
+++ b/src/test/java/net/snowflake/client/loader/FlatfileReadMultithreadIT.java
@@ -241,16 +241,6 @@ class ResultListener implements LoadResultListener {
   }
 
   @Override
-  public void resetErrorCount() {
-    errorCount.set(0);
-  }
-
-  @Override
-  public void resetErrorRecordCount() {
-    errorRecordCount.set(0);
-  }
-
-  @Override
   public void addErrorCount(int count) {
     errorCount.addAndGet(count);
   }
@@ -258,11 +248,6 @@ class ResultListener implements LoadResultListener {
   @Override
   public void addErrorRecordCount(int count) {
     errorRecordCount.addAndGet(count);
-  }
-
-  @Override
-  public void resetSubmittedRowCount() {
-    submittedRowCount.set(0);
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/loader/TestDataConfigBuilder.java
+++ b/src/test/java/net/snowflake/client/loader/TestDataConfigBuilder.java
@@ -8,13 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 
@@ -362,16 +356,6 @@ class TestDataConfigBuilder {
     }
 
     @Override
-    public void resetErrorCount() {
-      errorCount.set(0);
-    }
-
-    @Override
-    public void resetErrorRecordCount() {
-      errorRecordCount.set(0);
-    }
-
-    @Override
     public void addErrorCount(int count) {
       errorCount.addAndGet(count);
     }
@@ -379,11 +363,6 @@ class TestDataConfigBuilder {
     @Override
     public void addErrorRecordCount(int count) {
       errorRecordCount.addAndGet(count);
-    }
-
-    @Override
-    public void resetSubmittedRowCount() {
-      submittedRowCount.set(0);
     }
 
     @Override


### PR DESCRIPTION
We have some unused code in the JDBC driver. This was discovered when investigating code coverage; quite a bit of uncovered code is just not used. I think it makes sense to remove this code because:

1.) It will improve code coverage metrics
2.) It will make code readability and maintainability easier long-term
3.) It will (very slightly) reduce the amount of memory needed for the JDBC binary
4.) We can always add this code back in if we need it by looking back on version control

I propose taking this code out but tagging this version of the JDBC driver with a flag like **removed-code** in case any of the removed code is needed again at some other point.

This PR has passed Kafka and Spark connector tests.
For Spark, I ran the spark connector test suite available in the snowflake spark repo with the command ` build/sbt it:test`. For Kafka, I ran the comprehensive integration tests in the Kafka repo with the command `mvn verify -Dmaven.javadoc.skip=true`.