### PR TITLE
SNOW-357353 JDBC portion- change current_account() to current_account_locator()

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
@@ -405,7 +405,7 @@ public class DatabaseMetaDataInternalIT extends BaseJDBCTest {
   }
 
   private String getAccountName(Statement stmt) throws SQLException {
-    stmt.execute("select current_account()");
+    stmt.execute("select current_account_locator()");
     resultSet = stmt.getResultSet();
     assertTrue(resultSet.next());
     return resultSet.getString(1);

--- a/src/test/java/net/snowflake/client/jdbc/MultiStatementIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/MultiStatementIT.java
@@ -6,12 +6,7 @@ package net.snowflake.client.jdbc;
 import static net.snowflake.client.ConditionalIgnoreRule.ConditionalIgnore;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -665,7 +660,7 @@ public class MultiStatementIT extends BaseJDBCTest {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
 
-    ResultSet rs = statement.executeQuery("select current_account()");
+    ResultSet rs = statement.executeQuery("select current_account_locator()");
     rs.next();
     String accountName = rs.getString(1);
 


### PR DESCRIPTION
# Overview

SNOW-357353

Due to a GS-side change, current_account() returns the alias of the account name now instead of the actual account. current_account_locator() does what we want instead.


## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
