### PR TITLE
SNOW-472364 Add API to get query IDs for multi statements

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseStatement.java
@@ -168,4 +168,7 @@ public abstract class SFBaseStatement {
   public abstract long getConservativeMemoryLimit();
 
   public abstract int getConservativePrefetchThreads();
+
+  /** @return the child query IDs for the multiple statements query. */
+  public abstract String[] getChildQueryIds(String queryID) throws SQLException;
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -171,6 +171,24 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   }
 
   /**
+   * Return an array of child query ID for the given query ID.
+   *
+   * <p>If the given query ID is for a multiple statements query, it returns an array of its child
+   * statements, otherwise, it returns an array to include the given query ID.
+   *
+   * @param queryID The given query ID
+   * @return An array of child query IDs
+   * @throws SQLException If the query is running or the corresponding query is FAILED.
+   */
+  public String[] getChildQueryIds(String queryID) throws SQLException {
+    raiseSQLExceptionIfConnectionIsClosed();
+    // execute the statement and auto-close it as well
+    try (final Statement statement = this.createStatement()) {
+      return statement.unwrap(SnowflakeStatementV1.class).getChildQueryIds(queryID);
+    }
+  }
+
+  /**
    * Close the connection
    *
    * @throws SQLException failed to close the connection

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -325,6 +325,11 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     return Collections.unmodifiableList(batchQueryIDs);
   }
 
+  /** @return the child query IDs for the multiple statements query. */
+  public String[] getChildQueryIds(String queryID) throws SQLException {
+    return sfBaseStatement.getChildQueryIds(queryID);
+  }
+
   /**
    * Execute sql
    *

--- a/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
@@ -585,6 +585,10 @@ public class MockConnectionTest extends BaseJDBCTest {
     public SFBaseResultSet getResultSet() {
       return null;
     }
+
+    public String[] getChildQueryIds(String queryID) throws SQLException {
+      throw new SQLFeatureNotSupportedException("MockedSFBaseStatement.getChildQueryIds");
+    }
   }
 
   private static class MockJsonResultSet extends SFJsonResultSet {


### PR DESCRIPTION
# Overview

SNOW-472364

Add below function to SnowflakeConnectionV1 to get child query ID for multiple statements query.
`public String[] getChildQueryIds(String queryID) throws SQLException
`
In general, we have the query ID for the multiple statements. We can use `StmtUtil.getQueryResultJSON(String queryId, SFSession session)` to get the JsonResult. And then we can parse out the query IDs from it.

Design doc is https://docs.google.com/document/d/19CysvhnivP8KLmRBo7U9-N1ILk51YCB5GCu_H0Rp4RA/edit#heading=h.74dz4sbkqqz8

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

