### PR TITLE
generate aws s3 regional urls when a param is set

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -92,6 +92,8 @@ public abstract class SFBaseSession {
   // DatabaseMetadata.getSchemas), whether to search using multiple schemas with
   // session database
   private boolean metadataRequestUseSessionDatabase = false;
+  // Forces to use regional s3 end point API to generate regional url for aws endpoints
+  private boolean useRegionalS3EndpointsForPresignedURL = false;
   // Stores other parameters sent by server
   private final Map<String, Object> otherParameters = new HashMap<>();
 
@@ -524,6 +526,14 @@ public abstract class SFBaseSession {
 
   public void setWarehouse(String warehouse) {
     this.warehouse = warehouse;
+  }
+
+  public void setUseRegionalS3EndpointsForPresignedURL(boolean regionalS3Endpoint) {
+    this.useRegionalS3EndpointsForPresignedURL = regionalS3Endpoint;
+  }
+
+  public boolean getUseRegionalS3EndpointsForPresignedURL() {
+    return useRegionalS3EndpointsForPresignedURL;
   }
 
   /**

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -103,6 +103,8 @@ public class SessionUtil {
       "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX";
   public static final String CLIENT_METADATA_USE_SESSION_DATABASE =
       "CLIENT_METADATA_USE_SESSION_DATABASE";
+  public static final String FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS =
+      "FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS";
 
   static final String SF_HEADER_SERVICE_NAME = "X-Snowflake-Service";
 
@@ -175,7 +177,8 @@ public class SessionUtil {
               "JDBC_TREAT_DECIMAL_AS_INT",
               "JDBC_ENABLE_COMBINED_DESCRIBE",
               CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE,
-              CLIENT_VALIDATE_DEFAULT_PARAMETERS));
+              CLIENT_VALIDATE_DEFAULT_PARAMETERS,
+              FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS));
 
   /**
    * Returns Authenticator type
@@ -1380,9 +1383,15 @@ public class SessionUtil {
         if (session != null) {
           session.setValidateDefaultParameters(SFLoginInput.getBooleanValue(entry.getValue()));
         }
-      } else {
+      } else if (FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS.equalsIgnoreCase(
+          (entry.getKey()))) {
         if (session != null) {
-          session.setOtherParameter(entry.getKey(), entry.getValue());
+          session.setUseRegionalS3EndpointsForPresignedURL(
+              SFLoginInput.getBooleanValue(entry.getValue()));
+        } else {
+          if (session != null) {
+            session.setOtherParameter(entry.getKey(), entry.getValue());
+          }
         }
       }
     }

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -103,8 +103,8 @@ public class SessionUtil {
       "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX";
   public static final String CLIENT_METADATA_USE_SESSION_DATABASE =
       "CLIENT_METADATA_USE_SESSION_DATABASE";
-  public static final String FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS =
-      "FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS";
+  public static final String ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 =
+      "ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1";
 
   static final String SF_HEADER_SERVICE_NAME = "X-Snowflake-Service";
 
@@ -178,7 +178,7 @@ public class SessionUtil {
               "JDBC_ENABLE_COMBINED_DESCRIBE",
               CLIENT_ENABLE_CONSERVATIVE_MEMORY_USAGE,
               CLIENT_VALIDATE_DEFAULT_PARAMETERS,
-              FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS));
+              ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1));
 
   /**
    * Returns Authenticator type
@@ -1383,7 +1383,7 @@ public class SessionUtil {
         if (session != null) {
           session.setValidateDefaultParameters(SFLoginInput.getBooleanValue(entry.getValue()));
         }
-      } else if (FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS.equalsIgnoreCase(
+      } else if (ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1.equalsIgnoreCase(
           (entry.getKey()))) {
         if (session != null) {
           session.setUseRegionalS3EndpointsForPresignedURL(

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1385,8 +1385,7 @@ public class SessionUtil {
         if (session != null) {
           session.setValidateDefaultParameters(SFLoginInput.getBooleanValue(entry.getValue()));
         }
-      } else if (ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1.equalsIgnoreCase(
-          (entry.getKey()))) {
+      } else if (ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1.equalsIgnoreCase((entry.getKey()))) {
         if (session != null) {
           session.setUseRegionalS3EndpointsForPresignedURL(
               SFLoginInput.getBooleanValue(entry.getValue()));

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferConfig.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferConfig.java
@@ -23,6 +23,7 @@ public class SnowflakeFileTransferConfig {
   private String destFileName;
   private SFSession session; // Optional, added for S3 and Azure
   private String command; // Optional, added for S3 and Azure
+  private boolean useS3RegionalUrl; // only for S3 us-east-1 private link deployments
 
   public SnowflakeFileTransferConfig(Builder builder) {
     this.metadata = builder.metadata;
@@ -35,6 +36,7 @@ public class SnowflakeFileTransferConfig {
     this.destFileName = builder.destFileName;
     this.session = builder.session;
     this.command = builder.command;
+    this.useS3RegionalUrl = builder.useS3RegionalUrl;
   }
 
   public SnowflakeFileTransferMetadata getSnowflakeFileTransferMetadata() {
@@ -77,6 +79,10 @@ public class SnowflakeFileTransferConfig {
     return command;
   }
 
+  public boolean getUseS3RegionalUrl() {
+    return useS3RegionalUrl;
+  }
+
   // Builder class
   public static class Builder {
     private SnowflakeFileTransferMetadata metadata = null;
@@ -89,6 +95,7 @@ public class SnowflakeFileTransferConfig {
     private String destFileName = null;
     private SFSession session = null;
     private String command = null;
+    private boolean useS3RegionalUrl = false; // only for S3 us-east-1 private link deployments
 
     public static Builder newInstance() {
       return new Builder();
@@ -161,6 +168,11 @@ public class SnowflakeFileTransferConfig {
 
     public Builder setCommand(String command) {
       this.command = command;
+      return this;
+    }
+
+    public Builder setUseS3RegionalUrl(boolean useS3RegUrl) {
+      this.useS3RegionalUrl = useS3RegUrl;
       return this;
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -75,6 +75,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
   private String stageEndPoint = null; // FIPS endpoint, if needed
   private SFBaseSession session = null;
   private boolean isClientSideEncrypted = true;
+  private boolean isUseS3RegionalUrl = false;
 
   // socket factory used by s3 client's http client.
   private static SSLConnectionSocketFactory s3ConnectionSocketFactory = null;
@@ -86,9 +87,11 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       String stageRegion,
       String stageEndPoint,
       boolean isClientSideEncrypted,
-      SFBaseSession session)
+      SFBaseSession session,
+      boolean useS3RegionalUrl)
       throws SnowflakeSQLException {
     this.session = session;
+    this.isUseS3RegionalUrl = useS3RegionalUrl;
     setupSnowflakeS3Client(
         stageCredentials,
         clientConfig,
@@ -176,7 +179,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     if (stageRegion != null) {
       Region region = RegionUtils.getRegion(stageRegion);
       if (region != null) {
-        if (session.getUseRegionalS3EndpointsForPresignedURL()) {
+        if (this.isUseS3RegionalUrl) {
           amazonS3Builder.withEndpointConfiguration(
               new AwsClientBuilder.EndpointConfiguration(
                   "s3." + region.getName() + ".amazonaws.com", region.getName()));

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -13,6 +13,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.client.builder.ExecutorFactory;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
@@ -175,7 +176,13 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     if (stageRegion != null) {
       Region region = RegionUtils.getRegion(stageRegion);
       if (region != null) {
-        amazonS3Builder.withRegion(region.getName());
+        if (session.getUseRegionalS3EndpointsForPresignedURL()) {
+          amazonS3Builder.withEndpointConfiguration(
+              new AwsClientBuilder.EndpointConfiguration(
+                  "s3." + region.getName() + ".amazonaws.com", region.getName()));
+        } else {
+          amazonS3Builder.withRegion(region.getName());
+        }
       }
     }
     // Explicitly force to use virtual address style

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
@@ -21,7 +21,7 @@ public class StageInfo implements Serializable {
   private String storageAccount; // The Azure Storage account (Azure only)
   private String presignedUrl; // GCS gives us back a presigned URL instead of a cred
   private boolean isClientSideEncrypted; // whether to encrypt/decrypt files on the stage
-  private boolean isUseS3RegionalUrl; // whether to use s3 regional URL (AWS Only)
+  private boolean useS3RegionalUrl; // whether to use s3 regional URL (AWS Only)
 
   /*
    * Creates a StageInfo object
@@ -157,11 +157,11 @@ public class StageInfo implements Serializable {
   }
 
   public void setUseS3RegionalUrl(boolean useS3RegionalUrl) {
-    this.isUseS3RegionalUrl = useS3RegionalUrl;
+    this.useS3RegionalUrl = useS3RegionalUrl;
   }
 
   public boolean getUseS3RegionalUrl() {
-    return isUseS3RegionalUrl;
+    return useS3RegionalUrl;
   }
 
   private static boolean isSpecified(String arg) {

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StageInfo.java
@@ -21,6 +21,7 @@ public class StageInfo implements Serializable {
   private String storageAccount; // The Azure Storage account (Azure only)
   private String presignedUrl; // GCS gives us back a presigned URL instead of a cred
   private boolean isClientSideEncrypted; // whether to encrypt/decrypt files on the stage
+  private boolean isUseS3RegionalUrl; // whether to use s3 regional URL (AWS Only)
 
   /*
    * Creates a StageInfo object
@@ -153,6 +154,14 @@ public class StageInfo implements Serializable {
 
   public boolean getIsClientSideEncrypted() {
     return isClientSideEncrypted;
+  }
+
+  public void setUseS3RegionalUrl(boolean useS3RegionalUrl) {
+    this.isUseS3RegionalUrl = useS3RegionalUrl;
+  }
+
+  public boolean getUseS3RegionalUrl() {
+    return isUseS3RegionalUrl;
   }
 
   private static boolean isSpecified(String arg) {

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -56,6 +56,9 @@ public class StorageClientFactory {
 
     switch (stage.getStageType()) {
       case S3:
+        boolean useS3RegionalUrl =
+            (stage.getUseS3RegionalUrl()
+                || (session != null && session.getUseRegionalS3EndpointsForPresignedURL()));
         return createS3Client(
             stage.getCredentials(),
             parallel,
@@ -63,7 +66,8 @@ public class StorageClientFactory {
             stage.getRegion(),
             stage.getEndPoint(),
             stage.getIsClientSideEncrypted(),
-            session);
+            session,
+            useS3RegionalUrl);
 
       case AZURE:
         return createAzureClient(stage, encMat, session);
@@ -90,6 +94,7 @@ public class StorageClientFactory {
    * @param stageEndPoint the FIPS endpoint for the stage, if needed
    * @param isClientSideEncrypted whether client-side encryption should be used
    * @param session the active session
+   * @param useS3RegionalUrl
    * @return the SnowflakeS3Client instance created
    * @throws SnowflakeSQLException failure to create the S3 client
    */
@@ -100,7 +105,8 @@ public class StorageClientFactory {
       String stageRegion,
       String stageEndPoint,
       boolean isClientSideEncrypted,
-      SFBaseSession session)
+      SFBaseSession session,
+      boolean useS3RegionalUrl)
       throws SnowflakeSQLException {
     final int S3_TRANSFER_MAX_RETRIES = 3;
 
@@ -130,7 +136,8 @@ public class StorageClientFactory {
               stageRegion,
               stageEndPoint,
               isClientSideEncrypted,
-              session);
+              session,
+              useS3RegionalUrl);
     } catch (Exception ex) {
       logger.debug("Exception creating s3 client", ex);
       throw ex;

--- a/src/test/java/net/snowflake/client/AbstractDriverIT.java
+++ b/src/test/java/net/snowflake/client/AbstractDriverIT.java
@@ -308,10 +308,6 @@ public class AbstractDriverIT {
         properties.put(entry.getKey(), entry.getValue());
       }
     }
