### PR TITLE
SNOW-173219 Remove the reference to the change that adds support for MFA token caching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,6 @@
 **JDBC Driver 3.12.16**
 
 - \| SNOW-206907 | Added support for downscoping GCS credentials (which can be used instead of presigned URLs).
-- \| SNOW-175899 | Added support for MFA token caching.
 
 **JDBC Driver 3.12.15**
 


### PR DESCRIPTION
Description
Remove the reference to the change that adds support for MFA token caching.
This feature isn't available to customers yet, so it's not useful for customers to know that the
driver supports this feature.