### PR TITLE
SNOW-330467 Added other parameters map to session for Snowpark to read

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -92,6 +92,8 @@ public abstract class SFBaseSession {
   // DatabaseMetadata.getSchemas), whether to search using multiple schemas with
   // session database
   private boolean metadataRequestUseSessionDatabase = false;
+  // Stores other parameters sent by server
+  private final Map<String, Object> otherParameters = new HashMap<>();
 
   /**
    * Part of the JDBC API, where client applications may fetch a Map of Properties to set various
@@ -466,6 +468,14 @@ public abstract class SFBaseSession {
 
   public void setClientResultChunkSize(int clientResultChunkSize) {
     this.clientResultChunkSize = clientResultChunkSize;
+  }
+
+  public Object getOtherParameter(String key) {
+    return this.otherParameters.get(key);
+  }
+
+  public void setOtherParameter(String key, Object value) {
+    this.otherParameters.put(key, value);
   }
 
   public int getClientPrefetchThreads() {

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1380,6 +1380,10 @@ public class SessionUtil {
         if (session != null) {
           session.setValidateDefaultParameters(SFLoginInput.getBooleanValue(entry.getValue()));
         }
+      } else {
+        if (session != null) {
+          session.setOtherParameter(entry.getKey(), entry.getValue());
+        }
       }
     }
   }


### PR DESCRIPTION
# Overview

SNOW-330467 Snowpark need to read some parameters from server's response. So we want JDBC to surface those parameters. It is not very elegant to add a getter and a setter for each Snowpark parameters, as they are Snowpark specific and JDBC won't be using them. So added a HashMap for Snowpark to get its parameters.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
