### PR TITLE
Snow 294002 jdbc version bump to 3.13.1 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**JDBC Driver 3.13.1**
+
+- \| SNOW-258666 | Changed the driver to free up memory chunks when a thread is interrupted.
+- \| SNOW-281822 | Fixed a session token expiry error and made the heartbeat frequency configurable.
+
 **JDBC Driver 3.13.0**
 
 - \| SNOW-209530 | Changed the handling of proxy settings. Proxy parameters in the connection string now override the JVM proxy settings. When connecting to Azure, PUT/GET commands now go through the specified proxy.

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-jdbc-fips</artifactId>
-  <version>3.13.0</version>
+  <version>3.13.1</version>
   <packaging>jar</packaging>
 
   <name>snowflake-jdbc-fips</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-jdbc</artifactId>
-  <version>3.13.0</version>
+  <version>3.13.1</version>
   <packaging>jar</packaging>
 
   <name>snowflake-jdbc</name>


### PR DESCRIPTION
* SNOW-294002: Bumped up the Client PATCH version from 3.13.0 to 3.13.1