### PR TITLE
SNOW-366563 Fix London/Europe daylight savings offset with timestamp_ntz

### DIFF
--- a/src/main/java/net/snowflake/client/core/arrow/ArrowResultUtil.java
+++ b/src/main/java/net/snowflake/client/core/arrow/ArrowResultUtil.java
@@ -102,7 +102,7 @@ public class ArrowResultUtil {
    */
   private static long moveToTimeZoneOffset(
       long milliSecsSinceEpoch, TimeZone oldTZ, TimeZone newTZ) {
-    if (oldTZ.getRawOffset() == newTZ.getRawOffset() && oldTZ.hasSameRules(newTZ)) {
+    if (oldTZ.hasSameRules(newTZ)) {
       // same time zone
       return 0;
     }

--- a/src/main/java/net/snowflake/client/core/arrow/ArrowResultUtil.java
+++ b/src/main/java/net/snowflake/client/core/arrow/ArrowResultUtil.java
@@ -102,7 +102,7 @@ public class ArrowResultUtil {
    */
   private static long moveToTimeZoneOffset(
       long milliSecsSinceEpoch, TimeZone oldTZ, TimeZone newTZ) {
-    if (oldTZ.getRawOffset() == newTZ.getRawOffset()) {
+    if (oldTZ.getRawOffset() == newTZ.getRawOffset() && oldTZ.hasSameRules(newTZ)) {
       // same time zone
       return 0;
     }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneLatestIT.java
@@ -23,6 +23,8 @@ public class ResultSetMultiTimeZoneLatestIT extends BaseJDBCTest {
   @Parameterized.Parameters(name = "format={0}, tz={1}")
   public static Collection<Object[]> data() {
     // all tests in this class need to run for both query result formats json and arrow
+    // UTC and Europe/London have different offsets during daylight savings time so it is important
+    // to test both to ensure daylight savings time is correct
     String[] timeZones = new String[] {"UTC", "Asia/Singapore", "MEZ", "Europe/London"};
     String[] queryFormats = new String[] {"json", "arrow"};
     List<Object[]> ret = new ArrayList<>();

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneLatestIT.java
@@ -23,7 +23,7 @@ public class ResultSetMultiTimeZoneLatestIT extends BaseJDBCTest {
   @Parameterized.Parameters(name = "format={0}, tz={1}")
   public static Collection<Object[]> data() {
     // all tests in this class need to run for both query result formats json and arrow
-    String[] timeZones = new String[] {"UTC", "Asia/Singapore", "MEZ"};
+    String[] timeZones = new String[] {"UTC", "Asia/Singapore", "MEZ", "Europe/London"};
     String[] queryFormats = new String[] {"json", "arrow"};
     List<Object[]> ret = new ArrayList<>();
     for (String queryFormat : queryFormats) {
@@ -58,6 +58,29 @@ public class ResultSetMultiTimeZoneLatestIT extends BaseJDBCTest {
         .createStatement()
         .execute("alter session set jdbc_query_result_format = '" + queryResultFormat + "'");
     return connection;
+  }
+
+  /**
+   * This test is for SNOW-366563 where the timestamp was returning an incorrect value for daylight
+   * savings time due to the fact that UTC and Europe/London time have the same offset until
+   * daylight savings comes into effect. This tests that the timestamp value is accurate during
+   * daylight savings time.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testTimestampNTZWithDaylightSavings() throws SQLException {
+    Connection connection = init();
+    Statement statement = connection.createStatement();
+    statement.execute(
+        "alter session set TIMESTAMP_TYPE_MAPPING='TIMESTAMP_NTZ'," + "TIMEZONE='Europe/London'");
+    ResultSet rs = statement.executeQuery("select TIMESTAMP '2011-09-04 00:00:00'");
+    rs.next();
+    Timestamp expected = Timestamp.valueOf("2011-09-04 00:00:00");
+    assertEquals(expected, rs.getTimestamp(1));
+    rs.close();
+    statement.close();
+    connection.close();
   }
 
   /**


### PR DESCRIPTION
# Overview

SNOW-366563

A customer is having an issue where due to logic in the function ArrowUtil.moveToTimeZoneOffset(), the daylight savings appears wrong for London timezone because it's the same offset as UTC most, but not all, of the time.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

