### PR TITLE
SNOW-369447 Make MAX_CONNECTIONS and MAX_CONNECTIONS_PER_ROUTE changeable

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -68,6 +68,9 @@ public class HttpUtil {
   static final int DEFAULT_DOWNLOADED_CONDITION_TIMEOUT = 3600; // secs
 
   public static final String JDBC_TTL = "net.snowflake.jdbc.ttl";
+  public static final String JDBC_MAX_CONNECTIONS_PROPERTY = "net.snowflake.jdbc.max_connections";
+  public static final String JDBC_MAX_CONNECTIONS_PER_ROUTE_PROPERTY =
+      "net.snowflake.jdbc.max_connections_per_route";
 
   /**
    * The unique httpClient shared by all connections. This will benefit long- lived clients. Key =
@@ -269,15 +272,7 @@ public class HttpUtil {
     // set timeout so that we don't wait forever.
     // Setup the default configuration for all requests on this client
 
-    String ttlSystemProperty = systemGetProperty(JDBC_TTL);
-    int timeToLive = DEFAULT_TTL;
-    if (ttlSystemProperty != null) {
-      try {
-        timeToLive = Integer.parseInt(ttlSystemProperty);
-      } catch (NumberFormatException ex) {
-        logger.info("Failed to parse the system parameter {}", JDBC_TTL, ttlSystemProperty);
-      }
-    }
+    int timeToLive = convertSystemPropertyToIntValue(JDBC_TTL, DEFAULT_TTL);
     logger.debug("time to live in connection pooling manager: {}", timeToLive);
     if (DefaultRequestConfig == null) {
       DefaultRequestConfig =
@@ -318,8 +313,17 @@ public class HttpUtil {
       connectionManager =
           new PoolingHttpClientConnectionManager(
               registry, null, null, null, timeToLive, TimeUnit.SECONDS);
-      connectionManager.setMaxTotal(DEFAULT_MAX_CONNECTIONS);
-      connectionManager.setDefaultMaxPerRoute(DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
+      int maxConnections =
+          convertSystemPropertyToIntValue(JDBC_MAX_CONNECTIONS_PROPERTY, DEFAULT_MAX_CONNECTIONS);
+      int maxConnectionsPerRoute =
+          convertSystemPropertyToIntValue(
+              JDBC_MAX_CONNECTIONS_PER_ROUTE_PROPERTY, DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
+      logger.debug(
+          "Max connections total in connection pooling manager: {}; max connections per route: {}",
+          maxConnections,
+          maxConnectionsPerRoute);
+      connectionManager.setMaxTotal(maxConnections);
+      connectionManager.setDefaultMaxPerRoute(maxConnectionsPerRoute);
 
       HttpClientBuilder httpClientBuilder =
           HttpClientBuilder.create()
@@ -752,5 +756,28 @@ public class HttpUtil {
     } else {
       logger.debug("http.useProxy={}. JVM proxy not used.", httpUseProxy);
     }
+  }
+
+  /**
+   * Helper function to convert system properties to integers
+   *
+   * @param systemProperty name of the system property
+   * @param defaultValue default value used
+   * @return the value of the system property, else the default value
+   */
+  private static int convertSystemPropertyToIntValue(String systemProperty, int defaultValue) {
+    String systemPropertyValue = systemGetProperty(systemProperty);
+    int returnVal = defaultValue;
+    if (systemPropertyValue != null) {
+      try {
+        returnVal = Integer.parseInt(systemPropertyValue);
+      } catch (NumberFormatException ex) {
+        logger.info(
+            "Failed to parse the system parameter {} with value {}",
+            systemProperty,
+            systemPropertyValue);
+      }
+    }
+    return returnVal;
   }
 }

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -765,7 +765,7 @@ public class HttpUtil {
    * @param defaultValue default value used
    * @return the value of the system property, else the default value
    */
-  private static int convertSystemPropertyToIntValue(String systemProperty, int defaultValue) {
+  static int convertSystemPropertyToIntValue(String systemProperty, int defaultValue) {
     String systemPropertyValue = systemGetProperty(systemProperty);
     int returnVal = defaultValue;
     if (systemPropertyValue != null) {

--- a/src/test/java/net/snowflake/client/core/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilTest.java
@@ -5,6 +5,7 @@
 package net.snowflake.client.core;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import java.util.HashMap;
@@ -58,5 +59,28 @@ public class SessionUtilTest {
     SFBaseSession session = new MockConnectionTest.MockSnowflakeSFSession();
     SessionUtil.updateSfDriverParamValues(parameterMap, session);
     assert (((BooleanNode) session.getOtherParameter("other_parameter")).asBoolean());
+  }
+
+  @Test
+  public void testConvertSystemPropertyToIntValue() {
+    // Test that setting real value works
+    System.setProperty("net.snowflake.jdbc.max_connections", "500");
+    assertEquals(
+        500,
+        HttpUtil.convertSystemPropertyToIntValue(
+            HttpUtil.JDBC_MAX_CONNECTIONS_PROPERTY, HttpUtil.DEFAULT_MAX_CONNECTIONS));
+    // Test that entering a non-int sets the value to the default
+    System.setProperty("net.snowflake.jdbc.max_connections", "notAnInteger");
+    assertEquals(
+        HttpUtil.DEFAULT_MAX_CONNECTIONS,
+        HttpUtil.convertSystemPropertyToIntValue(
+            HttpUtil.JDBC_MAX_CONNECTIONS_PROPERTY, HttpUtil.DEFAULT_MAX_CONNECTIONS));
+    // Test another system property
+    System.setProperty("net.snowflake.jdbc.max_connections_per_route", "30");
+    assertEquals(
+        30,
+        HttpUtil.convertSystemPropertyToIntValue(
+            HttpUtil.JDBC_MAX_CONNECTIONS_PER_ROUTE_PROPERTY,
+            HttpUtil.DEFAULT_MAX_CONNECTIONS_PER_ROUTE));
   }
 }


### PR DESCRIPTION
# Overview

SNOW-369447

Customer request to make these values configurable. They now are with JVM parameters.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
