### PR TITLE
SNOW-258666 Clean up memory chunks after thread is interrupted

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -698,14 +698,6 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
           chunk.freeData();
         }
 
-        if (queryResultFormat == QueryResultFormat.ARROW) {
-          SFArrowResultSet.closeRootAllocator(rootAllocator);
-        } else {
-          chunkDataCache.clear();
-        }
-
-        releaseAllChunkMemoryUsage();
-
         logger.debug(
             "Total milliseconds waiting for chunks: {}, "
                 + "Total memory used: {}, total download time: {} millisec, "

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -682,6 +682,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
             downloaderFutures.forEach((k, v) -> v.cancel(true));
             // shutdown executor
             executor.shutdown();
+
             if (!executor.awaitTermination(SHUTDOWN_TIME, TimeUnit.SECONDS)) {
               logger.debug("Executor did not terminate in the specified time.");
               List<Runnable> droppedTasks = executor.shutdownNow(); // optional **
@@ -722,6 +723,11 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
             totalMillisDownloadingChunks.get(),
             totalMillisParsingChunks.get());
       } finally {
+        if (queryResultFormat == QueryResultFormat.ARROW) {
+          SFArrowResultSet.closeRootAllocator(rootAllocator);
+        } else {
+          chunkDataCache.clear();
+        }
         releaseAllChunkMemoryUsage();
       }
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -4,9 +4,19 @@
 
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.core.Constants.MB;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.*;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.GZIPInputStream;
 import net.snowflake.client.core.*;
 import net.snowflake.client.jdbc.SnowflakeResultChunk.DownloadState;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
