### PR TITLE
SNOW-330548 API changes to use SnowflakeResultSetSerializable in Stored Procs

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -9,6 +9,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SnowflakeConnectString;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.SnowflakeType;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
@@ -585,4 +586,8 @@ public abstract class SFBaseSession {
   public void clearSqlWarnings() {
     sqlWarnings.clear();
   }
+
+  public abstract int getNetworkTimeoutInMilli();
+
+  public abstract SnowflakeConnectString getSnowflakeConnectionString();
 }

--- a/src/main/java/net/snowflake/client/core/SFBaseStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseStatement.java
@@ -164,4 +164,8 @@ public abstract class SFBaseStatement {
     EXECUTE_UPDATE,
     EXECUTE_QUERY
   }
+
+  public abstract long getConservativeMemoryLimit();
+
+  public abstract int getConservativePrefetchThreads();
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -445,7 +445,7 @@ public class SnowflakeResultSetSerializableV1
    * @throws SnowflakeSQLException if failed to parse the result JSON node
    */
   public static SnowflakeResultSetSerializableV1 create(
-      JsonNode rootNode, SFSession sfSession, SFStatement sfStatement)
+      JsonNode rootNode, SFBaseSession sfSession, SFBaseStatement sfStatement)
       throws SnowflakeSQLException {
     SnowflakeResultSetSerializableV1 resultSetSerializable = new SnowflakeResultSetSerializableV1();
     logger.debug("Entering create()");
@@ -668,7 +668,7 @@ public class SnowflakeResultSetSerializableV1
    * @param rootNode result JSON node received from GS
    * @param sfStatement the snowflake statement
    */
-  private void parseChunkFiles(JsonNode rootNode, SFStatement sfStatement) {
+  private void parseChunkFiles(JsonNode rootNode, SFBaseStatement sfStatement) {
     JsonNode chunksNode = rootNode.path("data").path("chunks");
 
     if (!chunksNode.isMissingNode()) {
@@ -722,7 +722,7 @@ public class SnowflakeResultSetSerializableV1
     }
   }
 
-  private void adjustMemorySettings(SFStatement sfStatement) {
+  private void adjustMemorySettings(SFBaseStatement sfStatement) {
     this.resultPrefetchThreads = DEFAULT_CLIENT_PREFETCH_THREADS;
     if (this.statementType.isSelect()
         && this.parameters.containsKey(CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE)

--- a/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
@@ -502,6 +502,14 @@ public class MockConnectionTest extends BaseJDBCTest {
       return false;
     }
 
+    public long getConservativeMemoryLimit() {
+      return 0;
+    }
+
+    public int getConservativePrefetchThreads() {
+      return 0;
+    }
+
     @Override
     public SFBaseResultSet getResultSet() {
       return null;
@@ -587,6 +595,14 @@ public class MockConnectionTest extends BaseJDBCTest {
 
     @Override
     public void clearSqlWarnings() {}
+
+    public int getNetworkTimeoutInMilli() {
+      return 0;
+    }
+
+    public SnowflakeConnectString getSnowflakeConnectionString() {
+      return null;
+    }
   }
 
   private static class MockSFFileTransferAgent extends SFBaseFileTransferAgent {


### PR DESCRIPTION
# Overview

SNOW-330548
Updated the `Session` and `Statement` interface used in `ResultSetSerializable` to the common interfaces used by open source jdbc driver and stored procs jdbc. 


## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
