### PR TITLE
SNOW-224719 Support curly bracket syntax in JDBC

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeCallableStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeCallableStatementV1.java
@@ -42,7 +42,29 @@ final class SnowflakeCallableStatementV1 extends SnowflakePreparedStatementV1
       int resultSetConcurrency,
       int resultSetHoldability)
       throws SQLException {
-    super(connection, sql, skipParsing, resultSetType, resultSetConcurrency, resultSetHoldability);
+    super(
+        connection,
+        parseSqlEscapeSyntax(sql),
+        skipParsing,
+        resultSetType,
+        resultSetConcurrency,
+        resultSetHoldability);
+  }
+
+  /**
+   * Helper function to remove curly brackets for CallableStatement procedure calls, since GS parser
+   * does not support escape syntax for curly brackets
+   *
+   * @param originalSql original SQL text, possibly with curly brackets
+   * @return a string of SQL text with curly brackets removed
+   */
+  static String parseSqlEscapeSyntax(String originalSql) {
+    originalSql = originalSql.trim();
+    if (originalSql.startsWith("{") && originalSql.endsWith("}")) {
+      logger.info("Curly brackets {} removed before sending sql to server.");
+      return originalSql.substring(1, originalSql.length() - 1);
+    }
+    return originalSql;
   }
 
   /*

--- a/src/test/java/net/snowflake/client/jdbc/CallableStatementIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/CallableStatementIT.java
@@ -52,8 +52,8 @@ public class CallableStatementIT extends BaseJDBCTest {
   private final String deleteStoredProcedure = "drop procedure if exists square_it(FLOAT)";
   private final String deleteSecondStoredProcedure = "drop procedure if exists add_nums(INT, INT)";
 
-  private Connection connection = null;
-  private Statement statement = null;
+  protected Connection connection = null;
+  protected Statement statement = null;
 
   @Before
   public void setUp() throws SQLException {

--- a/src/test/java/net/snowflake/client/jdbc/CallableStatementLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/CallableStatementLatestIT.java
@@ -1,0 +1,73 @@
+package net.snowflake.client.jdbc;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import net.snowflake.client.category.TestCategoryStatement;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(TestCategoryStatement.class)
+public class CallableStatementLatestIT extends CallableStatementIT {
+
+  public CallableStatementLatestIT(String format) {
+    super(format);
+  }
+
+  /**
+   * Test that function that removes curly brackets from outside of call statements works properly
+   */
+  @Test
+  public void testParseSqlEscapeSyntaxFunction() {
+    String[] callStatements = {
+      "{call square_it(5)}", "call no_bracket_function(44)", "call {bracket_function(a=?)}"
+    };
+    String[] expectedStatements = {
+      "call square_it(5)", "call no_bracket_function(44)", "call {bracket_function(a=?)}"
+    };
+    for (int i = 0; i < callStatements.length; i++) {
+      assertEquals(
+          expectedStatements[i],
+          SnowflakeCallableStatementV1.parseSqlEscapeSyntax(callStatements[i]));
+    }
+  }
+
+  /**
+   * Test that prepareCall works the same as before with curly bracket syntax.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testPrepareCallWithCurlyBracketSyntax() throws SQLException {
+    // test CallableStatement with no binding parameters
+    connection = getConnection();
+    statement = connection.createStatement();
+    CallableStatement callableStatement = connection.prepareCall("{call square_it(5)}");
+    assertThat(callableStatement.getParameterMetaData().getParameterCount(), is(0));
+
+    // test CallableStatement with 1 binding parameter
+    callableStatement = connection.prepareCall("{call square_it(?)}");
+    // test that getParameterMetaData works with CallableStatement. At this point, it always returns
+    // the type as "text."
+    assertThat(callableStatement.getParameterMetaData().getParameterType(1), is(Types.VARCHAR));
+    callableStatement.getParameterMetaData().getParameterTypeName(1);
+    assertThat(callableStatement.getParameterMetaData().getParameterTypeName(1), is("text"));
+    callableStatement.setFloat(1, 7.0f);
+    ResultSet rs = callableStatement.executeQuery();
+    rs.next();
+    assertEquals(49.0f, rs.getFloat(1), 1.0f);
+
+    // test CallableStatement with 2 binding parameters
+    callableStatement = connection.prepareCall("{call add_nums(?,?)}");
+    callableStatement.setDouble(1, 32);
+    callableStatement.setDouble(2, 15);
+    rs = callableStatement.executeQuery();
+    rs.next();
+    assertEquals(47, rs.getDouble(1), .5);
+  }
+}


### PR DESCRIPTION
# Overview

SNOW-224719

This change removes curly brackets from the outside of CallableStatements in JDBC so that curly bracket syntax is supported. This may be a temporary measure until the GS parser supports this syntax without needing a JDBC modification, in which case this change will be reverted.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

