### PR TITLE
SNOW-207061: fixed isNull for TimestampTZ converter

### DIFF
--- a/src/main/java/net/snowflake/client/core/arrow/ThreeFieldStructToTimestampTZConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/ThreeFieldStructToTimestampTZConverter.java
@@ -38,6 +38,11 @@ public class ThreeFieldStructToTimestampTZConverter extends AbstractArrowVectorC
   }
 
   @Override
+  public boolean isNull(int index) {
+    return epochs.isNull(index);
+  }
+
+  @Override
   public String toString(int index) throws SFException {
     if (context.getTimestampTZFormatter() == null) {
       throw (SFException)

--- a/src/main/java/net/snowflake/client/core/arrow/TwoFieldStructToTimestampTZConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/TwoFieldStructToTimestampTZConverter.java
@@ -36,6 +36,11 @@ public class TwoFieldStructToTimestampTZConverter extends AbstractArrowVectorCon
   }
 
   @Override
+  public boolean isNull(int index) {
+    return epochs.isNull(index);
+  }
+
+  @Override
   public String toString(int index) throws SFException {
     if (context.getTimestampTZFormatter() == null) {
       throw (SFException)

--- a/src/test/java/net/snowflake/client/core/arrow/BigIntToFixedConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/BigIntToFixedConverterTest.java
@@ -5,6 +5,8 @@ package net.snowflake.client.core.arrow;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -61,6 +63,12 @@ public class BigIntToFixedConverterTest extends BaseConverterTest {
       long longVal = converter.toLong(i);
       Object longObject = converter.toObject(i);
       String longString = converter.toString(i);
+
+      if (longString != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
 
       if (nullValIndex.contains(i)) {
         assertThat(longVal, is(0L));

--- a/src/test/java/net/snowflake/client/core/arrow/BigIntToTimeConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/BigIntToTimeConverterTest.java
@@ -7,6 +7,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Time;
 import java.util.HashMap;
@@ -94,6 +96,12 @@ public class BigIntToTimeConverterTest extends BaseConverterTest {
           new Time(
               ResultUtil.getSFTime(testTimesJson[i], scale, new SFSession())
                   .getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS));
+
+      if (strVal != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
       if (nullValIndex.contains(j)) {
         assertThat(obj, is(nullValue()));
         assertThat(strVal, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/BigIntToTimestampLTZConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/BigIntToTimestampLTZConverterTest.java
@@ -6,6 +6,8 @@ package net.snowflake.client.core.arrow;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -99,6 +101,12 @@ public class BigIntToTimestampLTZConverterTest extends BaseConverterTest {
       Date date = converter.toDate(j, getTimeZone(), false);
       Time time = converter.toTime(j);
       String tsStr = converter.toString(j);
+
+      if (tsStr != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
 
       if (nullValIndex.contains(j)) {
         assertThat(ts, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/BigIntToTimestampNTZConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/BigIntToTimestampNTZConverterTest.java
@@ -6,6 +6,8 @@ package net.snowflake.client.core.arrow;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -125,6 +127,12 @@ public class BigIntToTimestampNTZConverterTest extends BaseConverterTest {
       Date date = converter.toDate(j, getTimeZone(), false);
       Time time = converter.toTime(j);
       String tsStr = converter.toString(j);
+
+      if (tsStr != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
 
       if (nullValIndex.contains(j)) {
         assertThat(ts, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/BitToBooleanConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/BitToBooleanConverterTest.java
@@ -3,6 +3,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -56,6 +58,12 @@ public class BitToBooleanConverterTest extends BaseConverterTest {
       boolean boolVal = converter.toBoolean(i);
       Object objectVal = converter.toObject(i);
       String stringVal = converter.toString(i);
+
+      if (stringVal != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
 
       if (nullValIndex.contains(i)) {
         assertThat(boolVal, is(false));

--- a/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
@@ -3,6 +3,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Date;
 import java.util.*;
@@ -86,6 +88,11 @@ public class DateConverterTest extends BaseConverterTest {
       int intVal = converter.toInt(j);
       String strVal = converter.toString(j);
       Object obj = converter.toObject(j);
+      if (strVal != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
       Object oldObj = ArrowResultUtil.getDate(intVal, TimeZone.getDefault(), TimeZone.getDefault());
       if (nullValIndex.contains(j)) {
         assertThat(intVal, is(0));

--- a/src/test/java/net/snowflake/client/core/arrow/DoubleToRealConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/DoubleToRealConverterTest.java
@@ -6,6 +6,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -68,6 +70,11 @@ public class DoubleToRealConverterTest extends BaseConverterTest {
       float floatVal = converter.toFloat(i);
       Object doubleObject = converter.toObject(i);
       String doubleString = converter.toString(i);
+      if (doubleObject != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
 
       if (nullValIndex.contains(i)) {
         assertThat(doubleVal, is((double) 0));

--- a/src/test/java/net/snowflake/client/core/arrow/IntToFixedConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/IntToFixedConverterTest.java
@@ -5,7 +5,7 @@ package net.snowflake.client.core.arrow;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -62,6 +62,11 @@ public class IntToFixedConverterTest extends BaseConverterTest {
       int intVal = converter.toInt(i);
       Object longObj = converter.toObject(i);
       String intString = converter.toString(i);
+      if (intString != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
 
       if (nullValIndex.contains(i)) {
         assertThat(intVal, is(0));

--- a/src/test/java/net/snowflake/client/core/arrow/IntToTimeConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/IntToTimeConverterTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.sql.Time;
@@ -98,6 +100,11 @@ public class IntToTimeConverterTest extends BaseConverterTest {
           new Time(
               ResultUtil.getSFTime(testTimesJson[i], scale, new SFSession())
                   .getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS));
+      if (strVal != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
       if (nullValIndex.contains(j)) {
         assertThat(obj, is(nullValue()));
         assertThat(strVal, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/SmallIntToFixedConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/SmallIntToFixedConverterTest.java
@@ -5,7 +5,7 @@ package net.snowflake.client.core.arrow;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -63,6 +63,11 @@ public class SmallIntToFixedConverterTest extends BaseConverterTest {
       short shortVal = converter.toShort(i);
       Object longObject = converter.toObject(i); // the logical type is long
       String shortString = converter.toString(i);
+      if (shortString != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
 
       if (nullValIndex.contains(i)) {
         assertThat(shortVal, is((short) 0));
@@ -223,6 +228,10 @@ public class SmallIntToFixedConverterTest extends BaseConverterTest {
     assertThat(false, is(converter.toBoolean(0)));
     assertThat(true, is(converter.toBoolean(1)));
     assertThat(false, is(converter.toBoolean(2)));
+    assertFalse(converter.isNull(0));
+    assertFalse(converter.isNull(1));
+    assertTrue(converter.isNull(2));
+    assertFalse(converter.isNull(3));
     TestUtil.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
 
     vector.close();

--- a/src/test/java/net/snowflake/client/core/arrow/ThreeFieldStructToTimestampTZConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/ThreeFieldStructToTimestampTZConverterTest.java
@@ -7,6 +7,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -155,6 +157,11 @@ public class ThreeFieldStructToTimestampTZConverterTest extends BaseConverterTes
       Date date = converter.toDate(j, getTimeZone(), false);
       Time time = converter.toTime(j);
       String tsStr = converter.toString(j);
+      if (tsStr != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
 
       if (nullValIndex.contains(j)) {
         assertThat(ts, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/TinyIntToFixedConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/TinyIntToFixedConverterTest.java
@@ -6,7 +6,7 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.util.*;
@@ -226,11 +226,15 @@ public class TinyIntToFixedConverterTest extends BaseConverterTest {
 
     final ArrowVectorConverter converter = new TinyIntToScaledFixedConverter(vector, 0, this, 3);
 
-    assertThat(false, is(converter.toBoolean(0)));
+    assertFalse(converter.toBoolean(0));
     TestUtil.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
-    assertThat(false, is(converter.toBoolean(2)));
+    assertFalse(converter.toBoolean(2));
     TestUtil.assertSFException(invalidConversionErrorCode, () -> converter.toBoolean(3));
 
+    assertFalse(converter.isNull(0));
+    assertFalse(converter.isNull(1));
+    assertTrue(converter.isNull(2));
+    assertFalse(converter.isNull(3));
     vector.close();
   }
 }

--- a/src/test/java/net/snowflake/client/core/arrow/TwoFieldStructToTimestampLTZConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/TwoFieldStructToTimestampLTZConverterTest.java
@@ -7,6 +7,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -138,6 +140,11 @@ public class TwoFieldStructToTimestampLTZConverterTest extends BaseConverterTest
       Date date = converter.toDate(j, getTimeZone(), false);
       Time time = converter.toTime(j);
       String tsStr = converter.toString(j);
+      if (tsStr != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
 
       if (nullValIndex.contains(j)) {
         assertThat(ts, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/TwoFieldStructToTimestampNTZConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/TwoFieldStructToTimestampNTZConverterTest.java
@@ -7,6 +7,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -159,6 +161,11 @@ public class TwoFieldStructToTimestampNTZConverterTest extends BaseConverterTest
       Date date = converter.toDate(j, getTimeZone(), false);
       Time time = converter.toTime(j);
       String tsStr = converter.toString(j);
+      if (tsStr != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
 
       if (nullValIndex.contains(j)) {
         assertThat(ts, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/TwoFieldStructToTimestampTZConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/TwoFieldStructToTimestampTZConverterTest.java
@@ -7,6 +7,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -127,6 +129,11 @@ public class TwoFieldStructToTimestampTZConverterTest extends BaseConverterTest 
       Date date = converter.toDate(j, getTimeZone(), false);
       Time time = converter.toTime(j);
       String tsStr = converter.toString(j);
+      if (tsStr != null) {
+        assertFalse(converter.isNull(j));
+      } else {
+        assertTrue(converter.isNull(j));
+      }
 
       if (nullValIndex.contains(j)) {
         assertThat(ts, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/VarBinaryToBinaryConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/VarBinaryToBinaryConverterTest.java
@@ -6,6 +6,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Base64;
@@ -63,6 +65,11 @@ public class VarBinaryToBinaryConverterTest extends BaseConverterTest {
       String stringVal = converter.toString(i);
       Object objectVal = converter.toObject(i);
       byte[] bytesVal = converter.toBytes(i);
+      if (stringVal != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
 
       if (nullValIndex.contains(i)) {
         assertThat(stringVal, is(nullValue()));

--- a/src/test/java/net/snowflake/client/core/arrow/VarCharConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/VarCharConverterTest.java
@@ -6,6 +6,8 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -63,6 +65,11 @@ public class VarCharConverterTest extends BaseConverterTest {
       String stringVal = converter.toString(i);
       Object objectVal = converter.toObject(i);
       byte[] bytesVal = converter.toBytes(i);
+      if (stringVal != null) {
+        assertFalse(converter.isNull(i));
+      } else {
+        assertTrue(converter.isNull(i));
+      }
 
       if (nullValIndex.contains(i)) {
         assertThat(stringVal, is(nullValue()));


### PR DESCRIPTION
This fixes unexpected null check behaviors by overriding `isNull` methods.