### PR TITLE
use ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 parameter to invoke regional s3 url

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -205,7 +205,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
         connection = getConnection(accountName);
         Statement statement = connection.createStatement();
 
-        if("s3testaccount".equalsIgnoreCase(accountName)) {
+        if ("s3testaccount".equalsIgnoreCase(accountName)) {
           statement.execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = true;");
         }
 
@@ -279,8 +279,10 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
       } finally {
         if (connection != null) {
           connection.createStatement().execute("DROP STAGE if exists " + testStageName);
-          if("s3testaccount".equalsIgnoreCase(accountName)) {
-            connection.createStatement().execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = false;");
+          if ("s3testaccount".equalsIgnoreCase(accountName)) {
+            connection
+                .createStatement()
+                .execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = false;");
           }
           connection.close();
         }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -205,6 +205,10 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
         connection = getConnection(accountName);
         Statement statement = connection.createStatement();
 
+        if("s3testaccount".equalsIgnoreCase(accountName)) {
+          statement.execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = true;");
+        }
+
         // create a stage to put the file in
         statement.execute("CREATE OR REPLACE STAGE " + testStageName);
 
@@ -275,6 +279,9 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
       } finally {
         if (connection != null) {
           connection.createStatement().execute("DROP STAGE if exists " + testStageName);
+          if("s3testaccount".equalsIgnoreCase(accountName)) {
+            connection.createStatement().execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = false;");
+          }
           connection.close();
         }
       }


### PR DESCRIPTION
# Overview

SNOW-299374
When the parameter ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 is set to true then driver invokes a different API to generate S3 regional url.
This does NOT break any existing customers. The above parameter will be set true to private link parameters in the AWS us-east-1 regions.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
