### PR TITLE
SNOW-272337 Add reason to SQLFeatureNotSupportedExceptions

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -26,6 +26,7 @@ import net.snowflake.client.jdbc.telemetry.TelemetryUtil;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryEvent;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.common.core.LoginInfoDTO;
+import net.snowflake.common.core.SqlState;
 
 /**
  * @author mknister
@@ -78,12 +79,16 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     String stackTrace = maskStacktrace(sw.toString());
     value.put("Stacktrace", stackTrace);
     value.put("Exception", ex.getClass().getSimpleName());
-    String reason = "";
-    StackTraceElement[] stackTraceArray = ex.getStackTrace();
-    if (stackTraceArray.length >= 1) {
-      reason = ex.getStackTrace()[0].toString();
+    // For SQLFeatureNotSupportedExceptions, add in reason for failure as "<function name> not
+    // supported"
+    if (value.get("SQLState").toString().contains(SqlState.FEATURE_NOT_SUPPORTED)) {
+      String reason = "";
+      StackTraceElement[] stackTraceArray = ex.getStackTrace();
+      if (stackTraceArray.length >= 1) {
+        reason = ex.getStackTrace()[0].getMethodName() + " not supported";
+      }
+      value.put("reason", reason);
     }
-    value.put("reason", reason);
     ibInstance.addLogToBatch(TelemetryUtil.buildJobData(value));
     return ibInstance.sendBatchAsync();
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -78,6 +78,12 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     String stackTrace = maskStacktrace(sw.toString());
     value.put("Stacktrace", stackTrace);
     value.put("Exception", ex.getClass().getSimpleName());
+    String reason = "";
+    StackTraceElement[] stackTraceArray = ex.getStackTrace();
+    if (stackTraceArray.length >= 1) {
+      reason = ex.getStackTrace()[0].toString();
+    }
+    value.put("reason", reason);
     ibInstance.addLogToBatch(TelemetryUtil.buildJobData(value));
     return ibInstance.sendBatchAsync();
   }


### PR DESCRIPTION
We throw SQLFeatureNotSupportedExceptions for any JDBC API call that we do not currently support. We track these exceptions via client telemetry and display the failures on our telemetry dashboard. 

We now want to be able to sort our SQLFeatureNotSupportedExceptions by which function threw the exception on the telemetry dashboard. It's difficult to dig through the stacktrace to find it. So I am adding a "reason" field for these exceptions that details which function has thrown it.