### PR TITLE
SNOW-194437 Revert small behavior change of negative time values

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -298,12 +298,6 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       // Convert to nanoseconds since midnight using the input time mod 24 hours.
       final long MS_IN_DAY = 86400 * 1000;
       long msSinceEpoch = x.getTime();
-      if (msSinceEpoch < 0) {
-        throw new SnowflakeSQLLoggedException(
-            connection.getSfSession(),
-            SqlState.INVALID_PARAMETER_VALUE,
-            "Invalid bind value " + msSinceEpoch + " for type TIME");
-      }
       // Use % + % instead of just % to get the nonnegative remainder.
       // TODO(mkember): Change to use Math.floorMod when Client is on Java 8.
       long msSinceMidnight = (msSinceEpoch % MS_IN_DAY + MS_IN_DAY) % MS_IN_DAY;

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
@@ -14,7 +14,6 @@ import java.util.Properties;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryStatement;
-import net.snowflake.common.core.SqlState;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -102,7 +101,8 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
       Time[][] timeValues = {
         {new Time(0), new Time(1)},
         {new Time(1000), new Time(Integer.MAX_VALUE)},
-        {new Time(123456), new Time(55555)}
+        {new Time(123456), new Time(55555)},
+        {Time.valueOf("01:02:00"), new Time(-100)},
       };
       for (int i = 0; i < timeValues.length; i++) {
         prepSt.setTime(1, timeValues[i][0]);
@@ -118,13 +118,6 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
         assertEquals(timeValues[i][1].toString(), rs.getTime(2).toString());
       }
       rs.close();
-      // test that negative time values results in an error
-      try {
-        prepSt.setTime(1, new Time(-100));
-        fail("Exception should have been thrown for negative setTime() value.");
-      } catch (SnowflakeSQLException e) {
-        assertEquals(e.getSQLState(), SqlState.INVALID_PARAMETER_VALUE);
-      }
       statement.execute("drop table if exists testStageBindTime");
       statement.execute("alter session unset CLIENT_STAGE_ARRAY_BINDING_THRESHOLD");
       statement.close();
@@ -497,10 +490,11 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
   public void testStageBatchTimes() throws SQLException {
     try (Connection connection = init()) {
       Time tMidnight = new Time(0);
+      Time tNeg = new Time(-1);
       Time tPos = new Time(1);
       Time tNow = new Time(System.currentTimeMillis());
       Time tNoon = new Time(12 * 60 * 60 * 1000);
-      Time[] times = new Time[] {tMidnight, tPos, tNow, tNoon, null};
+      Time[] times = new Time[] {tMidnight, tNeg, tPos, tNow, tNoon, null};
       int[] countResult;
       try {
         connection

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneIT.java
@@ -186,20 +186,26 @@ public class ResultSetMultiTimeZoneIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testTimeRange() throws SQLException {
-    final String insertTime = "insert into timeTest values (?), (?)";
+    final String insertTime = "insert into timeTest values (?), (?), (?), (?)";
     Connection connection = init();
     Statement statement = connection.createStatement();
     statement.execute("create or replace table timeTest (c1 time)");
 
-    long ms1 = 86400 * 1000; // 1970-01-02 00:00:00
-    long ms2 = 1451680250123L; // 2016-01-01 12:30:50.123
+    long ms1 = -2202968667333L; // 1900-03-11 09:15:33.667
+    long ms2 = -1; // 1969-12-31 23:59:99.999
+    long ms3 = 86400 * 1000; // 1970-01-02 00:00:00
+    long ms4 = 1451680250123L; // 2016-01-01 12:30:50.123
 
     Time tm1 = new Time(ms1);
     Time tm2 = new Time(ms2);
+    Time tm3 = new Time(ms3);
+    Time tm4 = new Time(ms4);
 
     PreparedStatement prepStatement = connection.prepareStatement(insertTime);
     prepStatement.setTime(1, tm1);
     prepStatement.setTime(2, tm2);
+    prepStatement.setTime(3, tm3);
+    prepStatement.setTime(4, tm4);
 
     prepStatement.execute();
 
@@ -216,6 +222,12 @@ public class ResultSetMultiTimeZoneIT extends BaseJDBCTest {
     resultSet.next();
     assertNotEquals(tm2, resultSet.getTime(1));
     assertEquals(new Time((ms2 % M + M) % M), resultSet.getTime(1));
+    resultSet.next();
+    assertNotEquals(tm3, resultSet.getTime(1));
+    assertEquals(new Time((ms3 % M + M) % M), resultSet.getTime(1));
+    resultSet.next();
+    assertNotEquals(tm4, resultSet.getTime(1));
+    assertEquals(new Time((ms4 % M + M) % M), resultSet.getTime(1));
     statement.execute("drop table if exists timeTest");
     connection.close();
   }


### PR DESCRIPTION
While implementing the ability to upload Time values via a stage bind, we noticed that negative Time values (such as Time(-100) do not throw an exception when being bound (either via stage or just insert), so I added in an exception along with the ability to bind via stage in this PR: https://github.com/snowflakedb/snowflake-jdbc/pull/338

However, the addition of this exception is a behavior change for both binding Time values via stage or via individual insert statements. Given the current stability push, I think we should take this behavior change back out and re-visit the issue of negative Time values later. 

With this change, the behavior of setTime() will not be altered at all.