-    for (Map.Entry<?, ?> entry : properties.entrySet()) {
-      System.out.printf("%s:%s\n", entry.getKey(), entry.getValue());
-    }
-    System.out.printf("Uri is %s\n", params.get("uri"));
     return DriverManager.getConnection(params.get("uri"), properties);
   }
 

--- a/src/test/java/net/snowflake/client/AbstractDriverIT.java
+++ b/src/test/java/net/snowflake/client/AbstractDriverIT.java
@@ -308,6 +308,10 @@ public class AbstractDriverIT {
         properties.put(entry.getKey(), entry.getValue());
       }
     }
+    for (Map.Entry<?, ?> entry : properties.entrySet()) {
+      System.out.printf("%s:%s\n", entry.getKey(), entry.getValue());
+    }
+    System.out.printf("Uri is %s\n", params.get("uri"));
     return DriverManager.getConnection(params.get("uri"), properties);
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -281,92 +281,6 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
     }
   }
 
-  @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
-  public void testPutS3RegionalUrl() throws Throwable {
-    Connection connection = null;
-    Statement statement = null;
-    ResultSet resultSet = null;
-
-    try {
-      Properties paramProperties = new Properties();
-      paramProperties.put("account", "s3testaccount");
-      paramProperties.put("user", "snowman");
-      paramProperties.put("password", "test");
-      connection =
-          getConnection(DONT_INJECT_SOCKET_TIMEOUT, paramProperties, true, false, "s3testaccount");
-
-      statement = connection.createStatement();
-
-      // load file test
-      // create a unique data file name by using current timestamp in millis
-      try {
-        // test external table load
-        statement.execute("CREATE OR REPLACE TABLE testLoadToLocalFS(a number)");
-
-        statement.execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = true;");
-
-        // put files
-        assertTrue(
-            "Failed to put a file",
-            statement.execute(
-                "PUT file://"
-                    + getFullPathFileInResource(TEST_DATA_FILE)
-                    + " @%testLoadToLocalFS/orders parallel=10"));
-
-        resultSet = statement.getResultSet();
-
-        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-
-        // assert column count
-        assertTrue(resultSetMetaData.getColumnCount() > 0);
-
-        assertTrue(resultSet.next()); // one row
-        assertFalse(resultSet.next());
-
-        findFile(
-            statement, "ls @%testLoadToLocalFS/ pattern='.*orders/" + TEST_DATA_FILE + ".g.*'");
-
-        // remove files
-        resultSet =
-            statement.executeQuery(
-                "rm @%testLoadToLocalFS/ pattern='.*orders/" + TEST_DATA_FILE + ".g.*'");
-
-        resultSetMetaData = resultSet.getMetaData();
-
-        // assert column count
-        assertTrue(resultSetMetaData.getColumnCount() >= 1);
-
-        // assert we get 1 row for the file we copied
-        assertTrue(resultSet.next());
-        assertNotNull(resultSet.getString(1));
-        assertFalse(resultSet.next());
-        try {
-          resultSet.getString(1); // no more row
-          fail("must fail");
-        } catch (SQLException ex) {
-          assertEquals((int) ErrorCode.COLUMN_DOES_NOT_EXIST.getMessageCode(), ex.getErrorCode());
-        }
-
-        Thread.sleep(100);
-
-        // show files again
-        resultSet = statement.executeQuery("ls @%testLoadToLocalFS/ pattern='.*orders/orders.*'");
-
-        // assert we get 0 row
-        assertFalse(resultSet.next());
-
-      } finally {
-        statement.execute("DROP TABLE IF EXISTS testLoadToLocalFS");
-        statement.execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = false;");
-        statement.close();
-      }
-
-    } finally {
-      closeSQLObjects(resultSet, statement, connection);
-    }
-  }
-
   /** Negative test for FileTransferMetadata. It is only supported for PUT. */
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
@@ -1029,5 +943,92 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
     fOut.transferFrom(fIn, fIn.size(), fIn.size());
     fOut.close();
     fIn.close();
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testPutS3RegionalUrl() throws Throwable {
+    Connection connection = null;
+    Statement statement = null;
+    ResultSet resultSet = null;
+
+    try {
+      Properties paramProperties = new Properties();
+      paramProperties.put("account", "s3testaccount");
+      paramProperties.put("user", "snowman");
+      paramProperties.put("password", "test");
+      paramProperties.put("role", "accountadmin");
+      connection =
+          getConnection(DONT_INJECT_SOCKET_TIMEOUT, paramProperties, true, false, "s3testaccount");
+
+      statement = connection.createStatement();
+
+      // load file test
+      // create a unique data file name by using current timestamp in millis
+      try {
+        // test external table load
+        statement.execute("CREATE OR REPLACE TABLE testLoadToLocalFS(a number)");
+
+        statement.execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = true;");
+
+        // put files
+        assertTrue(
+            "Failed to put a file",
+            statement.execute(
+                "PUT file://"
+                    + getFullPathFileInResource(TEST_DATA_FILE)
+                    + " @%testLoadToLocalFS/orders parallel=10"));
+
+        resultSet = statement.getResultSet();
+
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+
+        // assert column count
+        assertTrue(resultSetMetaData.getColumnCount() > 0);
+
+        assertTrue(resultSet.next()); // one row
+        assertFalse(resultSet.next());
+
+        findFile(
+            statement, "ls @%testLoadToLocalFS/ pattern='.*orders/" + TEST_DATA_FILE + ".g.*'");
+
+        // remove files
+        resultSet =
+            statement.executeQuery(
+                "rm @%testLoadToLocalFS/ pattern='.*orders/" + TEST_DATA_FILE + ".g.*'");
+
+        resultSetMetaData = resultSet.getMetaData();
+
+        // assert column count
+        assertTrue(resultSetMetaData.getColumnCount() >= 1);
+
+        // assert we get 1 row for the file we copied
+        assertTrue(resultSet.next());
+        assertNotNull(resultSet.getString(1));
+        assertFalse(resultSet.next());
+        try {
+          resultSet.getString(1); // no more row
+          fail("must fail");
+        } catch (SQLException ex) {
+          assertEquals((int) ErrorCode.COLUMN_DOES_NOT_EXIST.getMessageCode(), ex.getErrorCode());
+        }
+
+        Thread.sleep(100);
+
+        // show files again
+        resultSet = statement.executeQuery("ls @%testLoadToLocalFS/ pattern='.*orders/orders.*'");
+
+        // assert we get 0 row
+        assertFalse(resultSet.next());
+
+      } finally {
+        statement.execute("DROP TABLE IF EXISTS testLoadToLocalFS");
+        statement.execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = false;");
+        statement.close();
+      }
+
+    } finally {
+      closeSQLObjects(resultSet, statement, connection);
+    }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -231,6 +231,34 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
                   .setCommand(putCommand1)
                   .build());
         }
