### PR TITLE
SNOW-266144 added new code coverage test job and params to JDBC PC jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,9 @@ timestamps {
       string(name: 'branch', value: 'master'),
       string(name: 'TARGET_DOCKER_TEST_IMAGE', value: 'jdbc-centos6-default'),
       string(name: 'parent_job', value: env.JOB_NAME),
-      string(name: 'parent_build_number', value: env.BUILD_NUMBER)
+      string(name: 'parent_build_number', value: env.BUILD_NUMBER),
+	  string(name: 'timeout_value', value: '420'),
+	  string(name: 'PR_Key', value: scmInfo.GIT_BRANCH.substring(3))
     ]
     stage('Test') {
       parallel (
@@ -32,6 +34,8 @@ timestamps {
         'Test JDBC 3': { build job: 'RT-LanguageJDBC3-PC',parameters: params
             },
         'Test JDBC 4': { build job: 'RT-LanguageJDBC4-PC',parameters: params
+            },
+        'CodeCoverage JDBC': { build job: 'RT-LanguageJDBC-CodeCoverage-PC',parameters: params
             }
       )
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,8 @@ timestamps {
       string(name: 'TARGET_DOCKER_TEST_IMAGE', value: 'jdbc-centos6-default'),
       string(name: 'parent_job', value: env.JOB_NAME),
       string(name: 'parent_build_number', value: env.BUILD_NUMBER),
-	  string(name: 'timeout_value', value: '420'),
-	  string(name: 'PR_Key', value: scmInfo.GIT_BRANCH.substring(3))
+      string(name: 'timeout_value', value: '420'),
+      string(name: 'PR_Key', value: scmInfo.GIT_BRANCH.substring(3))
     ]
     stage('Test') {
       parallel (

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -525,6 +525,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
   }
 
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testCancelQueryBySystemFunction() throws Throwable {
     Statement statement = null;
     ResultSet resultSet = null;


### PR DESCRIPTION
Adding new test job for code coverage on PRs. Coupled with a change Ankit made to the Jenkins configuration, this will allow us to see code coverage on PRs before they are merged. This way we can monitor code coverage proactively and add tests to maintain current coverage levels before merging to master.

This also conditionally ignores a test that's been flaky on GithubActions.