### PR TITLE
SNOW-411516 Support SFAsyncResultSet.getResultSetSerializables(Long)

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -357,6 +357,9 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
   public List<SnowflakeResultSetSerializable> getResultSetSerializables(long maxSizeInBytes)
       throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
-    throw new SnowflakeLoggedFeatureNotSupportedException(session);
+    getRealResults();
+    return resultSetForNext
+        .unwrap(SnowflakeResultSet.class)
+        .getResultSetSerializables(maxSizeInBytes);
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncIT.java
@@ -294,22 +294,6 @@ public class ResultSetAsyncIT extends BaseJDBCTest {
     connection.close();
   }
 
-  /** At the moment, asynchronous result sets cannot be serialized. */
-  @Test
-  public void testIsSerializable() throws SQLException {
-    Connection connection = getConnection();
-    Statement statement = connection.createStatement();
-    ResultSet resultSet =
-        statement.unwrap(SnowflakeStatement.class).executeAsyncQuery("show parameters");
-    try {
-      resultSet.unwrap(SnowflakeResultSet.class).getResultSetSerializables(500);
-      fail(
-          "SFAsyncResultSet.getResultSetSerializables should return SQLFeatureNotSupportedException");
-    } catch (SQLFeatureNotSupportedException e) {
-      // Do nothing. Test passes if we catch this exception.
-    }
-  }
-
   /**
    * This is a corner case for if a user forgets to call one of these functions before attempting to
    * fetch real data. An empty ResultSet is initially returned form executeAsyncQuery() but is

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
@@ -223,12 +223,26 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
    * @throws Throwable If any error happens.
    */
   private void testBasicTableHarness(
-      int rowCount, long maxSizeInBytes, String whereClause, boolean needSetupTable)
+      int rowCount, long maxSizeInBytes, String whereClause, boolean needSetupTable, boolean async)
       throws Throwable {
     List<String> fileNameList = null;
     String originalResultCSVString = null;
     try (Connection connection = init()) {
       Statement statement = connection.createStatement();
+
+      if (developPrint) {
+        System.out.println(
+            "testBasicTableHarness: rowCount="
+                + rowCount
+                + ", maxSizeInBytes="
+                + maxSizeInBytes
+                + ", whereClause="
+                + whereClause
+                + ", needSetupTable="
+                + needSetupTable
+                + ", async="
+                + async);
+      }
 
       if (needSetupTable) {
         statement.execute(
@@ -245,7 +259,10 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
       }
 
       String sqlSelect = "select * from table_basic " + whereClause;
-      ResultSet rs = statement.executeQuery(sqlSelect);
+      ResultSet rs =
+          async
+              ? statement.executeQuery(sqlSelect)
+              : statement.unwrap(SnowflakeStatement.class).executeAsyncQuery(sqlSelect);
 
       fileNameList = serializeResultSet((SnowflakeResultSet) rs, maxSizeInBytes, "txt");
 
@@ -262,36 +279,52 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
   public void testBasicTableWithEmptyResult() throws Throwable {
     // Use complex WHERE clause in order to test both ARROW and JSON.
     // It looks GS only generates JSON format result.
-    testBasicTableHarness(10, 1024, "where int_c * int_c = 2", true);
+    testBasicTableHarness(10, 1024, "where int_c * int_c = 2", true, false);
+    // Test Async mode
+    testBasicTableHarness(10, 1024, "where int_c * int_c = 2", true, true);
   }
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testBasicTableWithOnlyFirstChunk() throws Throwable {
     // Result only includes first data chunk, test maxSize is small.
-    testBasicTableHarness(1, 1, "", true);
+    testBasicTableHarness(1, 1, "", true, false);
+    // Test Async mode
+    testBasicTableHarness(1, 1, "", true, true);
     // Result only includes first data chunk, test maxSize is big.
-    testBasicTableHarness(1, 1024 * 1024, "", false);
+    testBasicTableHarness(1, 1024 * 1024, "", false, false);
+    // Test async mode
+    testBasicTableHarness(1, 1024 * 1024, "", false, true);
   }
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testBasicTableWithOneFileChunk() throws Throwable {
     // Result only includes first data chunk, test maxSize is small.
-    testBasicTableHarness(300, 1, "", true);
+    testBasicTableHarness(300, 1, "", true, false);
+    // Test Async mode
+    testBasicTableHarness(300, 1, "", true, true);
     // Result only includes first data chunk, test maxSize is big.
-    testBasicTableHarness(300, 1024 * 1024, "", false);
+    testBasicTableHarness(300, 1024 * 1024, "", false, false);
+    // Test Async mode
+    testBasicTableHarness(300, 1024 * 1024, "", false, true);
   }
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testBasicTableWithSomeFileChunks() throws Throwable {
     // Result only includes first data chunk, test maxSize is small.
-    testBasicTableHarness(90000, 1, "", true);
+    testBasicTableHarness(90000, 1, "", true, false);
+    // Test Async mode
+    testBasicTableHarness(90000, 1, "", true, true);
     // Result only includes first data chunk, test maxSize is median.
-    testBasicTableHarness(90000, 3 * 1024 * 1024, "", false);
+    testBasicTableHarness(90000, 3 * 1024 * 1024, "", false, false);
+    // Test Async mode
+    testBasicTableHarness(90000, 3 * 1024 * 1024, "", false, true);
     // Result only includes first data chunk, test maxSize is big.
-    testBasicTableHarness(90000, 100 * 1024 * 1024, "", false);
+    testBasicTableHarness(90000, 100 * 1024 * 1024, "", false, false);
+    // Test Async mode
+    testBasicTableHarness(90000, 100 * 1024 * 1024, "", false, true);
   }
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
@@ -261,8 +261,8 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
       String sqlSelect = "select * from table_basic " + whereClause;
       ResultSet rs =
           async
-              ? statement.executeQuery(sqlSelect)
-              : statement.unwrap(SnowflakeStatement.class).executeAsyncQuery(sqlSelect);
+              ? statement.unwrap(SnowflakeStatement.class).executeAsyncQuery(sqlSelect)
+              : statement.executeQuery(sqlSelect);
 
       fileNameList = serializeResultSet((SnowflakeResultSet) rs, maxSizeInBytes, "txt");
 


### PR DESCRIPTION
# Overview

SNOW-411516

`SnowflakeResultSet.getResultSetSerializables(Long)` is an API for Spark Connector.
It is disabled for `SFAsyncResultSet` when developing this feature because it is not necessary at that time.

This PR is enable it for `SFAsyncResultSet`. The implementation is:
1. Call getRealResult() to wait for the real result is ready.
2. Call resultSetForNext.getResultSetSerializables() to get the result.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

