### PR TITLE
SNOW-210997 Fix output of logging test for Jenkins

### DIFF
--- a/src/main/java/net/snowflake/client/log/JDK14Logger.java
+++ b/src/main/java/net/snowflake/client/log/JDK14Logger.java
@@ -155,6 +155,11 @@ public class JDK14Logger implements SFLogger {
     snowflakeLogger.removeHandler(handler);
   }
 
+  public static void setUseParentHandlers(boolean value) {
+    Logger snowflakeLogger = Logger.getLogger(SFFormatter.CLASS_NAME_PREFIX);
+    snowflakeLogger.setUseParentHandlers(value);
+  }
+
   public static void setLevel(Level level) {
     Logger snowflakeLogger = Logger.getLogger(SFFormatter.CLASS_NAME_PREFIX);
     snowflakeLogger.setLevel(level);

--- a/src/test/java/net/snowflake/client/log/JDK14JCLWrapperLatestIT.java
+++ b/src/test/java/net/snowflake/client/log/JDK14JCLWrapperLatestIT.java
@@ -63,10 +63,12 @@ public class JDK14JCLWrapperLatestIT {
     // Set debug level to lowest so that all possible messages can be sent.
     logger.setLevel(Level.FINEST);
     logger.addHandler(this.handler);
+    logger.setUseParentHandlers(false);
   }
 
   @After
   public void tearDown() {
+    logger.setUseParentHandlers(true);
     logger.setLevel(logLevelToRestore);
     logger.removeHandler(this.handler);
   }


### PR DESCRIPTION
Just noticed after looking through JDBC3 test console outputs at an unrelated failure that after adding tests for the logging wrappers (https://github.com/snowflakedb/snowflake-jdbc/pull/384), the JDK14JCLWrapper test messages are getting printed to the console in Jenkins tests, which is unnecessary.

This change of removing parent handlers for the test prevents the log output from being printed to the console.