### PR TITLE
SNOW-466639: Fix logging StorageExceptionExtendedInformation

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -241,7 +241,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       logger.debug(
           "Failed to retrieve BLOB metadata: {} - {}",
           ex.getErrorCode(),
-          FormatStorageExceptionExtendedInformation(ex.getExtendedErrorInformation()));
+          FormatStorageExtendedErrorInformation(ex.getExtendedErrorInformation()));
       throw new StorageProviderException(ex);
     } catch (URISyntaxException ex) {
       logger.debug("Cannot retrieve BLOB properties, invalid URI: {}", ex);
@@ -678,7 +678,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
             se.getErrorCode(),
             se.getHttpStatusCode(),
             se.getMessage(),
-            FormatStorageExceptionExtendedInformation(se.getExtendedErrorInformation()));
+            FormatStorageExtendedErrorInformation(se.getExtendedErrorInformation()));
       } else {
         logger.debug(
             "Encountered exception ({}) during {}, retry count: {}",
@@ -742,8 +742,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
    * @param info the StorageExtendedErrorInformation object
    * @return
    */
-  private static String FormatStorageExceptionExtendedInformation(
-      StorageExtendedErrorInformation info) {
+  static String FormatStorageExtendedErrorInformation(StorageExtendedErrorInformation info) {
     if (info == null) {
       return "";
     }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -758,9 +758,10 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       sb.append(", AdditionalDetails= { ");
       for (Map.Entry<String, String[]> detail : details.entrySet()) {
         sb.append(detail.getKey());
-        sb.append("= ");
+        sb.append("=");
 
         for (String value : detail.getValue()) {
+          sb.append(" ");
           sb.append(value);
         }
         sb.append(",");

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -758,10 +758,9 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       sb.append(", AdditionalDetails= { ");
       for (Map.Entry<String, String[]> detail : details.entrySet()) {
         sb.append(detail.getKey());
-        sb.append("=");
+        sb.append("= ");
 
         for (String value : detail.getValue()) {
-          sb.append(" ");
           sb.append(value);
         }
         sb.append(",");

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -241,7 +241,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       logger.debug(
           "Failed to retrieve BLOB metadata: {} - {}",
           ex.getErrorCode(),
-          ex.getExtendedErrorInformation());
+          FormatStorageExceptionExtendedInformation(ex.getExtendedErrorInformation()));
       throw new StorageProviderException(ex);
     } catch (URISyntaxException ex) {
       logger.debug("Cannot retrieve BLOB properties, invalid URI: {}", ex);
@@ -678,7 +678,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
             se.getErrorCode(),
             se.getHttpStatusCode(),
             se.getMessage(),
-            se.getExtendedErrorInformation());
+            FormatStorageExceptionExtendedInformation(se.getExtendedErrorInformation()));
       } else {
         logger.debug(
             "Encountered exception ({}) during {}, retry count: {}",
@@ -736,8 +736,44 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
     }
   }
 
+  /**
+   * Format the StorageExtendedErrorInformation to a String.
+   *
+   * @param info the StorageExtendedErrorInformation object
+   * @return
+   */
+  private static String FormatStorageExceptionExtendedInformation(
+      StorageExtendedErrorInformation info) {
+    if (info == null) {
+      return "";
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("StorageExceptionExtendedErrorInformation: {ErrorCode= ");
+    sb.append(info.getErrorCode());
+    sb.append(", ErrorMessage= ");
+    sb.append(info.getErrorMessage());
+
+    HashMap<String, String[]> details = info.getAdditionalDetails();
+    if (details != null) {
+      sb.append(", AdditionalDetails= { ");
+      for (Map.Entry<String, String[]> detail : details.entrySet()) {
+        sb.append(detail.getKey());
+        sb.append("= ");
+
+        for (String value : detail.getValue()) {
+          sb.append(value);
+        }
+        sb.append(",");
+      }
+      sb.setCharAt(sb.length() - 1, '}'); // overwrite the last comma
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
   /*
-   * Builds a URI to a Azure Storage account endpoint
+   * Builds a URI to an Azure Storage account endpoint
    *
    *  @param storageEndPoint   the storage endpoint name
    *  @param storageAccount    the storage account name

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClientTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClientTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.client.jdbc.cloud.storage;
+
+import static org.junit.Assert.assertEquals;
+
+import com.microsoft.azure.storage.StorageExtendedErrorInformation;
+import java.util.HashMap;
+import org.junit.Test;
+
+public class SnowflakeAzureClientTest {
+  @Test
+  public void testFormatStorageExtendedErrorInformation() {
+    String expectedStr0 =
+        "StorageExceptionExtendedErrorInformation: {ErrorCode= 403, ErrorMessage= Server refuses"
+            + " to authorize the request, AdditionalDetails= {}}";
+    String expectedStr1 =
+        "StorageExceptionExtendedErrorInformation: {ErrorCode= 403, ErrorMessage= Server refuses"
+            + " to authorize the request, AdditionalDetails= { key1= helloworld,key2= ,key3="
+            + " fakemessage}}";
+    StorageExtendedErrorInformation info = new StorageExtendedErrorInformation();
+    info.setErrorCode("403");
+    info.setErrorMessage("Server refuses to authorize the request");
+    String formatedStr = SnowflakeAzureClient.FormatStorageExtendedErrorInformation(info);
+    assertEquals(expectedStr0, formatedStr);
+
+    HashMap<String, String[]> map = new HashMap<>();
+    map.put("key1", new String[] {"hello", "world"});
+    map.put("key2", new String[] {});
+    map.put("key3", new String[] {"fake", "message"});
+    info.setAdditionalDetails(map);
+    formatedStr = SnowflakeAzureClient.FormatStorageExtendedErrorInformation(info);
+    assertEquals(expectedStr1, formatedStr);
+  }
+}

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClientTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClientTest.java
@@ -18,8 +18,8 @@ public class SnowflakeAzureClientTest {
             + " to authorize the request, AdditionalDetails= {}}";
     String expectedStr1 =
         "StorageExceptionExtendedErrorInformation: {ErrorCode= 403, ErrorMessage= Server refuses"
-            + " to authorize the request, AdditionalDetails= { key1= helloworld,key2= ,key3="
-            + " fakemessage}}";
+            + " to authorize the request, AdditionalDetails= { key1= hello world,key2=,key3="
+            + " fake message}}";
     StorageExtendedErrorInformation info = new StorageExtendedErrorInformation();
     info.setErrorCode("403");
     info.setErrorMessage("Server refuses to authorize the request");

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClientTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClientTest.java
@@ -18,8 +18,8 @@ public class SnowflakeAzureClientTest {
             + " to authorize the request, AdditionalDetails= {}}";
     String expectedStr1 =
         "StorageExceptionExtendedErrorInformation: {ErrorCode= 403, ErrorMessage= Server refuses"
-            + " to authorize the request, AdditionalDetails= { key1= hello world,key2=,key3="
-            + " fake message}}";
+            + " to authorize the request, AdditionalDetails= { key1= helloworld,key2= ,key3="
+            + " fakemessage}}";
     StorageExtendedErrorInformation info = new StorageExtendedErrorInformation();
     info.setErrorCode("403");
     info.setErrorMessage("Server refuses to authorize the request");


### PR DESCRIPTION
# Overview

SNOW-466639
Currently JDBC failed to log StorageExceptionExtendedInformation correctly. It's something like `Extended error info=net.snowflake.client.jdbc.internal.microsoft.azure.storage.StorageExtendedErrorInformation@408e96d9`. This pr is to  fix the issue.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

