### PR TITLE
Make SnowflakeBaseResultSet and SnowflakeResultSetV1 Public Classes

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -20,7 +20,7 @@ import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 
 /** Base class for query result set and metadata result set */
-abstract class SnowflakeBaseResultSet implements ResultSet {
+public abstract class SnowflakeBaseResultSet implements ResultSet {
   static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeBaseResultSet.class);
   private final int resultSetType;
   private final int resultSetConcurrency;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -18,7 +18,8 @@ import net.snowflake.client.core.SFBaseResultSet;
 import net.snowflake.client.core.SFException;
 
 /** Snowflake ResultSet implementation */
-class SnowflakeResultSetV1 extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet {
+public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
+    implements SnowflakeResultSet, ResultSet {
   private final SFBaseResultSet sfBaseResultSet;
 
   /**

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -33,7 +33,8 @@ public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
    * @param statement query statement that generates this result set
    * @throws SQLException if failed to construct snowflake result set metadata
    */
-  SnowflakeResultSetV1(SFBaseResultSet sfBaseResultSet, Statement statement) throws SQLException {
+  public SnowflakeResultSetV1(SFBaseResultSet sfBaseResultSet, Statement statement)
+      throws SQLException {
     super(statement);
     this.sfBaseResultSet = sfBaseResultSet;
     try {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -344,8 +344,8 @@ public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
    *     less than it. But if user specifies a small value which may be smaller than the data size
    *     of one result chunk. So the definition can't be guaranteed completely. For this special
    *     case, one serializable object is used to wrap the data chunk.
-   * @return a list of ResultSetSerializables
-   * @throws if fails to get the ResultSetSerializable objects.
+   * @return a list of ResultSetSerializables.
+   * @throws SQLException If it fails to get the ResultSetSerializable objects.
    */
   @Override
   public List<SnowflakeResultSetSerializable> getResultSetSerializables(long maxSizeInBytes)


### PR DESCRIPTION
These classes, as part of the new `SFConnectionHandler` interface, need public visibility for outside packages to implement and use them.