### PR TITLE
SNOW-281822 Fix session token expiry and heartbeat frequency settings

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -4,15 +4,14 @@
 
 package net.snowflake.client.core;
 
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.SnowflakeType;
-import net.snowflake.client.jdbc.telemetry.Telemetry;
-
 import java.sql.DriverPropertyInfo;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.telemetry.Telemetry;
 
 /**
  * Snowflake session implementation base. The methods and fields contained within this class are

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -4,14 +4,15 @@
 
 package net.snowflake.client.core;
 
-import java.sql.DriverPropertyInfo;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.SnowflakeType;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
+
+import java.sql.DriverPropertyInfo;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Snowflake session implementation base. The methods and fields contained within this class are
@@ -358,6 +359,10 @@ public abstract class SFBaseSession {
     } else {
       this.heartbeatFrequency = frequency;
     }
+  }
+
+  public int getHeartbeatFrequency() {
+    return this.heartbeatFrequency;
   }
 
   public boolean getAutoCommit() {

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -58,6 +58,7 @@ public abstract class SFBaseSession {
   // Inject failure for testing
   private String injectFileUploadFailure;
   private boolean enableHeartbeat;
+  protected int heartbeatFrequency = 3600;
   private boolean formatDateWithTimezone;
   private boolean enableCombineDescribe;
   private boolean clientTelemetryEnabled = false;
@@ -347,6 +348,16 @@ public abstract class SFBaseSession {
 
   public void setEnableHeartbeat(boolean enableHeartbeat) {
     this.enableHeartbeat = enableHeartbeat;
+  }
+
+  public void setHeartbeatFrequency(int frequency) {
+    if (frequency < 900) {
+      this.heartbeatFrequency = 900;
+    } else if (frequency > 3600) {
+      this.heartbeatFrequency = 3600;
+    } else {
+      this.heartbeatFrequency = frequency;
+    }
   }
 
   public boolean getAutoCommit() {

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -350,6 +350,12 @@ public abstract class SFBaseSession {
     this.enableHeartbeat = enableHeartbeat;
   }
 
+  /**
+   * Set the heartbeat frequency in seconds. This is the frequency with which the session token is
+   * refreshed.
+   *
+   * @param frequency heartbeat frequency in seconds
+   */
   public void setHeartbeatFrequency(int frequency) {
     if (frequency < 900) {
       this.heartbeatFrequency = 900;
@@ -360,6 +366,7 @@ public abstract class SFBaseSession {
     }
   }
 
+  /** Retrieve session heartbeat frequency in seconds */
   public int getHeartbeatFrequency() {
     return this.heartbeatFrequency;
   }

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -90,7 +90,6 @@ public class SFSession extends SFBaseSession {
   // session parameters
   private Map<String, Object> sessionParametersMap = new HashMap<>();
   private boolean passcodeInPassword = false;
-  private int heartbeatFrequency = 3600;
 
   // deprecated
   private Level tracingLevel = Level.INFO;
@@ -601,7 +600,7 @@ public class SFSession extends SFBaseSession {
       logger.debug("start heartbeat, master token validity: " + masterTokenValidityInSeconds);
 
       HeartbeatBackground.getInstance()
-          .addSession(this, masterTokenValidityInSeconds, this.heartbeatFrequency);
+          .addSession(this, masterTokenValidityInSeconds, heartbeatFrequency);
     } else {
       logger.debug("heartbeat not enabled for the session");
     }

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1282,6 +1282,10 @@ public class SessionUtil {
         if (session != null) {
           session.setEnableHeartbeat((Boolean) entry.getValue());
         }
+      } else if (CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY.equalsIgnoreCase(entry.getKey())) {
+        if (session != null) {
+          session.setHeartbeatFrequency((int) entry.getValue());
+        }
       } else if ("CLIENT_ENABLE_LOG_INFO_STATEMENT_PARAMETERS".equalsIgnoreCase(entry.getKey())) {
         boolean enableLogging = (Boolean) entry.getValue();
         if (session != null && session.getPreparedStatementLogging() != enableLogging) {

--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -9,7 +9,10 @@ import java.sql.*;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
-import net.snowflake.client.core.*;
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+import net.snowflake.client.core.SFSession;
 import net.snowflake.common.core.SqlState;
 
 /** SFAsyncResultSet implementation */
@@ -98,7 +101,11 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
     if (this.queryID == null) {
       throw new SQLException("QueryID unknown");
     }
-    return session.getQueryStatus(this.queryID);
+    try {
+      return session.getQueryStatus(this.queryID);
+    } catch (SFException e) {
+      throw new SQLException(e);
+    }
   }
 
   /**

--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -101,11 +101,7 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
     if (this.queryID == null) {
       throw new SQLException("QueryID unknown");
     }
-    try {
-      return session.getQueryStatus(this.queryID);
-    } catch (SFException e) {
-      throw new SQLException(e);
-    }
+    return session.getQueryStatus(this.queryID);
   }
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -645,34 +645,6 @@ public class ConnectionIT extends BaseJDBCTest {
   }
 
   /**
-   * Verify the passed heartbeat frequency, which is too small, is changed to the smallest valid
-   * value.
-   */
-  @Test
-  public void testHeartbeatFrequencyTooSmall() throws Exception {
-    Properties paramProperties = new Properties();
-    paramProperties.put(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY, 2);
-    Connection connection = getConnection(paramProperties);
-
-    connection.getClientInfo(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY);
-
-    for (Enumeration<?> enums = paramProperties.propertyNames(); enums.hasMoreElements(); ) {
-      String key = (String) enums.nextElement();
-      ResultSet rs =
-          connection
-              .createStatement()
-              .executeQuery(String.format("show parameters like '%s'", key));
-      rs.next();
-      String value = rs.getString("value");
-
-      assertThat(key, value, equalTo("900"));
-    }
-
-    SFSession session = connection.unwrap(SnowflakeConnectionV1.class).getSfSession();
-    assertEquals(900, session.getHeartbeatFrequency());
-  }
-
-  /**
    * Verify the passed heartbeat frequency, which is too large, is changed to the maximum valid
    * value.
    */
@@ -697,33 +669,6 @@ public class ConnectionIT extends BaseJDBCTest {
     }
     SFSession session = connection.unwrap(SnowflakeConnectionV1.class).getSfSession();
     assertEquals(3600, session.getHeartbeatFrequency());
-  }
-
-  /**
-   * Verify the passed heartbeat frequency matches the output value if the input is valid (between
-   * 900 and 3600).
-   */
-  @Test
-  public void testHeartbeatFrequencyValidValue() throws Exception {
-    Properties paramProperties = new Properties();
-    paramProperties.put(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY, 1800);
-    Connection connection = getConnection(paramProperties);
-
-    connection.getClientInfo(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY);
-
-    for (Enumeration<?> enums = paramProperties.propertyNames(); enums.hasMoreElements(); ) {
-      String key = (String) enums.nextElement();
-      ResultSet rs =
-          connection
-              .createStatement()
-              .executeQuery(String.format("show parameters like '%s'", key));
-      rs.next();
-      String value = rs.getString("value");
-
-      assertThat(key, value, equalTo(paramProperties.get(key).toString()));
-    }
-    SFSession session = connection.unwrap(SnowflakeConnectionV1.class).getSfSession();
-    assertEquals(1800, session.getHeartbeatFrequency());
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -3,6 +3,7 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
 import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
 import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -13,6 +14,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.*;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -20,6 +22,7 @@ import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryConnection;
 import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFSession;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.common.core.SqlState;
 import org.junit.After;
@@ -62,6 +65,61 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       TelemetryService.disable();
     }
     service.resetNumOfRetryToTriggerTelemetry();
+  }
+
+  /**
+   * Verify the passed heartbeat frequency matches the output value if the input is valid (between
+   * 900 and 3600).
+   */
+  @Test
+  public void testHeartbeatFrequencyValidValue() throws Exception {
+    Properties paramProperties = new Properties();
+    paramProperties.put(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY, 1800);
+    Connection connection = getConnection(paramProperties);
+
+    connection.getClientInfo(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY);
+
+    for (Enumeration<?> enums = paramProperties.propertyNames(); enums.hasMoreElements(); ) {
+      String key = (String) enums.nextElement();
+      ResultSet rs =
+          connection
+              .createStatement()
+              .executeQuery(String.format("show parameters like '%s'", key));
+      rs.next();
+      String value = rs.getString("value");
+
+      assertThat(key, value, equalTo(paramProperties.get(key).toString()));
+    }
+    SFSession session = connection.unwrap(SnowflakeConnectionV1.class).getSfSession();
+    assertEquals(1800, session.getHeartbeatFrequency());
+  }
+
+  /**
+   * Verify the passed heartbeat frequency, which is too small, is changed to the smallest valid
+   * value.
+   */
+  @Test
+  public void testHeartbeatFrequencyTooSmall() throws Exception {
+    Properties paramProperties = new Properties();
+    paramProperties.put(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY, 2);
+    Connection connection = getConnection(paramProperties);
+
+    connection.getClientInfo(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY);
+
+    for (Enumeration<?> enums = paramProperties.propertyNames(); enums.hasMoreElements(); ) {
+      String key = (String) enums.nextElement();
+      ResultSet rs =
+          connection
+              .createStatement()
+              .executeQuery(String.format("show parameters like '%s'", key));
+      rs.next();
+      String value = rs.getString("value");
+
+      assertThat(key, value, equalTo("900"));
+    }
+
+    SFSession session = connection.unwrap(SnowflakeConnectionV1.class).getSfSession();
+    assertEquals(900, session.getHeartbeatFrequency());
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -77,8 +77,6 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     paramProperties.put(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY, 1800);
     Connection connection = getConnection(paramProperties);
 
-    connection.getClientInfo(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY);
-
     for (Enumeration<?> enums = paramProperties.propertyNames(); enums.hasMoreElements(); ) {
       String key = (String) enums.nextElement();
       ResultSet rs =
@@ -103,8 +101,6 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     Properties paramProperties = new Properties();
     paramProperties.put(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY, 2);
     Connection connection = getConnection(paramProperties);
-
-    connection.getClientInfo(CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY);
 
     for (Enumeration<?> enums = paramProperties.propertyNames(); enums.hasMoreElements(); ) {
       String key = (String) enums.nextElement();

--- a/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
@@ -1,0 +1,77 @@
+package net.snowflake.client.jdbc;
+
+import static org.junit.Assert.*;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.logging.Logger;
+import net.snowflake.client.ConditionalIgnoreRule;
+import net.snowflake.client.RunningOnGithubAction;
+import net.snowflake.client.core.QueryStatus;
+import org.junit.Test;
+
+/**
+ * Test class for using heartbeat with asynchronous querying. This is a "Latest" class because old
+ * driver versions do not contain the asynchronous querying API.
+ */
+public class HeartbeatAsyncLatestIT extends HeartbeatIT {
+  private static Logger logger = Logger.getLogger(HeartbeatAsyncLatestIT.class.getName());
+
+  /**
+   * create a new connection with or without keep alive parameter and submit an asynchronous query.
+   * The async query will not fail if the session token expires, but the functions fetching the
+   * query results require a valid session token.
+   *
+   * @param useKeepAliveSession Enables/disables client session keep alive
+   * @param queryIdx The query index
+   * @throws SQLException Will be thrown if any of the driver calls fail
+   */
+  @Override
+  protected void submitQuery(boolean useKeepAliveSession, int queryIdx)
+      throws SQLException, InterruptedException {
+    Connection connection = null;
+    ResultSet resultSet = null;
+    try {
+      Properties sessionParams = new Properties();
+      sessionParams.put(
+          "CLIENT_SESSION_KEEP_ALIVE",
+          useKeepAliveSession ? Boolean.TRUE.toString() : Boolean.FALSE.toString());
+
+      connection = getConnection(sessionParams);
+
+      Statement stmt = connection.createStatement();
+      // Query will take 30 seconds to run, but ResultSet will be returned immediately
+      resultSet =
+          stmt.unwrap(SnowflakeStatement.class)
+              .executeAsyncQuery("SELECT count(*) FROM TABLE(generator(timeLimit => 30))");
+      Thread.sleep(61000); // sleep 61 seconds to await original session expiration time
+      QueryStatus qs = resultSet.unwrap(SnowflakeResultSet.class).getStatus();
+      // Ensure query succeeded
+      assertEquals(QueryStatus.SUCCESS, qs);
+
+      // assert we get 1 row
+      assertTrue(resultSet.next());
+      assertFalse(resultSet.next());
+
+      logger.fine("Query " + queryIdx + " passed ");
+    } finally {
+      resultSet.close();
+      connection.close();
+    }
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testAsynchronousQuerySuccess() throws Exception {
+    testSuccess();
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testAsynchronousQueryFailure() throws Exception {
+    testFailure();
+  }
+}

--- a/src/test/java/net/snowflake/client/jdbc/HeartbeatIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/HeartbeatIT.java
@@ -78,7 +78,7 @@ public class HeartbeatIT extends AbstractDriverIT {
    * @param queryIdx The query index
    * @throws SQLException Will be thrown if any of the driver calls fail
    */
-  void submitQuery(boolean useKeepAliveSession, int queryIdx)
+  protected void submitQuery(boolean useKeepAliveSession, int queryIdx)
       throws SQLException, InterruptedException {
     Connection connection = null;
     Statement statement = null;


### PR DESCRIPTION
A customer's issue with session token expiring exposed 2 bugs:

1. ResultSet#getQueryStatus() function did not contain any logic to renew the session token when GS sent back an error saying the session had expired. It simply threw a SQLException. This change adds in a retry to renew the session. This error should now not occur at all when the session token heartbeat is enabled.

2. The parameter value CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY could be set by the user, but the value was not actually propagated to the scheduleHeartbeat() function. This means the heartbeats were always 3600 seconds apart, in spite of the fact that the frequency should be able to be changed (within range of 900 to 3600). Now, the heartbeat can actually be changed.