### PR TITLE
Disable key-value table feature for jdbc client

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
@@ -441,6 +441,11 @@ public class DatabaseMetaDataInternalIT extends BaseJDBCTest {
 
     // set parameter
     stmt.execute("alter session set ENABLE_DRIVER_TERSE_SHOW = true;");
+    // SNOW-487548: disable the key-value feature to hide is_hybrid column
+    // in show tables command. The column is controlled by two parameters:
+    // enable_key_value_table and qa_mode.
+    stmt.execute("alter session set ENABLE_KEY_VALUE_TABLE = false;");
+    stmt.execute("alter session set qa_mode = false;");
 
     databaseMetaData = connection.getMetaData();
 


### PR DESCRIPTION
# Overview

SNOW-487548: BPTP Test failure: net.snowflake.client.jdbc.DatabaseMetaDataInternalIT::testGetTables

This PR disables the key-value table feature at the session level for the JDBC driver test so that the order of columns in the snow tables command does not changes. 
Please note that the key-value feature is not enabled in PROD. 
 


## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

