### PR TITLE
SNOW-348866 Expose PUT metadata parsing for sessionless PUT

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -1351,9 +1351,11 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           new SnowflakeFileTransferMetadataV1(
               stageInfo.getPresignedUrl(),
               sourceFileName,
-              encryptionMaterial.get(0).getQueryStageMasterKey(),
-              encryptionMaterial.get(0).getQueryId(),
-              encryptionMaterial.get(0).getSmkId(),
+              encryptionMaterial.get(0) != null
+                  ? encryptionMaterial.get(0).getQueryStageMasterKey()
+                  : null,
+              encryptionMaterial.get(0) != null ? encryptionMaterial.get(0).getQueryId() : null,
+              encryptionMaterial.get(0) != null ? encryptionMaterial.get(0).getSmkId() : null,
               commandType,
               stageInfo));
     }
@@ -1984,6 +1986,11 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     FileBackedOutputStream fileBackedOutputStream = null;
 
     RemoteStoreFileEncryptionMaterial encMat = metadata.getEncryptionMaterial();
+    if (encMat.getQueryId() == null
+        && encMat.getQueryStageMasterKey() == null
+        && encMat.getSmkId() == null) {
+      encMat = null;
+    }
     // SNOW-16082: we should capture exception if we fail to compress or
     // calculate digest.
     try {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -1287,6 +1287,15 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     return result;
   }
 
+  /**
+   * This is API function to parse the File Transfer Metadatas from a supplied PUT call response.
+   *
+   * <p>NOTE: It only supports PUT on S3/AZURE/GCS
+   *
+   * @param jsonNode JSON doc returned by GS from PUT call
+   * @return The file transfer metadatas for to-be-transferred files.
+   * @throws SnowflakeSQLException if any error occurs
+   */
   public static List<SnowflakeFileTransferMetadata> getFileTransferMetadatas(JsonNode jsonNode)
       throws SnowflakeSQLException {
     CommandType commandType = CommandType.UPLOAD;
@@ -1295,10 +1304,10 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     }
 
     if (commandType != CommandType.UPLOAD) {
-      throw new SnowflakeSQLLoggedException(
-          null, // TODO: should be session,
-          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+      throw new SnowflakeSQLException(
+          new Exception(),
           SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
           "This API only supports PUT command");
     }
 
@@ -1333,7 +1342,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         && stageInfo.getStageType() != StageInfo.StageType.AZURE
         && stageInfo.getStageType() != StageInfo.StageType.S3) {
       throw new SnowflakeSQLException(
-          new Exception(), // session,
+          new Exception(),
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR.getMessageCode(),
           "This API only supports S3/AZURE/GCS");

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -146,8 +146,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
   }
 
   /**
-   * Get the encryption information for an UPLOAD or DOWNLOAD given
-   * a PUT command response JsonNode
+   * Get the encryption information for an UPLOAD or DOWNLOAD given a PUT command response JsonNode
    *
    * @param commandType CommandType of action (e.g UPLOAD or DOWNLOAD)
    * @param jsonNode JsonNod of PUT call response
@@ -1298,21 +1297,19 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    */
   public static List<SnowflakeFileTransferMetadata> getFileTransferMetadatas(JsonNode jsonNode)
       throws SnowflakeSQLException {
-    CommandType commandType = !jsonNode.path("data").path("command").isMissingNode() ?
-            CommandType.valueOf(jsonNode.path("data").path("command").asText()) :
-            CommandType.UPLOAD;
+    CommandType commandType =
+        !jsonNode.path("data").path("command").isMissingNode()
+            ? CommandType.valueOf(jsonNode.path("data").path("command").asText())
+            : CommandType.UPLOAD;
     if (commandType != CommandType.UPLOAD) {
       throw new SnowflakeSQLException(
-          ErrorCode.INTERNAL_ERROR,
-          "This API only supports PUT commands");
+          ErrorCode.INTERNAL_ERROR, "This API only supports PUT commands");
     }
 
     JsonNode locationsNode = jsonNode.path("data").path("src_locations");
 
     if (!locationsNode.isArray()) {
-      throw new SnowflakeSQLException(
-              ErrorCode.INTERNAL_ERROR,
-              "src_locations must be an array");
+      throw new SnowflakeSQLException(ErrorCode.INTERNAL_ERROR, "src_locations must be an array");
     }
 
     final String[] srcLocations;
@@ -1321,16 +1318,15 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
       srcLocations = mapper.readValue(locationsNode.toString(), String[].class);
     } catch (Exception ex) {
       throw new SnowflakeSQLException(
-          ErrorCode.INTERNAL_ERROR,
-          "Failed to parse the locations due to: " + ex.getMessage());
+          ErrorCode.INTERNAL_ERROR, "Failed to parse the locations due to: " + ex.getMessage());
     }
 
     try {
       encryptionMaterial = getEncryptionMaterial(commandType, jsonNode);
     } catch (Exception ex) {
       throw new SnowflakeSQLException(
-              ErrorCode.INTERNAL_ERROR,
-              "Failed to parse encryptionMaterial due to: " + ex.getMessage());
+          ErrorCode.INTERNAL_ERROR,
+          "Failed to parse encryptionMaterial due to: " + ex.getMessage());
     }
 
     // For UPLOAD we expect encryptionMaterial to have length 1
@@ -1346,7 +1342,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         && stageInfo.getStageType() != StageInfo.StageType.S3) {
       throw new SnowflakeSQLException(
           ErrorCode.INTERNAL_ERROR,
-          "This API only supports S3/AZURE/GCS, received="+stageInfo.getStageType());
+          "This API only supports S3/AZURE/GCS, received=" + stageInfo.getStageType());
     }
 
     for (String sourceFilePath : sourceFiles) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -990,23 +990,21 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
       logger.debug("Command type: {}", commandType);
 
       if (commandType == CommandType.UPLOAD) {
-        logger.debug("autoCompress: {}", autoCompress);
-        logger.debug("source compression: {}", sourceCompression);
+        logger.debug("autoCompress: {}, source compression: {}", autoCompress, sourceCompression);
       } else {
         logger.debug("local download location: {}", localLocation);
       }
 
