### PR TITLE
SNOW-251457 change timezone formatter to default timezone instead of utc

### DIFF
--- a/src/main/java/net/snowflake/client/core/ResultUtil.java
+++ b/src/main/java/net/snowflake/client/core/ResultUtil.java
@@ -5,6 +5,12 @@
 package net.snowflake.client.core;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.*;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeUtil;
 import net.snowflake.client.log.ArgSupplier;
@@ -14,13 +20,6 @@ import net.snowflake.common.core.SFTime;
 import net.snowflake.common.core.SFTimestamp;
 import net.snowflake.common.core.SnowflakeDateTimeFormat;
 import net.snowflake.common.util.TimeUtil;
-
-import java.math.BigDecimal;
-import java.sql.Date;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.sql.Types;
-import java.util.*;
 
 public class ResultUtil {
   static final SFLogger logger = SFLoggerFactory.getLogger(ResultUtil.class);

--- a/src/main/java/net/snowflake/client/core/ResultUtil.java
+++ b/src/main/java/net/snowflake/client/core/ResultUtil.java
@@ -5,12 +5,6 @@
 package net.snowflake.client.core;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.math.BigDecimal;
-import java.sql.Date;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.sql.Types;
-import java.util.*;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeUtil;
 import net.snowflake.client.log.ArgSupplier;
@@ -20,6 +14,13 @@ import net.snowflake.common.core.SFTime;
 import net.snowflake.common.core.SFTimestamp;
 import net.snowflake.common.core.SnowflakeDateTimeFormat;
 import net.snowflake.common.util.TimeUtil;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.*;
 
 public class ResultUtil {
   static final SFLogger logger = SFLoggerFactory.getLogger(ResultUtil.class);
@@ -326,7 +327,7 @@ public class ResultUtil {
    * @return date in string
    */
   public static String getDateAsString(Date date, SnowflakeDateTimeFormat dateFormatter) {
-    return dateFormatter.format(date, timeZoneUTC);
+    return dateFormatter.format(date, TimeZone.getDefault());
   }
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
@@ -3,11 +3,9 @@
  */
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.ConditionalIgnoreRule;
-import net.snowflake.client.RunningOnGithubAction;
-import net.snowflake.client.category.TestCategoryResultSet;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -16,11 +14,11 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.Properties;
-import java.util.TimeZone;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import net.snowflake.client.ConditionalIgnoreRule;
+import net.snowflake.client.RunningOnGithubAction;
+import net.snowflake.client.category.TestCategoryResultSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /** Test ResultSet */
 @Category(TestCategoryResultSet.class)
@@ -72,18 +70,6 @@ public class ResultSetIT extends ResultSet0IT {
     statement.execute("drop table if exists bintable");
     statement.close();
     connection.close();
-  }
-
-  @Test
-  public void testGetString() throws SQLException {
-    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Singapore"));
-    //System.setProperty("user.timezone", "Europe/Stockholm");
-    Connection connection = getConnection();
-    Statement statement = connection.createStatement();
-    ResultSet resultSet = statement.executeQuery("SELECT '2020-08-01'::DATE as D1");
-    resultSet.next();
-    String s = resultSet.getString(1);
-    System.out.println("Expected: 2020-08-01\nActual: " + s);
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
@@ -3,9 +3,11 @@
  */
 package net.snowflake.client.jdbc;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import net.snowflake.client.ConditionalIgnoreRule;
+import net.snowflake.client.RunningOnGithubAction;
+import net.snowflake.client.category.TestCategoryResultSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -14,11 +16,11 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.Properties;
-import net.snowflake.client.ConditionalIgnoreRule;
-import net.snowflake.client.RunningOnGithubAction;
-import net.snowflake.client.category.TestCategoryResultSet;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 /** Test ResultSet */
 @Category(TestCategoryResultSet.class)
@@ -70,6 +72,18 @@ public class ResultSetIT extends ResultSet0IT {
     statement.execute("drop table if exists bintable");
     statement.close();
     connection.close();
+  }
+
+  @Test
+  public void testGetString() throws SQLException {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Singapore"));
+    //System.setProperty("user.timezone", "Europe/Stockholm");
+    Connection connection = getConnection();
+    Statement statement = connection.createStatement();
+    ResultSet resultSet = statement.executeQuery("SELECT '2020-08-01'::DATE as D1");
+    resultSet.next();
+    String s = resultSet.getString(1);
+    System.out.println("Expected: 2020-08-01\nActual: " + s);
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneIT.java
@@ -318,6 +318,20 @@ public class ResultSetMultiTimeZoneIT extends BaseJDBCTest {
   }
 
   @Test
+  public void testGetStringForDates() throws SQLException {
+    Connection connection = init();
+    Statement statement = connection.createStatement();
+    String expectedDate1 = "2020-08-01";
+    String expectedDate2 = "1920-11-11";
+    ResultSet rs = statement.executeQuery("SELECT '" + expectedDate1 + "'::DATE as D1");
+    rs.next();
+    assertEquals(expectedDate1, rs.getString(1));
+    rs = statement.executeQuery("SELECT '" + expectedDate2 + "'::DATE as D1");
+    rs.next();
+    assertEquals(expectedDate2, rs.getString(1));
+  }
+
+  @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testDateTimeRelatedTypeConversion() throws SQLException {
     Connection connection = init();


### PR DESCRIPTION
Dates can be fetched with the getString() function and are fetched with their session offset in string form. They are then returned as strings by the JVM with no session offset. Currently, there is a bug where dates fetched with getString() are returned with an offset between UTC time and the JVM timezone. The dates should just be returned as the string values that they are with no offset. This change corrects that bug.