### PR TITLE
SNOW-198566: Replace double-checked locking with resource holder pattern

### DIFF
--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -5,12 +5,11 @@
 package net.snowflake.client.core;
 
 import com.google.common.base.Strings;
+import java.net.MalformedURLException;
+import java.net.URL;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
-
-import java.net.MalformedURLException;
-import java.net.URL;
 
 public class CredentialManager {
   private static final SFLogger logger = SFLoggerFactory.getLogger(CredentialManager.class);

--- a/src/main/java/net/snowflake/client/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/core/CredentialManager.java
@@ -5,17 +5,16 @@
 package net.snowflake.client.core;
 
 import com.google.common.base.Strings;
-import java.net.MalformedURLException;
-import java.net.URL;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 public class CredentialManager {
   private static final SFLogger logger = SFLoggerFactory.getLogger(CredentialManager.class);
   private SecureStorageManager secureStorageManager;
-
-  private static CredentialManager instance;
 
   private CredentialManager() {
     if (Constants.getOS() == Constants.OS.MAC) {
@@ -29,15 +28,12 @@ public class CredentialManager {
     }
   }
 
+  private static class CredentialManagerHolder {
+    private static final CredentialManager INSTANCE = new CredentialManager();
+  }
+
   public static CredentialManager getInstance() {
-    if (instance == null) {
-      synchronized (CredentialManager.class) {
-        if (instance == null) {
-          instance = new CredentialManager();
-        }
-      }
-    }
-    return instance;
+    return CredentialManagerHolder.INSTANCE;
   }
 
   /**

--- a/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
@@ -187,7 +187,8 @@ public class SecureStorageAppleManager implements SecureStorageManager {
     private static SecurityLib INSTANCE = null;
 
     private static class ResourceHolder {
-      private static final SecurityLib INSTANCE = (SecurityLib) Native.loadLibrary("Security", SecurityLib.class);
+      private static final SecurityLib INSTANCE =
+          (SecurityLib) Native.loadLibrary("Security", SecurityLib.class);
     }
 
     public static SecurityLib getInstance() {

--- a/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageAppleManager.java
@@ -186,13 +186,13 @@ public class SecureStorageAppleManager implements SecureStorageManager {
   static class SecurityLibManager {
     private static SecurityLib INSTANCE = null;
 
+    private static class ResourceHolder {
+      private static final SecurityLib INSTANCE = (SecurityLib) Native.loadLibrary("Security", SecurityLib.class);
+    }
+
     public static SecurityLib getInstance() {
       if (INSTANCE == null) {
-        synchronized (SecurityLibManager.class) {
-          if (INSTANCE == null) {
-            INSTANCE = (SecurityLib) Native.loadLibrary("Security", SecurityLib.class);
-          }
-        }
+        INSTANCE = ResourceHolder.INSTANCE;
       }
       return INSTANCE;
     }

--- a/src/main/java/net/snowflake/client/core/SecureStorageWindowsManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageWindowsManager.java
@@ -259,10 +259,9 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
     private static Advapi32Lib INSTANCE = null;
 
     private static class ResourceHolder {
-      private static final Advapi32Lib INSTANCE = 
-                (Advapi32Lib)
-                    Native.loadLibrary(
-                        "advapi32", Advapi32Lib.class, W32APIOptions.UNICODE_OPTIONS);
+      private static final Advapi32Lib INSTANCE =
+          (Advapi32Lib)
+              Native.loadLibrary("advapi32", Advapi32Lib.class, W32APIOptions.UNICODE_OPTIONS);
     }
 
     public static Advapi32Lib getInstance() {

--- a/src/main/java/net/snowflake/client/core/SecureStorageWindowsManager.java
+++ b/src/main/java/net/snowflake/client/core/SecureStorageWindowsManager.java
@@ -258,16 +258,16 @@ public class SecureStorageWindowsManager implements SecureStorageManager {
   static class Advapi32LibManager {
     private static Advapi32Lib INSTANCE = null;
 
-    public static Advapi32Lib getInstance() {
-      if (INSTANCE == null) {
-        synchronized (Advapi32LibManager.class) {
-          if (INSTANCE == null) {
-            INSTANCE =
+    private static class ResourceHolder {
+      private static final Advapi32Lib INSTANCE = 
                 (Advapi32Lib)
                     Native.loadLibrary(
                         "advapi32", Advapi32Lib.class, W32APIOptions.UNICODE_OPTIONS);
-          }
-        }
+    }
+
+    public static Advapi32Lib getInstance() {
+      if (INSTANCE == null) {
+        INSTANCE = ResourceHolder.INSTANCE;
       }
       return INSTANCE;
     }


### PR DESCRIPTION
Since double-checked locking is a known bug in Java, we replace corresponding code with resource holder pattern.

Basically, the constructor is not guaranteed to finish before memory allocation. Then it's possible that thread A triggers the lazy initialization for `INSTANCE` and thread B might be able to see the allocated memory address for `INSTANCE` and use it while the constructor for it hasn't finished.

References:
https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2168
http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html