### PR TITLE
SNOW-334161 fixing nullptrexception in Arrow getBigDecimal function

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -496,7 +496,8 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
 
   @Override
   public BigDecimal getBigDecimal(int columnIndex, int scale) throws SFException {
-    return getBigDecimal(columnIndex).setScale(scale, RoundingMode.HALF_UP);
+    BigDecimal bigDec = getBigDecimal(columnIndex);
+    return bigDec == null ? null : bigDec.setScale(scale, RoundingMode.HALF_UP);
   }
 
   @Override


### PR DESCRIPTION
# Overview

SNOW-334161

There is a function getBigDecimal(int colIndex, int scale) that throws a NullPointerException when the BigDecimal value is null and Arrow format is used. This change checks for null and returns the null value rather than throwing an exception when .setScale() is called.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
