### PR TITLE
SNOW-165204 Fix exception thrown by calling getObject() on very large number

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
@@ -62,10 +62,8 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
         return getInt(columnIndex);
 
       case Types.DECIMAL:
-        return getBigDecimal(columnIndex);
-
       case Types.BIGINT:
-        return getLong(columnIndex);
+        return getBigDecimal(columnIndex);
 
       case Types.DOUBLE:
         return getDouble(columnIndex);

--- a/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
@@ -35,8 +35,8 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
   // Precision of maximum long value in Java (2^63-1). Precision is 19
   private static final int LONG_PRECISION = 19;
 
-  BigDecimal MAX_LONG_VAL = new BigDecimal(Long.MAX_VALUE);
-  BigDecimal MIN_LONG_VAL = new BigDecimal(Long.MIN_VALUE);
+  private static final BigDecimal MAX_LONG_VAL = new BigDecimal(Long.MAX_VALUE);
+  private static final BigDecimal MIN_LONG_VAL = new BigDecimal(Long.MIN_VALUE);
 
   /**
    * Given a column index, get current row's value as an object

--- a/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
@@ -62,8 +62,10 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
         return getInt(columnIndex);
 
       case Types.DECIMAL:
-      case Types.BIGINT:
         return getBigDecimal(columnIndex);
+
+      case Types.BIGINT:
+        return getBigInt(columnIndex);
 
       case Types.DOUBLE:
         return getDouble(columnIndex);
@@ -88,6 +90,24 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
                 null,
                 null);
     }
+  }
+
+  /**
+   * Sometimes large BIGINTS overflow the java Long type. In these cases, return a BigDecimal type
+   * instead.
+   *
+   * @param columnIndex the column index
+   * @return an object of type long or BigDecimal depending on number size
+   * @throws SFException
+   */
+  private Object getBigInt(int columnIndex) throws SFException {
+    BigDecimal bigNum = getBigDecimal(columnIndex);
+    BigDecimal MAX_LONG_VAL = new BigDecimal(Long.MAX_VALUE);
+    BigDecimal MIN_LONG_VAL = new BigDecimal(Long.MIN_VALUE);
+    if (bigNum.compareTo(MAX_LONG_VAL) == 1 || bigNum.compareTo(MIN_LONG_VAL) == -1) {
+      return bigNum;
+    }
+    return getLong(columnIndex);
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetJsonVsArrowIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetJsonVsArrowIT.java
@@ -1061,18 +1061,7 @@ public class ResultSetJsonVsArrowIT extends BaseJDBCTest {
       double val = Double.parseDouble(cases[i].toString());
       assertEquals(val, rs.getDouble(1), delta);
       assertEquals(new BigDecimal(rs.getString(1)), rs.getBigDecimal(1));
-      if (isJSON()) {
-        try {
-          rs.getObject(1);
-          fail();
-        } catch (Exception e) {
-          SQLException se = (SQLException) e;
-          assertEquals((int) ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), se.getErrorCode());
-          assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getSqlState(), se.getSQLState());
-        }
-      } else {
-        assertEquals(rs.getBigDecimal(1), rs.getObject(1));
-      }
+      assertEquals(rs.getBigDecimal(1), rs.getObject(1));
       try {
         rs.getByte(1);
         fail();

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -357,6 +357,7 @@ public class ResultSetLatestIT extends ResultSet0IT {
   public void testGetObjectWithBigInt() throws SQLException {
     Connection connection = init();
     Statement statement = connection.createStatement();
+    statement.execute("alter session set jdbc_query_result_format ='json'");
     // test with greatest possible number and greatest negative possible number
     String[] extremeNumbers = {
       "99999999999999999999999999999999999999", "-99999999999999999999999999999999999999"

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.sql.*;
@@ -343,6 +344,29 @@ public class ResultSetLatestIT extends ResultSet0IT {
       SnowflakeChunkDownloader.setInjectedDownloaderException(null);
     }
 
+    statement.close();
+    connection.close();
+  }
+
+  /**
+   * SNOW-165204 Fix exception that resulted from fetching too large a number with getObject().
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testGetObjectWithBigInt() throws SQLException {
+    Connection connection = init();
+    Statement statement = connection.createStatement();
+    // test with greatest possible number and greatest negative possible number
+    String[] extremeNumbers = {
+      "99999999999999999999999999999999999999", "-99999999999999999999999999999999999999"
+    };
+    for (int i = 0; i < extremeNumbers.length; i++) {
+      ResultSet resultSet = statement.executeQuery("select " + extremeNumbers[i]);
+      resultSet.next();
+      assertEquals(Types.BIGINT, resultSet.getMetaData().getColumnType(1));
+      assertEquals(new BigDecimal(extremeNumbers[i]), resultSet.getObject(1));
+    }
     statement.close();
     connection.close();
   }


### PR DESCRIPTION
getObject() called getLong() in JSON for numbers of type BIGINT. Sometimes the numbers were too large for a type long to hold, resulting in an exception. getObject() now calls getBigDecimal() for type BIGINT to avoid this problem. In Arrow format, this was already the case.