### PR TITLE
SNOW-330467 Fix typo in setOtherParameter's logic

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1396,10 +1396,10 @@ public class SessionUtil {
         if (session != null) {
           session.setUseRegionalS3EndpointsForPresignedURL(
               SFLoginInput.getBooleanValue(entry.getValue()));
-        } else {
-          if (session != null) {
-            session.setOtherParameter(entry.getKey(), entry.getValue());
-          }
+        }
+      } else {
+        if (session != null) {
+          session.setOtherParameter(entry.getKey(), entry.getValue());
         }
       }
     }

--- a/src/test/java/net/snowflake/client/core/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilTest.java
@@ -6,7 +6,12 @@ package net.snowflake.client.core;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import net.snowflake.client.jdbc.MockConnectionTest;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class SessionUtilTest {
 
@@ -45,5 +50,14 @@ public class SessionUtilTest {
         !SessionUtil.isPrefixEqual(
             "http://testaccount.snowflakecomputing.com/blah",
             "https://testaccount.snowflakecomputing.com/"));
+  }
+
+  @Test
+  public void testParameterParsing() {
+    Map<String, Object> parameterMap = new HashMap<>();
+    parameterMap.put("other_parameter", BooleanNode.getTrue());
+    SFBaseSession session = new MockConnectionTest.MockSnowflakeSFSession();
+    SessionUtil.updateSfDriverParamValues(parameterMap, session);
+    assert(((BooleanNode) session.getOtherParameter("other_parameter")).asBoolean());
   }
 }

--- a/src/test/java/net/snowflake/client/core/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilTest.java
@@ -7,11 +7,10 @@ package net.snowflake.client.core;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.node.BooleanNode;
-import net.snowflake.client.jdbc.MockConnectionTest;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
+import net.snowflake.client.jdbc.MockConnectionTest;
+import org.junit.Test;
 
 public class SessionUtilTest {
 
@@ -58,6 +57,6 @@ public class SessionUtilTest {
     parameterMap.put("other_parameter", BooleanNode.getTrue());
     SFBaseSession session = new MockConnectionTest.MockSnowflakeSFSession();
     SessionUtil.updateSfDriverParamValues(parameterMap, session);
-    assert(((BooleanNode) session.getOtherParameter("other_parameter")).asBoolean());
+    assert (((BooleanNode) session.getOtherParameter("other_parameter")).asBoolean());
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -19,6 +20,7 @@ import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.common.core.SnowflakeDateTimeFormat;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 
 /**
  * IT test for testing the "pluggable" implementation of SnowflakeConnection, SnowflakeStatement,
@@ -565,7 +567,7 @@ public class MockConnectionTest extends BaseJDBCTest {
     }
   }
 
-  private static class MockSnowflakeSFSession extends SFBaseSession {
+  public static class MockSnowflakeSFSession extends SFBaseSession {
 
     @Override
     public boolean isSafeToClose() {

--- a/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -20,7 +19,6 @@ import net.snowflake.client.jdbc.telemetry.Telemetry;
 import net.snowflake.common.core.SnowflakeDateTimeFormat;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
 
 /**
  * IT test for testing the "pluggable" implementation of SnowflakeConnection, SnowflakeStatement,


### PR DESCRIPTION
# Overview

SNOW-330467 Fix a typo in setOtherParameter's logic.


## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
