### PR TITLE
SNOW-492055 File transfer upload logic should check for errors in tasks submitted to ThreadPoolExecutor

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -1489,7 +1489,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         throw new SnowflakeSQLLoggedException(
             session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
       } catch (ExecutionException ex) {
-        throw ex.getCause();
+        throw new SnowflakeSQLException(
+            ex.getCause(), SqlState.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getMessageCode());
       }
       logger.debug("Done with uploading from a stream");
     } finally {


### PR DESCRIPTION
# Overview

SNOW-492055
Problem:

* Create ThreadPoolExecutor
* Add a task to that executor
* executor.awaitTermination

The above code logic waits for the task to complete but it does not bubble up the exception in the task. Because of that `SnowflakeFIleTransferAgent:uploadStream` and the other related methods are not returning the exceptions back to the calling thread.

The fix in this PR is a quick fix since we have to do an urgent patch release. 

The right solution here is not to use `ExecutorService` at all if only 1 task will be added and the thread will do a blocking wait for the task to finish.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

