### PR TITLE
SNOW-473749 Fix bug where time(3) objects weren't honoring USE_SESSION_TIMEZONE when called with getTimestamp() in Arrow format

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -3,15 +3,11 @@
  */
 package net.snowflake.client.jdbc;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.client.category.TestCategoryResultSet;
-import net.snowflake.client.core.SFBaseSession;
-import net.snowflake.client.jdbc.telemetry.*;
-import net.snowflake.common.core.SFBinary;
-import org.apache.arrow.vector.Float8Vector;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -19,10 +15,13 @@ import java.nio.ByteBuffer;
 import java.sql.*;
 import java.util.*;
 import java.util.regex.Pattern;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import net.snowflake.client.category.TestCategoryResultSet;
+import net.snowflake.client.core.SFBaseSession;
+import net.snowflake.client.jdbc.telemetry.*;
+import net.snowflake.common.core.SFBinary;
+import org.apache.arrow.vector.Float8Vector;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -47,11 +46,19 @@ public class ResultSetLatestIT extends ResultSet0IT {
     Connection con = getConnection();
     Statement statement = con.createStatement();
     statement.execute("alter session set jdbc_query_result_format = 'arrow'");
-    statement.execute("create or replace table SRC_DATE_TIME (C2_TIME_3 TIME(3), C3_TIME_5 TIME(5), C4_TIME TIME(9))");
-    statement.execute("insert into SRC_DATE_TIME values ('10:30:50.123456789','10:30:50.123456789123456789','10:30:50.123456789')");
+    statement.execute(
+        "create or replace table SRC_DATE_TIME (C2_TIME_3 TIME(3), C3_TIME_5 TIME(5), C4_TIME TIME(9))");
+    statement.execute(
+        "insert into SRC_DATE_TIME values ('10:30:50.123456789','10:30:50.123456789123456789','10:30:50.123456789')");
     ResultSet rs = statement.executeQuery("select * from SRC_DATE_TIME");
     rs.next();
-    System.out.println("Time(3): " + rs.getTimestamp(1) + ", Time(5): " + rs.getTimestamp(2) + ", Time(9): " + rs.getTimestamp(3));
+    System.out.println(
+        "Time(3): "
+            + rs.getTimestamp(1)
+            + ", Time(5): "
+            + rs.getTimestamp(2)
+            + ", Time(9): "
+            + rs.getTimestamp(3));
   }
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -3,15 +3,11 @@
  */
 package net.snowflake.client.jdbc;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.client.category.TestCategoryResultSet;
-import net.snowflake.client.core.SFBaseSession;
-import net.snowflake.client.jdbc.telemetry.*;
-import net.snowflake.common.core.SFBinary;
-import org.apache.arrow.vector.Float8Vector;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -22,10 +18,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import net.snowflake.client.category.TestCategoryResultSet;
+import net.snowflake.client.core.SFBaseSession;
+import net.snowflake.client.jdbc.telemetry.*;
+import net.snowflake.common.core.SFBinary;
+import org.apache.arrow.vector.Float8Vector;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -3,21 +3,7 @@
  */
 package net.snowflake.client.jdbc;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.RoundingMode;
-import java.nio.ByteBuffer;
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 import net.snowflake.client.category.TestCategoryResultSet;
 import net.snowflake.client.core.SFBaseSession;
 import net.snowflake.client.jdbc.telemetry.*;
