### PR TITLE
SNOW-188629: Increase timeout for telemetry OOB

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -324,7 +324,7 @@ public class TelemetryService {
     private TelemetryService instance;
     private String payload;
     private String payloadLogStr;
-    private static final int TIMEOUT = 3000; // 3 second timeout limit
+    private static final int TIMEOUT = 5000; // 5 second timeout limit
     private static final RequestConfig config =
         RequestConfig.custom()
             .setConnectionRequestTimeout(TIMEOUT)

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -324,7 +324,7 @@ public class TelemetryService {
     private TelemetryService instance;
     private String payload;
     private String payloadLogStr;
-    private static final int TIMEOUT = 5000; // 5 seconds timeout limit
+    private static final int TIMEOUT = 5000; // 5 second timeout limit
     private static final RequestConfig config =
         RequestConfig.custom()
             .setConnectionRequestTimeout(TIMEOUT)

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -324,7 +324,7 @@ public class TelemetryService {
     private TelemetryService instance;
     private String payload;
     private String payloadLogStr;
-    private static final int TIMEOUT = 5000; // 5 second timeout limit
+    private static final int TIMEOUT = 5000; // 5 seconds timeout limit
     private static final RequestConfig config =
         RequestConfig.custom()
             .setConnectionRequestTimeout(TIMEOUT)


### PR DESCRIPTION
Some jdbc flaky tests failed with `Telemetry event has not been reported successfully. Error: Response: null; Error: Read timed out`. After some investigations, I think it's because we got timeout for sockets used by telemetryOOB. And the reason for timeout can be complex. Since this looks like a transient issue, retry failed tests would help. But IMO, retry would be the last solution for the issue, it comes with other risks which may give more pain. So I wanted to try to increase TIMEOUT settings for telemetry OOB first and see it that solves flaky tests.