### PR TITLE
SNOW-285142 alter failing test due to account changes

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalLatestIT.java
@@ -143,7 +143,7 @@ public class DatabaseMetaDataInternalLatestIT extends BaseJDBCTest {
     assertFalse(resultSet.next());
     resultSet = databaseMetaData.getFunctionColumns(null, "%", "%", "%");
     // we have 81 columns returned
-    assertEquals(81, getSizeOfResultSet(resultSet));
+    assertEquals(4, getSizeOfResultSet(resultSet));
     // setting catalog to % will result in 0 columns. % does not apply for catalog, only for other
     // params
     resultSet = databaseMetaData.getFunctionColumns("%", "%", "%", "%");


### PR DESCRIPTION
Fixes BPTP failure. Someone pushed a server-side change that altered the number of functions in the Jenkins test account, which then caused this unit test to fail because it counted the number of function columns returned.