### PR TITLE
use s3 regional url when parameter is set

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -93,7 +93,7 @@ public abstract class SFBaseSession {
   // session database
   private boolean metadataRequestUseSessionDatabase = false;
   // Forces to use regional s3 end point API to generate regional url for aws endpoints
-  private boolean useRegionalS3EndpointsForPresignedURL;
+  private boolean useRegionalS3EndpointsForPresignedURL = false;
 
   /**
    * Part of the JDBC API, where client applications may fetch a Map of Properties to set various

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -92,6 +92,8 @@ public abstract class SFBaseSession {
   // DatabaseMetadata.getSchemas), whether to search using multiple schemas with
   // session database
   private boolean metadataRequestUseSessionDatabase = false;
+  //Forces to use regional s3 end point API to generate regional url for aws endpoints
+  private boolean useRegionalS3EndpointsForPresignedURL;
 
   /**
    * Part of the JDBC API, where client applications may fetch a Map of Properties to set various
@@ -514,6 +516,14 @@ public abstract class SFBaseSession {
 
   public void setWarehouse(String warehouse) {
     this.warehouse = warehouse;
+  }
+
+  public void setUseRegionalS3EndpointsForPresignedURL(boolean regionalS3Endpoint) {
+    this.useRegionalS3EndpointsForPresignedURL = regionalS3Endpoint;
+  }
+
+  public boolean getUseRegionalS3EndpointsForPresignedURL() {
+    return useRegionalS3EndpointsForPresignedURL;
   }
 
   /**

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -92,7 +92,7 @@ public abstract class SFBaseSession {
   // DatabaseMetadata.getSchemas), whether to search using multiple schemas with
   // session database
   private boolean metadataRequestUseSessionDatabase = false;
-  //Forces to use regional s3 end point API to generate regional url for aws endpoints
+  // Forces to use regional s3 end point API to generate regional url for aws endpoints
   private boolean useRegionalS3EndpointsForPresignedURL;
 
   /**

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1383,9 +1383,11 @@ public class SessionUtil {
         if (session != null) {
           session.setValidateDefaultParameters(SFLoginInput.getBooleanValue(entry.getValue()));
         }
-      } else if (FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS.equalsIgnoreCase((entry.getKey()))) {
+      } else if (FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS.equalsIgnoreCase(
+          (entry.getKey()))) {
         if (session != null) {
-          session.setUseRegionalS3EndpointsForPresignedURL(SFLoginInput.getBooleanValue(entry.getValue()));
+          session.setUseRegionalS3EndpointsForPresignedURL(
+              SFLoginInput.getBooleanValue(entry.getValue()));
         }
       }
     }

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -103,6 +103,8 @@ public class SessionUtil {
       "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX";
   public static final String CLIENT_METADATA_USE_SESSION_DATABASE =
       "CLIENT_METADATA_USE_SESSION_DATABASE";
+  public static final String FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS =
+      "FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS";
 
   static final String SF_HEADER_SERVICE_NAME = "X-Snowflake-Service";
 
@@ -175,7 +177,8 @@ public class SessionUtil {
               "JDBC_TREAT_DECIMAL_AS_INT",
               "JDBC_ENABLE_COMBINED_DESCRIBE",
               CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE,
-              CLIENT_VALIDATE_DEFAULT_PARAMETERS));
+              CLIENT_VALIDATE_DEFAULT_PARAMETERS,
+              FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS));
 
   /**
    * Returns Authenticator type
@@ -1379,6 +1382,10 @@ public class SessionUtil {
       } else if (CLIENT_VALIDATE_DEFAULT_PARAMETERS.equalsIgnoreCase(entry.getKey())) {
         if (session != null) {
           session.setValidateDefaultParameters(SFLoginInput.getBooleanValue(entry.getValue()));
+        }
+      } else if (FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS.equalsIgnoreCase((entry.getKey()))) {
+        if (session != null) {
+          session.setUseRegionalS3EndpointsForPresignedURL(SFLoginInput.getBooleanValue(entry.getValue()));
         }
       }
     }

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1388,9 +1388,10 @@ public class SessionUtil {
         if (session != null) {
           session.setUseRegionalS3EndpointsForPresignedURL(
               SFLoginInput.getBooleanValue(entry.getValue()));
-      } else {
-        if (session != null) {
-          session.setOtherParameter(entry.getKey(), entry.getValue());
+        } else {
+          if (session != null) {
+            session.setOtherParameter(entry.getKey(), entry.getValue());
+          }
         }
       }
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -13,6 +13,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.client.builder.ExecutorFactory;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
@@ -175,7 +176,13 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     if (stageRegion != null) {
       Region region = RegionUtils.getRegion(stageRegion);
       if (region != null) {
-        amazonS3Builder.withRegion(region.getName());
+        if (session.getUseRegionalS3EndpointsForPresignedURL()) {
+          amazonS3Builder.withEndpointConfiguration(
+              new AwsClientBuilder.EndpointConfiguration(
+                  "s3." + region.getName() + ".amazonaws.com", region.getName()));
+        } else {
+          amazonS3Builder.withRegion(region.getName());
+        }
       }
     }
     // Explicitly force to use virtual address style

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -2897,63 +2897,63 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
     Connection connection = null;
     Statement statement = null;
-    boolean testS3stageRegionalUrl = false;
-    List<String> accounts =
-        Arrays.asList(null, "azureaccount", "gcpaccount", "s3testaccount", "s3testaccount");
-    for (int i = 0; i < accounts.size(); i++) {
-      try {
-        connection = getConnection(accounts.get(i));
+    boolean[] privateLink = {false, true};
 
-        statement = connection.createStatement();
-
-        String sourceFilePath = getFullPathFileInResource(TEST_DATA_FILE);
-
-        File destFolder = tmpFolder.newFolder();
-        String destFolderCanonicalPath = destFolder.getCanonicalPath();
-        String destFolderCanonicalPathWithSeparator = destFolderCanonicalPath + File.separator;
-
+    List<String> accounts = Arrays.asList(null, "s3testaccount", "azureaccount", "gcpaccount");
+    for (boolean testS3stageRegionalUrl : privateLink) {
+      for (int i = 0; i < accounts.size(); i++) {
         try {
-          statement.execute("CREATE OR REPLACE STAGE testPutGet_stage");
+          connection = getConnection(accounts.get(i));
 
-          if (testS3stageRegionalUrl) {
-            statement.execute(
-                "alter session set FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS=true;");
-          }
-          if (!testS3stageRegionalUrl
-              && accounts.get(i).compareToIgnoreCase("s3testaccount") == 0) {
-            testS3stageRegionalUrl = true;
-          }
+          statement = connection.createStatement();
 
-          assertTrue(
-              "Failed to put a file",
-              statement.execute("PUT file://" + sourceFilePath + " @testPutGet_stage"));
+          String sourceFilePath = getFullPathFileInResource(TEST_DATA_FILE);
 
-          findFile(statement, "ls @testPutGet_stage/");
+          File destFolder = tmpFolder.newFolder();
+          String destFolderCanonicalPath = destFolder.getCanonicalPath();
+          String destFolderCanonicalPathWithSeparator = destFolderCanonicalPath + File.separator;
 
-          // download the file we just uploaded to stage
-          assertTrue(
-              "Failed to get a file",
+          try {
+            statement.execute("CREATE OR REPLACE STAGE testPutGet_stage");
+
+            if (testS3stageRegionalUrl) {
               statement.execute(
-                  "GET @testPutGet_stage 'file://" + destFolderCanonicalPath + "' parallel=8"));
+                  "alter session set FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS=true;");
+            }
 
-          // Make sure that the downloaded file exists, it should be gzip compressed
-          File downloaded = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
-          assert (downloaded.exists());
+            assertTrue(
+                "Failed to put a file",
+                statement.execute("PUT file://" + sourceFilePath + " @testPutGet_stage"));
 
-          Process p =
-              Runtime.getRuntime()
-                  .exec("gzip -d " + destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
-          p.waitFor();
+            findFile(statement, "ls @testPutGet_stage/");
 
-          File original = new File(sourceFilePath);
-          File unzipped = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE);
-          assert (original.length() == unzipped.length());
+            // download the file we just uploaded to stage
+            assertTrue(
+                "Failed to get a file",
+                statement.execute(
+                    "GET @testPutGet_stage 'file://" + destFolderCanonicalPath + "' parallel=8"));
+
+            // Make sure that the downloaded file exists, it should be gzip compressed
+            File downloaded =
+                new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
+            assert (downloaded.exists());
+
+            Process p =
+                Runtime.getRuntime()
+                    .exec(
+                        "gzip -d " + destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
+            p.waitFor();
+
+            File original = new File(sourceFilePath);
+            File unzipped = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE);
+            assert (original.length() == unzipped.length());
+          } finally {
+            statement.execute("DROP STAGE IF EXISTS testGetPut_stage");
+            statement.close();
+          }
         } finally {
-          statement.execute("DROP STAGE IF EXISTS testGetPut_stage");
-          statement.close();
+          closeSQLObjects(null, statement, connection);
         }
-      } finally {
-        closeSQLObjects(null, statement, connection);
       }
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -2898,7 +2898,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     Connection connection = null;
     Statement statement = null;
     boolean testS3stageRegionalUrl = false;
-    List<String> accounts = Arrays.asList(null, "s3testaccount", "s3testaccount", "azureaccount", "gcpaccount");
+    List<String> accounts =
+        Arrays.asList(null, "s3testaccount", "s3testaccount", "azureaccount", "gcpaccount");
     for (int i = 0; i < accounts.size(); i++) {
       try {
         connection = getConnection(accounts.get(i));
@@ -2916,7 +2917,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
           if (!testS3stageRegionalUrl
               && accounts.get(i).compareToIgnoreCase("s3testaccount") == 0) {
-            statement.execute("alter session set FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS=true;");
+            statement.execute(
+                "alter session set FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS=true;");
             testS3stageRegionalUrl = true;
           }
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -2897,7 +2897,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
     Connection connection = null;
     Statement statement = null;
-    List<String> accounts = Arrays.asList(null, "s3testaccount", "azureaccount", "gcpaccount");
+    boolean testS3stageRegionalUrl = false;
+    List<String> accounts = Arrays.asList(null, "s3testaccount", "s3testaccount", "azureaccount", "gcpaccount");
     for (int i = 0; i < accounts.size(); i++) {
       try {
         connection = getConnection(accounts.get(i));
@@ -2912,6 +2913,12 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
         try {
           statement.execute("CREATE OR REPLACE STAGE testPutGet_stage");
+
+          if (!testS3stageRegionalUrl
+              && accounts.get(i).compareToIgnoreCase("s3testaccount") == 0) {
+            statement.execute("alter session set FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS=true;");
+            testS3stageRegionalUrl = true;
+          }
 
           assertTrue(
               "Failed to put a file",

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -2899,7 +2899,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     Statement statement = null;
     boolean testS3stageRegionalUrl = false;
     List<String> accounts =
-        Arrays.asList(null, "s3testaccount", "s3testaccount", "azureaccount", "gcpaccount");
+        Arrays.asList(null, "azureaccount", "gcpaccount", "s3testaccount", "s3testaccount");
     for (int i = 0; i < accounts.size(); i++) {
       try {
         connection = getConnection(accounts.get(i));
@@ -2915,10 +2915,12 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
         try {
           statement.execute("CREATE OR REPLACE STAGE testPutGet_stage");
 
-          if (!testS3stageRegionalUrl
-              && accounts.get(i).compareToIgnoreCase("s3testaccount") == 0) {
+          if (testS3stageRegionalUrl) {
             statement.execute(
                 "alter session set FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS=true;");
+          }
+          if (!testS3stageRegionalUrl
+              && accounts.get(i).compareToIgnoreCase("s3testaccount") == 0) {
             testS3stageRegionalUrl = true;
           }
 


### PR DESCRIPTION
# Overview

SNOW-299374

When the parameter FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS is set to true then invoke a different API to generate S3 url. 
This does NOT break any existing customers. The above parameter will be set true to private link parameters in the AWS us-east-1 regions. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
