### PR TITLE
SNOW-250701 Do not try to renew cloud storage tokens if the session is null

### DIFF
--- a/src/main/java/net/snowflake/client/core/Constants.java
+++ b/src/main/java/net/snowflake/client/core/Constants.java
@@ -13,6 +13,9 @@ public final class Constants {
   // Session expired error code as returned from Snowflake
   public static final int SESSION_EXPIRED_GS_CODE = 390112;
 
+  // Cloud storage credentials expired error code
+  public static final int CLOUD_STORAGE_CREDENTIALS_EXPIRED = 240001;
+
   // Session gone error code as returned from Snowflake
   public static final int SESSION_GONE = 390111;
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -657,7 +657,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
           SnowflakeFileTransferAgent.renewExpiredToken(session, command, azClient);
         } else {
           // If session is null we cannot renew the token so throw the ExpiredToken exception
-          throw new SnowflakeSQLException(se.getErrorCode(), SESSION_EXPIRED_GS_CODE, "Azure credentials may have expired");
+          throw new SnowflakeSQLException(
+              se.getErrorCode(), SESSION_EXPIRED_GS_CODE, "Azure credentials may have expired");
         }
       }
       // If we have exceeded the max number of retries, propagate the error

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -3,7 +3,7 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
-import static net.snowflake.client.core.Constants.SESSION_EXPIRED_GS_CODE;
+import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.util.Base64;
@@ -658,7 +658,9 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
         } else {
           // If session is null we cannot renew the token so throw the ExpiredToken exception
           throw new SnowflakeSQLException(
-              se.getErrorCode(), SESSION_EXPIRED_GS_CODE, "Azure credentials may have expired");
+              se.getErrorCode(),
+              CLOUD_STORAGE_CREDENTIALS_EXPIRED,
+              "Azure credentials may have expired");
         }
       }
       // If we have exceeded the max number of retries, propagate the error

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -3,6 +3,7 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
+import static net.snowflake.client.core.Constants.SESSION_EXPIRED_GS_CODE;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.util.Base64;
@@ -656,7 +657,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
           SnowflakeFileTransferAgent.renewExpiredToken(session, command, azClient);
         } else {
           // If session is null we cannot renew the token so throw the ExpiredToken exception
-          throw new SnowflakeSQLException(se.getErrorCode(), "Azure credentials may have expired");
+          throw new SnowflakeSQLException(se.getErrorCode(), SESSION_EXPIRED_GS_CODE, "Azure credentials may have expired");
         }
       }
       // If we have exceeded the max number of retries, propagate the error

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -652,7 +652,12 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       if (((StorageException) ex).getHttpStatusCode() == 403) {
         // A 403 indicates that the SAS token has expired,
         // we need to refresh the Azure client with the new token
-        SnowflakeFileTransferAgent.renewExpiredToken(session, command, azClient);
+        if (session != null) {
+          SnowflakeFileTransferAgent.renewExpiredToken(session, command, azClient);
+        } else {
+          // If session is null we cannot renew the token so throw the ExpiredToken exception
+          throw new SnowflakeSQLException(se.getErrorCode(), "Azure credentials may have expired");
+        }
       }
       // If we have exceeded the max number of retries, propagate the error
       if (retryCount > azClient.getMaxRetries()) {

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -911,13 +911,15 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           // ignore
         }
 
