### PR TITLE
SNOW-213443 SNOW-206549

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.client.core;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 import static org.apache.http.client.config.CookieSpecs.DEFAULT;
 import static org.apache.http.client.config.CookieSpecs.IGNORE_COOKIES;
 
@@ -139,14 +140,9 @@ public class HttpUtil {
     builder.append(SnowflakeDriver.implementVersion);
     builder.append(" (");
     // Generate OS platform and version from system properties
-    String osPlatform =
-        (SnowflakeUtil.systemGetProperty("os.name") != null)
-            ? SnowflakeUtil.systemGetProperty("os.name")
-            : "";
+    String osPlatform = (systemGetProperty("os.name") != null) ? systemGetProperty("os.name") : "";
     String osVersion =
-        (SnowflakeUtil.systemGetProperty("os.version") != null)
-            ? SnowflakeUtil.systemGetProperty("os.version")
-            : "";
+        (systemGetProperty("os.version") != null) ? systemGetProperty("os.version") : "";
     // Append OS platform and version separated by a space
     builder.append(osPlatform);
     builder.append(" ");
@@ -155,9 +151,7 @@ public class HttpUtil {
     builder.append(") JAVA/");
     // Generate string for language version from system properties and append it
     String languageVersion =
-        (SnowflakeUtil.systemGetProperty("java.version") != null)
-            ? SnowflakeUtil.systemGetProperty("java.version")
-            : "";
+        (systemGetProperty("java.version") != null) ? systemGetProperty("java.version") : "";
     builder.append(languageVersion);
     String userAgent = builder.toString();
     return userAgent;
@@ -177,7 +171,7 @@ public class HttpUtil {
     // set timeout so that we don't wait forever.
     // Setup the default configuration for all requests on this client
 
-    String ttlSystemProperty = System.getProperty(JDBC_TTL);
+    String ttlSystemProperty = systemGetProperty(JDBC_TTL);
     int timeToLive = DEFAULT_TTL;
     if (ttlSystemProperty != null) {
       try {

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -12,11 +12,7 @@ import com.amazonaws.http.apache.SdkProxyRoutePlanner;
 import com.google.common.base.Strings;
 import com.microsoft.azure.storage.OperationContext;
 import com.snowflake.client.jdbc.SnowflakeDriver;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.Socket;
@@ -65,11 +61,11 @@ public class HttpUtil {
   static final int DEFAULT_MAX_CONNECTIONS_PER_ROUTE = 300;
   static final int DEFAULT_CONNECTION_TIMEOUT = 60000;
   static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 300000; // ms
-  static final int DEFAULT_TTL = 3500; // secs
+  static final int DEFAULT_TTL = -1; // secs
   static final int DEFAULT_IDLE_CONNECTION_TIMEOUT = 5; // secs
   static final int DEFAULT_DOWNLOADED_CONDITION_TIMEOUT = 3600; // secs
 
-  public static final String JDBC_TTL_JVM = "net.snowflake.jdbc.ttlTimeout";
+  public static final String JDBC_TTL_JVM = "net.snowflake.jdbc.ttl";
 
   /** The unique httpClient shared by all connections. This will benefit long- lived clients */
   private static Map<OCSPMode, CloseableHttpClient> httpClient = new ConcurrentHashMap<>();

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -65,7 +65,7 @@ public class HttpUtil {
   static final int DEFAULT_IDLE_CONNECTION_TIMEOUT = 5; // secs
   static final int DEFAULT_DOWNLOADED_CONDITION_TIMEOUT = 3600; // secs
 
-  public static final String JDBC_TTL_JVM = "net.snowflake.jdbc.ttl";
+  public static final String JDBC_TTL = "net.snowflake.jdbc.ttl";
 
   /** The unique httpClient shared by all connections. This will benefit long- lived clients */
   private static Map<OCSPMode, CloseableHttpClient> httpClient = new ConcurrentHashMap<>();
@@ -177,13 +177,13 @@ public class HttpUtil {
     // set timeout so that we don't wait forever.
     // Setup the default configuration for all requests on this client
 
-    String ttlSystemProperty = System.getProperty(JDBC_TTL_JVM);
+    String ttlSystemProperty = System.getProperty(JDBC_TTL);
     int timeToLive = DEFAULT_TTL;
     if (ttlSystemProperty != null) {
       try {
         timeToLive = Integer.parseInt(ttlSystemProperty);
       } catch (NumberFormatException ex) {
-        logger.info("Failed to parse the system parameter {}", JDBC_TTL_JVM, ttlSystemProperty);
+        logger.info("Failed to parse the system parameter {}", JDBC_TTL, ttlSystemProperty);
       }
     }
     logger.debug("time to live in connection pooling manager: {}", timeToLive);


### PR DESCRIPTION
A few customers using connection pooling applications are experiencing issues related to expired connections that continue to sit in the pool after the connection to the cloud (Azure, GCP, etc) has marked them as expired. For these customers, we have provided custom jars with the "time to live" parameter exposed, which controls how long a connection can stay alive in the pool while unused. There have been several requests to expose this setting in GA with a jvm parameter.

I think this is a good idea because it will reduce the number of custom jars being sent and I don't see any security implications.

The time to live parameter can be configured with the jvm param **net.snowflake.jdbc.ttl**.