### PR TITLE
SNOW-464020: azure iterator exception bug fix

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -12,6 +14,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
 import net.snowflake.client.core.*;
 import net.snowflake.client.jdbc.cloud.storage.*;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
@@ -26,22 +41,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.DigestOutputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.GZIPOutputStream;
-
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 /**
  * Class for uploading/downloading files
@@ -2323,20 +2322,21 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
         try {
           compareAndSkipRemoteFiles(objectSummaries, destFileNameToSrcFileMap);
-          break;  // exit retry loop
+          break; // exit retry loop
         } catch (Exception ex) {
-          // This exception retry logic is mainly for Azure iterator. Since Azure iterator is a lazy iterator,
+          // This exception retry logic is mainly for Azure iterator. Since Azure iterator is a lazy
+          // iterator,
           // it can throw exceptions during the for-each calls. To be more specific, iterator apis,
           // e.g. hasNext(), may throw Storage service error.
           logger.debug(
-                  "Comparison with existing files in remote storage encountered exception.", ex);
+              "Comparison with existing files in remote storage encountered exception.", ex);
           if (ex instanceof StorageProviderException) {
             ex =
-                    (Exception)
-                            ex.getCause(); // Cause of StorageProviderException is always an Exception
+                (Exception)
+                    ex.getCause(); // Cause of StorageProviderException is always an Exception
           }
           storageClient.handleStorageException(
-                  ex, ++retryCount, "compareRemoteFiles", session, command);
+              ex, ++retryCount, "compareRemoteFiles", session, command);
         }
       } while (retryCount <= storageClient.getMaxRetries());
     } else if (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS) {


### PR DESCRIPTION
# Overview

SNOW-464020
The previous pr only wraps `compareAndSkipRemoteFiles` with a do-while retry loop. But it didn't work well. After checking the source code of azure-storage v5.0.0, it seems we need to regenerate the iterator from azure-client object. So in this pr, we move `compareAndSkipRemoteFiles` up into the do-while retry loop of `storageClient.listObjects`. If the SAS token expires, the `storageClient` will be refreshed, i.e., having a fresh new SAS token, then the returned `objectSummaries` will also contain the new SAS.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

