### PR TITLE
SNOW-373633 Change JDBC version to be taken from static string instead of version.properties

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -23,7 +23,7 @@ public class SnowflakeDriver implements Driver {
   static SnowflakeDriver INSTANCE;
 
   public static final Properties EMPTY_PROPERTIES = new Properties();
-  public static String implementVersion = null;
+  public static String implementVersion = "3.13.5";
 
   static int majorVersion = 0;
   static int minorVersion = 0;
@@ -90,11 +90,9 @@ public class SnowflakeDriver implements Driver {
 
   private static void initializeClientVersionFromManifest() {
     /*
-     * Get JDBC version numbers from version.properties in snowflake-jdbc
+     * Get JDBC version numbers from static string in snowflake-jdbc
      */
     try {
-      implementVersion = versionResourceBundleManager.getLocalizedMessage("version");
-
       // parse implementation version major.minor.change
       if (implementVersion != null) {
         String[] versionBreakdown = implementVersion.split("\\.");
@@ -115,7 +113,8 @@ public class SnowflakeDriver implements Driver {
             SqlState.INTERNAL_ERROR,
             ErrorCode.INTERNAL_ERROR.getMessageCode(),
             /*session = */ null,
-            "Snowflake JDBC Version is not set. " + "Ensure version.properties is included.");
+            "Snowflake JDBC Version is not set. "
+                + "Ensure static version string was initialized.");
       }
     } catch (Throwable ex) {
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -120,6 +120,15 @@ public class SnowflakeDriver implements Driver {
     }
   }
 
+  /**
+   * For testing purposes only- used to compare that JDBC version in pom.xml matches static string
+   *
+   * @return String with version from pom.xml file
+   */
+  static String getClientVersionStringFromManifest() {
+    return versionResourceBundleManager.getLocalizedMessage("version");
+  }
+
   public static boolean isDisableArrowResultFormat() {
     return disableArrowResultFormat;
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -23,7 +23,7 @@ public class SnowflakeDriver implements Driver {
   static SnowflakeDriver INSTANCE;
 
   public static final Properties EMPTY_PROPERTIES = new Properties();
-  public static String implementVersion = "3.13.5";
+  public static String implementVersion = "3.13.6";
 
   static int majorVersion = 0;
   static int minorVersion = 0;

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -3,6 +3,8 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.jdbc.SnowflakeDriver.getClientVersionStringFromManifest;
+import static net.snowflake.client.jdbc.SnowflakeDriver.implementVersion;
 import static net.snowflake.client.jdbc.SnowflakeDriverIT.findFile;
 import static net.snowflake.client.jdbc.SnowflakeResultSetSerializableV1.mapper;
 import static org.junit.Assert.*;
@@ -11,10 +13,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.*;
 import java.nio.channels.FileChannel;
 import java.sql.*;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
-import java.util.UUID;
+import java.util.*;
 import java.util.zip.GZIPInputStream;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
@@ -65,6 +64,11 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
       inputStream1.close();
       inputStream2.close();
     }
+  }
+
+  @Test
+  public void testStaticVersionMatchesManifest() {
+    assertEquals(implementVersion, getClientVersionStringFromManifest());
   }
 
   @Test


### PR DESCRIPTION
# Overview

SNOW-373633

Hey @sfc-gh-abhatnagar, we would like to make the version string for JDBC a static value to avoid an issue with version retrieval when customers use the source jar vs a compiled jar. This change would require the version to now be changed in 2 places instead of 1- the` implementVersion` static string in SnowflakeDriver.java as well as in the pom.xml file. Is this okay with you?


## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