-      logger.debug("Source files:");
-      for (String srcFile : sourceFiles) {
-        logger.debug("file: {}", srcFile);
-      }
-      logger.debug("stageLocation: {}", stageInfo.getLocation());
-      logger.debug("parallel: {}", parallel);
-      logger.debug("overwrite: {}", overwrite);
-      logger.debug("destLocationType: {}", stageInfo.getStageType());
-      logger.debug("stageRegion: {}", stageInfo.getRegion());
-      logger.debug("endPoint: {}", stageInfo.getEndPoint());
-      logger.debug("storageAccount: {}", stageInfo.getStorageAccount());
+      logger.debug("Source files: {}", String.join(",", sourceFiles));
+      logger.debug(
+          "stageLocation: {}, parallel: {}, overwrite: {}, destLocationType: {}, stageRegion: {}, endPoint: {}, storageAccount: {}",
+          stageInfo.getLocation(),
+          parallel,
+          overwrite,
+          stageInfo.getStageType(),
+          stageInfo.getRegion(),
+          stageInfo.getEndPoint(),
+          stageInfo.getStorageAccount());
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
@@ -81,105 +81,107 @@ public class FileUploaderSessionlessTest {
           + "  \"success\": true\n"
           + "}";
 
-  private final String exampleAzureJsonString = "{\n" +
-          "  \"data\": {\n" +
-          "    \"uploadInfo\": {\n" +
-          "      \"locationType\": \"AZURE\",\n" +
-          "      \"location\": \"EXAMPLE_LOCATION/\",\n" +
-          "      \"path\": \"EXAMPLE_PATH/\",\n" +
-          "      \"region\": \"westus\",\n" +
-          "      \"storageAccount\": \"sfcdevstage\",\n" +
-          "      \"isClientSideEncrypted\": true,\n" +
-          "      \"creds\": {\n" +
-          "        \"AZURE_SAS_TOKEN\": \"EXAMPLE_AZURE_SAS_TOKEN\"\n" +
-          "      },\n" +
-          "      \"presignedUrl\": null,\n" +
-          "      \"endPoint\": \"blob.core.windows.net\"\n" +
-          "    },\n" +
-          "    \"src_locations\": [\n" +
-          "      \"/foo/orders_100.csv\"\n" +
-          "    ],\n" +
-          "    \"parallel\": 4,\n" +
-          "    \"threshold\": 209715200,\n" +
-          "    \"autoCompress\": true,\n" +
-          "    \"overwrite\": false,\n" +
-          "    \"sourceCompression\": \"auto_detect\",\n" +
-          "    \"clientShowEncryptionParameter\": false,\n" +
-          "    \"queryId\": \"EXAMPLE_QUERY_ID\",\n" +
-          "    \"encryptionMaterial\": {\n" +
-          "      \"queryStageMasterKey\": \"EXAMPLE_QUERY_STAGE_MASTER_KEY\",\n" +
-          "      \"queryId\": \"EXAMPLE_QUERY_ID\",\n" +
-          "      \"smkId\": 123\n" +
-          "    },\n" +
-          "    \"stageInfo\": {\n" +
-          "      \"locationType\": \"AZURE\",\n" +
-          "      \"location\": \"EXAMPLE_LOCATION/\",\n" +
-          "      \"path\": \"EXAMPLE_PATH/\",\n" +
-          "      \"region\": \"westus\",\n" +
-          "      \"storageAccount\": \"EXAMPLE_STORAGE_ACCOUNT\",\n" +
-          "      \"isClientSideEncrypted\": true,\n" +
-          "      \"creds\": {\n" +
-          "        \"AZURE_SAS_TOKEN\": \"EXAMPLE_AZURE_SAS_TOKEN\"\n" +
-          "      },\n" +
-          "      \"presignedUrl\": null,\n" +
-          "      \"endPoint\": \"blob.core.windows.net\"\n" +
-          "    },\n" +
-          "    \"command\": \"UPLOAD\",\n" +
-          "    \"kind\": null,\n" +
-          "    \"operation\": \"Node\"\n" +
-          "  },\n" +
-          "  \"code\": null,\n" +
-          "  \"message\": null,\n" +
-          "  \"success\": true\n" +
-          "}";
+  private final String exampleAzureJsonString =
+      "{\n"
+          + "  \"data\": {\n"
+          + "    \"uploadInfo\": {\n"
+          + "      \"locationType\": \"AZURE\",\n"
+          + "      \"location\": \"EXAMPLE_LOCATION/\",\n"
+          + "      \"path\": \"EXAMPLE_PATH/\",\n"
+          + "      \"region\": \"westus\",\n"
+          + "      \"storageAccount\": \"sfcdevstage\",\n"
+          + "      \"isClientSideEncrypted\": true,\n"
+          + "      \"creds\": {\n"
+          + "        \"AZURE_SAS_TOKEN\": \"EXAMPLE_AZURE_SAS_TOKEN\"\n"
+          + "      },\n"
+          + "      \"presignedUrl\": null,\n"
+          + "      \"endPoint\": \"blob.core.windows.net\"\n"
+          + "    },\n"
+          + "    \"src_locations\": [\n"
+          + "      \"/foo/orders_100.csv\"\n"
+          + "    ],\n"
+          + "    \"parallel\": 4,\n"
+          + "    \"threshold\": 209715200,\n"
+          + "    \"autoCompress\": true,\n"
+          + "    \"overwrite\": false,\n"
+          + "    \"sourceCompression\": \"auto_detect\",\n"
+          + "    \"clientShowEncryptionParameter\": false,\n"
+          + "    \"queryId\": \"EXAMPLE_QUERY_ID\",\n"
+          + "    \"encryptionMaterial\": {\n"
+          + "      \"queryStageMasterKey\": \"EXAMPLE_QUERY_STAGE_MASTER_KEY\",\n"
+          + "      \"queryId\": \"EXAMPLE_QUERY_ID\",\n"
+          + "      \"smkId\": 123\n"
+          + "    },\n"
+          + "    \"stageInfo\": {\n"
+          + "      \"locationType\": \"AZURE\",\n"
+          + "      \"location\": \"EXAMPLE_LOCATION/\",\n"
+          + "      \"path\": \"EXAMPLE_PATH/\",\n"
+          + "      \"region\": \"westus\",\n"
+          + "      \"storageAccount\": \"EXAMPLE_STORAGE_ACCOUNT\",\n"
+          + "      \"isClientSideEncrypted\": true,\n"
+          + "      \"creds\": {\n"
+          + "        \"AZURE_SAS_TOKEN\": \"EXAMPLE_AZURE_SAS_TOKEN\"\n"
+          + "      },\n"
+          + "      \"presignedUrl\": null,\n"
+          + "      \"endPoint\": \"blob.core.windows.net\"\n"
+          + "    },\n"
+          + "    \"command\": \"UPLOAD\",\n"
+          + "    \"kind\": null,\n"
+          + "    \"operation\": \"Node\"\n"
+          + "  },\n"
+          + "  \"code\": null,\n"
+          + "  \"message\": null,\n"
+          + "  \"success\": true\n"
+          + "}";
 
-  private final String exampleGCSJsonString = "{\n" +
-          "  \"data\": {\n" +
-          "    \"uploadInfo\": {\n" +
-          "      \"locationType\": \"GCS\",\n" +
-          "      \"location\": \"foo/tables/9224/\",\n" +
-          "      \"path\": \"tables/9224/\",\n" +
-          "      \"region\": \"US-WEST1\",\n" +
-          "      \"storageAccount\": \"\",\n" +
-          "      \"isClientSideEncrypted\": true,\n" +
-          "      \"creds\": {},\n" +
-          "      \"presignedUrl\": \"EXAMPLE_PRESIGNED_URL\",\n" +
-          "      \"endPoint\": \"\"\n" +
-          "    },\n" +
-          "    \"src_locations\": [\n" +
-          "      \"/foo/bart/orders_100.csv\"\n" +
-          "    ],\n" +
-          "    \"parallel\": 4,\n" +
-          "    \"threshold\": 209715200,\n" +
-          "    \"autoCompress\": true,\n" +
-          "    \"overwrite\": false,\n" +
-          "    \"sourceCompression\": \"auto_detect\",\n" +
-          "    \"clientShowEncryptionParameter\": false,\n" +
-          "    \"queryId\": \"EXAMPLE_QUERY_ID\",\n" +
-          "    \"encryptionMaterial\": {\n" +
-          "      \"queryStageMasterKey\": \"EXAMPLE_QUERY_STAGE_MASTER_KEY\",\n" +
-          "      \"queryId\": \"EXAMPLE_QUERY_ID\",\n" +
-          "      \"smkId\": 123\n" +
-          "    },\n" +
-          "    \"stageInfo\": {\n" +
-          "      \"locationType\": \"GCS\",\n" +
-          "      \"location\": \"foo/tables/9224/\",\n" +
-          "      \"path\": \"tables/9224/\",\n" +
-          "      \"region\": \"US-WEST1\",\n" +
-          "      \"storageAccount\": \"\",\n" +
-          "      \"isClientSideEncrypted\": true,\n" +
-          "      \"creds\": {},\n" +
-          "      \"presignedUrl\": \"EXAMPLE_PRESIGNED_URL\",\n" +
-          "      \"endPoint\": \"\"\n" +
-          "    },\n" +
-          "    \"command\": \"UPLOAD\",\n" +
-          "    \"kind\": null,\n" +
-          "    \"operation\": \"Node\"\n" +
-          "  },\n" +
-          "  \"code\": null,\n" +
-          "  \"message\": null,\n" +
-          "  \"success\": true\n" +
-          "}";
+  private final String exampleGCSJsonString =
+      "{\n"
+          + "  \"data\": {\n"
+          + "    \"uploadInfo\": {\n"
+          + "      \"locationType\": \"GCS\",\n"
+          + "      \"location\": \"foo/tables/9224/\",\n"
+          + "      \"path\": \"tables/9224/\",\n"
+          + "      \"region\": \"US-WEST1\",\n"
+          + "      \"storageAccount\": \"\",\n"
+          + "      \"isClientSideEncrypted\": true,\n"
+          + "      \"creds\": {},\n"
+          + "      \"presignedUrl\": \"EXAMPLE_PRESIGNED_URL\",\n"
+          + "      \"endPoint\": \"\"\n"
+          + "    },\n"
+          + "    \"src_locations\": [\n"
+          + "      \"/foo/bart/orders_100.csv\"\n"
+          + "    ],\n"
+          + "    \"parallel\": 4,\n"
+          + "    \"threshold\": 209715200,\n"
+          + "    \"autoCompress\": true,\n"
+          + "    \"overwrite\": false,\n"
+          + "    \"sourceCompression\": \"auto_detect\",\n"
+          + "    \"clientShowEncryptionParameter\": false,\n"
+          + "    \"queryId\": \"EXAMPLE_QUERY_ID\",\n"
+          + "    \"encryptionMaterial\": {\n"
+          + "      \"queryStageMasterKey\": \"EXAMPLE_QUERY_STAGE_MASTER_KEY\",\n"
+          + "      \"queryId\": \"EXAMPLE_QUERY_ID\",\n"
+          + "      \"smkId\": 123\n"
+          + "    },\n"
+          + "    \"stageInfo\": {\n"
+          + "      \"locationType\": \"GCS\",\n"
+          + "      \"location\": \"foo/tables/9224/\",\n"
+          + "      \"path\": \"tables/9224/\",\n"
+          + "      \"region\": \"US-WEST1\",\n"
+          + "      \"storageAccount\": \"\",\n"
+          + "      \"isClientSideEncrypted\": true,\n"
+          + "      \"creds\": {},\n"
+          + "      \"presignedUrl\": \"EXAMPLE_PRESIGNED_URL\",\n"
+          + "      \"endPoint\": \"\"\n"
+          + "    },\n"
+          + "    \"command\": \"UPLOAD\",\n"
+          + "    \"kind\": null,\n"
+          + "    \"operation\": \"Node\"\n"
+          + "  },\n"
+          + "  \"code\": null,\n"
+          + "  \"message\": null,\n"
+          + "  \"success\": true\n"
+          + "}";
 
   private JsonNode exampleS3JsonNode;
   private JsonNode exampleAzureJsonNode;
@@ -202,15 +204,15 @@ public class FileUploaderSessionlessTest {
             "EXAMPLE_QUERY_STAGE_MASTER_KEY", "EXAMPLE_QUERY_ID", 123L);
     expected.add(content);
 
-    for (JsonNode exampleNode: exampleNodes) {
+    for (JsonNode exampleNode : exampleNodes) {
       List<RemoteStoreFileEncryptionMaterial> encryptionMaterials =
-              SnowflakeFileTransferAgent.getEncryptionMaterial(
-                      SFBaseFileTransferAgent.CommandType.UPLOAD, exampleNode);
+          SnowflakeFileTransferAgent.getEncryptionMaterial(
+              SFBaseFileTransferAgent.CommandType.UPLOAD, exampleNode);
 
       Assert.assertEquals(1, encryptionMaterials.size());
       Assert.assertEquals(
-              expected.get(0).getQueryStageMasterKey(),
-              encryptionMaterials.get(0).getQueryStageMasterKey());
+          expected.get(0).getQueryStageMasterKey(),
+          encryptionMaterials.get(0).getQueryStageMasterKey());
       Assert.assertEquals(expected.get(0).getQueryId(), encryptionMaterials.get(0).getQueryId());
       Assert.assertEquals(expected.get(0).getSmkId(), encryptionMaterials.get(0).getSmkId());
     }
@@ -307,11 +309,11 @@ public class FileUploaderSessionlessTest {
   @Test
   public void testGetFileTransferMetadatasAzure() throws Exception {
     List<SnowflakeFileTransferMetadata> metadataList =
-            SnowflakeFileTransferAgent.getFileTransferMetadatas(exampleAzureJsonNode);
+        SnowflakeFileTransferAgent.getFileTransferMetadatas(exampleAzureJsonNode);
     Assert.assertEquals(1, metadataList.size());
 
     SnowflakeFileTransferMetadataV1 metadata =
-            (SnowflakeFileTransferMetadataV1) metadataList.get(0);
+        (SnowflakeFileTransferMetadataV1) metadataList.get(0);
 
     // StageInfo check
     StageInfo stageInfo = metadata.getStageInfo();
@@ -330,8 +332,8 @@ public class FileUploaderSessionlessTest {
     // EncryptionMaterial check
     Assert.assertEquals("EXAMPLE_QUERY_ID", metadata.getEncryptionMaterial().getQueryId());
     Assert.assertEquals(
-            "EXAMPLE_QUERY_STAGE_MASTER_KEY",
-            metadata.getEncryptionMaterial().getQueryStageMasterKey());
+        "EXAMPLE_QUERY_STAGE_MASTER_KEY",
+        metadata.getEncryptionMaterial().getQueryStageMasterKey());
     Assert.assertEquals(123L, (long) metadata.getEncryptionMaterial().getSmkId());
 
     // Misc check
@@ -343,11 +345,11 @@ public class FileUploaderSessionlessTest {
   @Test
   public void testGetFileTransferMetadatasGCS() throws Exception {
     List<SnowflakeFileTransferMetadata> metadataList =
-            SnowflakeFileTransferAgent.getFileTransferMetadatas(exampleGCSJsonNode);
+        SnowflakeFileTransferAgent.getFileTransferMetadatas(exampleGCSJsonNode);
     Assert.assertEquals(1, metadataList.size());
 
     SnowflakeFileTransferMetadataV1 metadata =
-            (SnowflakeFileTransferMetadataV1) metadataList.get(0);
+        (SnowflakeFileTransferMetadataV1) metadataList.get(0);
 
     // StageInfo check
     StageInfo stageInfo = metadata.getStageInfo();
@@ -365,8 +367,8 @@ public class FileUploaderSessionlessTest {
     // EncryptionMaterial check
     Assert.assertEquals("EXAMPLE_QUERY_ID", metadata.getEncryptionMaterial().getQueryId());
     Assert.assertEquals(
-            "EXAMPLE_QUERY_STAGE_MASTER_KEY",
-            metadata.getEncryptionMaterial().getQueryStageMasterKey());
+        "EXAMPLE_QUERY_STAGE_MASTER_KEY",
+        metadata.getEncryptionMaterial().getQueryStageMasterKey());
     Assert.assertEquals(123L, (long) metadata.getEncryptionMaterial().getSmkId());
 
     // Misc check

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
@@ -20,7 +20,7 @@ public class FileUploaderSessionlessTest {
   @Rule public TemporaryFolder folder = new TemporaryFolder();
   private ObjectMapper mapper = new ObjectMapper();
 
-  private final String exampleJsonString =
+  private final String exampleS3JsonString =
       "{\n"
           + "  \"data\": {\n"
           + "    \"uploadInfo\": {\n"
@@ -81,35 +81,144 @@ public class FileUploaderSessionlessTest {
           + "  \"success\": true\n"
           + "}";
 
-  private JsonNode exampleJsonNode;
+  private final String exampleAzureJsonString = "{\n" +
+          "  \"data\": {\n" +
+          "    \"uploadInfo\": {\n" +
+          "      \"locationType\": \"AZURE\",\n" +
+          "      \"location\": \"EXAMPLE_LOCATION/\",\n" +
+          "      \"path\": \"EXAMPLE_PATH/\",\n" +
+          "      \"region\": \"westus\",\n" +
+          "      \"storageAccount\": \"sfcdevstage\",\n" +
+          "      \"isClientSideEncrypted\": true,\n" +
+          "      \"creds\": {\n" +
+          "        \"AZURE_SAS_TOKEN\": \"EXAMPLE_AZURE_SAS_TOKEN\"\n" +
+          "      },\n" +
+          "      \"presignedUrl\": null,\n" +
+          "      \"endPoint\": \"blob.core.windows.net\"\n" +
+          "    },\n" +
+          "    \"src_locations\": [\n" +
+          "      \"/foo/orders_100.csv\"\n" +
+          "    ],\n" +
+          "    \"parallel\": 4,\n" +
+          "    \"threshold\": 209715200,\n" +
+          "    \"autoCompress\": true,\n" +
+          "    \"overwrite\": false,\n" +
+          "    \"sourceCompression\": \"auto_detect\",\n" +
+          "    \"clientShowEncryptionParameter\": false,\n" +
+          "    \"queryId\": \"EXAMPLE_QUERY_ID\",\n" +
+          "    \"encryptionMaterial\": {\n" +
+          "      \"queryStageMasterKey\": \"EXAMPLE_QUERY_STAGE_MASTER_KEY\",\n" +
+          "      \"queryId\": \"EXAMPLE_QUERY_ID\",\n" +
+          "      \"smkId\": 123\n" +
+          "    },\n" +
+          "    \"stageInfo\": {\n" +
+          "      \"locationType\": \"AZURE\",\n" +
+          "      \"location\": \"EXAMPLE_LOCATION/\",\n" +
+          "      \"path\": \"EXAMPLE_PATH/\",\n" +
+          "      \"region\": \"westus\",\n" +
+          "      \"storageAccount\": \"EXAMPLE_STORAGE_ACCOUNT\",\n" +
+          "      \"isClientSideEncrypted\": true,\n" +
+          "      \"creds\": {\n" +
+          "        \"AZURE_SAS_TOKEN\": \"EXAMPLE_AZURE_SAS_TOKEN\"\n" +
+          "      },\n" +
+          "      \"presignedUrl\": null,\n" +
+          "      \"endPoint\": \"blob.core.windows.net\"\n" +
+          "    },\n" +
+          "    \"command\": \"UPLOAD\",\n" +
+          "    \"kind\": null,\n" +
+          "    \"operation\": \"Node\"\n" +
+          "  },\n" +
+          "  \"code\": null,\n" +
+          "  \"message\": null,\n" +
+          "  \"success\": true\n" +
+          "}";
+
+  private final String exampleGCSJsonString = "{\n" +
+          "  \"data\": {\n" +
+          "    \"uploadInfo\": {\n" +
+          "      \"locationType\": \"GCS\",\n" +
+          "      \"location\": \"foo/tables/9224/\",\n" +
+          "      \"path\": \"tables/9224/\",\n" +
+          "      \"region\": \"US-WEST1\",\n" +
+          "      \"storageAccount\": \"\",\n" +
+          "      \"isClientSideEncrypted\": true,\n" +
+          "      \"creds\": {},\n" +
+          "      \"presignedUrl\": \"EXAMPLE_PRESIGNED_URL\",\n" +
+          "      \"endPoint\": \"\"\n" +
+          "    },\n" +
+          "    \"src_locations\": [\n" +
+          "      \"/foo/bart/orders_100.csv\"\n" +
+          "    ],\n" +
+          "    \"parallel\": 4,\n" +
+          "    \"threshold\": 209715200,\n" +
+          "    \"autoCompress\": true,\n" +
+          "    \"overwrite\": false,\n" +
+          "    \"sourceCompression\": \"auto_detect\",\n" +
+          "    \"clientShowEncryptionParameter\": false,\n" +
+          "    \"queryId\": \"EXAMPLE_QUERY_ID\",\n" +
+          "    \"encryptionMaterial\": {\n" +
+          "      \"queryStageMasterKey\": \"EXAMPLE_QUERY_STAGE_MASTER_KEY\",\n" +
+          "      \"queryId\": \"EXAMPLE_QUERY_ID\",\n" +
+          "      \"smkId\": 123\n" +
+          "    },\n" +
+          "    \"stageInfo\": {\n" +
+          "      \"locationType\": \"GCS\",\n" +
+          "      \"location\": \"foo/tables/9224/\",\n" +
+          "      \"path\": \"tables/9224/\",\n" +
+          "      \"region\": \"US-WEST1\",\n" +
+          "      \"storageAccount\": \"\",\n" +
+          "      \"isClientSideEncrypted\": true,\n" +
+          "      \"creds\": {},\n" +
+          "      \"presignedUrl\": \"EXAMPLE_PRESIGNED_URL\",\n" +
+          "      \"endPoint\": \"\"\n" +
+          "    },\n" +
+          "    \"command\": \"UPLOAD\",\n" +
+          "    \"kind\": null,\n" +
+          "    \"operation\": \"Node\"\n" +
+          "  },\n" +
+          "  \"code\": null,\n" +
+          "  \"message\": null,\n" +
+          "  \"success\": true\n" +
+          "}";
+
+  private JsonNode exampleS3JsonNode;
+  private JsonNode exampleAzureJsonNode;
+  private JsonNode exampleGCSJsonNode;
+  private List<JsonNode> exampleNodes;
 
   @Before
   public void setup() throws Exception {
-    exampleJsonNode = mapper.readTree(exampleJsonString);
+    exampleS3JsonNode = mapper.readTree(exampleS3JsonString);
+    exampleAzureJsonNode = mapper.readTree(exampleAzureJsonString);
+    exampleGCSJsonNode = mapper.readTree(exampleGCSJsonString);
+    exampleNodes = Arrays.asList(exampleS3JsonNode, exampleAzureJsonNode, exampleGCSJsonNode);
   }
 
   @Test
   public void testGetEncryptionMaterial() throws Exception {
-    List<RemoteStoreFileEncryptionMaterial> encryptionMaterials =
-        SnowflakeFileTransferAgent.getEncryptionMaterial(
-            SFBaseFileTransferAgent.CommandType.UPLOAD, exampleJsonNode);
-
     List<RemoteStoreFileEncryptionMaterial> expected = new ArrayList<>();
     RemoteStoreFileEncryptionMaterial content =
         new RemoteStoreFileEncryptionMaterial(
             "EXAMPLE_QUERY_STAGE_MASTER_KEY", "EXAMPLE_QUERY_ID", 123L);
     expected.add(content);
-    Assert.assertEquals(1, encryptionMaterials.size());
-    Assert.assertEquals(
-        expected.get(0).getQueryStageMasterKey(),
-        encryptionMaterials.get(0).getQueryStageMasterKey());
-    Assert.assertEquals(expected.get(0).getQueryId(), encryptionMaterials.get(0).getQueryId());
-    Assert.assertEquals(expected.get(0).getSmkId(), encryptionMaterials.get(0).getSmkId());
+
+    for (JsonNode exampleNode: exampleNodes) {
+      List<RemoteStoreFileEncryptionMaterial> encryptionMaterials =
+              SnowflakeFileTransferAgent.getEncryptionMaterial(
+                      SFBaseFileTransferAgent.CommandType.UPLOAD, exampleNode);
+
+      Assert.assertEquals(1, encryptionMaterials.size());
+      Assert.assertEquals(
+              expected.get(0).getQueryStageMasterKey(),
+              encryptionMaterials.get(0).getQueryStageMasterKey());
+      Assert.assertEquals(expected.get(0).getQueryId(), encryptionMaterials.get(0).getQueryId());
+      Assert.assertEquals(expected.get(0).getSmkId(), encryptionMaterials.get(0).getSmkId());
+    }
   }
 
   @Test
-  public void testGetStageData() throws Exception {
-    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleJsonNode);
+  public void testGetS3StageData() throws Exception {
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleS3JsonNode);
     Map<String, String> expectedCreds = new HashMap<>();
     expectedCreds.put("AWS_ID", "EXAMPLE_AWS_ID");
     expectedCreds.put("AWS_KEY", "EXAMPLE_AWS_KEY");
@@ -127,9 +236,38 @@ public class FileUploaderSessionlessTest {
   }
 
   @Test
-  public void testGetFileTransferMetadatas() throws Exception {
+  public void testGetAzureStageData() throws Exception {
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleAzureJsonNode);
+    Map<String, String> expectedCreds = new HashMap<>();
+    expectedCreds.put("AZURE_SAS_TOKEN", "EXAMPLE_AZURE_SAS_TOKEN");
+
+    Assert.assertEquals(StageInfo.StageType.AZURE, stageInfo.getStageType());
+    Assert.assertEquals("EXAMPLE_LOCATION/", stageInfo.getLocation());
+    Assert.assertEquals(expectedCreds, stageInfo.getCredentials());
+    Assert.assertEquals("westus", stageInfo.getRegion());
+    Assert.assertEquals("blob.core.windows.net", stageInfo.getEndPoint());
+    Assert.assertEquals("EXAMPLE_STORAGE_ACCOUNT", stageInfo.getStorageAccount());
+    Assert.assertEquals(true, stageInfo.getIsClientSideEncrypted());
+  }
+
+  @Test
+  public void testGetGCSStageData() throws Exception {
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleGCSJsonNode);
+    Map<String, String> expectedCreds = new HashMap<>();
+
+    Assert.assertEquals(StageInfo.StageType.GCS, stageInfo.getStageType());
+    Assert.assertEquals("foo/tables/9224/", stageInfo.getLocation());
+    Assert.assertEquals(expectedCreds, stageInfo.getCredentials());
+    Assert.assertEquals("US-WEST1", stageInfo.getRegion());
+    Assert.assertEquals(null, stageInfo.getEndPoint());
+    Assert.assertEquals(null, stageInfo.getStorageAccount());
+    Assert.assertEquals(true, stageInfo.getIsClientSideEncrypted());
+  }
+
+  @Test
+  public void testGetFileTransferMetadatasS3() throws Exception {
     List<SnowflakeFileTransferMetadata> metadataList =
-        SnowflakeFileTransferAgent.getFileTransferMetadatas(exampleJsonNode);
+        SnowflakeFileTransferAgent.getFileTransferMetadatas(exampleS3JsonNode);
     Assert.assertEquals(1, metadataList.size());
 
     SnowflakeFileTransferMetadataV1 metadata =
@@ -167,6 +305,77 @@ public class FileUploaderSessionlessTest {
   }
 
   @Test
+  public void testGetFileTransferMetadatasAzure() throws Exception {
+    List<SnowflakeFileTransferMetadata> metadataList =
+            SnowflakeFileTransferAgent.getFileTransferMetadatas(exampleAzureJsonNode);
+    Assert.assertEquals(1, metadataList.size());
+
+    SnowflakeFileTransferMetadataV1 metadata =
+            (SnowflakeFileTransferMetadataV1) metadataList.get(0);
+
+    // StageInfo check
+    StageInfo stageInfo = metadata.getStageInfo();
+
+    Map<String, String> expectedCreds = new HashMap<>();
+    expectedCreds.put("AZURE_SAS_TOKEN", "EXAMPLE_AZURE_SAS_TOKEN");
+
+    Assert.assertEquals(StageInfo.StageType.AZURE, stageInfo.getStageType());
+    Assert.assertEquals("EXAMPLE_LOCATION/", stageInfo.getLocation());
+    Assert.assertEquals(expectedCreds, stageInfo.getCredentials());
+    Assert.assertEquals("westus", stageInfo.getRegion());
+    Assert.assertEquals("blob.core.windows.net", stageInfo.getEndPoint());
+    Assert.assertEquals("EXAMPLE_STORAGE_ACCOUNT", stageInfo.getStorageAccount());
+    Assert.assertEquals(true, stageInfo.getIsClientSideEncrypted());
+
+    // EncryptionMaterial check
+    Assert.assertEquals("EXAMPLE_QUERY_ID", metadata.getEncryptionMaterial().getQueryId());
+    Assert.assertEquals(
+            "EXAMPLE_QUERY_STAGE_MASTER_KEY",
+            metadata.getEncryptionMaterial().getQueryStageMasterKey());
+    Assert.assertEquals(123L, (long) metadata.getEncryptionMaterial().getSmkId());
+
+    // Misc check
+    Assert.assertEquals(SFBaseFileTransferAgent.CommandType.UPLOAD, metadata.getCommandType());
+    Assert.assertNull(metadata.getPresignedUrl());
+    Assert.assertEquals("orders_100.csv", metadata.getPresignedUrlFileName());
+  }
+
+  @Test
+  public void testGetFileTransferMetadatasGCS() throws Exception {
+    List<SnowflakeFileTransferMetadata> metadataList =
+            SnowflakeFileTransferAgent.getFileTransferMetadatas(exampleGCSJsonNode);
+    Assert.assertEquals(1, metadataList.size());
+
+    SnowflakeFileTransferMetadataV1 metadata =
+            (SnowflakeFileTransferMetadataV1) metadataList.get(0);
+
+    // StageInfo check
+    StageInfo stageInfo = metadata.getStageInfo();
+
+    Map<String, String> expectedCreds = new HashMap<>();
+
+    Assert.assertEquals(StageInfo.StageType.GCS, stageInfo.getStageType());
+    Assert.assertEquals("foo/tables/9224/", stageInfo.getLocation());
+    Assert.assertEquals(expectedCreds, stageInfo.getCredentials());
+    Assert.assertEquals("US-WEST1", stageInfo.getRegion());
+    Assert.assertEquals(null, stageInfo.getEndPoint());
+    Assert.assertEquals(null, stageInfo.getStorageAccount());
+    Assert.assertEquals(true, stageInfo.getIsClientSideEncrypted());
+
+    // EncryptionMaterial check
+    Assert.assertEquals("EXAMPLE_QUERY_ID", metadata.getEncryptionMaterial().getQueryId());
+    Assert.assertEquals(
+            "EXAMPLE_QUERY_STAGE_MASTER_KEY",
+            metadata.getEncryptionMaterial().getQueryStageMasterKey());
+    Assert.assertEquals(123L, (long) metadata.getEncryptionMaterial().getSmkId());
+
+    // Misc check
+    Assert.assertEquals(SFBaseFileTransferAgent.CommandType.UPLOAD, metadata.getCommandType());
+    Assert.assertEquals("EXAMPLE_PRESIGNED_URL", metadata.getPresignedUrl());
+    Assert.assertEquals("orders_100.csv", metadata.getPresignedUrlFileName());
+  }
+
+  @Test
   public void testGetFileTransferMetadatasUploadError() throws Exception {
     JsonNode downloadNode = mapper.readTree("{\"data\": {\"command\": \"DOWNLOAD\"}}");
     try {
@@ -175,7 +384,7 @@ public class FileUploaderSessionlessTest {
     } catch (SnowflakeSQLException err) {
       Assert.assertEquals((long) ErrorCode.INTERNAL_ERROR.getMessageCode(), err.getErrorCode());
       Assert.assertEquals(
-          "JDBC driver internal error: This API only supports PUT command.", err.getMessage());
+          "JDBC driver internal error: This API only supports PUT commands.", err.getMessage());
     }
   }
 
@@ -194,7 +403,7 @@ public class FileUploaderSessionlessTest {
 
   @Test
   public void testGetFileTransferMetadatasUnsupportedLocationError() throws Exception {
-    JsonNode modifiedNode = exampleJsonNode.deepCopy();
+    JsonNode modifiedNode = exampleS3JsonNode.deepCopy();
     ObjectNode foo = (ObjectNode) modifiedNode.path("data").path("stageInfo");
     foo.put("locationType", "LOCAL_FS");
     try {

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
@@ -197,6 +197,26 @@ public class FileUploaderSessionlessTest {
   }
 
   @Test
+  public void testGetEncryptionMaterialMissing() throws Exception {
+    JsonNode modifiedNode = exampleS3JsonNode.deepCopy();
+    ObjectNode foo = (ObjectNode) modifiedNode.path("data");
+    foo.remove("encryptionMaterial");
+
+    List<RemoteStoreFileEncryptionMaterial> expected = new ArrayList<>();
+    RemoteStoreFileEncryptionMaterial content =
+        new RemoteStoreFileEncryptionMaterial(
+            "EXAMPLE_QUERY_STAGE_MASTER_KEY", "EXAMPLE_QUERY_ID", 123L);
+    expected.add(content);
+
+    List<RemoteStoreFileEncryptionMaterial> encryptionMaterials =
+        SnowflakeFileTransferAgent.getEncryptionMaterial(
+            SFBaseFileTransferAgent.CommandType.UPLOAD, modifiedNode);
+
+    Assert.assertEquals(1, encryptionMaterials.size());
+    Assert.assertNull(encryptionMaterials.get(0));
+  }
+
+  @Test
   public void testGetEncryptionMaterial() throws Exception {
     List<RemoteStoreFileEncryptionMaterial> expected = new ArrayList<>();
     RemoteStoreFileEncryptionMaterial content =
@@ -299,6 +319,48 @@ public class FileUploaderSessionlessTest {
         "EXAMPLE_QUERY_STAGE_MASTER_KEY",
         metadata.getEncryptionMaterial().getQueryStageMasterKey());
     Assert.assertEquals(123L, (long) metadata.getEncryptionMaterial().getSmkId());
+
+    // Misc check
+    Assert.assertEquals(SFBaseFileTransferAgent.CommandType.UPLOAD, metadata.getCommandType());
+    Assert.assertNull(metadata.getPresignedUrl());
+    Assert.assertEquals("orders_100.csv", metadata.getPresignedUrlFileName());
+  }
+
+  @Test
+  public void testGetFileTransferMetadatasS3MissingEncryption() throws Exception {
+    JsonNode modifiedNode = exampleS3JsonNode.deepCopy();
+    ObjectNode foo = (ObjectNode) modifiedNode.path("data");
+    foo.remove("encryptionMaterial");
+
+    List<SnowflakeFileTransferMetadata> metadataList =
+        SnowflakeFileTransferAgent.getFileTransferMetadatas(modifiedNode);
+    Assert.assertEquals(1, metadataList.size());
+
+    SnowflakeFileTransferMetadataV1 metadata =
+        (SnowflakeFileTransferMetadataV1) metadataList.get(0);
+
+    // StageInfo check
+    StageInfo stageInfo = metadata.getStageInfo();
+
+    Map<String, String> expectedCreds = new HashMap<>();
+    expectedCreds.put("AWS_ID", "EXAMPLE_AWS_ID");
+    expectedCreds.put("AWS_KEY", "EXAMPLE_AWS_KEY");
+    expectedCreds.put("AWS_KEY_ID", "EXAMPLE_AWS_KEY_ID");
+    expectedCreds.put("AWS_SECRET_KEY", "EXAMPLE_AWS_SECRET_KEY");
+    expectedCreds.put("AWS_TOKEN", "EXAMPLE_AWS_TOKEN");
+
+    Assert.assertEquals(StageInfo.StageType.S3, stageInfo.getStageType());
+    Assert.assertEquals("stage/location/foo/", stageInfo.getLocation());
+    Assert.assertEquals(expectedCreds, stageInfo.getCredentials());
+    Assert.assertEquals("us-west-2", stageInfo.getRegion());
+    Assert.assertEquals(null, stageInfo.getEndPoint());
+    Assert.assertEquals(null, stageInfo.getStorageAccount());
+    Assert.assertEquals(true, stageInfo.getIsClientSideEncrypted());
+
+    // EncryptionMaterial check
+    Assert.assertNull(metadata.getEncryptionMaterial().getQueryId());
+    Assert.assertNull(metadata.getEncryptionMaterial().getQueryStageMasterKey());
+    Assert.assertNull(metadata.getEncryptionMaterial().getSmkId());
 
     // Misc check
     Assert.assertEquals(SFBaseFileTransferAgent.CommandType.UPLOAD, metadata.getCommandType());

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
@@ -202,12 +202,6 @@ public class FileUploaderSessionlessTest {
     ObjectNode foo = (ObjectNode) modifiedNode.path("data");
     foo.remove("encryptionMaterial");
 
-    List<RemoteStoreFileEncryptionMaterial> expected = new ArrayList<>();
-    RemoteStoreFileEncryptionMaterial content =
-        new RemoteStoreFileEncryptionMaterial(
-            "EXAMPLE_QUERY_STAGE_MASTER_KEY", "EXAMPLE_QUERY_ID", 123L);
-    expected.add(content);
-
     List<RemoteStoreFileEncryptionMaterial> encryptionMaterials =
         SnowflakeFileTransferAgent.getEncryptionMaterial(
             SFBaseFileTransferAgent.CommandType.UPLOAD, modifiedNode);

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+package net.snowflake.client.jdbc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.*;
+import net.snowflake.client.jdbc.cloud.storage.StageInfo;
+import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests for SnowflakeFileTransferAgent.expandFileNames */
+public class FileUploaderSessionlessTest {
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+  private ObjectMapper mapper = new ObjectMapper();
+
+  private final String exampleJsonString =
+      "{\n"
+          + "  \"data\": {\n"
+          + "    \"uploadInfo\": {\n"
+          + "      \"locationType\": \"S3\",\n"
+          + "      \"location\": \"example/location\",\n"
+          + "      \"path\": \"tables/19805757505/\",\n"
+          + "      \"region\": \"us-west-2\",\n"
+          + "      \"storageAccount\": null,\n"
+          + "      \"isClientSideEncrypted\": true,\n"
+          + "      \"creds\": {\n"
+          + "        \"AWS_KEY_ID\": \"EXAMPLE_AWS_KEY_ID\",\n"
+          + "        \"AWS_SECRET_KEY\": \"EXAMPLE_AWS_SECRET_KEY\",\n"
+          + "        \"AWS_TOKEN\": \"EXAMPLE_AWS_TOKEN\",\n"
+          + "        \"AWS_ID\": \"EXAMPLE_AWS_ID\",\n"
+          + "        \"AWS_KEY\": \"EXAMPLE_AWS_KEY\"\n"
+          + "      },\n"
+          + "      \"presignedUrl\": null,\n"
+          + "      \"endPoint\": null\n"
+          + "    },\n"
+          + "    \"src_locations\": [\n"
+          + "      \"/tmp/files/orders_100.csv\"\n"
+          + "    ],\n"
+          + "    \"parallel\": 4,\n"
+          + "    \"threshold\": 209715200,\n"
+          + "    \"autoCompress\": true,\n"
+          + "    \"overwrite\": false,\n"
+          + "    \"sourceCompression\": \"auto_detect\",\n"
+          + "    \"clientShowEncryptionParameter\": true,\n"
+          + "    \"queryId\": \"EXAMPLE_QUERY_ID\",\n"
+          + "    \"encryptionMaterial\": {\n"
+          + "      \"queryStageMasterKey\": \"EXAMPLE_QUERY_STAGE_MASTER_KEY\",\n"
+          + "      \"queryId\": \"EXAMPLE_QUERY_ID\",\n"
+          + "      \"smkId\": 123\n"
+          + "    },\n"
+          + "    \"stageInfo\": {\n"
+          + "      \"locationType\": \"S3\",\n"
+          + "      \"location\": \"stage/location/foo/\",\n"
+          + "      \"path\": \"tables/19805757505/\",\n"
+          + "      \"region\": \"us-west-2\",\n"
+          + "      \"storageAccount\": null,\n"
+          + "      \"isClientSideEncrypted\": true,\n"
+          + "      \"creds\": {\n"
+          + "        \"AWS_KEY_ID\": \"EXAMPLE_AWS_KEY_ID\",\n"
+          + "        \"AWS_SECRET_KEY\": \"EXAMPLE_AWS_SECRET_KEY\",\n"
+          + "        \"AWS_TOKEN\": \"EXAMPLE_AWS_TOKEN\",\n"
+          + "        \"AWS_ID\": \"EXAMPLE_AWS_ID\",\n"
+          + "        \"AWS_KEY\": \"EXAMPLE_AWS_KEY\"\n"
+          + "      },\n"
+          + "      \"presignedUrl\": null,\n"
+          + "      \"endPoint\": null\n"
+          + "    },\n"
+          + "    \"command\": \"UPLOAD\",\n"
+          + "    \"kind\": null,\n"
+          + "    \"operation\": \"Node\"\n"
+          + "  },\n"
+          + "  \"code\": null,\n"
+          + "  \"message\": null,\n"
+          + "  \"success\": true\n"
+          + "}";
+
+  private JsonNode exampleJsonNode;
+
+  @Before
+  public void setup() throws Exception {
+    exampleJsonNode = mapper.readTree(exampleJsonString);
+  }
+
+  @Test
+  public void testGetEncryptionMaterial() throws Exception {
+    List<RemoteStoreFileEncryptionMaterial> encryptionMaterials =
+        SnowflakeFileTransferAgent.getEncryptionMaterial(
+            SFBaseFileTransferAgent.CommandType.UPLOAD, exampleJsonNode);
+
+    List<RemoteStoreFileEncryptionMaterial> expected = new ArrayList<>();
+    RemoteStoreFileEncryptionMaterial content =
+        new RemoteStoreFileEncryptionMaterial(
+            "EXAMPLE_QUERY_STAGE_MASTER_KEY", "EXAMPLE_QUERY_ID", 123L);
+    expected.add(content);
+    Assert.assertEquals(1, encryptionMaterials.size());
+    Assert.assertEquals(
+        expected.get(0).getQueryStageMasterKey(),
+        encryptionMaterials.get(0).getQueryStageMasterKey());
+    Assert.assertEquals(expected.get(0).getQueryId(), encryptionMaterials.get(0).getQueryId());
+    Assert.assertEquals(expected.get(0).getSmkId(), encryptionMaterials.get(0).getSmkId());
+  }
+
+  @Test
+  public void testGetStageData() throws Exception {
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleJsonNode);
+    Map<String, String> expectedCreds = new HashMap<>();
+    expectedCreds.put("AWS_ID", "EXAMPLE_AWS_ID");
+    expectedCreds.put("AWS_KEY", "EXAMPLE_AWS_KEY");
+    expectedCreds.put("AWS_KEY_ID", "EXAMPLE_AWS_KEY_ID");
+    expectedCreds.put("AWS_SECRET_KEY", "EXAMPLE_AWS_SECRET_KEY");
+    expectedCreds.put("AWS_TOKEN", "EXAMPLE_AWS_TOKEN");
+
+    Assert.assertEquals(StageInfo.StageType.S3, stageInfo.getStageType());
+    Assert.assertEquals("stage/location/foo/", stageInfo.getLocation());
+    Assert.assertEquals(expectedCreds, stageInfo.getCredentials());
+    Assert.assertEquals("us-west-2", stageInfo.getRegion());
+    Assert.assertEquals(null, stageInfo.getEndPoint());
+    Assert.assertEquals(null, stageInfo.getStorageAccount());
+    Assert.assertEquals(true, stageInfo.getIsClientSideEncrypted());
+  }
+}


### PR DESCRIPTION
# Overview

SNOW-348866

Allows clients to pass in data from a PUT command for file upload without creating a Snowflake session.


## Pre-review checklist
- [x] This change has passed precommit
- [x] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
