### PR TITLE
SNOW-343977: Change parameter types to base types for SFArrowResultSet and SFResul…

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -49,7 +49,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
   private boolean sortResult;
 
   /** statement generate current result set */
-  protected SFStatement statement;
+  protected SFBaseStatement statement;
 
   /** is array bind supported */
   private final boolean arrayBindSupported;
@@ -99,15 +99,15 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
    * <p>The constructor will initialize the ResultSetMetaData.
    *
    * @param resultSetSerializable result data after parsing json
-   * @param session SFSession object
+   * @param session SFBaseSession object
    * @param statement statement object
    * @param sortResult true if sort results otherwise false
    * @throws SQLException exception raised from general SQL layers
    */
-  SFArrowResultSet(
+  public SFArrowResultSet(
       SnowflakeResultSetSerializableV1 resultSetSerializable,
-      SFSession session,
-      SFStatement statement,
+      SFBaseSession session,
+      SFBaseStatement statement,
       boolean sortResult)
       throws SQLException {
     this(resultSetSerializable, session.getTelemetryClient(), sortResult);

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -60,7 +60,7 @@ public class SFResultSet extends SFJsonResultSet {
 
   private ChunkDownloader chunkDownloader;
 
-  protected SFStatement statement;
+  protected SFBaseStatement statement;
 
   private final boolean arrayBindSupported;
 
@@ -84,13 +84,13 @@ public class SFResultSet extends SFJsonResultSet {
    */
   public SFResultSet(
       SnowflakeResultSetSerializableV1 resultSetSerializable,
-      SFStatement statement,
+      SFBaseStatement statement,
       boolean sortResult)
       throws SQLException {
     this(resultSetSerializable, statement.getSFBaseSession().getTelemetryClient(), sortResult);
 
     this.statement = statement;
-    SFSession session = (SFSession) statement.getSFBaseSession();
+    SFBaseSession session = statement.getSFBaseSession();
     session.setDatabase(resultSetSerializable.getFinalDatabaseName());
     session.setSchema(resultSetSerializable.getFinalSchemaName());
     session.setRole(resultSetSerializable.getFinalRoleName());

--- a/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetFactory.java
@@ -25,14 +25,13 @@ class SFResultSetFactory {
   static SFBaseResultSet getResultSet(JsonNode result, SFStatement statement, boolean sortResult)
       throws SQLException {
 
-    // This should only be invoked from an SFSession connection
-    SFSession session = (SFSession) statement.getSFBaseSession();
     SnowflakeResultSetSerializableV1 resultSetSerializable =
-        SnowflakeResultSetSerializableV1.create(result, session, statement);
+        SnowflakeResultSetSerializableV1.create(result, statement.getSFBaseSession(), statement);
 
     switch (resultSetSerializable.getQueryResultFormat()) {
       case ARROW:
-        return new SFArrowResultSet(resultSetSerializable, session, statement, sortResult);
+        return new SFArrowResultSet(
+            resultSetSerializable, statement.getSFBaseSession(), statement, sortResult);
       case JSON:
         return new SFResultSet(resultSetSerializable, statement, sortResult);
       default:


### PR DESCRIPTION
Another stored-proc related change. We wish to change the types for these constructor parameters so we can reuse the ResultSet classes.