### PR TITLE
SNOW-412040 Fix ResultSet.getQueryID() so it returns correct query ID for PUT/GET statements

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
@@ -4,13 +4,14 @@
 
 package net.snowflake.client.core;
 
-import java.sql.SQLException;
-import java.util.List;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.SFBaseFileTransferAgent.CommandType;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
+
+import java.sql.SQLException;
+import java.util.List;
 
 /**
  * Fixed view result set. This class iterates through any fixed view implementation and return the
@@ -22,11 +23,13 @@ public class SFFixedViewResultSet extends SFJsonResultSet {
   private SnowflakeFixedView fixedView;
   private Object[] nextRow = null;
   private final CommandType commandType;
+  private final String queryID;
 
-  public SFFixedViewResultSet(SnowflakeFixedView fixedView, CommandType commandType)
+  public SFFixedViewResultSet(SnowflakeFixedView fixedView, CommandType commandType, String queryID)
       throws SnowflakeSQLException {
     this.fixedView = fixedView;
     this.commandType = commandType;
+    this.queryID = queryID;
 
     try {
       resultSetMetaData =
@@ -140,6 +143,6 @@ public class SFFixedViewResultSet extends SFJsonResultSet {
 
   @Override
   public String getQueryId() {
-    return "";
+    return queryID;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
@@ -4,14 +4,13 @@
 
 package net.snowflake.client.core;
 
+import java.sql.SQLException;
+import java.util.List;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.jdbc.SFBaseFileTransferAgent.CommandType;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
-
-import java.sql.SQLException;
-import java.util.List;
 
 /**
  * Fixed view result set. This class iterates through any fixed view implementation and return the

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -12,6 +14,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
 import net.snowflake.client.core.*;
 import net.snowflake.client.jdbc.cloud.storage.*;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
@@ -26,22 +41,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.DigestOutputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.GZIPOutputStream;
-
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 /**
  * Class for uploading/downloading files

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -103,7 +103,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     return this.stageInfo;
   }
 
-  public String getQueryID() { return this.queryID; }
+  public String getQueryID() {
+    return this.queryID;
+  }
 
   /**
    * Get value of big file threshold. For testing purposes.
@@ -1215,7 +1217,6 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
     JsonNode jsonNode = (JsonNode) result;
     logger.debug("response: {}", jsonNode.toString());
-
 
     SnowflakeUtil.checkErrorAndThrowException(jsonNode);
     return jsonNode;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -102,10 +102,6 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     return this.stageInfo;
   }
 
-  public String getQueryID() {
-    return this.queryID;
-  }
-
   /**
    * Get value of big file threshold. For testing purposes.
    *

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -3,6 +3,22 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
+import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
+import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.*;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryConnection;
@@ -16,23 +32,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.sql.*;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
-
-import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
-import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
 /**
  * Connection integration tests for the latest JDBC driver. This doesn't work for the oldest

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -120,22 +120,36 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     assertEquals(900, session.getHeartbeatFrequency());
   }
 
+  /**
+   * Test that PUT/GET statements can return query IDs. If there is a group of files
+   * uploaded/downloaded, the getResultSet() function will return the query ID of the last PUT or
+   * GET statement in the batch.
+   *
+   * @throws Throwable
+   */
   @Test
-  public void putStatementNullQueryID() throws SQLException {
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void putStatementNullQueryID() throws Throwable {
     Connection con = getConnection();
     Statement statement = con.createStatement();
     String sourceFilePath = getFullPathFileInResource(TEST_DATA_FILE);
+    File destFolder = tmpFolder.newFolder();
+    String destFolderCanonicalPath = destFolder.getCanonicalPath();
     statement.execute("CREATE OR REPLACE STAGE testPutGet_stage");
     String putStatement = "PUT file://" + sourceFilePath + " @testPutGet_stage";
     ResultSet resultSet =
-            statement
-                    .unwrap(SnowflakeStatement.class)
-                    .executeAsyncQuery(putStatement);
+        statement.unwrap(SnowflakeStatement.class).executeAsyncQuery(putStatement);
     String queryID = resultSet.unwrap(SnowflakeResultSet.class).getQueryID();
     assertTrue(
-            Pattern.matches(
-                    "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}",
-                    queryID));
+        Pattern.matches("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}", queryID));
+    resultSet =
+        statement
+            .unwrap(SnowflakeStatement.class)
+            .executeAsyncQuery(
+                "GET @testPutGet_stage 'file://" + destFolderCanonicalPath + "' parallel=8");
+    queryID = resultSet.unwrap(SnowflakeResultSet.class).getQueryID();
+    assertTrue(
+        Pattern.matches("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}", queryID));
   }
 
   @Test


### PR DESCRIPTION
# Overview

SNOW-412040

PUT/GET statements are not supported for asynchronous querying execution, but some customers still want to use the framework of asynchronous resultsets so that they can get back the query IDs of their PUT or GET queries.

Currently, no query IDs are returned for PUT or GET statements. This PR fixes that. If there is a batch of PUT statements in 1 ResultSet (for example, using a put statement with wildcards), the query ID returned is the last query ID in the batch of statements.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

