### PR TITLE
SNOW-405374 Add questions to PR template for external pull request creators

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,22 @@
 
 SNOW-XXXXX
 
+## External contributors - please answer these questions before submitting a pull request. Thanks!
+
+1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.
+   Fixes #
+
+2. Please describe how your code solves the related issue.
+
+   Please write a short description of how your code change solves the related issue.
+
+3. Have you added new automated test(s) that verify correctness of your code?
+
+   Yes
+   or
+   No
 
 ## Pre-review checklist
 - [ ] This change has passed precommit
 - [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,18 +4,25 @@ SNOW-XXXXX
 
 ## External contributors - please answer these questions before submitting a pull request. Thanks!
 
-1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.
-   Fixes #
+Please answer these questions before submitting your pull requests. Thanks!
 
-2. Please describe how your code solves the related issue.
+1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.
+
+   Fixes #NNNN 
+
+
+2. Fill out the following pre-review checklist:
+
+   - [ ] I am adding a new automated test(s) to verify correctness of my new code
+   - [ ] I am adding new logging messages
+   - [ ] I am modyfying authorization mechanisms
+   - [ ] I am adding new credentials
+   - [ ] I am modyfying OCSP code
+   - [ ] I am adding a new dependency
+
+3. Please describe how your code solves the related issue.
 
    Please write a short description of how your code change solves the related issue.
-
-3. Have you added new automated test(s) that verify correctness of your code?
-
-   Yes
-   or
-   No
 
 ## Pre-review checklist
 - [ ] This change has passed precommit


### PR DESCRIPTION
# Overview

SNOW-405374

Non-snowflake github users sometimes create PRs that go unnoticed because they have not created a linked github issue. Changing the template to tell them to create a github issue should fix the workflow.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
