### PR TITLE
SNOW-250222 Fix integer overflow problem within calculateUpdateCount function

### DIFF
--- a/src/main/java/net/snowflake/client/core/ResultUtil.java
+++ b/src/main/java/net/snowflake/client/core/ResultUtil.java
@@ -420,7 +420,7 @@ public class ResultUtil {
           SFResultSetMetaData resultSetMetaData = resultSet.getMetaData();
 
           int columnIndex = resultSetMetaData.getColumnIndex("rows_loaded");
-          updateCount += columnIndex == -1 ? 0 : resultSet.getInt(columnIndex + 1);
+          updateCount += columnIndex == -1 ? 0 : resultSet.getLong(columnIndex + 1);
         } else if (statementType == SFStatementType.INSERT
             || statementType == SFStatementType.UPDATE
             || statementType == SFStatementType.DELETE

--- a/src/main/java/net/snowflake/client/loader/ProcessQueue.java
+++ b/src/main/java/net/snowflake/client/loader/ProcessQueue.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.loader;
 
+import static java.lang.Math.toIntExact;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -89,8 +91,8 @@ public class ProcessQueue implements Runnable {
           }
           // Create a temporary table to hold all uploaded data
 
-          int loaded = 0;
-          int parsed = 0;
+          long loaded = 0;
+          long parsed = 0;
           int errorCount = 0;
           String lastErrorRow = "";
 
@@ -144,12 +146,12 @@ public class ProcessQueue implements Runnable {
 
           while (rs.next()) {
             // Get the number of rows actually loaded
-            loaded += rs.getInt("rows_loaded");
+            loaded += rs.getLong("rows_loaded");
             // Get the number of rows parsed
-            parsed += rs.getInt("rows_parsed");
+            parsed += rs.getLong("rows_parsed");
           }
 
-          int errorRecordCount = parsed - loaded;
+          int errorRecordCount = toIntExact(parsed - loaded);
           LOGGER.debug(
               "errorRecordCount=[{}]," + " parsed=[{}]," + " loaded=[{}]",
               errorRecordCount,

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -3,6 +3,21 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.security.*;
+import java.sql.*;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import net.snowflake.client.ConditionalIgnoreRule.ConditionalIgnore;
 import net.snowflake.client.RunningNotOnTestaccount;
 import net.snowflake.client.RunningOnGithubAction;
@@ -16,22 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.*;
-import java.security.*;
-import java.sql.*;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
 /** Connection integration tests */
 @Category(TestCategoryConnection.class)
@@ -58,26 +57,6 @@ public class ConnectionIT extends BaseJDBCTest {
     con.close();
     assertTrue(con.isClosed());
     con.close(); // ensure no exception
-  }
-
-  @Test
-  public void testIntegerOverflow() throws SQLException
-  {
-    Connection con = getConnection();
-    Statement statement = con.createStatement();
-    // create large table
-    /** ALREADY DONE
-    statement.execute("create or replace table largeTable (c1 number) as select seq1() from table(generator(rowcount => 3000000000))");
-    //statement.execute("create or replace stage teststage");
-    // copy data into file
-    statement.execute("copy into @~/largedata.gz from largeTable\n" +
-            "  single = true\n" +
-            "  MAX_FILE_SIZE = 5368709120");
-     **/
-    statement.execute("create or replace table secondaryTable (c1 number)");
-    ResultSet rs = statement.executeQuery("copy into secondaryTable (c1) from (select $1 from @~/) ON_ERROR=CONTINUE;");
-    rs.next();
-    System.out.println(rs.getString(1));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -3,21 +3,6 @@
  */
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-
-import java.io.*;
-import java.security.*;
-import java.sql.*;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import net.snowflake.client.ConditionalIgnoreRule.ConditionalIgnore;
 import net.snowflake.client.RunningNotOnTestaccount;
 import net.snowflake.client.RunningOnGithubAction;
@@ -31,6 +16,22 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.*;
+import java.security.*;
+import java.sql.*;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 /** Connection integration tests */
 @Category(TestCategoryConnection.class)
@@ -57,6 +58,26 @@ public class ConnectionIT extends BaseJDBCTest {
     con.close();
     assertTrue(con.isClosed());
     con.close(); // ensure no exception
+  }
+
+  @Test
+  public void testIntegerOverflow() throws SQLException
+  {
+    Connection con = getConnection();
+    Statement statement = con.createStatement();
+    // create large table
+    /** ALREADY DONE
+    statement.execute("create or replace table largeTable (c1 number) as select seq1() from table(generator(rowcount => 3000000000))");
+    //statement.execute("create or replace stage teststage");
+    // copy data into file
+    statement.execute("copy into @~/largedata.gz from largeTable\n" +
+            "  single = true\n" +
+            "  MAX_FILE_SIZE = 5368709120");
+     **/
+    statement.execute("create or replace table secondaryTable (c1 number)");
+    ResultSet rs = statement.executeQuery("copy into secondaryTable (c1) from (select $1 from @~/) ON_ERROR=CONTINUE;");
+    rs.next();
+    System.out.println(rs.getString(1));
   }
 
   @Test


### PR DESCRIPTION
This function throws an exception when a COPY type of statement is made and the number of rows altered is greater than INT_MAX. This is because the updateCount variable calls ResultSet#getInt(), which overflows. The solution is to have it call ResultSet#getLong() instead so no overflow is reached.

This is locally reproducible and the change works with manual testing. However, it is not feasible to add a test case because this only happens with statements of type COPY and for more than INT_MAX rows copied, which takes about an hour to run each time. 