### PR TITLE
SNOW-259255 Add ability to set TIMESTAMP_NTZ and TIMESTAMP_LTZ types via PreparedStatement.setObject(int parameterIndex, Object x, int targetSqlType) function

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -34,6 +34,8 @@ public class SnowflakeUtil {
 
   public static final int EXTRA_TYPES_TIMESTAMP_TZ = 50001;
 
+  public static final int EXTRA_TYPES_TIMESTAMP_NTZ = 50002;
+
   // reauthenticate
   private static final int ID_TOKEN_EXPIRED_GS_CODE = 390110;
   private static final int SESSION_NOT_EXIST_GS_CODE = 390111;


### PR DESCRIPTION
# Overview

SNOW-259255

Customer was unhappy with setting session parameter CLIENT_TIMESTAMP_TYPE_MAPPING when they want to switch between setting TIMESTAMP_NTZ and TIMESTAMP_LTZ types, so requested the ability to set timestamps using setObject() function with the additional parameter for the specific snowflake timestamp types. Documentation for setObject here: https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html#setObject-int-java.lang.Object-int-. Have added a new TIMESTAMP_NTZ int value that customer can use, 50002.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
