### PR TITLE
SNOW-331319 Fix flaky async test

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
@@ -43,10 +43,10 @@ public class HeartbeatAsyncLatestIT extends HeartbeatIT {
       connection = getConnection(sessionParams);
 
       Statement stmt = connection.createStatement();
-      // Query will take 30 seconds to run, but ResultSet will be returned immediately
+      // Query will take 10 seconds to run, but ResultSet will be returned immediately
       resultSet =
           stmt.unwrap(SnowflakeStatement.class)
-              .executeAsyncQuery("SELECT count(*) FROM TABLE(generator(timeLimit => 30))");
+              .executeAsyncQuery("SELECT count(*) FROM TABLE(generator(timeLimit => 10))");
       Thread.sleep(61000); // sleep 61 seconds to await original session expiration time
       QueryStatus qs = resultSet.unwrap(SnowflakeResultSet.class).getStatus();
       // Ensure query succeeded

--- a/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
@@ -50,24 +50,21 @@ public class HeartbeatAsyncLatestIT extends HeartbeatIT {
       Thread.sleep(61000); // sleep 61 seconds to await original session expiration time
       QueryStatus qs = resultSet.unwrap(SnowflakeResultSet.class).getStatus();
       int retry = 0;
-      int MAX_RETRY = 10;
+      int MAX_RETRY = 20;
       // Ensure query succeeded. Avoid flaky test failure by waiting until query is complete to
       // assert the query status is a success.
       while (QueryStatus.isStillRunning(qs) && retry < MAX_RETRY) {
-        Thread.sleep(1000);
+        Thread.sleep(3000);
         retry++;
         qs = resultSet.unwrap(SnowflakeResultSet.class).getStatus();
       }
-      if (retry < MAX_RETRY) {
-        assertEquals(QueryStatus.SUCCESS, qs);
+      // Query should succeed eventually. Assert this is the case.
+      assertEquals(QueryStatus.SUCCESS, qs);
 
-        // assert we get 1 row
-        assertTrue(resultSet.next());
-        assertFalse(resultSet.next());
-        logger.fine("Query " + queryIdx + " passed ");
-      } else {
-        logger.fine("Query took too long to complete. Aborting test.");
-      }
+      // assert we get 1 row
+      assertTrue(resultSet.next());
+      assertFalse(resultSet.next());
+      logger.fine("Query " + queryIdx + " passed ");
 
     } finally {
       resultSet.close();

--- a/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
@@ -43,20 +43,32 @@ public class HeartbeatAsyncLatestIT extends HeartbeatIT {
       connection = getConnection(sessionParams);
 
       Statement stmt = connection.createStatement();
-      // Query will take 10 seconds to run, but ResultSet will be returned immediately
+      // Query will take 5 seconds to run, but ResultSet will be returned immediately
       resultSet =
           stmt.unwrap(SnowflakeStatement.class)
-              .executeAsyncQuery("SELECT count(*) FROM TABLE(generator(timeLimit => 10))");
+              .executeAsyncQuery("SELECT count(*) FROM TABLE(generator(timeLimit => 5))");
       Thread.sleep(61000); // sleep 61 seconds to await original session expiration time
       QueryStatus qs = resultSet.unwrap(SnowflakeResultSet.class).getStatus();
-      // Ensure query succeeded
-      assertEquals(QueryStatus.SUCCESS, qs);
+      int retry = 0;
+      int MAX_RETRY = 10;
+      // Ensure query succeeded. Avoid flaky test failure by waiting until query is complete to
+      // assert the query status is a success.
+      while (QueryStatus.isStillRunning(qs) && retry < MAX_RETRY) {
+        Thread.sleep(1000);
+        retry++;
+        qs = resultSet.unwrap(SnowflakeResultSet.class).getStatus();
+      }
+      if (retry < MAX_RETRY) {
+        assertEquals(QueryStatus.SUCCESS, qs);
 
-      // assert we get 1 row
-      assertTrue(resultSet.next());
-      assertFalse(resultSet.next());
+        // assert we get 1 row
+        assertTrue(resultSet.next());
+        assertFalse(resultSet.next());
+        logger.fine("Query " + queryIdx + " passed ");
+      } else {
+        logger.fine("Query took too long to complete. Aborting test.");
+      }
 
-      logger.fine("Query " + queryIdx + " passed ");
     } finally {
       resultSet.close();
       connection.close();


### PR DESCRIPTION
# Overview

SNOW-331319

Often this test fails because it asserts that the query status should be SUCCESS, but GS can take a really long time to run so sometimes the query status is RUNNING instead. This change should fix the flakiness by 1.) Shortening the query runtime so it's more likely to be done, and 2.) Implementing a retry if the query is still running.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
