### PR TITLE
SNOW-500624 JVM http proxy properties do not work for PUT/GET

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -356,9 +356,7 @@ public abstract class SFBaseSession {
         // There are 2 possible parameters for non proxy hosts that can be combined into 1
         String combinedNonProxyHosts = Strings.isNullOrEmpty(nonProxyHosts) ? "" : nonProxyHosts;
         if (!Strings.isNullOrEmpty(noProxy)) {
-          if (!Strings.isNullOrEmpty(combinedNonProxyHosts)) {
-            combinedNonProxyHosts += "|";
-          }
+          combinedNonProxyHosts += combinedNonProxyHosts.length() == 0 ? "" : "|";
           combinedNonProxyHosts += noProxy;
         }
         if (!Strings.isNullOrEmpty(httpsProxyHost) && !Strings.isNullOrEmpty(httpsProxyPort)) {
@@ -395,6 +393,12 @@ public abstract class SFBaseSession {
                   "", /* user = empty */
                   "", /* password = empty */
                   "http");
+        } else {
+          // Not enough parameters set to use the proxy.
+          logger.debug(
+              "http.useProxy={} but valid host and port were not provided. No proxy in use.",
+              httpUseProxy);
+          ocspAndProxyKey = new HttpClientSettingsKey(getOCSPMode());
         }
       } else {
         // If no proxy is used or JVM http proxy is used, no need for setting parameters

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -341,16 +341,26 @@ public abstract class SFBaseSession {
       String httpsProxyHost = systemGetProperty("https.proxyHost");
       String httpsProxyPort = systemGetProperty("https.proxyPort");
       String noProxy = systemGetEnv("NO_PROXY");
+      String nonProxyHosts = systemGetProperty("http.nonProxyHosts");
       // log the JVM parameters that are being used
       if (httpUseProxy) {
         logger.debug(
-            "http.useProxy={}, http.proxyHost={}, http.proxyPort={}, https.proxyHost={}, https.proxyPort={}, NO_PROXY={}",
+            "http.useProxy={}, http.proxyHost={}, http.proxyPort={}, https.proxyHost={}, https.proxyPort={}, http.nonProxyHosts={}, NO_PROXY={}",
             httpUseProxy,
             httpProxyHost,
             httpProxyPort,
             httpsProxyHost,
             httpsProxyPort,
+            nonProxyHosts,
             noProxy);
+        // There are 2 possible parameters for non proxy hosts that can be combined into 1
+        String combinedNonProxyHosts = Strings.isNullOrEmpty(nonProxyHosts) ? "" : nonProxyHosts;
+        if (!Strings.isNullOrEmpty(noProxy)) {
+          if (!Strings.isNullOrEmpty(combinedNonProxyHosts)) {
+            combinedNonProxyHosts += "|";
+          }
+          combinedNonProxyHosts += noProxy;
+        }
         if (!Strings.isNullOrEmpty(httpsProxyHost) && !Strings.isNullOrEmpty(httpsProxyPort)) {
           int proxyPort;
           try {
@@ -364,7 +374,7 @@ public abstract class SFBaseSession {
                   getOCSPMode(),
                   httpsProxyHost,
                   proxyPort,
-                  noProxy,
+                  combinedNonProxyHosts,
                   "", /* user = empty */
                   "", /* password = empty */
                   "https");
@@ -381,7 +391,7 @@ public abstract class SFBaseSession {
                   getOCSPMode(),
                   httpProxyHost,
                   proxyPort,
-                  noProxy,
+                  combinedNonProxyHosts,
                   "", /* user = empty */
                   "", /* password = empty */
                   "http");

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -522,6 +522,42 @@ public class SnowflakeUtil {
     return null;
   }
 
+  /** System.setEnv function. Can be used for unit tests. */
+  public static void systemSetEnv(String key, String value) {
+    try {
+      Map<String, String> env = System.getenv();
+      Class<?> cl = env.getClass();
+      Field field = cl.getDeclaredField("m");
+      field.setAccessible(true);
+      Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+      writableEnv.put(key, value);
+    } catch (Exception e) {
+      System.out.println("Failed to set value");
+      logger.error(
+          "Failed to set environment variable {}. Exception raised: {}", key, e.getMessage());
+    }
+  }
+
+  /**
+   * System.unsetEnv function to remove a system environment parameter in the map
+   *
+   * @param key
+   */
+  public static void systemUnsetEnv(String key) {
+    try {
+      Map<String, String> env = System.getenv();
+      Class<?> cl = env.getClass();
+      Field field = cl.getDeclaredField("m");
+      field.setAccessible(true);
+      Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+      writableEnv.remove(key);
+    } catch (Exception e) {
+      System.out.println("Failed to unset value");
+      logger.error(
+          "Failed to remove environment variable {}. Exception raised: {}", key, e.getMessage());
+    }
+  }
+
   /**
    * Setup JDBC proxy properties if necessary.
    *

--- a/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
@@ -542,8 +542,8 @@ public class CustomProxyLatestIT {
     }
 
     // SET USER AND PASSWORD FIRST
-    String user = "mknister";
-    String passwd = "Argumentc1inicspam!";
+    String user = "USER";
+    String passwd = "PASSWORD";
     Properties _connectionProperties = new Properties();
     _connectionProperties.put("user", user);
     _connectionProperties.put("password", passwd);

--- a/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
@@ -389,7 +389,8 @@ public class CustomProxyLatestIT {
   public void testProxyConnectionWithAzure() throws ClassNotFoundException, SQLException {
     String connectionUrl =
         "jdbc:snowflake://aztestaccount.east-us-2.azure.snowflakecomputing.com/?tracing=ALL";
-    runAzureProxyConnection(connectionUrl, true, true);
+    runAzureProxyConnection(
+        connectionUrl, /* usesConnectionProperties */ true, /* usesIncorrectJVMParameters */ true);
   }
 
   @Test
@@ -401,7 +402,8 @@ public class CustomProxyLatestIT {
             + "&proxyHost=localhost&proxyPort=8080"
             + "&proxyUser=testuser1&proxyPassword=test"
             + "&useProxy=true";
-    runAzureProxyConnection(connectionUrl, false, true);
+    runAzureProxyConnection(
+        connectionUrl, /* usesConnectionProperties */ false, /* usesIncorrectJVMParameters */ true);
   }
 
   @Test
@@ -415,7 +417,10 @@ public class CustomProxyLatestIT {
             + "&proxyUser=testuser1&proxyPassword=test"
             + "&useProxy=true";
     try {
-      runAzureProxyConnection(connectionUrl, false, true);
+      runAzureProxyConnection(
+          connectionUrl, /* usesConnectionProperties */
+          false, /* usesIncorrectJVMParameters */
+          true);
       fail();
     } catch (SQLException e) {
       assertEquals(SqlState.CONNECTION_EXCEPTION, e.getSQLState());
@@ -427,7 +432,10 @@ public class CustomProxyLatestIT {
             + "&proxyUser=testuser1&proxyPassword=test"
             + "&useProxy=true";
     try {
-      runAzureProxyConnection(connectionUrl, false, true);
+      runAzureProxyConnection(
+          connectionUrl, /* usesConnectionProperties */
+          false, /* usesIncorrectJVMParameters */
+          true);
       fail();
     } catch (SQLException e) {
       assertEquals(SqlState.CONNECTION_EXCEPTION, e.getSQLState());
@@ -440,7 +448,10 @@ public class CustomProxyLatestIT {
             + "&proxyUser=testuser1&proxyPassword=test"
             + "&useProxy=true";
     try {
-      runAzureProxyConnection(connectionUrl, false, true);
+      runAzureProxyConnection(
+          connectionUrl, /* usesConnectionProperties */
+          false, /* usesIncorrectJVMParameters */
+          true);
       fail();
     } catch (SQLException e) {
       assertEquals(SqlState.CONNECTION_EXCEPTION, e.getSQLState());
@@ -452,7 +463,10 @@ public class CustomProxyLatestIT {
             + "&proxyUser=testuser1&proxyPassword=test"
             + "&useProxy=true";
     try {
-      runAzureProxyConnection(connectionUrl, false, true);
+      runAzureProxyConnection(
+          connectionUrl, /* usesConnectionProperties */
+          false, /* usesIncorrectJVMParameters */
+          true);
       fail();
     } catch (SQLException e) {
       assertEquals(SqlState.CONNECTION_EXCEPTION, e.getSQLState());
@@ -464,17 +478,23 @@ public class CustomProxyLatestIT {
   public void testProxyConnectionWithJVMParameters() throws SQLException, ClassNotFoundException {
     String connectionUrl =
         "jdbc:snowflake://aztestaccount.east-us-2.azure.snowflakecomputing.com/?tracing=ALL";
+    // Set valid JVM system properties
     System.setProperty("http.useProxy", "true");
     System.setProperty("http.proxyHost", "localhost");
     System.setProperty("http.proxyPort", "8080");
-    System.setProperty("http.nonProxyHosts", "*.snowflake.com");
-    runAzureProxyConnection(connectionUrl, false, false);
+    System.setProperty("http.nonProxyHosts", "*.snowflakecomputing.com");
+    SnowflakeUtil.systemSetEnv("NO_PROXY", "*.google.com");
+    runAzureProxyConnection(
+        connectionUrl, /* usesConnectionProperties */
+        false, /* usesIncorrectJVMParameters */
+        false);
+    SnowflakeUtil.systemUnsetEnv("NO_PROXY");
   }
 
   @Test
   @Ignore
   public void testProxyConnectionWithAzureWithWrongConnectionString()
-      throws ClassNotFoundException, SQLException {
+      throws ClassNotFoundException {
     String connectionUrl =
         "jdbc:snowflake://aztestaccount.east-us-2.azure.snowflakecomputing.com/?tracing=ALL"
             + "&proxyHost=localhost&proxyPort=31281"
@@ -482,7 +502,10 @@ public class CustomProxyLatestIT {
             + "&nonProxyHosts=*.foo.com%7Clocalhost&useProxy=true";
 
     try {
-      runAzureProxyConnection(connectionUrl, false, true);
+      runAzureProxyConnection(
+          connectionUrl, /* usesConnectionProperties */
+          false, /* usesIncorrectJVMParameters */
+          true);
     } catch (SQLException e) {
       assertThat(
           "JDBC driver encountered communication error",
@@ -492,7 +515,7 @@ public class CustomProxyLatestIT {
   }
 
   public void runAzureProxyConnection(
-      String connectionUrl, boolean usesProperties, boolean usesJVMProperties)
+      String connectionUrl, boolean usesProperties, boolean usesIncorrectJVMProperties)
       throws ClassNotFoundException, SQLException {
     Authenticator.setDefault(
         new Authenticator() {
@@ -509,9 +532,8 @@ public class CustomProxyLatestIT {
     // Enable these parameters to use JVM proxy parameters instead of connection string proxy
     // parameters.
     // Connection parameters override JVM  proxy params, so these incorrect params won't cause
-    // failures IF
-    // connection proxy params are enabled and working.
-    if (usesJVMProperties) {
+    // failures IF connection proxy params are enabled and working.
+    if (usesIncorrectJVMProperties) {
       System.setProperty("http.useProxy", "true");
       System.setProperty("http.proxyHost", "fakehost");
       System.setProperty("http.proxyPort", "8081");
@@ -520,8 +542,8 @@ public class CustomProxyLatestIT {
     }
 
     // SET USER AND PASSWORD FIRST
-    String user = "USER";
-    String passwd = "PASSWORD";
+    String user = "mknister";
+    String passwd = "Argumentc1inicspam!";
     Properties _connectionProperties = new Properties();
     _connectionProperties.put("user", user);
     _connectionProperties.put("password", passwd);

--- a/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
@@ -467,6 +467,7 @@ public class CustomProxyLatestIT {
     System.setProperty("http.useProxy", "true");
     System.setProperty("http.proxyHost", "localhost");
     System.setProperty("http.proxyPort", "8080");
+    System.setProperty("http.nonProxyHosts", "*.snowflake.com");
     runAzureProxyConnection(connectionUrl, false, false);
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
@@ -24,7 +24,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 // To run these tests, you must:
-// 1.) Start up a proxy connection. The simplest ways are via Squid or BurpSuite
+// 1.) Start up a proxy connection. The simplest ways are via Squid or BurpSuite. Confluence doc on
+// setup here:
+// https://snowflakecomputing.atlassian.net/wiki/spaces/EN/pages/65438343/How+to+setup+Proxy+Server+for+Client+tests
 // 2.) Enter your own username and password for the account you're connecting to
 // 3.) Adjust parameters like role, database, schema, etc to match with account accordingly
 
@@ -473,6 +475,16 @@ public class CustomProxyLatestIT {
     }
   }
 
+  /**
+   * Before running this test, change the user and password in runAzureProxyConnection() to
+   * appropriate values. Set up a proxy with Burpsuite so you can see what POST and GET requests are
+   * going through the proxy.
+   *
+   * <p>This tests that the NonProxyHosts field is sucessfully updated for the same HttpClient
+   * object.
+   *
+   * @throws SQLException
+   */
   @Test
   @Ignore
   public void testProxyConnectionWithJVMParameters() throws SQLException, ClassNotFoundException {


### PR DESCRIPTION
# Overview

SNOW-500624

When setting properties via the JVM, the http proxy properties were not passed along to the AzureClient or S3Clients, which means http proxies set via JVM were not used for PUT/GET. The fix for this is to pass the JVM properties to the driver, which then sets the proxy properties.

This fix was already made for https proxies, but not for http proxies.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [x] This change has passed precommit
- [x] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