-        if (se.getCode() == 401 && session != null && command != null) {
-          // A 401 indicates that the access token has expired,
-          // we need to refresh the GCS client with the new token
-          SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
-        } else if (se.getCode() == 401 && command != null) {
-          throw new SnowflakeSQLException(
-              se.getMessage(), CLOUD_STORAGE_CREDENTIALS_EXPIRED, "GCS credentials have expired");
+        if (se.getCode() == 401 && command != null) {
+          if (session != null) {
+            // A 401 indicates that the access token has expired,
+            // we need to refresh the GCS client with the new token
+            SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
+          } else {
+            throw new SnowflakeSQLException(
+                se.getMessage(), CLOUD_STORAGE_CREDENTIALS_EXPIRED, "GCS credentials have expired");
+          }
         }
       }
     } else if (ex instanceof InterruptedException

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -3,6 +3,7 @@
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
+import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.util.Base64;
@@ -914,6 +915,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           // A 401 indicates that the access token has expired,
           // we need to refresh the GCS client with the new token
           SnowflakeFileTransferAgent.renewExpiredToken(session, command, this);
+        } else if (se.getCode() == 401 && command != null) {
+          throw new SnowflakeSQLException(
+              se.getMessage(), CLOUD_STORAGE_CREDENTIALS_EXPIRED, "GCS credentials have expired");
         }
       }
     } else if (ex instanceof InterruptedException

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -4,7 +4,7 @@
 
 package net.snowflake.client.jdbc.cloud.storage;
 
-import static net.snowflake.client.core.Constants.SESSION_EXPIRED_GS_CODE;
+import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.AmazonClientException;
@@ -741,7 +741,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
               SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);
             } else {
               throw new SnowflakeSQLException(
-                  s3ex.getErrorCode(), SESSION_EXPIRED_GS_CODE, "S3 credentials have expired");
+                  s3ex.getErrorCode(),
+                  CLOUD_STORAGE_CREDENTIALS_EXPIRED,
+                  "S3 credentials have expired");
             }
           }
         }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -740,7 +740,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
             if (session != null) {
               SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);
             } else {
-              throw new SnowflakeSQLException(s3ex.getErrorCode(), SESSION_EXPIRED_GS_CODE, "S3 credentials have expired");
+              throw new SnowflakeSQLException(
+                  s3ex.getErrorCode(), SESSION_EXPIRED_GS_CODE, "S3 credentials have expired");
             }
           }
         }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -735,7 +735,12 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         if (ex instanceof AmazonS3Exception) {
           AmazonS3Exception s3ex = (AmazonS3Exception) ex;
           if (s3ex.getErrorCode().equalsIgnoreCase(EXPIRED_AWS_TOKEN_ERROR_CODE)) {
-            SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);
+            // If session is null we cannot renew the token so throw the ExpiredToken exception
+            if (session != null) {
+              SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);
+            } else {
+              throw new SnowflakeSQLException(s3ex.getErrorCode(), "S3 credentials have expired");
+            }
           }
         }
       }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.client.jdbc.cloud.storage;
 
+import static net.snowflake.client.core.Constants.SESSION_EXPIRED_GS_CODE;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.AmazonClientException;
@@ -739,7 +740,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
             if (session != null) {
               SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);
             } else {
-              throw new SnowflakeSQLException(s3ex.getErrorCode(), "S3 credentials have expired");
+              throw new SnowflakeSQLException(s3ex.getErrorCode(), SESSION_EXPIRED_GS_CODE, "S3 credentials have expired");
             }
           }
         }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeGcsClientHandleExceptionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeGcsClientHandleExceptionLatestIT.java
@@ -61,10 +61,7 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
         new StorageException(401, "Unauthenticated"), 0, "upload", sfSession, command);
     Mockito.verify(spyingClient, Mockito.times(1)).renew(Mockito.anyMap());
 
-    // Unauthenticated, session or command null, not renew, renew called remaining 1
-    spyingClient.handleStorageException(
-        new StorageException(401, "Unauthenticated"), 0, "upload", null, command);
-    Mockito.verify(spyingClient, Mockito.times(1)).renew(Mockito.anyMap());
+    // Unauthenticated, command null, not renew, renew called remaining 1
     spyingClient.handleStorageException(
         new StorageException(401, "Unauthenticated"), 0, "upload", sfSession, null);
     Mockito.verify(spyingClient, Mockito.times(1)).renew(Mockito.anyMap());
@@ -145,6 +142,13 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
   public void errorUnknownException() throws SQLException {
     // Unauthenticated, renew is called.
     spyingClient.handleStorageException(new Exception(), 0, "upload", sfSession, command);
+  }
+
+  @Test(expected = SnowflakeSQLException.class)
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void errorWithNullSession() throws SQLException {
+    spyingClient.handleStorageException(
+        new StorageException(401, "Unauthenticated"), 0, "upload", null, command);
   }
 
   @After


### PR DESCRIPTION
# Overview

SNOW-350701

Sessionless file uploads cannot renew their credentials if they expire.  Currently we throw a NPE trying if we try to renew tokens for sessionless upload.  This PR updates the logic to throw an ExpiredToken error instead if the session is null

## Pre-review checklist
- [x] This change has passed precommit
- [x] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
