### PR TITLE
SNOW-256737 Continued: Introduced SFBaseStatement

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -123,7 +123,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     useSessionTimezone = resultSetSerializable.getUseSessionTimezone();
 
     // update the driver/session with common parameters from GS
-    SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSession());
+    SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSFBaseSession());
 
     // if server gives a send time, log time it took to arrive
     if (resultSetSerializable.getSendResultTime() != 0) {

--- a/src/main/java/net/snowflake/client/core/SFBaseStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseStatement.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.client.core;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+
+public abstract class SFBaseStatement {
+  protected static final int MAX_STATEMENT_PARAMETERS = 1000;
+  static final SFLogger logger = SFLoggerFactory.getLogger(SFBaseStatement.class);
+  // statement level parameters
+  protected final Map<String, Object> statementParametersMap = new HashMap<>();
+  // timeout in seconds
+  protected int queryTimeout = 0;
+
+  /**
+   * Add a statement parameter
+   *
+   * <p>Make sure a property is not added more than once and the number of properties does not
+   * exceed limit.
+   *
+   * @param propertyName property name
+   * @param propertyValue property value
+   * @throws SFException if too many parameters for a statement
+   */
+  public void addProperty(String propertyName, Object propertyValue) throws SFException {
+    statementParametersMap.put(propertyName, propertyValue);
+
+    // for query timeout, we implement it on client side for now
+    if ("query_timeout".equalsIgnoreCase(propertyName)) {
+      queryTimeout = (Integer) propertyValue;
+    }
+
+    // check if the number of session properties exceed limit
+    if (statementParametersMap.size() > MAX_STATEMENT_PARAMETERS) {
+      throw new SFException(ErrorCode.TOO_MANY_STATEMENT_PARAMETERS, MAX_STATEMENT_PARAMETERS);
+    }
+  }
+
+  /**
+   * Describe a statement
+   *
+   * @param sql statement
+   * @return metadata of statement including result set metadata and binding information
+   * @throws SQLException if connection is already closed
+   * @throws SFException if result set is null
+   */
+  public abstract SFStatementMetaData describe(String sql) throws SFException, SQLException;
+
+  /**
+   * Execute sql
+   *
+   * @param sql sql statement.
+   * @param parametersBinding parameters to bind
+   * @param caller the JDBC interface method that called this method, if any
+   * @return whether there is result set or not
+   * @throws SQLException if failed to execute sql
+   * @throws SFException exception raised from Snowflake components
+   * @throws SQLException if SQL error occurs
+   */
+  public abstract SFBaseResultSet execute(
+      String sql, Map<String, ParameterBindingDTO> parametersBinding, CallingMethod caller)
+      throws SQLException, SFException;
+
+  /**
+   * Execute sql asynchronously
+   *
+   * @param sql sql statement.
+   * @param parametersBinding parameters to bind
+   * @param caller the JDBC interface method that called this method, if any
+   * @return whether there is result set or not
+   * @throws SQLException if failed to execute sql
+   * @throws SFException exception raised from Snowflake components
+   * @throws SQLException if SQL error occurs
+   */
+  public abstract SFBaseResultSet asyncExecute(
+      String sql, Map<String, ParameterBindingDTO> parametersBinding, CallingMethod caller)
+      throws SQLException, SFException;
+
+  public abstract void close();
+
+  public abstract void cancel() throws SFException, SQLException;
+
+  public void executeSetProperty(final String sql) {
+    logger.debug("setting property");
+
+    // tokenize the sql
+    String[] tokens = sql.split("\\s+");
+
+    if (tokens.length < 2) {
+      return;
+    }
+
+    if ("sort".equalsIgnoreCase(tokens[1])) {
+      if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2])) {
+        logger.debug("setting sort on");
+
+        this.getSFBaseSession().setSessionPropertyByKey("sort", true);
+      } else {
+        logger.debug("setting sort off");
+        this.getSFBaseSession().setSessionPropertyByKey("sort", false);
+      }
+    }
+  }
+
+  public abstract boolean hasChildren();
+
+  public abstract SFBaseSession getSFBaseSession();
+
+  public abstract SFBaseResultSet getResultSet();
+
+  public abstract boolean getMoreResults(int current) throws SQLException;
+
+  public enum CallingMethod {
+    EXECUTE,
+    EXECUTE_UPDATE,
+    EXECUTE_QUERY
+  }
+}

--- a/src/main/java/net/snowflake/client/core/SFBaseStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseStatement.java
@@ -135,6 +135,7 @@ public abstract class SFBaseStatement {
     }
   }
 
+  /** If this is a multi-statement, i.e., has child results. */
   public abstract boolean hasChildren();
 
   /** Returns the SFBaseSession associated with this SFBaseStatement. */

