### PR TITLE
SNOW-394504 Fix underscore issue in JDBC by replacing all underscores with hyphens in account names

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -9,11 +9,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 
@@ -124,6 +120,9 @@ public class SnowflakeConnectString implements Serializable {
         // If this is a global URL, then extract out the external ID part
         if (host.contains(".global.")) {
           account = account.substring(0, account.lastIndexOf('-'));
+        }
+        if (account.contains("_")) {
+          account.replaceAll("_", "-");
         }
         parameters.put("ACCOUNT", account);
       }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -122,7 +122,7 @@ public class SnowflakeConnectString implements Serializable {
           account = account.substring(0, account.lastIndexOf('-'));
         }
         if (account.contains("_")) {
-          account.replaceAll("_", "-");
+          account = account.replaceAll("_", "-");
         }
         parameters.put("ACCOUNT", account);
       }


### PR DESCRIPTION
# Overview

SNOW-394504

JDBC libraries do not support having underscores in account names, even though Snowflake GS is able to support this. After talking to Dennis (slack conversation here: [https://snowflake.slack.com/archives/C0292U1LEQP/p1628032200020600](https://snowflake.slack.com/archives/C0292U1LEQP/p1628032200020600)), it turns out there is GS support to handle the underscore-to-hyphen switch for both old and new account formats. So replacing all account underscores with hyphens in JDBC will fix the JDBC underscore issue.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

