### PR TITLE
SNOW-466174: Add stacktrace to sfformater

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -882,6 +882,9 @@
                     <java.util.logging.config.file>
                       ${basedir}/src/test/resources/logging.properties
                     </java.util.logging.config.file>
+                    <net.snowflake.jdbc.log.sfformatter.dump.stacktrace>
+                      true
+                    </net.snowflake.jdbc.log.sfformatter.dump.stacktrace>
                   </systemPropertyVariables>
                 </configuration>
               </execution>

--- a/src/main/java/net/snowflake/client/log/SFFormatter.java
+++ b/src/main/java/net/snowflake/client/log/SFFormatter.java
@@ -3,6 +3,8 @@
  */
 package net.snowflake.client.log;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -11,6 +13,7 @@ import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import net.snowflake.client.jdbc.SnowflakeDriver;
+import net.snowflake.client.util.SecretDetector;
 
 /** SFFormatter */
 public class SFFormatter extends Formatter {
@@ -46,6 +49,16 @@ public class SFFormatter extends Formatter {
       className = "c.s" + className.substring(INFORMATICA_V1_CLASS_NAME_PREFIX.length());
     }
 
+    String throwable = "";
+    if (record.getThrown() != null) {
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      pw.println();
+      record.getThrown().printStackTrace(pw);
+      pw.close();
+      throwable = SecretDetector.maskSecrets(sw.toString());
+    }
+
     StringBuilder builder = new StringBuilder(1000);
     builder.append(df.format(new Date(record.getMillis()))).append(" ");
     builder.append(className).append(" ");
@@ -53,6 +66,7 @@ public class SFFormatter extends Formatter {
     builder.append(methodName).append(":");
     builder.append(lineNumber).append(" - ");
     builder.append(formatMessage(record));
+    builder.append(throwable);
     builder.append("\n");
     return builder.toString();
   }

--- a/src/main/java/net/snowflake/client/log/SFFormatter.java
+++ b/src/main/java/net/snowflake/client/log/SFFormatter.java
@@ -3,6 +3,8 @@
  */
 package net.snowflake.client.log;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.DateFormat;
@@ -31,6 +33,9 @@ public class SFFormatter extends Formatter {
 
   public static final String INFORMATICA_V1_CLASS_NAME_PREFIX = "com.snowflake";
 
+  public static final String SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE =
+      "net.snowflake.jdbc.log.sfformatter.dump.stacktrace";
+
   @Override
   public String format(LogRecord record) {
     int lineNumber = -1;
@@ -50,7 +55,8 @@ public class SFFormatter extends Formatter {
     }
 
     String throwable = "";
-    if (record.getThrown() != null) {
+    String dumpStack = systemGetProperty(SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE);
+    if (dumpStack != null && dumpStack.equals("true") && record.getThrown() != null) {
       StringWriter sw = new StringWriter();
       PrintWriter pw = new PrintWriter(sw);
       pw.println();

--- a/src/test/java/net/snowflake/client/log/JDK14LoggerIT.java
+++ b/src/test/java/net/snowflake/client/log/JDK14LoggerIT.java
@@ -3,16 +3,9 @@
  */
 package net.snowflake.client.log;
 
-import java.util.logging.Formatter;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
+import java.util.logging.*;
 import net.snowflake.client.category.TestCategoryCore;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.*;
 import org.junit.experimental.categories.Category;
 
 /** A class for testing {@link JDK14Logger} */
@@ -48,6 +41,9 @@ public class JDK14LoggerIT extends AbstractLoggerIT {
 
   /** Message last logged using JDK14Logger. */
   private String lastLogMessage = null;
+
+  /** Output string logged by Formatter.format function */
+  private String lastLogOutput = null;
 
   /** Level at which last message was logged using JDK14Logger. */
   private Level lastLogMessageLevel = null;
@@ -108,6 +104,10 @@ public class JDK14LoggerIT extends AbstractLoggerIT {
     return this.lastLogMessage;
   }
 
+  String getLoggedOutput() {
+    return this.lastLogOutput;
+  }
+
   @Override
   LogLevel getLoggedMessageLevel() {
     return fromJavaCoreLoggerLevel(this.lastLogMessageLevel);
@@ -116,6 +116,7 @@ public class JDK14LoggerIT extends AbstractLoggerIT {
   @Override
   void clearLastLoggedMessageAndLevel() {
     this.lastLogMessage = null;
+    this.lastLogOutput = null;
     this.lastLogMessageLevel = null;
   }
 
@@ -174,9 +175,10 @@ public class JDK14LoggerIT extends AbstractLoggerIT {
 
     @Override
     public void publish(LogRecord record) {
-      // Assign the log message and it's level to the outer class instance
+      // Assign the log message, log output and it's level to the outer class instance
       // variables so that it can see the messages logged
       lastLogMessage = getFormatter().formatMessage(record);
+      lastLogOutput = getFormatter().format(record);
       lastLogMessageLevel = record.getLevel();
     }
 
@@ -185,5 +187,21 @@ public class JDK14LoggerIT extends AbstractLoggerIT {
 
     @Override
     public void close() {}
+  }
+
+  /**
+   * This test intends to check if the exception stack trace will be generated in JDK14Logger with
+   * SFFormatter.
+   */
+  @Test
+  public void testLogException() {
+    final String exceptionStr = "FakeExceptionInStack";
+    clearLastLoggedMessageAndLevel();
+
+    LOGGER.debug("test exception", new Exception(exceptionStr));
+
+    String loggedMsg = getLoggedOutput();
+    Assert.assertTrue(
+        "Log output should contain stack trace for exception", loggedMsg.contains(exceptionStr));
   }
 }

--- a/src/test/java/net/snowflake/client/log/JDK14LoggerLatestIT.java
+++ b/src/test/java/net/snowflake/client/log/JDK14LoggerLatestIT.java
@@ -3,6 +3,8 @@
  */
 package net.snowflake.client.log;
 
+import static net.snowflake.client.log.SFFormatter.SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE;
+
 import java.util.logging.*;
 import net.snowflake.client.category.TestCategoryCore;
 import org.junit.*;
@@ -199,10 +201,21 @@ public class JDK14LoggerLatestIT extends AbstractLoggerIT {
     final String exceptionStr = "FakeExceptionInStack";
     clearLastLoggedMessageAndLevel();
 
-    LOGGER.debug("test exception", new Exception(exceptionStr));
-
+    LOGGER.debug("test exception, no stack", new Exception(exceptionStr));
     String loggedMsg = getLoggedOutput();
-    Assert.assertTrue(
-        "Log output should contain stack trace for exception", loggedMsg.contains(exceptionStr));
+    Assert.assertFalse(
+        "Log output should not contain stack trace for exception",
+        loggedMsg.contains(exceptionStr));
+
+    try {
+      System.setProperty(SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE, "true");
+      LOGGER.debug("test exception, dump stack", new Exception(exceptionStr));
+
+      loggedMsg = getLoggedOutput();
+      Assert.assertTrue(
+          "Log output should contain stack trace for exception", loggedMsg.contains(exceptionStr));
+    } finally {
+      System.clearProperty(SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE);
+    }
   }
 }

--- a/src/test/java/net/snowflake/client/log/JDK14LoggerLatestIT.java
+++ b/src/test/java/net/snowflake/client/log/JDK14LoggerLatestIT.java
@@ -39,6 +39,9 @@ public class JDK14LoggerLatestIT extends AbstractLoggerIT {
    */
   private static boolean useParentHandlersToRestore = true;
 
+  /** Used for storing SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE before starting the tests. */
+  private static String dumpStackToRestore = null;
+
   /** This handler will be added to the internal logger to get logged messages. */
   private TestJDK14LogHandler handler = new TestJDK14LogHandler(new SFFormatter());
 
@@ -57,12 +60,18 @@ public class JDK14LoggerLatestIT extends AbstractLoggerIT {
     useParentHandlersToRestore = internalLogger.getUseParentHandlers();
 
     internalLogger.setUseParentHandlers(false);
+
+    dumpStackToRestore = System.getProperty(SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE);
+    System.clearProperty(SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE);
   }
 
   @AfterClass
   public static void oneTimeTearDown() {
     internalLogger.setLevel(logLevelToRestore);
     internalLogger.setUseParentHandlers(useParentHandlersToRestore);
+    if (dumpStackToRestore != null) {
+      System.setProperty(SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE, dumpStackToRestore);
+    }
   }
 
   @Before

--- a/src/test/java/net/snowflake/client/log/SFFormatterTest.java
+++ b/src/test/java/net/snowflake/client/log/SFFormatterTest.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.log;
 
+import static net.snowflake.client.log.SFFormatter.SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.text.DateFormat;
@@ -70,9 +72,20 @@ public class SFFormatterTest {
     String record =
         recordGenerator.generateLogRecordString(
             Level.FINE, "TestMessage", new Exception(exceptionStr));
-    assertTrue(
-        "SFFormatter output should contain stack trace for exception",
+    assertFalse(
+        "SFFormatter output should not contain stack trace for exception",
         record.contains(exceptionStr));
+    try {
+      System.setProperty(SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE, "true");
+      record =
+          recordGenerator.generateLogRecordString(
+              Level.FINE, "TestMessage", new Exception(exceptionStr));
+      assertTrue(
+          "SFFormatter output should contain stack trace for exception",
+          record.contains(exceptionStr));
+    } finally {
+      System.clearProperty(SYS_PROPERTY_SF_FORMATTER_DUMP_STACKTRACE);
+    }
   }
 
   /**

--- a/src/test/java/net/snowflake/client/log/SFFormatterTest.java
+++ b/src/test/java/net/snowflake/client/log/SFFormatterTest.java
@@ -63,6 +63,18 @@ public class SFFormatterTest {
     }
   }
 
+  /** This test intends to check if the exception stack trace will be generated in SFFormatter */
+  @Test
+  public void testOutputStackTrace() {
+    final String exceptionStr = "FakeExceptionInStack";
+    String record =
+        recordGenerator.generateLogRecordString(
+            Level.FINE, "TestMessage", new Exception(exceptionStr));
+    assertTrue(
+        "SFFormatter output should contain stack trace for exception",
+        record.contains(exceptionStr));
+  }
+
   /**
    * The bulk version test of testUTCTimeStampSimple()
    *
@@ -80,7 +92,7 @@ public class SFFormatterTest {
    * constructor
    */
   private class LRGenerator {
-    // Required by SFFormatter as a log record without these fiels would cause NullPointerException
+    // Required by SFFormatter as a log record without these fields would cause NullPointerException
     // in
     // our SF formatter
     // add more fields to plug in the log record if required for testing
@@ -103,9 +115,15 @@ public class SFFormatterTest {
      * @return A LogRecord instance
      */
     public LogRecord generateLogRecord(Level level, String message) {
-      LogRecord record = new LogRecord(Level.INFO, "null");
+      LogRecord record = new LogRecord(level, message);
       record.setSourceClassName(this.srcClassName);
       record.setSourceMethodName(this.srcMethodName);
+      return record;
+    }
+
+    public LogRecord generateLogRecord(Level level, String message, Exception ex) {
+      LogRecord record = generateLogRecord(level, message);
+      record.setThrown(ex);
       return record;
     }
 
@@ -118,6 +136,10 @@ public class SFFormatterTest {
      */
     public String generateLogRecordString(Level level, String message) {
       return formatter.format(this.generateLogRecord(level, message));
+    }
+
+    public String generateLogRecordString(Level level, String message, Exception ex) {
+      return formatter.format(this.generateLogRecord(level, message, ex));
     }
 
     /**


### PR DESCRIPTION
# Overview

SNOW-466174
Currently the SFFormatter doesn't print out stack trace of an exception in logger. However, this is inconvenient for us to debug RT because the SFFormatter-JDK14Logger is used in RT. So this pr is to print stack trace when an exception iteself is passed into logger as an argument.

CASEC: https://github.com/snowflakedb/security_reviews/pull/1066 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

