### PR TITLE
SNOW-255552 fix nullptrexception in ResultSet.getCharacterStream

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -4,6 +4,11 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SqlState;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -14,10 +19,6 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.common.core.SqlState;
 
 /** Base class for query result set and metadata result set */
 abstract class SnowflakeBaseResultSet implements ResultSet {
@@ -302,7 +303,8 @@ abstract class SnowflakeBaseResultSet implements ResultSet {
   public Reader getCharacterStream(int columnIndex) throws SQLException {
     logger.debug("public Reader getCharacterStream(int columnIndex)");
     raiseSQLExceptionIfResultSetIsClosed();
-    return new StringReader(getString(columnIndex));
+    String streamData = getString(columnIndex);
+    return (streamData == null) ? null : new StringReader(streamData);
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -4,11 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.SFSession;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-import net.snowflake.common.core.SqlState;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -19,6 +14,10 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+import net.snowflake.common.core.SqlState;
 
 /** Base class for query result set and metadata result set */
 abstract class SnowflakeBaseResultSet implements ResultSet {

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -3,10 +3,14 @@
  */
 package net.snowflake.client.jdbc;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.client.category.TestCategoryResultSet;
+import net.snowflake.client.jdbc.telemetry.*;
+import net.snowflake.common.core.SFBinary;
+import org.apache.arrow.vector.Float8Vector;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.sql.*;
@@ -14,12 +18,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-import net.snowflake.client.category.TestCategoryResultSet;
-import net.snowflake.client.jdbc.telemetry.*;
-import net.snowflake.common.core.SFBinary;
-import org.apache.arrow.vector.Float8Vector;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -101,6 +102,25 @@ public class ResultSetLatestIT extends ResultSet0IT {
     assertEquals(parameterValues.get("schema").textValue(), schema);
     assertNull(parameterValues.get("general_name_pattern").textValue());
     assertNull(parameterValues.get("specific_name_pattern").textValue());
+  }
+
+  /**
+   * Test that there is no nullptr exception thrown when null value is retrieved from character
+   * stream
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testGetCharacterStreamNull() throws SQLException {
+    Connection connection = init();
+    Statement statement = connection.createStatement();
+    statement.execute("create or replace table JDBC_NULL_CHARSTREAM (col1 varchar(16))");
+    statement.execute("insert into JDBC_NULL_CHARSTREAM values(NULL)");
+    ResultSet rs = statement.executeQuery("select * from JDBC_NULL_CHARSTREAM");
+    rs.next();
+    assertNull(rs.getCharacterStream(1));
+    rs.close();
+    connection.close();
   }
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -3,14 +3,10 @@
  */
 package net.snowflake.client.jdbc;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.client.category.TestCategoryResultSet;
-import net.snowflake.client.jdbc.telemetry.*;
-import net.snowflake.common.core.SFBinary;
-import org.apache.arrow.vector.Float8Vector;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.sql.*;
@@ -18,9 +14,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import net.snowflake.client.category.TestCategoryResultSet;
+import net.snowflake.client.jdbc.telemetry.*;
+import net.snowflake.common.core.SFBinary;
+import org.apache.arrow.vector.Float8Vector;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest


### PR DESCRIPTION
When getCharacterStream() calls getString(), a nullptrexception is thrown when the string returns a null value. That has been fixed by checking for null after getString() is called.