### PR TITLE
SNOW-204185: Try to fix a corner case which causes the resultset hang

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -9,26 +9,11 @@ import static net.snowflake.client.core.Constants.MB;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.PushbackInputStream;
-import java.io.StringWriter;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPInputStream;
@@ -974,13 +959,13 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
 
             resultChunk.getLock().unlock();
           }
-        } catch (SnowflakeSQLException ex) {
+        } catch (Throwable th) {
           resultChunk.getLock().lock();
           try {
             logger.debug("get lock to set chunk download error");
             resultChunk.setDownloadState(DownloadState.FAILURE);
             StringWriter errors = new StringWriter();
-            ex.printStackTrace(new PrintWriter(errors));
+            th.printStackTrace(new PrintWriter(errors));
             resultChunk.setDownloadError(errors.toString());
 
             logger.debug("wake up consumer if it is waiting for a chunk to be ready");
@@ -994,8 +979,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
           logger.debug(
               "Thread {} Exception encountered ({}:{}) fetching #chunk{} from: {}, Error {}",
               Thread.currentThread().getId(),
-              ex.getClass().getName(),
-              ex.getLocalizedMessage(),
+              th.getClass().getName(),
+              th.getLocalizedMessage(),
               chunkIndex,
               resultChunk.getScrubbedUrl(),
               resultChunk.getDownloadError());

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -918,9 +918,6 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
 
       private long startTime;
 
-      // For testing purpose
-      private Throwable injectedException = SnowflakeChunkDownloader.injectedDownloaderException;
-
       public Void call() {
         resultChunk.getLock().lock();
         try {
@@ -942,9 +939,9 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         TelemetryService.getInstance().updateContext(downloader.snowflakeConnectionString);
 
         try {
-          if (injectedException != null) {
+          if (SnowflakeChunkDownloader.injectedDownloaderException != null) {
             // Normal flow will never hit here. This is only for testing purpose
-            throw injectedException;
+            throw SnowflakeChunkDownloader.injectedDownloaderException;
           }
 
           InputStream is = getInputStream();

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -307,17 +307,19 @@ public class ResultSetLatestIT extends ResultSet0IT {
     ResultSet resultSet = statement.executeQuery(query);
     resultSet.next(); // should finish successfully
 
-    SnowflakeChunkDownloader.setInjectedDownloaderException(
-        new OutOfMemoryError("Fake OOM error for testing"));
-    resultSet = statement.executeQuery(query);
     try {
-      resultSet.next();
-      fail("Should not reach here. Last next() command is supposed to throw an exception");
-    } catch (SnowflakeSQLException ex) {
-      // pass
+      SnowflakeChunkDownloader.setInjectedDownloaderException(
+          new OutOfMemoryError("Fake OOM error for testing"));
+      resultSet = statement.executeQuery(query);
+      try {
+        while (resultSet.next())
+          ;
+        fail("Should not reach here. Last next() command is supposed to throw an exception");
+      } catch (SnowflakeSQLException ex) {
+        // pass, do nothing
+      }
     } finally {
-      statement.close();
-      connection.close();
+      SnowflakeChunkDownloader.setInjectedDownloaderException(null);
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -312,6 +312,8 @@ public class ResultSetLatestIT extends ResultSet0IT {
           new OutOfMemoryError("Fake OOM error for testing"));
       resultSet = statement.executeQuery(query);
       try {
+        // Normally this step won't cause too long. Because we will get exception once trying to get
+        // result from the first chunk downloader
         while (resultSet.next())
           ;
         fail("Should not reach here. Last next() command is supposed to throw an exception");
@@ -321,6 +323,9 @@ public class ResultSetLatestIT extends ResultSet0IT {
     } finally {
       SnowflakeChunkDownloader.setInjectedDownloaderException(null);
     }
+
+    statement.close();
+    connection.close();
   }
 
   private byte[] intToByteArray(int i) {

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -293,6 +293,34 @@ public class ResultSetLatestIT extends ResultSet0IT {
     assertArrayEquals(decoded, resultSet.getBytes(12));
   }
 
+  // SNOW-204185
+  // 30s for timeout. This test usually finishes in around 10s.
+  @Test(timeout = 30000)
+  public void testResultChunkDownloaderException() throws SQLException {
+    Connection connection = init();
+    Statement statement = connection.createStatement();
+
+    // The generated resultSet must be big enough for triggering result chunk downloader
+    String query =
+        "select current_date(), true,2345234, 2343.0, 'testrgint\\n\\t' from table(generator(rowcount=>10000))";
+
+    ResultSet resultSet = statement.executeQuery(query);
+    resultSet.next(); // should finish successfully
+
+    SnowflakeChunkDownloader.setInjectedDownloaderException(
+        new OutOfMemoryError("Fake OOM error for testing"));
+    resultSet = statement.executeQuery(query);
+    try {
+      resultSet.next();
+      fail("Should not reach here. Last next() command is supposed to throw an exception");
+    } catch (SnowflakeSQLException ex) {
+      // pass
+    } finally {
+      statement.close();
+      connection.close();
+    }
+  }
+
   private byte[] intToByteArray(int i) {
     return BigInteger.valueOf(i).toByteArray();
   }


### PR DESCRIPTION
As stated by @sfc-gh-mrui , for current chunkdownloader's worker threads who do the real download job, we only catch the SnowflakeSQLException. But if worker threads failed with some other exceptions like OOM, the worker threads finished silently without "notify" the main thread. As a result, the main thread will wait for the worker thread until timeout, which is 3600 seconds. 

Proposed solution, change SnowflakeSQLException to Throwable. Since it's hard to write a test for this case, I wanted to get some opinions on it. To me, looks like this change won't cause other issues.