### PR TITLE
SNOW-449297 Fix implementation of Connection.isValid()

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -567,11 +567,21 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
   @Override
   public boolean isValid(int timeout) throws SQLException {
-    // TODO: run query here or ping
     if (timeout < 0) {
       throw new SQLException("timeout is less than 0");
+    } else if (isClosed) {
+      return false;
+    } else {
+      try {
+        Statement statement = this.createStatement();
+        statement.setQueryTimeout(timeout);
+        statement.execute("select 1");
+        statement.close();
+      } catch (SQLException ex) {
+        return false;
+      }
+      return true;
     }
-    return !isClosed; // no exception is raised
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/HeartbeatAsyncLatestIT.java
@@ -83,4 +83,21 @@ public class HeartbeatAsyncLatestIT extends HeartbeatIT {
   public void testAsynchronousQueryFailure() throws Exception {
     testFailure();
   }
+
+  /** Test that isValid() function returns false when session is expired */
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testIsValidWithInvalidSession() throws Exception {
+    Connection connection = null;
+    try {
+      connection = getConnection();
+      // assert that connection starts out valid
+      assertTrue(connection.isValid(5));
+      Thread.sleep(61000); // sleep 61 seconds to await session expiration time
+      // assert that connection is no longer valid after session has expired
+      assertFalse(connection.isValid(5));
+    } finally {
+      connection.close();
+    }
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-449297

Snowflake's implementation of Connection.isValid() returns true whenever the connection is not closed, even if the connection is no longer able to connect due to an invalid/expired session. This fixes the behavior so isValid() only returns true whenever the session is not closed and not expired. Documentation for isValid:https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#isValid-int-

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