@@ -22,17 +32,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
-
-import java.io.*;
-import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.zip.GZIPInputStream;
-
-import static net.snowflake.client.core.Constants.MB;
 
 /**
  * Class for managing async download of offline result chunks
@@ -668,10 +667,6 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         nextChunkToConsume);
   }
 
-  public void throwDummyException() throws InterruptedException {
-    throw new InterruptedException();
-  }
-
   /**
    * terminate the downloader
    *
@@ -681,54 +676,52 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
   public DownloaderMetrics terminate() throws InterruptedException {
     if (!terminated.getAndSet(true)) {
       try {
-      if (executor != null) {
-        if (!executor.isShutdown()) {
-          // cancel running downloaders
-          downloaderFutures.forEach((k, v) -> v.cancel(true));
-          // shutdown executor
-          executor.shutdown();
-          throwDummyException();
-          if (!executor.awaitTermination(SHUTDOWN_TIME, TimeUnit.SECONDS)) {
-            logger.debug("Executor did not terminate in the specified time.");
-            List<Runnable> droppedTasks = executor.shutdownNow(); // optional **
-            logger.debug(
-                "Executor was abruptly shut down. "
-                    + droppedTasks.size()
-                    + " tasks will not be executed."); // optional **
+        if (executor != null) {
+          if (!executor.isShutdown()) {
+            // cancel running downloaders
+            downloaderFutures.forEach((k, v) -> v.cancel(true));
+            // shutdown executor
+            executor.shutdown();
+            if (!executor.awaitTermination(SHUTDOWN_TIME, TimeUnit.SECONDS)) {
+              logger.debug("Executor did not terminate in the specified time.");
+              List<Runnable> droppedTasks = executor.shutdownNow(); // optional **
+              logger.debug(
+                  "Executor was abruptly shut down. "
+                      + droppedTasks.size()
+                      + " tasks will not be executed."); // optional **
+            }
           }
         }
-      }
-      for (SnowflakeResultChunk chunk : chunks) {
-        // explicitly free each chunk since Arrow chunk may hold direct memory
-        chunk.freeData();
-      }
+        for (SnowflakeResultChunk chunk : chunks) {
+          // explicitly free each chunk since Arrow chunk may hold direct memory
+          chunk.freeData();
+        }
 
-      if (queryResultFormat == QueryResultFormat.ARROW) {
-        SFArrowResultSet.closeRootAllocator(rootAllocator);
-      } else {
-        chunkDataCache.clear();
-      }
+        if (queryResultFormat == QueryResultFormat.ARROW) {
+          SFArrowResultSet.closeRootAllocator(rootAllocator);
+        } else {
+          chunkDataCache.clear();
+        }
 
-      releaseAllChunkMemoryUsage();
+        releaseAllChunkMemoryUsage();
 
-      logger.debug(
-          "Total milliseconds waiting for chunks: {}, "
-              + "Total memory used: {}, total download time: {} millisec, "
-              + "total parsing time: {} milliseconds, total chunks: {}",
-          numberMillisWaitingForChunks,
-          Runtime.getRuntime().totalMemory(),
-          totalMillisDownloadingChunks.get(),
-          totalMillisParsingChunks.get(),
-          chunks.size());
+        logger.debug(
+            "Total milliseconds waiting for chunks: {}, "
+                + "Total memory used: {}, total download time: {} millisec, "
+                + "total parsing time: {} milliseconds, total chunks: {}",
+            numberMillisWaitingForChunks,
+            Runtime.getRuntime().totalMemory(),
+            totalMillisDownloadingChunks.get(),
+            totalMillisParsingChunks.get(),
+            chunks.size());
 
-      chunks = null;
+        chunks = null;
 
-      return new DownloaderMetrics(
-          numberMillisWaitingForChunks,
-          totalMillisDownloadingChunks.get(),
-          totalMillisParsingChunks.get());
-      }
-      finally {
+        return new DownloaderMetrics(
+            numberMillisWaitingForChunks,
+            totalMillisDownloadingChunks.get(),
+            totalMillisParsingChunks.get());
+      } finally {
         releaseAllChunkMemoryUsage();
       }
     }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -3,6 +3,19 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
+import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
+import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryConnection;
@@ -16,20 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.sql.*;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-
-import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
-import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
 /**
  * Connection integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -79,27 +78,25 @@ public class ConnectionLatestIT extends BaseJDBCTest {
 
     try {
 
-    // now run a query for 120 seconds
-    // 10000 rows should be enough to force result into multiple chunks
-    resultSet =
-            statement.executeQuery(
-                    "select seq8(), randstr(1000, random()) from table(generator(rowcount => 10000))");
-    statement.close();
-    }
-    catch (SQLException ex)
-    {
-      System.out.println("Current memory usage: " + SnowflakeChunkDownloader.getCurrentMemoryUsage());
+      // now run a query for 120 seconds
+      // 10000 rows should be enough to force result into multiple chunks
+      resultSet =
+          statement.executeQuery(
+              "select seq8(), randstr(1000, random()) from table(generator(rowcount => 10000))");
+      statement.close();
+    } catch (SQLException ex) {
+      System.out.println(
+          "Current memory usage: " + SnowflakeChunkDownloader.getCurrentMemoryUsage());
       assertThat(
-              "closing statement didn't release memory allocated for result",
-              SnowflakeChunkDownloader.getCurrentMemoryUsage(),
-              equalTo(initialMemoryUsage));
+          "closing statement didn't release memory allocated for result",
+          SnowflakeChunkDownloader.getCurrentMemoryUsage(),
+          equalTo(initialMemoryUsage));
     }
     int cnt = 0;
     while (resultSet.next()) {
       ++cnt;
     }
     closeSQLObjects(resultSet, statement, connection);
-
   }
 
   /**


### PR DESCRIPTION
The Denodo application issues a Thread.interrupt() after cancelling statements. This led to the discovery that when an InterruptedException occurs, the JDBC driver simply throws an exception but does not clear available memory that is being used. 

This code change moves the memory-freeing code into a **finally** block so that it executes regardless of whether an interrupt happens or not. 

The test case injects a fake interrupt exception into the terminate() function and tests that all memory is released when the exception is caught.