### PR TITLE
SNOW-291736 Minor API changes for java stored procs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,25 +387,6 @@
         </executions>
       </plugin>
       <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.3.0</version>
-            <configuration>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-            </configuration>
-            <executions>
-                <execution>
-                    <id>assemble-all</id>
-                    <phase>package</phase>
-                    <goals>
-                        <goal>single</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,25 @@
         </executions>
       </plugin>
       <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.3.0</version>
+            <configuration>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+            </configuration>
+            <executions>
+                <execution>
+                    <id>assemble-all</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>

--- a/src/main/java/net/snowflake/client/core/SFBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseResultSet.java
@@ -148,11 +148,11 @@ public abstract class SFBaseResultSet {
     throw new SFException(ErrorCode.FEATURE_UNSUPPORTED, "seek to a previous row");
   }
 
-  protected int getNumberOfBinds() {
+  public int getNumberOfBinds() {
     return numberOfBinds;
   }
 
-  protected List<MetaDataOfBinds> getMetaDataOfBinds() {
+  public List<MetaDataOfBinds> getMetaDataOfBinds() {
     return metaDataOfBinds;
   }
 

--- a/src/main/java/net/snowflake/client/core/SFStatementMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFStatementMetaData.java
@@ -33,7 +33,7 @@ public class SFStatementMetaData {
 
   private final boolean isValidMetaData;
 
-  SFStatementMetaData(
+  public SFStatementMetaData(
       SFResultSetMetaData resultSetMetaData,
       SFStatementType statementType,
       int numberOfBinds,

--- a/src/main/java/net/snowflake/client/jdbc/SFBaseFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFBaseFileTransferAgent.java
@@ -31,6 +31,7 @@ import net.snowflake.common.util.ClassUtil;
  */
 public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
   protected boolean compressSourceFromStream;
+  protected String destStagePath;
   protected String destFileNameForStreamSource;
   protected InputStream sourceStream;
   protected boolean sourceFromStream;
@@ -100,6 +101,15 @@ public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
   public void setSourceStream(InputStream sourceStream) {
     this.sourceStream = sourceStream;
     this.sourceFromStream = true;
+  }
+
+  /**
+   * Sets the destination stage path
+   *
+   * @param destStagePath The target destination stage path.
+   */
+  public void setDestStagePath(String destStagePath) {
+    this.destStagePath = destStagePath;
   }
 
   /**

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -841,29 +841,31 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
     SnowflakeStatementV1 stmt = this.createStatement().unwrap(SnowflakeStatementV1.class);
 
-    StringBuilder putCommand = new StringBuilder();
-
-    // use a placeholder for source file
-    putCommand.append("put file:///tmp/placeholder ");
+    StringBuilder destStage = new StringBuilder();
 
     // add stage name
     if (!(stageName.startsWith("@") || stageName.startsWith("'@") || stageName.startsWith("$$@"))) {
-      putCommand.append("@");
+      destStage.append("@");
     }
-    putCommand.append(stageName);
+    destStage.append(stageName);
 
     // add dest prefix
     if (destPrefix != null) {
       if (!destPrefix.startsWith("/")) {
-        putCommand.append("/");
+        destStage.append("/");
       }
-      putCommand.append(destPrefix);
+      destStage.append(destPrefix);
     }
 
+    StringBuilder putCommand = new StringBuilder();
+    // use a placeholder for source file
+    putCommand.append("put file:///tmp/placeholder ");
+    putCommand.append(destStage.toString());
     putCommand.append(" overwrite=true");
 
     SFBaseFileTransferAgent transferAgent =
         sfConnectionHandler.getFileTransferAgent(putCommand.toString(), stmt.getSFBaseStatement());
+    transferAgent.setDestStagePath(destStage.toString());
     transferAgent.setSourceStream(inputStream);
     transferAgent.setDestFileNameForStreamSource(destFileName);
     transferAgent.setCompressSourceFromStream(compressData);


### PR DESCRIPTION
SNOW-291736 Minor API changes for java stored procs 
1. Made the constructor of `SFStatementMetadata` public so it can be used by Stored Procs implementation.
2. Set the destination stage path for uploadStream in the `FileTransferAgent` object  so that it can be used by Stored Procs implementation.