### PR TITLE
Add shutdown() to the ExecutorService in sendTelemetryClient

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/telemetry/NoOpTelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/NoOpTelemetryClient.java
@@ -4,7 +4,6 @@
 package net.snowflake.client.jdbc.telemetry;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 /** Telemetry client that is doing nothing. Mainly used in testing code */
@@ -21,10 +20,5 @@ public class NoOpTelemetryClient implements Telemetry {
   }
 
   @Override
-  public void postProcess(
-      ExecutorService threadExecutor,
-      String queryId,
-      String sqlState,
-      int vendorCode,
-      Throwable ex) {}
+  public void postProcess(String queryId, String sqlState, int vendorCode, Throwable ex) {}
 }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/Telemetry.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/Telemetry.java
@@ -3,7 +3,6 @@
  */
 package net.snowflake.client.jdbc.telemetry;
 
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 public interface Telemetry {
@@ -24,10 +23,5 @@ public interface Telemetry {
    */
   Future<Boolean> sendBatchAsync();
 
-  void postProcess(
-      ExecutorService threadExecutor,
-      String queryId,
-      String sqlState,
-      int vendorCode,
-      Throwable ex);
+  void postProcess(String queryId, String sqlState, int vendorCode, Throwable ex);
 }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/Telemetry.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/Telemetry.java
@@ -23,5 +23,14 @@ public interface Telemetry {
    */
   Future<Boolean> sendBatchAsync();
 
+  /**
+   * A hook for post-processing after sending telemetry data. Can be used, for example, for
+   * additional error handling.
+   *
+   * @param queryId The query id
+   * @param sqlState The SQL state as defined in net.snowflake.common.core.SqlState
+   * @param vendorCode The vendor code for localized messages
+   * @param ex The throwable that caused this.
+   */
   void postProcess(String queryId, String sqlState, int vendorCode, Throwable ex);
 }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -11,7 +11,6 @@ import java.rmi.UnexpectedException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.LinkedList;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.ObjectMapperFactory;
@@ -211,12 +210,7 @@ public class TelemetryClient implements Telemetry {
   }
 
   @Override
-  public void postProcess(
-      ExecutorService threadExecutor,
-      String queryId,
-      String sqlState,
-      int vendorCode,
-      Throwable ex) {
+  public void postProcess(String queryId, String sqlState, int vendorCode, Throwable ex) {
     // This is a no-op.
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.*;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -675,13 +674,7 @@ public class MockConnectionTest extends BaseJDBCTest {
         }
 
         @Override
-        public void postProcess(
-            ExecutorService threadExecutor,
-            String queryId,
-            String sqlState,
-            int vendorCode,
-            Throwable ex) {
-          threadExecutor.shutdown();
+        public void postProcess(String queryId, String sqlState, int vendorCode, Throwable ex) {
           // For this test, we simply write the message to the list of errors seen using a string.
           errorsEncountered.add(ex.getMessage() + "_" + sqlState);
         }


### PR DESCRIPTION
Cleanly send a shutdown signal to the `ExecutorService` responsible for in-band telemetry uploads.