+        for (SnowflakeFileTransferMetadata oneMetadata : metadatas1) {
+          InputStream inputStream = new FileInputStream(srcPath1);
+          SnowflakeFileTransferAgent.uploadWithoutConnection(
+              SnowflakeFileTransferConfig.Builder.newInstance()
+                  .setSnowflakeFileTransferMetadata(oneMetadata)
+                  .setUploadStream(inputStream)
+                  .setRequireCompress(true)
+                  .setNetworkTimeoutInMilli(0)
+                  .setOcspMode(OCSPMode.FAIL_OPEN)
+                  .setSFSession(sfSession)
+                  .setCommand(putCommand1)
+                  .setUseS3RegionalUrl(false)
+                  .build());
+        }
+        for (SnowflakeFileTransferMetadata oneMetadata : metadatas1) {
+          InputStream inputStream = new FileInputStream(srcPath1);
+          SnowflakeFileTransferAgent.uploadWithoutConnection(
+              SnowflakeFileTransferConfig.Builder.newInstance()
+                  .setSnowflakeFileTransferMetadata(oneMetadata)
+                  .setUploadStream(inputStream)
+                  .setRequireCompress(true)
+                  .setNetworkTimeoutInMilli(0)
+                  .setOcspMode(OCSPMode.FAIL_OPEN)
+                  .setSFSession(sfSession)
+                  .setCommand(putCommand1)
+                  .setUseS3RegionalUrl(true)
+                  .build());
+        }
 
         // Test Put file with external compression
         String putCommand2 = "put file:///dummy/path/file2.gz @" + testStageName;

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -289,7 +289,9 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
     ResultSet resultSet = null;
 
     try {
-      connection = getConnection(DONT_INJECT_SOCKET_TIMEOUT, null, true, false, "s3testaccount");
+      Properties paramProperties = new Properties();
+      paramProperties.put("account", "s3testaccount");
+      connection = getConnection(DONT_INJECT_SOCKET_TIMEOUT, paramProperties, true, false, "s3testaccount");
 
       statement = connection.createStatement();
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -291,7 +291,8 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
     try {
       Properties paramProperties = new Properties();
       paramProperties.put("account", "s3testaccount");
-      connection = getConnection(DONT_INJECT_SOCKET_TIMEOUT, paramProperties, true, false, "s3testaccount");
+      connection =
+          getConnection(DONT_INJECT_SOCKET_TIMEOUT, paramProperties, true, false, "s3testaccount");
 
       statement = connection.createStatement();
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -291,6 +291,8 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
     try {
       Properties paramProperties = new Properties();
       paramProperties.put("account", "s3testaccount");
+      paramProperties.put("user", "snowman");
+      paramProperties.put("password", "test");
       connection =
           getConnection(DONT_INJECT_SOCKET_TIMEOUT, paramProperties, true, false, "s3testaccount");
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -205,6 +205,10 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
         connection = getConnection(accountName);
         Statement statement = connection.createStatement();
 
+        if ("s3testaccount".equalsIgnoreCase(accountName)) {
+          statement.execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = true;");
+        }
+
         // create a stage to put the file in
         statement.execute("CREATE OR REPLACE STAGE " + testStageName);
 
@@ -275,6 +279,11 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
       } finally {
         if (connection != null) {
           connection.createStatement().execute("DROP STAGE if exists " + testStageName);
+          if ("s3testaccount".equalsIgnoreCase(accountName)) {
+            connection
+                .createStatement()
+                .execute("alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = false;");
+          }
           connection.close();
         }
       }


### PR DESCRIPTION
# Overview
When the parameter ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 is set to true then driver invokes a different API to generate S3 regional url.
This does NOT break any existing customers. The above parameter will be set true to private link parameters in the AWS us-east-1 regions.
SNOW-299374


## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