@@ -25,6 +11,18 @@ import net.snowflake.common.core.SFBinary;
 import org.apache.arrow.vector.Float8Vector;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import java.sql.*;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -41,6 +39,19 @@ public class ResultSetLatestIT extends ResultSet0IT {
 
   ResultSetLatestIT(String queryResultFormat) {
     super(queryResultFormat);
+  }
+
+  @Test
+  public void testTimeIssue() throws SQLException {
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+    Connection con = getConnection();
+    Statement statement = con.createStatement();
+    statement.execute("alter session set jdbc_query_result_format = 'arrow'");
+    statement.execute("create or replace table SRC_DATE_TIME (C2_TIME_3 TIME(3), C3_TIME_5 TIME(5), C4_TIME TIME(9))");
+    statement.execute("insert into SRC_DATE_TIME values ('10:30:50.123456789','10:30:50.123456789123456789','10:30:50.123456789')");
+    ResultSet rs = statement.executeQuery("select * from SRC_DATE_TIME");
+    rs.next();
+    System.out.println("Time(3): " + rs.getTimestamp(1) + ", Time(5): " + rs.getTimestamp(2) + ", Time(9): " + rs.getTimestamp(3));
   }
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -3,18 +3,7 @@
  */
 package net.snowflake.client.jdbc;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.RoundingMode;
-import java.nio.ByteBuffer;
-import java.sql.*;
-import java.util.*;
-import java.util.regex.Pattern;
 import net.snowflake.client.category.TestCategoryResultSet;
 import net.snowflake.client.core.SFBaseSession;
 import net.snowflake.client.jdbc.telemetry.*;
@@ -22,6 +11,21 @@ import net.snowflake.common.core.SFBinary;
 import org.apache.arrow.vector.Float8Vector;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -38,27 +42,6 @@ public class ResultSetLatestIT extends ResultSet0IT {
 
   ResultSetLatestIT(String queryResultFormat) {
     super(queryResultFormat);
-  }
-
-  @Test
-  public void testTimeIssue() throws SQLException {
-    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
-    Connection con = getConnection();
-    Statement statement = con.createStatement();
-    statement.execute("alter session set jdbc_query_result_format = 'arrow'");
-    statement.execute(
-        "create or replace table SRC_DATE_TIME (C2_TIME_3 TIME(3), C3_TIME_5 TIME(5), C4_TIME TIME(9))");
-    statement.execute(
-        "insert into SRC_DATE_TIME values ('10:30:50.123456789','10:30:50.123456789123456789','10:30:50.123456789')");
-    ResultSet rs = statement.executeQuery("select * from SRC_DATE_TIME");
-    rs.next();
-    System.out.println(
-        "Time(3): "
-            + rs.getTimestamp(1)
-            + ", Time(5): "
-            + rs.getTimestamp(2)
-            + ", Time(9): "
-            + rs.getTimestamp(3));
   }
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneLatestIT.java
@@ -63,6 +63,36 @@ public class ResultSetMultiTimeZoneLatestIT extends BaseJDBCTest {
   }
 
   /**
+   * This tests that all time values (regardless of precision) return the same wallclock value when
+   * getTimestamp() is called.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testTimesWithGetTimestamp() throws SQLException {
+    Connection connection = init();
+    Statement statement = connection.createStatement();
+    String timeStringValue = "10:30:50.123456789";
+    String timestampStringValue = "1970-01-01 " + timeStringValue;
+    int length = timestampStringValue.length();
+    statement.execute(
+        "create or replace table SRC_DATE_TIME (C2_TIME_3 TIME(3), C3_TIME_5 TIME(5), C4_TIME TIME(9))");
+    statement.execute(
+        "insert into SRC_DATE_TIME values ('"
+            + timeStringValue
+            + "','"
+            + timeStringValue
+            + "','"
+            + timeStringValue
+            + "')");
+    ResultSet rs = statement.executeQuery("select * from SRC_DATE_TIME");
+    rs.next();
+    assertEquals(timestampStringValue.substring(0, length - 6), rs.getTimestamp(1).toString());
+    assertEquals(timestampStringValue.substring(0, length - 4), rs.getTimestamp(2).toString());
+    assertEquals(timestampStringValue, rs.getTimestamp(3).toString());
+  }
+
+  /**
    * This test is for SNOW-366563 where the timestamp was returning an incorrect value for daylight
    * savings time due to the fact that UTC and Europe/London time have the same offset until
    * daylight savings comes into effect. This tests that the timestamp value is accurate during


### PR DESCRIPTION
# Overview

SNOW-473749

This is a PR to fix a bug where calling getTimestamp() on a Time object with precision of 3 or under in Arrow format didn't honor the session parameter USE_SESSION_TIMEZONE to display wallclock time.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

