### PR TITLE
SNOW-136474 Adjustable file threshold for put in jdbc

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -108,6 +108,15 @@ public class SnowflakeFileTransferAgent implements SnowflakeFixedView {
     return this.stageInfo;
   }
 
+  /**
+   * Get value of big file threshold. For testing purposes.
+   *
+   * @return integer value in bytes of threshold
+   */
+  int getBigFileThreshold() {
+    return this.bigFileThreshold;
+  }
+
   // Encryption material
   private List<RemoteStoreFileEncryptionMaterial> encryptionMaterial;
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -2938,7 +2938,6 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
         String destFolderCanonicalPathWithSeparator = destFolderCanonicalPath + File.separator;
 
         try {
-          statement.execute("alter session set CLIENT_MULTIPART_UPLOAD_THRESHOLD_IN_PUT=5");
           statement.execute("CREATE OR REPLACE STAGE testPutGet_stage");
 
           assertTrue(

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -970,7 +970,6 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
         connection = getConnection(accounts.get(i));
 
         statement = connection.createStatement();
-        // statement.execute("alter session set CLIENT_MULTIPART_UPLOAD_THRESHOLD_IN_PUT=1");
 
         // load file test
         // create a unique data file name by using current timestamp in millis

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -74,6 +74,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
   }
 
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPutThreshold() throws SQLException {
     try (Connection connection = getConnection()) {
       // assert that threshold equals default 200 from server side
@@ -91,6 +92,9 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
       String commandWithPut = command + " threshold=314572800";
       agent = new SnowflakeFileTransferAgent(commandWithPut, sfSession, sfStatement);
       assertEquals(314572800, agent.getBigFileThreshold());
+      // assert that after put statement, threshold goes back to previous session threshold
+      agent = new SnowflakeFileTransferAgent(command, sfSession, sfStatement);
+      assertEquals(200 * 1024 * 1024, agent.getBigFileThreshold());
       // Attempt to set threshold to an invalid value such as a negative number
       String commandWithInvalidThreshold = command + " threshold=-1";
       try {
@@ -100,9 +104,6 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
       catch (SQLException e) {
         assertEquals(SqlState.INVALID_PARAMETER_VALUE, e.getSQLState());
       }
-      // assert that after put statement, threshold goes back to previous session threshold
-      agent = new SnowflakeFileTransferAgent(command, sfSession, sfStatement);
-      assertEquals(200 * 1024 * 1024, agent.getBigFileThreshold());
       statement.close();
     } catch (SQLException ex) {
       throw ex;

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -20,6 +20,7 @@ import net.snowflake.client.category.TestCategoryOthers;
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.core.SFStatement;
+import net.snowflake.common.core.SqlState;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
@@ -90,6 +91,15 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
       String commandWithPut = command + " threshold=314572800";
       agent = new SnowflakeFileTransferAgent(commandWithPut, sfSession, sfStatement);
       assertEquals(314572800, agent.getBigFileThreshold());
+      // Attempt to set threshold to an invalid value such as a negative number
+      String commandWithInvalidThreshold = command + " threshold=-1";
+      try {
+        agent = new SnowflakeFileTransferAgent(commandWithInvalidThreshold, sfSession, sfStatement);
+      }
+      // assert invalid value causes exception to be thrown of type INVALID_PARAMETER_VALUE
+      catch (SQLException e) {
+        assertEquals(SqlState.INVALID_PARAMETER_VALUE, e.getSQLState());
+      }
       // assert that after put statement, threshold goes back to previous session threshold
       agent = new SnowflakeFileTransferAgent(command, sfSession, sfStatement);
       assertEquals(200 * 1024 * 1024, agent.getBigFileThreshold());

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -75,27 +75,22 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
   @Test
   public void testPutThreshold() throws SQLException {
     try (Connection connection = getConnection()) {
-      // assert that setting threshold via session parameter sets the big file threshold
-      // appropriately
+      // assert that threshold equals default 200 from server side
       SFSession sfSession = connection.unwrap(SnowflakeConnectionV1.class).getSfSession();
       Statement statement = connection.createStatement();
       SFStatement sfStatement = statement.unwrap(SnowflakeStatementV1.class).getSfStatement();
-      statement.execute("alter session set CLIENT_MULTIPART_UPLOAD_THRESHOLD_IN_PUT=50");
       statement.execute("CREATE OR REPLACE STAGE PUTTHRESHOLDSTAGE");
       String command =
           "PUT file://" + getFullPathFileInResource(TEST_DATA_FILE) + " @PUTTHRESHOLDSTAGE";
       SnowflakeFileTransferAgent agent =
           new SnowflakeFileTransferAgent(command, sfSession, sfStatement);
-      assertEquals(50 * 1024 * 1024, agent.getBigFileThreshold());
+      assertEquals(200 * 1024 * 1024, agent.getBigFileThreshold());
       // assert that setting threshold via put statement directly sets the big file threshold
       // appropriately
-      String commandWithPut = command + " threshold=300";
+      String commandWithPut = command + " threshold=314572800";
       agent = new SnowflakeFileTransferAgent(commandWithPut, sfSession, sfStatement);
-      assertEquals(300 * 1024 * 1024, agent.getBigFileThreshold());
+      assertEquals(314572800, agent.getBigFileThreshold());
       // assert that after put statement, threshold goes back to previous session threshold
-      agent = new SnowflakeFileTransferAgent(command, sfSession, sfStatement);
-      assertEquals(50 * 1024 * 1024, agent.getBigFileThreshold());
-      statement.execute("alter session unset CLIENT_MULTIPART_UPLOAD_THRESHOLD_IN_PUT");
       agent = new SnowflakeFileTransferAgent(command, sfSession, sfStatement);
       assertEquals(200 * 1024 * 1024, agent.getBigFileThreshold());
       statement.close();


### PR DESCRIPTION
This PR is so the JDBC driver can read the put threshold value from the server side. This isn't affected by all the server-side threshold reverts. GS is still able to to send threshold data to the driver regardless.