--- a/src/main/java/net/snowflake/client/core/SFBaseStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseStatement.java
@@ -12,9 +12,9 @@ import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
 /**
- * Base abstract class for an SFStatement implementation. Statements are used in both executing
- * queries, both in standard and prepared forms. They are accessed by users via the public API
- * class, SnowflakeStatementV(x).
+ * Base abstract class for an SFStatement implementation. Statements are used in executing queries,
+ * both in standard and prepared forms. They are accessed by users via the public API class,
+ * SnowflakeStatementV(x).
  */
 public abstract class SFBaseStatement {
   // maximum number of parameters for the statement; if this threshold is exceeded,

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -87,10 +87,10 @@ public class SFResultSet extends SFJsonResultSet {
       SFStatement statement,
       boolean sortResult)
       throws SQLException {
-    this(resultSetSerializable, statement.getSession().getTelemetryClient(), sortResult);
+    this(resultSetSerializable, statement.getSFBaseSession().getTelemetryClient(), sortResult);
 
     this.statement = statement;
-    SFSession session = (SFSession) statement.getSession();
+    SFSession session = (SFSession) statement.getSFBaseSession();
     session.setDatabase(resultSetSerializable.getFinalDatabaseName());
     session.setSchema(resultSetSerializable.getFinalSchemaName());
     session.setRole(resultSetSerializable.getFinalRoleName());
@@ -99,7 +99,7 @@ public class SFResultSet extends SFJsonResultSet {
     this.formatDateWithTimezone = resultSetSerializable.getFormatDateWithTimeZone();
 
     // update the driver/session with common parameters from GS
-    SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSession());
+    SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSFBaseSession());
 
     // if server gives a send time, log time it took to arrive
     if (resultSetSerializable.getSendResultTime() != 0) {

--- a/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
@@ -26,7 +26,7 @@ class SFResultSetFactory {
       throws SQLException {
 
     // This should only be invoked from an SFSession connection
-    SFSession session = (SFSession) statement.getSession();
+    SFSession session = (SFSession) statement.getSFBaseSession();
     SnowflakeResultSetSerializableV1 resultSetSerializable =
         SnowflakeResultSetSerializableV1.create(result, session, statement);
 
@@ -37,7 +37,7 @@ class SFResultSetFactory {
         return new SFResultSet(resultSetSerializable, statement, sortResult);
       default:
         throw new SnowflakeSQLLoggedException(
-            statement.getSession(),
+            statement.getSFBaseSession(),
             ErrorCode.INTERNAL_ERROR,
             "Unsupported query result format: "
                 + resultSetSerializable.getQueryResultFormat().name());

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -761,6 +761,7 @@ public class SFSession extends SFBaseSession {
     this.enableCombineDescribe = enable;
   }
 
+  @Override
   public synchronized Telemetry getTelemetryClient() {
     // initialize for the first time. this should only be done after session
     // properties have been set, else the client won't properly resolve the URL.

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -32,12 +32,7 @@ import net.snowflake.common.core.SqlState;
 import org.apache.http.client.methods.HttpRequestBase;
 
 /** Snowflake statement */
-public class SFStatement {
-  public enum CallingMethod {
-    EXECUTE,
-    EXECUTE_UPDATE,
-    EXECUTE_QUERY
-  }
+public class SFStatement extends SFBaseStatement {
 
   static final SFLogger logger = SFLoggerFactory.getLogger(SFStatement.class);
 
@@ -57,17 +52,9 @@ public class SFStatement {
 
   private final AtomicBoolean canceling = new AtomicBoolean(false);
 
-  // timeout in seconds
-  private int queryTimeout = 0;
-
   private boolean isFileTransfer = false;
 
   private SnowflakeFileTransferAgent transferAgent = null;
-
-  // statement level parameters
-  private final Map<String, Object> statementParametersMap = new HashMap<>();
-
-  private static final int MAX_STATEMENT_PARAMETERS = 1000;
 
   private static final int MAX_BINDING_PARAMS_FOR_LOGGING = 1000;
 
@@ -89,30 +76,6 @@ public class SFStatement {
     Integer queryTimeout = session == null ? null : session.getQueryTimeout();
     this.queryTimeout = queryTimeout != null ? queryTimeout : this.queryTimeout;
     verifyArrowSupport();
-  }
-
-  /**
-   * Add a statement parameter
-   *
-   * <p>Make sure a property is not added more than once and the number of properties does not
-   * exceed limit.
-   *
-   * @param propertyName property name
-   * @param propertyValue property value
-   * @throws SFException if too many parameters for a statement
-   */
-  public void addProperty(String propertyName, Object propertyValue) throws SFException {
-    statementParametersMap.put(propertyName, propertyValue);
-
-    // for query timeout, we implement it on client side for now
-    if ("query_timeout".equalsIgnoreCase(propertyName)) {
-      queryTimeout = (Integer) propertyValue;
-    }
-
-    // check if the number of session properties exceed limit
-    if (statementParametersMap.size() > MAX_STATEMENT_PARAMETERS) {
-      throw new SFException(ErrorCode.TOO_MANY_STATEMENT_PARAMETERS, MAX_STATEMENT_PARAMETERS);
-    }
   }
 
   private void verifyArrowSupport() {
@@ -664,6 +627,13 @@ public class SFStatement {
     return conservativeMemoryLimit;
   }
 
+  @Override
+  public SFBaseResultSet execute(
+      String sql, Map<String, ParameterBindingDTO> parametersBinding, CallingMethod caller)
+      throws SQLException, SFException {
+    return execute(sql, false, parametersBinding, caller);
+  }
+
   private void reauthenticate() throws SFException, SnowflakeSQLException {
     SFLoginInput input =
         new SFLoginInput()
@@ -868,29 +838,7 @@ public class SFStatement {
     transferAgent = null;
   }
 
-  public void executeSetProperty(final String sql) {
-    logger.debug("setting property");
-
-    // tokenize the sql
-    String[] tokens = sql.split("\\s+");
-
-    if (tokens.length < 2) {
-      return;
-    }
-
-    if ("sort".equalsIgnoreCase(tokens[1])) {
-      if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2])) {
-        logger.debug("setting sort on");
-
-        this.session.setSessionPropertyByKey("sort", true);
-      } else {
-        logger.debug("setting sort off");
-        this.session.setSessionPropertyByKey("sort", false);
-      }
-    }
-  }
-
-  public SFBaseSession getSession() {
+  public SFBaseSession getSFBaseSession() {
     return session;
   }
 
@@ -950,6 +898,7 @@ public class SFStatement {
     return !childResults.isEmpty();
   }
 
+  @Override
   public SFBaseResultSet asyncExecute(
       String sql, Map<String, ParameterBindingDTO> parametersBinding, CallingMethod caller)
       throws SQLException, SFException {

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -145,6 +145,7 @@ public class SFStatement extends SFBaseStatement {
    * @throws SQLException if connection is already closed
    * @throws SFException if result set is null
    */
+  @Override
   public SFStatementMetaData describe(String sql) throws SFException, SQLException {
     SFBaseResultSet baseResultSet = executeQuery(sql, null, true, false, null);
 
@@ -763,6 +764,7 @@ public class SFStatement extends SFBaseStatement {
     }
   }
 
+  @Override
   public void close() {
     logger.debug("public void close()");
 
@@ -789,6 +791,7 @@ public class SFStatement extends SFBaseStatement {
     transferAgent = null;
   }
 
+  @Override
   public void cancel() throws SFException, SQLException {
     logger.debug("public void cancel()");
 
@@ -838,6 +841,7 @@ public class SFStatement extends SFBaseStatement {
     transferAgent = null;
   }
 
+  @Override
   public SFBaseSession getSFBaseSession() {
     return session;
   }
@@ -851,15 +855,7 @@ public class SFStatement extends SFBaseStatement {
     return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
   }
 
-  /**
-   * Sets the result set to the next one, if available.
-   *
-   * @param current What to do with the current result. One of Statement.CLOSE_CURRENT_RESULT,
-   *     Statement.CLOSE_ALL_RESULTS, or Statement.KEEP_CURRENT_RESULT
-   * @return true if there is a next result and it's a result set false if there are no more
-   *     results, or there is a next result and it's an update count
-   * @throws SQLException if something fails while getting the next result
-   */
+  @Override
   public boolean getMoreResults(int current) throws SQLException {
     // clean up current result, if exists
     if (resultSet != null
@@ -890,10 +886,12 @@ public class SFStatement extends SFBaseStatement {
     }
   }
 
+  @Override
   public SFBaseResultSet getResultSet() {
     return resultSet;
   }
 
+  @Override
   public boolean hasChildren() {
     return !childResults.isEmpty();
   }

--- a/src/main/java/net/snowflake/client/jdbc/DefaultSFConnectionHandler.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultSFConnectionHandler.java
@@ -88,6 +88,12 @@ public class DefaultSFConnectionHandler implements SFConnectionHandler {
     return sfSession;
   }
 
+  /** Returns the default SFStatement client implementation. */
+  @Override
+  public SFBaseStatement getSFStatement() {
+    return new SFStatement(sfSession);
+  }
+
   private void initialize(SnowflakeConnectString conStr) throws SQLException {
     logger.debug(
         "Trying to establish session, JDBC driver version: {}", SnowflakeDriver.implementVersion);

--- a/src/main/java/net/snowflake/client/jdbc/SFConnectionHandler.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFConnectionHandler.java
@@ -4,6 +4,7 @@ import java.sql.*;
 import java.util.Properties;
 import net.snowflake.client.core.SFBaseResultSet;
 import net.snowflake.client.core.SFBaseSession;
+import net.snowflake.client.core.SFBaseStatement;
 
 /**
  * Class that presents the implementation of a Snowflake Connection. This allows for alternate
@@ -21,8 +22,11 @@ public interface SFConnectionHandler {
   /** Initializes the SnowflakeConnection */
   void initializeConnection(String url, Properties info) throws SQLException;
 
-  /** Gets the SFSessionInterface implementation for this connection implementation */
+  /** Gets the SFBaseSession implementation for this connection implementation */
   SFBaseSession getSFSession();
+
+  /** Returns the SFStatementInterface implementation for this connection implementation */
+  SFBaseStatement getSFStatement() throws SQLException;
 
   /** Creates a result set from a query id. */
   ResultSet createResultSet(String queryID, Connection connection) throws SQLException;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -424,18 +424,14 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   @Override
   public Statement createStatement(
       int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-    if (isUsingDefaultConnectionHandler) {
-      logger.debug(
-          "Statement createStatement(int resultSetType, "
-              + "int resultSetConcurrency, int resultSetHoldability");
+    logger.debug(
+        "Statement createStatement(int resultSetType, "
+            + "int resultSetConcurrency, int resultSetHoldability");
 
-      Statement stmt =
-          new SnowflakeStatementV1(this, resultSetType, resultSetConcurrency, resultSetHoldability);
-      openStatements.add(stmt);
-      return stmt;
-    } else {
-      throw new SnowflakeLoggedFeatureNotSupportedException(sfSession);
-    }
+    Statement stmt =
+        new SnowflakeStatementV1(this, resultSetType, resultSetConcurrency, resultSetHoldability);
+    openStatements.add(stmt);
+    return stmt;
   }
 
   @Override
@@ -488,36 +484,28 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   public PreparedStatement prepareStatement(
       String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
       throws SQLException {
-    if (isUsingDefaultConnectionHandler) {
-      logger.debug("PreparedStatement prepareStatement(String sql, " + "int resultSetType,");
+    logger.debug("PreparedStatement prepareStatement(String sql, " + "int resultSetType,");
 
-      PreparedStatement stmt =
-          new SnowflakePreparedStatementV1(
-              this, sql, false, resultSetType, resultSetConcurrency, resultSetHoldability);
-      openStatements.add(stmt);
-      return stmt;
-    } else {
-      throw new SnowflakeLoggedFeatureNotSupportedException(sfSession);
-    }
+    PreparedStatement stmt =
+        new SnowflakePreparedStatementV1(
+            this, sql, false, resultSetType, resultSetConcurrency, resultSetHoldability);
+    openStatements.add(stmt);
+    return stmt;
   }
 
   public PreparedStatement prepareStatement(String sql, boolean skipParsing) throws SQLException {
-    if (isUsingDefaultConnectionHandler) {
-      logger.debug("PreparedStatement prepareStatement(String sql, boolean skipParsing)");
-      raiseSQLExceptionIfConnectionIsClosed();
-      PreparedStatement stmt =
-          new SnowflakePreparedStatementV1(
-              this,
-              sql,
-              skipParsing,
-              ResultSet.TYPE_FORWARD_ONLY,
-              ResultSet.CONCUR_READ_ONLY,
-              ResultSet.CLOSE_CURSORS_AT_COMMIT);
-      openStatements.add(stmt);
-      return stmt;
-    } else {
-      throw new SnowflakeLoggedFeatureNotSupportedException(sfSession);
-    }
+    logger.debug("PreparedStatement prepareStatement(String sql, boolean skipParsing)");
+    raiseSQLExceptionIfConnectionIsClosed();
+    PreparedStatement stmt =
+        new SnowflakePreparedStatementV1(
+            this,
+            sql,
+            skipParsing,
+            ResultSet.TYPE_FORWARD_ONLY,
+            ResultSet.CONCUR_READ_ONLY,
+            ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    openStatements.add(stmt);
+    return stmt;
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -93,7 +93,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   private void describeSqlIfNotTried() throws SQLException {
     if (!alreadyDescribed) {
       try {
-        this.statementMetaData = sfStatementInterface.describe(sql);
+        this.statementMetaData = sfBaseStatement.describe(sql);
       } catch (SFException e) {
         throw new SnowflakeSQLLoggedException(connection.getSFBaseSession(), e);
       } catch (SnowflakeSQLException e) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -93,7 +93,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   private void describeSqlIfNotTried() throws SQLException {
     if (!alreadyDescribed) {
       try {
-        this.statementMetaData = sfStatement.describe(sql);
+        this.statementMetaData = sfStatementInterface.describe(sql);
       } catch (SFException e) {
         throw new SnowflakeSQLLoggedException(connection.getSFBaseSession(), e);
       } catch (SnowflakeSQLException e) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -901,7 +901,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     }
   }
 
-  public SFBaseStatement getStatementHandler() throws SQLException {
+  public SFBaseStatement getSFBaseStatement() throws SQLException {
     return sfBaseStatement;
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -52,7 +52,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   // max field size limited to 16MB
   private final int maxFieldSize = 16777216;
 
-  SFStatement sfStatement;
+  SFBaseStatement sfStatementInterface;
 
   private boolean poolable;
 
@@ -111,8 +111,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
 
-    sfStatement =
-        (connection != null) ? new SFStatement((SFSession) connection.getSFBaseSession()) : null;
+    sfStatementInterface = (connection != null) ? connection.getHandler().getSFStatement() : null;
   }
 
   protected void raiseSQLExceptionIfStatementIsClosed() throws SQLException {
@@ -187,8 +186,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     SFBaseResultSet sfResultSet;
     try {
       sfResultSet =
-          sfStatement.execute(
-              sql, false, parameterBindings, SFStatement.CallingMethod.EXECUTE_UPDATE);
+          sfStatementInterface.execute(
+              sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_UPDATE);
       sfResultSet.setSession(this.connection.getSFBaseSession());
       updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       queryID = sfResultSet.getQueryId();
@@ -226,9 +225,20 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       throws SQLException {
     SFBaseResultSet sfResultSet;
     try {
-      sfResultSet =
-          sfStatement.execute(
-              sql, asyncExec, parameterBindings, SFStatement.CallingMethod.EXECUTE_QUERY);
+      if (asyncExec) {
+        if (!connection.getHandler().supportsAsyncQuery()) {
+          throw new SQLFeatureNotSupportedException(
+              "Async execution not supported in current context.");
+        }
+        sfResultSet =
+            sfStatementInterface.asyncExecute(
+                sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_QUERY);
+      } else {
+        sfResultSet =
+            sfStatementInterface.execute(
+                sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_QUERY);
+      }
+
       sfResultSet.setSession(this.connection.getSFBaseSession());
     } catch (SFException ex) {
       throw new SnowflakeSQLException(
@@ -240,9 +250,9 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     }
 
     if (asyncExec) {
-      resultSet = new SFAsyncResultSet(sfResultSet, this);
+      resultSet = connection.getHandler().createAsyncResultSet(sfResultSet, this);
     } else {
-      resultSet = new SnowflakeResultSetV1(sfResultSet, this);
+      resultSet = connection.getHandler().createResultSet(sfResultSet, this);
     }
 
     return getResultSet();
@@ -274,7 +284,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     SFBaseResultSet sfResultSet;
     try {
       sfResultSet =
-          sfStatement.execute(sql, false, parameterBindings, SFStatement.CallingMethod.EXECUTE);
+          sfStatementInterface.execute(
+              sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE);
       sfResultSet.setSession(this.connection.getSFBaseSession());
       if (resultSet != null) {
         openResultSets.add(resultSet);
@@ -287,7 +298,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       // if CLIENT_SFSQL is not set, or if a statement
       // is multi-statement
       if (!sfResultSet.getStatementType().isGenerateResultSet()
-          && (!connection.getSFBaseSession().isSfSQLMode() || sfStatement.hasChildren())) {
+          && (!connection.getSFBaseSession().isSfSQLMode() || sfStatementInterface.hasChildren())) {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
         if (resultSet != null) {
           openResultSets.add(resultSet);
@@ -558,8 +569,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       resultSet.close();
     }
 
-    boolean hasResultSet = sfStatement.getMoreResults(current);
-    SFBaseResultSet sfResultSet = sfStatement.getResultSet();
+    boolean hasResultSet = sfStatementInterface.getMoreResults(current);
+    SFBaseResultSet sfResultSet = sfStatementInterface.getResultSet();
 
     if (hasResultSet) // result set returned
     {
@@ -638,7 +649,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
 
   private long getUpdateCountIfDML() throws SQLException {
     raiseSQLExceptionIfStatementIsClosed();
-    if (updateCount != -1 && sfStatement.getResultSet().getStatementType().isDML()) {
+    if (updateCount != -1 && sfStatementInterface.getResultSet().getStatementType().isDML()) {
       return updateCount;
     }
     return -1;
@@ -711,8 +722,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
 
     this.maxRows = max;
     try {
-      if (this.sfStatement != null) {
-        this.sfStatement.addProperty("rows_per_resultset", max);
+      if (this.sfStatementInterface != null) {
+        this.sfStatementInterface.addProperty("rows_per_resultset", max);
       }
     } catch (SFException ex) {
       throw new SnowflakeSQLException(
@@ -742,8 +753,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     logger.debug("setParameter");
 
     try {
-      if (this.sfStatement != null) {
-        this.sfStatement.addProperty(name, value);
+      if (this.sfStatementInterface != null) {
+        this.sfStatementInterface.addProperty(name, value);
       }
     } catch (SFException ex) {
       throw new SnowflakeSQLException(ex);
@@ -757,8 +768,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
 
     this.queryTimeout = seconds;
     try {
-      if (this.sfStatement != null) {
-        this.sfStatement.addProperty("query_timeout", seconds);
+      if (this.sfStatementInterface != null) {
+        this.sfStatementInterface.addProperty("query_timeout", seconds);
       }
     } catch (SFException ex) {
       throw new SnowflakeSQLException(
@@ -824,7 +835,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       }
     }
     openResultSets.clear();
-    sfStatement.close();
+    sfStatementInterface.close();
     if (removeClosedStatementFromConnection) {
       connection.removeClosedStatement(this);
     }
@@ -836,7 +847,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     raiseSQLExceptionIfStatementIsClosed();
 
     try {
-      sfStatement.cancel();
+      sfStatementInterface.cancel();
     } catch (SFException ex) {
       throw new SnowflakeSQLException(ex, ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
@@ -887,12 +898,23 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
         }*/
       }
     } else {
-      this.sfStatement.executeSetProperty(sql);
+      this.sfStatementInterface.executeSetProperty(sql);
     }
   }
 
-  public SFStatement getSfStatement() throws SQLException {
-    return sfStatement;
+  public SFBaseStatement getStatementHandler() throws SQLException {
+    return sfStatementInterface;
+  }
+
+  // Convenience method to return an SFStatement-typed SFStatementInterface object, but
+  // performs the type-checking as necessary.
+  public SFStatement getSfStatement() throws SnowflakeSQLException {
+    if (sfStatementInterface instanceof SFStatement) {
+      return (SFStatement) sfStatementInterface;
+    }
+
+    throw new SnowflakeSQLException(
+        "getSfStatement() called with a different SFStatementInterface type.");
   }
 
   public void removeClosedResultSet(ResultSet rs) {

--- a/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
@@ -1,0 +1,618 @@
+package net.snowflake.client.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.sql.*;
+import java.util.*;
+import net.snowflake.client.category.TestCategoryConnection;
+import net.snowflake.client.core.*;
+import net.snowflake.client.jdbc.telemetry.NoOpTelemetryClient;
+import net.snowflake.client.jdbc.telemetry.Telemetry;
+import net.snowflake.common.core.SnowflakeDateTimeFormat;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * IT test for testing the "pluggable" implementation of SnowflakeConnection, SnowflakeStatement,
+ * and ResultSet. These tests will query Snowflake normally, retrieve the JSON result, and replay it
+ * back using a custom implementation of these objects that simply echoes a given JSON response.
+ */
+@Category(TestCategoryConnection.class)
+public class MockConnectionTest extends BaseJDBCTest {
+
+  private static final String testTableName = "test_custom_conn_table";
+
+  private static SFResultSetMetaData getRSMDFromResponse(JsonNode rootNode, SFBaseSession sfSession)
+      throws SnowflakeSQLException {
+
+    String queryId = rootNode.path("data").path("queryId").asText();
+
+    Map<String, Object> parameters =
+        SessionUtil.getCommonParams(rootNode.path("data").path("parameters"));
+
+    String sqlTimestampFormat =
+        (String) ResultUtil.effectiveParamValue(parameters, "TIMESTAMP_OUTPUT_FORMAT");
+
+    // Special handling of specialized formatters, use a helper function
+    SnowflakeDateTimeFormat ntzFormat =
+        ResultUtil.specializedFormatter(
+            parameters, "timestamp_ntz", "TIMESTAMP_NTZ_OUTPUT_FORMAT", sqlTimestampFormat);
+
+    SnowflakeDateTimeFormat ltzFormat =
+        ResultUtil.specializedFormatter(
+            parameters, "timestamp_ltz", "TIMESTAMP_LTZ_OUTPUT_FORMAT", sqlTimestampFormat);
+
+    SnowflakeDateTimeFormat tzFormat =
+        ResultUtil.specializedFormatter(
+            parameters, "timestamp_tz", "TIMESTAMP_TZ_OUTPUT_FORMAT", sqlTimestampFormat);
+
+    String sqlDateFormat =
+        (String) ResultUtil.effectiveParamValue(parameters, "DATE_OUTPUT_FORMAT");
+
+    SnowflakeDateTimeFormat dateFormatter =
+        SnowflakeDateTimeFormat.fromSqlFormat(Objects.requireNonNull(sqlDateFormat));
+
+    String sqlTimeFormat =
+        (String) ResultUtil.effectiveParamValue(parameters, "TIME_OUTPUT_FORMAT");
+
+    SnowflakeDateTimeFormat timeFormatter =
+        SnowflakeDateTimeFormat.fromSqlFormat(Objects.requireNonNull(sqlTimeFormat));
+
+    List<SnowflakeColumnMetadata> resultColumnMetadata = new ArrayList<>();
+    int columnCount = rootNode.path("data").path("rowtype").size();
+    for (int i = 0; i < columnCount; i++) {
+      JsonNode colNode = rootNode.path("data").path("rowtype").path(i);
+
+      SnowflakeColumnMetadata columnMetadata =
+          SnowflakeUtil.extractColumnMetadata(
+              colNode, sfSession.isJdbcTreatDecimalAsInt(), sfSession);
+
+      resultColumnMetadata.add(columnMetadata);
+    }
+
+    return new SFResultSetMetaData(
+        resultColumnMetadata,
+        queryId,
+        sfSession,
+        false,
+        ntzFormat,
+        ltzFormat,
+        tzFormat,
+        dateFormatter,
+        timeFormatter);
+  }
+
+  private static ObjectNode getJsonFromDataType(DataType dataType) {
+
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode type = mapper.createObjectNode();
+
+    if (dataType == DataType.INT) {
+      type.put("name", "someIntColumn");
+      type.put("database", "");
+      type.put("schema", "");
+      type.put("table", "");
+      type.put("scale", 0);
+      type.put("precision", 18);
+      type.put("type", "fixed");
+      type.put("length", (Integer) null);
+      type.put("byteLength", (Integer) null);
+      type.put("nullable", true);
+      type.put("collation", (String) null);
+    } else if (dataType == DataType.STRING) {
+      type.put("name", "someStringColumn");
+      type.put("database", "");
+      type.put("schema", "");
+      type.put("table", "");
+      type.put("scale", (Integer) null);
+      type.put("precision", (Integer) null);
+      type.put("length", 16777216);
+      type.put("type", "text");
+      type.put("byteLength", 16777216);
+      type.put("nullable", true);
+      type.put("collation", (String) null);
+    }
+
+    return type;
+  }
+
+  public Connection initMockConnection(SFConnectionHandler implementation) throws SQLException {
+    return new SnowflakeConnectionV1(implementation);
+  }
+
+  /**
+   * Test running some queries, and plugging in the raw JSON response from those queries into a
+   * MockConnection. The results retrieved from the MockConnection should be the same as those from
+   * the original connection.
+   */
+  @Test
+  public void testMockResponse() throws SQLException, JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode rawResponse =
+        mapper.readTree(
+            "{\n"
+                + "   \"data\":{\n"
+                + "      \"parameters\":[\n"
+                + "         {\n"
+                + "            \"name\":\"TIMESTAMP_OUTPUT_FORMAT\",\n"
+                + "            \"value\":\"DY, DD MON YYYY HH24:MI:SS TZHTZM\"\n"
+                + "         },\n"
+                + "         {\n"
+                + "            \"name\":\"TIME_OUTPUT_FORMAT\",\n"
+                + "            \"value\":\"HH24:MI:SS\"\n"
+                + "         },\n"
+                + "         {\n"
+                + "            \"name\":\"TIMESTAMP_TZ_OUTPUT_FORMAT\",\n"
+                + "            \"value\":\"\"\n"
+                + "         },\n"
+                + "         {\n"
+                + "            \"name\":\"TIMESTAMP_NTZ_OUTPUT_FORMAT\",\n"
+                + "            \"value\":\"\"\n"
+                + "         },\n"
+                + "         {\n"
+                + "            \"name\":\"DATE_OUTPUT_FORMAT\",\n"
+                + "            \"value\":\"YYYY-MM-DD\"\n"
+                + "         },\n"
+                + "         {\n"
+                + "            \"name\":\"TIMESTAMP_LTZ_OUTPUT_FORMAT\",\n"
+                + "            \"value\":\"\"\n"
+                + "         }\n"
+                + "      ],\n"
+                + "      \"rowtype\":[\n"
+                + "         {\n"
+                + "            \"name\":\"COLA\",\n"
+                + "            \"database\":\"TESTDB\",\n"
+                + "            \"schema\":\"TESTSCHEMA\",\n"
+                + "            \"table\":\"TEST_CUSTOM_CONN_TABLE\",\n"
+                + "            \"scale\":null,\n"
+                + "            \"precision\":null,\n"
+                + "            \"length\":16777216,\n"
+                + "            \"type\":\"text\",\n"
+                + "            \"byteLength\":16777216,\n"
+                + "            \"nullable\":true,\n"
+                + "            \"collation\":null\n"
+                + "         },\n"
+                + "         {\n"
+                + "            \"name\":\"COLB\",\n"
+                + "            \"database\":\"TESTDB\",\n"
+                + "            \"schema\":\"TESTSCHEMA\",\n"
+                + "            \"table\":\"TEST_CUSTOM_CONN_TABLE\",\n"
+                + "            \"scale\":0,\n"
+                + "            \"precision\":38,\n"
+                + "            \"length\":null,\n"
+                + "            \"type\":\"fixed\",\n"
+                + "            \"byteLength\":null,\n"
+                + "            \"nullable\":true,\n"
+                + "            \"collation\":null\n"
+                + "         }\n"
+                + "      ],\n"
+                + "      \"rowset\":[\n"
+                + "         [\n"
+                + "            \"rowOne\",\n"
+                + "            \"1\"\n"
+                + "         ],\n"
+                + "         [\n"
+                + "            \"rowTwo\",\n"
+                + "            \"2\"\n"
+                + "         ]\n"
+                + "      ],\n"
+                + "      \"total\":2,\n"
+                + "      \"returned\":2,\n"
+                + "      \"queryId\":\"0199922f-015a-7715-0000-0014000123ca\",\n"
+                + "      \"databaseProvider\":null,\n"
+                + "      \"finalDatabaseName\":\"TESTDB\",\n"
+                + "      \"finalSchemaName\":\"TESTSCHEMA\",\n"
+                + "      \"finalWarehouseName\":\"DEV\",\n"
+                + "      \"finalRoleName\":\"SYSADMIN\",\n"
+                + "      \"numberOfBinds\":0,\n"
+                + "      \"arrayBindSupported\":false,\n"
+                + "      \"statementTypeId\":4096,\n"
+                + "      \"version\":1,\n"
+                + "      \"sendResultTime\":1610498856446,\n"
+                + "      \"queryResultFormat\":\"json\"\n"
+                + "   },\n"
+                + "   \"code\":null,\n"
+                + "   \"message\":null,\n"
+                + "   \"success\":true\n"
+                + "}");
+
+    MockSnowflakeConnectionImpl mockImpl = new MockSnowflakeConnectionImpl(rawResponse);
+    Connection mockConnection = initMockConnection(mockImpl);
+
+    ResultSet fakeResultSet =
+        mockConnection.prepareStatement("select count(*) from " + testTableName).executeQuery();
+    fakeResultSet.next();
+    String val = fakeResultSet.getString(1);
+    assertEquals("colA value from the mock connection was not what was expected", "rowOne", val);
+
+    mockConnection.close();
+  }
+
+  /**
+   * Fabricates fake JSON responses with some int data, and asserts the correct results via
+   * retrieval from MockJsonResultSet
+   */
+  @Test
+  public void testMockedResponseWithRows() throws SQLException {
+    // Test with some ints
+    List<DataType> dataTypes = Arrays.asList(DataType.INT, DataType.INT, DataType.INT);
+    List<Object> row1 = Arrays.asList(1, 2, null);
+    List<Object> row2 = Arrays.asList(4, null, 6);
+    List<List<Object>> rowsToTest = Arrays.asList(row1, row2);
+
+    JsonNode responseWithRows = createDummyResponseWithRows(rowsToTest, dataTypes);
+
+    MockSnowflakeConnectionImpl mockImpl = new MockSnowflakeConnectionImpl(responseWithRows);
+    Connection mockConnection = initMockConnection(mockImpl);
+
+    ResultSet fakeResultSet =
+        mockConnection.prepareStatement("select * from fakeTable").executeQuery();
+    compareResultSets(fakeResultSet, rowsToTest, dataTypes);
+
+    mockConnection.close();
+
+    // Now test with some strings
+    dataTypes = Arrays.asList(DataType.STRING, DataType.STRING);
+    row1 = Arrays.asList("hi", "bye");
+    row2 = Arrays.asList(null, "snowflake");
+    List<Object> row3 = Arrays.asList("is", "great");
+    rowsToTest = Arrays.asList(row1, row2, row3);
+
+    responseWithRows = createDummyResponseWithRows(rowsToTest, dataTypes);
+
+    mockImpl = new MockSnowflakeConnectionImpl(responseWithRows);
+    mockConnection = initMockConnection(mockImpl);
+
+    fakeResultSet = mockConnection.prepareStatement("select * from fakeTable").executeQuery();
+    compareResultSets(fakeResultSet, rowsToTest, dataTypes);
+
+    mockConnection.close();
+
+    // Mixed data
+    dataTypes = Arrays.asList(DataType.STRING, DataType.INT);
+    row1 = Arrays.asList("foo", 2);
+    row2 = Arrays.asList("bar", 4);
+    row3 = Arrays.asList("baz", null);
+    rowsToTest = Arrays.asList(row1, row2, row3);
+
+    responseWithRows = createDummyResponseWithRows(rowsToTest, dataTypes);
+
+    mockImpl = new MockSnowflakeConnectionImpl(responseWithRows);
+    mockConnection = initMockConnection(mockImpl);
+
+    fakeResultSet = mockConnection.prepareStatement("select * from fakeTable").executeQuery();
+    compareResultSets(fakeResultSet, rowsToTest, dataTypes);
+
+    mockConnection.close();
+  }
+
+  private JsonNode createDummyResponseWithRows(List<List<Object>> rows, List<DataType> dataTypes) {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode rootNode = mapper.createObjectNode();
+    ObjectNode dataNode = rootNode.putObject("data");
+
+    createResultSetMetadataResponse(dataNode, dataTypes);
+    createRowsetJson(dataNode, rows, dataTypes);
+
+    return rootNode;
+  }
+
+  /**
+   * Creates the metadata portion of the response, i.e.,
+   *
+   * <p>parameters: [time format, date format, timestamp format, timestamp_ltz format, timestamp_tz
+   * format, timestamp_ntz format, ] queryId rowType
+   *
+   * @param dataNode ObjectNode representing the "data" portion of the JSON response
+   * @param dataTypes datatypes of the rows used in the generated response
+   */
+  private void createResultSetMetadataResponse(ObjectNode dataNode, List<DataType> dataTypes) {
+    ArrayNode parameters = dataNode.putArray("parameters");
+
+    parameters.add(createParameterJson("TIME_OUTPUT_FORMAT", "HH24:MI:SS"));
+    parameters.add(createParameterJson("DATE_OUTPUT_FORMAT", "YYYY-MM-DD"));
+    parameters.add(
+        createParameterJson("TIMESTAMP_OUTPUT_FORMAT", "DY, DD MON YYYY HH24:MI:SS TZHTZM"));
+    parameters.add(createParameterJson("TIMESTAMP_LTZ_OUTPUT_FORMAT", ""));
+    parameters.add(createParameterJson("TIMESTAMP_NTZ_OUTPUT_FORMAT", ""));
+    parameters.add(createParameterJson("TIMESTAMP_TZ_OUTPUT_FORMAT", ""));
+
+    dataNode.put("queryId", "81998ae8-01e5-e08d-0000-10140001201a");
+
+    ArrayNode rowType = dataNode.putArray("rowtype");
+
+    for (DataType type : dataTypes) {
+      rowType.add(getJsonFromDataType(type));
+    }
+  }
+
+  /**
+   * Creates a parameter key-value pairing in JSON, with name and value
+   *
+   * @return an ObjectNode with the parameter name and value
+   */
+  private ObjectNode createParameterJson(String parameterName, String parameterValue) {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode parameterObject = mapper.createObjectNode();
+    parameterObject.put("name", parameterName);
+    parameterObject.put("value", parameterValue);
+
+    return parameterObject;
+  }
+
+  /**
+   * Adds the data portion of the mocked response JSON
+   *
+   * @param dataNode The ObjectNode representing the "data" portion of the JSON response
+   * @param rows The rows to add to the rowset.
+   * @param dataTypes datatypes of the provided set of rows
+   */
+  private void createRowsetJson(
+      ObjectNode dataNode, List<List<Object>> rows, List<DataType> dataTypes) {
+    ArrayNode rowsetNode = dataNode.putArray("rowset");
+
+    if (rows == null || rows.isEmpty()) {
+      return;
+    }
+
+    for (List<Object> row : rows) {
+      Iterator<Object> rowData = row.iterator();
+      ArrayNode rowJson = rowsetNode.addArray();
+      for (DataType type : dataTypes) {
+        if (type == DataType.INT) {
+          rowJson.add((Integer) rowData.next());
+        } else if (type == DataType.STRING) {
+          rowJson.add((String) rowData.next());
+        }
+      }
+    }
+  }
+
+  /**
+   * Utility method to check that the integer result set is equivalent to the given list of list of
+   * ints
+   */
+  private void compareResultSets(
+      ResultSet resultSet, List<List<Object>> expectedRows, List<DataType> dataTypes)
+      throws SQLException {
+    if (expectedRows == null || expectedRows.size() == 0) {
+      assertFalse(resultSet.next());
+      return;
+    }
+
+    int numRows = expectedRows.size();
+
+    int resultSetRows = 0;
+
+    Iterator<List<Object>> rowIterator = expectedRows.iterator();
+
+    while (resultSet.next() && rowIterator.hasNext()) {
+      List<Object> expectedRow = rowIterator.next();
+      int columnIdx = 0;
+      for (DataType type : dataTypes) {
+        Object expected = expectedRow.get(columnIdx);
+        columnIdx++;
+        if (type == DataType.INT) {
+          if (expected == null) {
+            expected = 0;
+          }
+          int actual = resultSet.getInt(columnIdx);
+          assertEquals(expected, actual);
+        } else if (type == DataType.STRING) {
+          String actual = resultSet.getString(columnIdx);
+          assertEquals(expected, actual);
+        }
+      }
+
+      resultSetRows++;
+    }
+
+    // If the result set has more rows than expected, finish the count
+    while (resultSet.next()) {
+      resultSetRows++;
+    }
+
+    assertEquals("row-count was not what was expected", numRows, resultSetRows);
+  }
+
+  // DataTypes supported with mock responses in test:
+  // Currently only String and Integer are supported
+  private enum DataType {
+    INT,
+    STRING
+  }
+
+  private static class MockedSFBaseStatement extends SFBaseStatement {
+    JsonNode mockedResponse;
+    MockSnowflakeSFSession sfSession;
+
+    MockedSFBaseStatement(JsonNode mockedResponse, MockSnowflakeSFSession session) {
+      this.mockedResponse = mockedResponse;
+      this.sfSession = session;
+    }
+
+    @Override
+    public void addProperty(String propertyName, Object propertyValue) {}
+
+    @Override
+    public SFStatementMetaData describe(String sql) {
+      return null;
+    }
+
+    @Override
+    public SFBaseResultSet execute(
+        String sql, Map<String, ParameterBindingDTO> parametersBinding, CallingMethod caller)
+        throws SQLException, SFException {
+      return new MockJsonResultSet(mockedResponse, sfSession);
+    }
+
+    @Override
+    public SFBaseResultSet asyncExecute(
+        String sql, Map<String, ParameterBindingDTO> parametersBinding, CallingMethod caller)
+        throws SQLException, SFException {
+      return null;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void cancel() {}
+
+    @Override
+    public void executeSetProperty(String sql) {}
+
+    @Override
+    public boolean hasChildren() {
+      return false;
+    }
+
+    @Override
+    public SFBaseSession getSFBaseSession() {
+      return sfSession;
+    }
+
+    @Override
+    public boolean getMoreResults(int current) {
+      return false;
+    }
+
+    @Override
+    public SFBaseResultSet getResultSet() {
+      return null;
+    }
+  }
+
+  private static class MockJsonResultSet extends SFJsonResultSet {
+
+    JsonNode resultJson;
+    int currentRowIdx = -1;
+    int rowCount;
+
+    public MockJsonResultSet(JsonNode mockedJsonResponse, MockSnowflakeSFSession sfSession)
+        throws SnowflakeSQLException {
+      setSession(sfSession);
+      this.resultJson = mockedJsonResponse.path("data").path("rowset");
+      this.resultSetMetaData = MockConnectionTest.getRSMDFromResponse(mockedJsonResponse, session);
+      this.rowCount = resultJson.size();
+    }
+
+    @Override
+    public boolean next() {
+      currentRowIdx++;
+      return currentRowIdx < rowCount;
+    }
+
+    @Override
+    protected Object getObjectInternal(int columnIndex) {
+      return JsonResultChunk.extractCell(resultJson, currentRowIdx, columnIndex - 1);
+    }
+
+    @Override
+    public boolean isLast() {
+      return (currentRowIdx + 1) == rowCount;
+    }
+
+    @Override
+    public boolean isAfterLast() {
+      return (currentRowIdx >= rowCount);
+    }
+
+    @Override
+    public SFStatementType getStatementType() {
+      return null;
+    }
+
+    @Override
+    public void setStatementType(SFStatementType statementType) {}
+
+    @Override
+    public String getQueryId() {
+      return null;
+    }
+  }
+
+  private static class MockSnowflakeSFSession extends SFBaseSession {
+
+    @Override
+    public boolean isSafeToClose() {
+      return false;
+    }
+
+    @Override
+    public List<DriverPropertyInfo> checkProperties() {
+      return null;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void raiseError(Throwable exc, String jobId, String requestId) {}
+
+    @Override
+    public Telemetry getTelemetryClient() {
+      return new NoOpTelemetryClient();
+    }
+
+    @Override
+    public List<SFException> getSqlWarnings() {
+      return null;
+    }
+
+    @Override
+    public void clearSqlWarnings() {}
+  }
+
+  private static class MockSnowflakeConnectionImpl implements SFConnectionHandler {
+
+    JsonNode jsonResponse;
+    MockSnowflakeSFSession session;
+
+    public MockSnowflakeConnectionImpl(JsonNode jsonResponse) {
+      this.jsonResponse = jsonResponse;
+      this.session = new MockSnowflakeSFSession();
+    }
+
+    @Override
+    public boolean supportsAsyncQuery() {
+      return false;
+    }
+
+    @Override
+    public void initializeConnection(String url, Properties info) throws SQLException {}
+
+    @Override
+    public SFBaseSession getSFSession() {
+      return session;
+    }
+
+    @Override
+    public SFBaseStatement getSFStatement() {
+      return new MockedSFBaseStatement(jsonResponse, session);
+    }
+
+    @Override
+    public ResultSet createResultSet(String queryID, Connection connection) throws SQLException {
+      return null;
+    }
+
+    @Override
+    public SnowflakeBaseResultSet createResultSet(SFBaseResultSet resultSet, Statement statement)
+        throws SQLException {
+      return new SnowflakeResultSetV1(resultSet, statement);
+    }
+
+    @Override
+    public SnowflakeBaseResultSet createAsyncResultSet(
+        SFBaseResultSet resultSet, Statement statement) throws SQLException {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces the second piece of the refactor for SNOW-256737, which contains the abstract class for `SFStatement`s, `SFBaseStatement`.

For more details, see explanations here.

Note that due to a Github Actions hanging issue, this PR is merging into `session_only`, so the diffs introduced by this set of changes can be reviewed without the diffs of the unmerged `session_only` branch.