### PR TITLE
Fixed null message from exception

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -1058,7 +1058,7 @@ public class SnowflakeResultSetSerializableV1
         throw new SnowflakeSQLLoggedException(
             possibleSession.orElse(/* session = */ null),
             ErrorCode.INTERNAL_ERROR,
-            "Fail to retrieve row count for first arrow chunk: " + ex.getCause());
+            "Fail to retrieve row count for first arrow chunk: " + ex.getMessage());
       } finally {
         if (root != null) {
           root.clear();


### PR DESCRIPTION
I think the call to getCause in this case was actually supposed to be a getMessage.  For my case, getCause returns null as the exception has no chained cause.