### PR TITLE
SNOW-160809: Fix empty batch when using array bind

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -780,6 +780,12 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     int[] updateCounts = null;
     try {
       if (this.statementMetaData.isArrayBindSupported()) {
+        if (batchSize <= 0) {
+          logger.debug(
+              "executeBatch() using array bind with no batch data. Return int[0] directly");
+          return new int[0];
+        }
+
         int updateCount = (int) executeUpdateInternal(this.sql, batchParameterBindings, false);
 
         // when update count is the same as the number of bindings in the batch,

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -781,8 +781,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     try {
       if (this.statementMetaData.isArrayBindSupported()) {
         if (batchSize <= 0) {
-          logger.debug(
-              "executeBatch() using array bind with no batch data. Return int[0] directly");
+          logger.warn("executeBatch() using array bind with no batch data. Return int[0] directly");
           return new int[0];
         }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -781,7 +781,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
     try {
       if (this.statementMetaData.isArrayBindSupported()) {
         if (batchSize <= 0) {
-          logger.warn("executeBatch() using array bind with no batch data. Return int[0] directly");
+          logger.debug(
+              "executeBatch() using array bind with no batch data. Return int[0] directly");
           return new int[0];
         }
 

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
@@ -126,28 +126,6 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
   }
 
   @Test
-  public void testExecuteEmptyBatch() throws SQLException {
-    try (Connection connection = init()) {
-      try (PreparedStatement prepStatement = connection.prepareStatement(insertSQL)) {
-        // executeBatch shouldn't throw exceptions
-        assertEquals(
-            "For empty batch, we should return int[0].", 0, prepStatement.executeBatch().length);
-      }
-
-      connection
-          .createStatement()
-          .execute(
-              "ALTER SESSION SET CLIENT_STAGE_ARRAY_BINDING_THRESHOLD = 0"); // disable stage bind
-      // we need a new PreparedStatement to pick up the changed status (not use stage bind)
-      try (PreparedStatement prepStatement = connection.prepareStatement(insertSQL)) {
-        // executeBatch shouldn't throw exceptions
-        assertEquals(
-            "For empty batch, we should return int[0].", 0, prepStatement.executeBatch().length);
-      }
-    }
-  }
-
-  @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testInsertBatch() throws SQLException {
     int[] countResult;

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1IT.java
@@ -126,6 +126,28 @@ public class PreparedStatement1IT extends PreparedStatement0IT {
   }
 
   @Test
+  public void testExecuteEmptyBatch() throws SQLException {
+    try (Connection connection = init()) {
+      try (PreparedStatement prepStatement = connection.prepareStatement(insertSQL)) {
+        // executeBatch shouldn't throw exceptions
+        assertEquals(
+            "For empty batch, we should return int[0].", 0, prepStatement.executeBatch().length);
+      }
+
+      connection
+          .createStatement()
+          .execute(
+              "ALTER SESSION SET CLIENT_STAGE_ARRAY_BINDING_THRESHOLD = 0"); // disable stage bind
+      // we need a new PreparedStatement to pick up the changed status (not use stage bind)
+      try (PreparedStatement prepStatement = connection.prepareStatement(insertSQL)) {
+        // executeBatch shouldn't throw exceptions
+        assertEquals(
+            "For empty batch, we should return int[0].", 0, prepStatement.executeBatch().length);
+      }
+    }
+  }
+
+  @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testInsertBatch() throws SQLException {
     int[] countResult;

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1LatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1LatestIT.java
@@ -131,7 +131,16 @@ public class PreparedStatement1LatestIT extends PreparedStatement0IT {
     }
   }
 
+  /**
+   * Test to ensure when giving no input batch data, no exceptions will be thrown
+   *
+   * <p>Ignored on GitHub Action because CLIENT_STAGE_ARRAY_BINDING_THRESHOLD parameter is not
+   * available to customers so cannot be set when running on Github Action
+   *
+   * @throws SQLException arises if any exception occurs
+   */
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testExecuteEmptyBatch() throws SQLException {
     try (Connection connection = init()) {
       try (PreparedStatement prepStatement = connection.prepareStatement(insertSQL)) {

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1LatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1LatestIT.java
@@ -130,4 +130,26 @@ public class PreparedStatement1LatestIT extends PreparedStatement0IT {
       statement.close();
     }
   }
+
+  @Test
+  public void testExecuteEmptyBatch() throws SQLException {
+    try (Connection connection = init()) {
+      try (PreparedStatement prepStatement = connection.prepareStatement(insertSQL)) {
+        // executeBatch shouldn't throw exceptions
+        assertEquals(
+            "For empty batch, we should return int[0].", 0, prepStatement.executeBatch().length);
+      }
+
+      connection
+          .createStatement()
+          .execute(
+              "ALTER SESSION SET CLIENT_STAGE_ARRAY_BINDING_THRESHOLD = 0"); // disable stage bind
+      // we need a new PreparedStatement to pick up the changed status (not use stage bind)
+      try (PreparedStatement prepStatement = connection.prepareStatement(insertSQL)) {
+        // executeBatch shouldn't throw exceptions
+        assertEquals(
+            "For empty batch, we should return int[0].", 0, prepStatement.executeBatch().length);
+      }
+    }
+  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatementArrow2IT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatementArrow2IT.java
@@ -8,7 +8,7 @@ import org.junit.experimental.categories.Category;
 
 /** Test PreparedStatement in ARROW format 2/2 */
 @Category(TestCategoryArrow.class)
-public class PreparedStatementArrow2IT extends PreparedStatement2LatestIT {
+public class PreparedStatementArrow2IT extends PreparedStatement2IT {
   public PreparedStatementArrow2IT() {
     super("arrow");
   }


### PR DESCRIPTION
When there is no data in batch, we return directly.