### PR TITLE
SNOW-458293 make chunk downloader max retry configurable with a server side parameter

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -76,6 +76,7 @@ public class SessionUtil {
   private static final String JDBC_TREAT_TIMESTAMP_NTZ_AS_UTC = "JDBC_TREAT_TIMESTAMP_NTZ_AS_UTC";
   private static final String JDBC_FORMAT_DATE_WITH_TIMEZONE = "JDBC_FORMAT_DATE_WITH_TIMEZONE";
   private static final String JDBC_USE_SESSION_TIMEZONE = "JDBC_USE_SESSION_TIMEZONE";
+  public static final String JDBC_CHUNK_DOWNLOADER_MAX_RETRY = "JDBC_CHUNK_DOWNLOADER_MAX_RETRY";
   private static final String CLIENT_RESULT_CHUNK_SIZE_JVM =
       "net.snowflake.jdbc.clientResultChunkSize";
   public static final String CLIENT_RESULT_CHUNK_SIZE = "CLIENT_RESULT_CHUNK_SIZE";

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -122,6 +122,10 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
   private static final int MAX_NUM_OF_RETRY = 10;
   private static final int MAX_RETRY_JITTER = 1000; // milliseconds
 
+  // Only controls the max retry number when prefetch runs out of memory
+  // Default value is MAX_NUM_OF_RETRY, which is 10
+  private int prefetchMaxRetry = MAX_NUM_OF_RETRY;
+
   private static Throwable injectedDownloaderException = null; // for testing purpose
 
   // This function should only be used for testing purpose
@@ -195,6 +199,13 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         (resultSetSerializable.getSession() != null)
             ? resultSetSerializable.getSession().orElse(null)
             : null;
+    if (this.session != null) {
+      Object prefetchMaxRetry =
+          this.session.getOtherParameter(SessionUtil.JDBC_CHUNK_DOWNLOADER_MAX_RETRY);
+      if (prefetchMaxRetry != null) {
+        this.prefetchMaxRetry = (int) prefetchMaxRetry;
+      }
+    }
     this.memoryLimit = resultSetSerializable.getMemoryLimit();
     if (this.session != null
         && session.getMemoryLimitForTesting() != SFBaseSession.MEMORY_LIMIT_UNSET) {
@@ -374,7 +385,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         // cancel the reserved memory
         logger.debug("cancel the reserved memory.");
         curMem = currentMemoryUsage.addAndGet(-neededChunkMemory);
-        if (getPrefetchMemRetry > MAX_NUM_OF_RETRY) {
+        if (getPrefetchMemRetry > prefetchMaxRetry) {
           logger.debug(
               "Retry limit for prefetch has been reached. Cancel reserved memory and prefetch attempt.");
           break;


### PR DESCRIPTION

# Overview

SNOW-458293 this change will add a new parameter in GS to control the max retry number in JDBC's chunk downloader https://github.com/snowflakedb/snowflake/pull/38246/files. GS will include the value of that parameter in its response to the client. Then JDBC will stored this parameter in otherParameter. This change does not depends on GS's change, if this parameter JDBC_CHUNK_DOWNLOADER_MAX_RETRY is not included in GS's response, JDBC will use a default value of 10.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

