### PR TITLE
SNOW-475617 Fix issue where double-quotes schemas, databases, objects, etc return empty resultset for DatabaseMetadata get() functions.

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -4,16 +4,10 @@
 
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.jdbc.DBMetadataResultSetMetadata.*;
-import static net.snowflake.client.jdbc.SnowflakeType.convertStringToType;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Strings;
-import java.sql.*;
-import java.util.*;
-import java.util.regex.Pattern;
 import net.snowflake.client.core.ObjectMapperFactory;
 import net.snowflake.client.core.SFBaseSession;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
@@ -26,6 +20,13 @@ import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.client.util.SFPair;
 import net.snowflake.common.core.SqlState;
 import net.snowflake.common.util.Wildcard;
+
+import java.sql.*;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static net.snowflake.client.jdbc.DBMetadataResultSetMetadata.*;
+import static net.snowflake.client.jdbc.SnowflakeType.convertStringToType;
 
 public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
 
@@ -195,6 +196,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
   // Quotes must be escaped with another quote when creating an object, but they need to be added
   // back in to compare if returned result matches input argument.
   private String addQuotesBack(String unquotedString) {
+    //String quotedString = unquotedString.replaceAll("^\"|\"$", "");
     return unquotedString.replace("\"", "\"\"");
   }
 
@@ -1066,7 +1068,9 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
         while (showObjectResultSet.next()) {
           String catalogName = showObjectResultSet.getString("catalog_name");
           String schemaName = showObjectResultSet.getString("schema_name");
-          String procedureName = showObjectResultSet.getString("name");
+          System.out.println(schemaName);
+
+          String procedureName = showObjectResultSet.getString("name").replace("\"", "\\\"");
           String remarks = showObjectResultSet.getString("description");
           String specificName = showObjectResultSet.getString("arguments");
           short procedureType = procedureReturnsResult;

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -3,26 +3,8 @@
  */
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
-import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.sql.*;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryConnection;
@@ -41,6 +23,25 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.*;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
+import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
+import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
 /**
  * Connection integration tests for the latest JDBC driver. This doesn't work for the oldest
  * supported driver. Revisit this tests whenever bumping up the oldest supported driver to examine
@@ -55,11 +56,38 @@ public class ConnectionLatestIT extends BaseJDBCTest {
 
   @Before
   public void setUp() {
-    TelemetryService service = TelemetryService.getInstance();
+    /*TelemetryService service = TelemetryService.getInstance();
     service.updateContextForIT(getConnectionParameters());
     defaultState = service.isEnabled();
     service.setNumOfRetryToTriggerTelemetry(3);
-    TelemetryService.enable();
+    TelemetryService.enable();*/
+  }
+
+  @Test
+  public void testHarshConnection() throws SQLException {
+    // build connection properties
+    Properties properties = new Properties();
+    properties.put("user","snowman"); // replace "" with your user name
+    properties.put("password", "test"); // replace "" with your password
+    properties.put("warehouse", "testwh"); // replace "" with target warehouse name
+    properties.put("db", "testdb"); // replace "" with target database name
+    properties.put("schema", "testschema"); // replace "" with target schema name
+    //properties.put("account", "testaccount_test");
+    properties.put("tracing", "all");
+    properties.put("host", "testaccount_test.snowflakecomputing.com");
+    // optional tracing property
+    // Replace <account> with your account, as provided by Snowflake.
+    // Replace <region_id> with the name of the region where your account is located.
+    // If your platform is AWS and your region ID is US West, you can omit the region ID segment.
+    // Replace <platform> with your platform, for example "azure".
+    // If your platform is AWS, you may omit the platform.
+    // Note that if you omit the region ID or the platform, you should also omit the
+    // corresponding "."  E.g. if your platform is AWS and your region is US West, then your
+    // connectStr will look similar to:
+    // "jdbc:snowflake://xy12345.snowflakecomputing.com";
+    String connectStr = "jdbc:snowflake://testaccount_test.snowflakecomputing.com/?tracing=ALL&useProxy=true&proxyHost=127.0.0.1&proxyPort=8080";
+    Connection con = DriverManager.getConnection(connectStr, properties);
+
   }
 
   @After

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
@@ -710,10 +710,13 @@ public class DatabaseMetaDataIT extends BaseJDBCTest {
   public void testGetImportedKeys() throws Throwable {
     try (Connection connection = getConnection()) {
       String database = connection.getCatalog();
-      String schema = connection.getSchema();
+      String schema = "TEST\\_SCHEMA\\_\"\"WITH\\_QUOTES\"\"";
       final String targetTable1 = "T0";
       final String targetTable2 = "T1";
 
+      connection
+              .createStatement()
+              .execute("create or replace schema \"TEST_SCHEMA_\"\"WITH_QUOTES\"\"\"");
       connection
           .createStatement()
           .execute("create or replace table " + targetTable1 + "(C1 int primary key, C2 string)");

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
@@ -3,19 +3,7 @@
  */
 package net.snowflake.client.jdbc;
 
-import static java.sql.DatabaseMetaData.procedureReturnsResult;
-import static java.sql.ResultSetMetaData.columnNullableUnknown;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.*;
-
 import com.google.common.base.Strings;
-import java.sql.*;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.TestUtil;
@@ -23,12 +11,25 @@ import net.snowflake.client.category.TestCategoryOthers;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.sql.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.sql.DatabaseMetaData.procedureReturnsResult;
+import static java.sql.ResultSetMetaData.columnNullableUnknown;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.*;
+
 /** Database Metadata IT */
 @Category(TestCategoryOthers.class)
 public class DatabaseMetaDataIT extends BaseJDBCTest {
   private static final Pattern VERSION_PATTERN =
       Pattern.compile("^(\\d+)\\.(\\d+)(?:\\.\\d+)+\\s*.*");
-  private static final String PI_PROCEDURE =
+  protected static final String PI_PROCEDURE =
       "create or replace procedure GETPI()\n"
           + "    returns float not null\n"
           + "    language javascript\n"

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -151,7 +151,7 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
       assertEquals(2, getSizeOfResultSet(rs));
       rs = metaData.getColumns(database, querySchema, null, "AMOUNT");
       assertEquals(2, getSizeOfResultSet(rs));
-      rs = metaData.getProcedures(database, querySchema, null);
+      rs = metaData.getProcedureColumns(database, querySchema, null, null);
       assertEquals(1, getSizeOfResultSet(rs));
       rs.close();
       statement.close();

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -3,20 +3,19 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.jdbc.DatabaseMetaDataIT.verifyResultSetMetaDataColumns;
+import static net.snowflake.client.jdbc.SnowflakeDatabaseMetaData.*;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.*;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryOthers;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import java.sql.*;
-import java.util.Map;
-import java.util.Properties;
-
-import static net.snowflake.client.jdbc.DatabaseMetaDataIT.verifyResultSetMetaDataColumns;
-import static net.snowflake.client.jdbc.SnowflakeDatabaseMetaData.*;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.*;
 
 /**
  * DatabaseMetaData test for the latest JDBC driver. This doesn't work for the oldest supported

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -3,19 +3,21 @@
  */
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.jdbc.DatabaseMetaDataIT.verifyResultSetMetaDataColumns;
-import static net.snowflake.client.jdbc.SnowflakeDatabaseMetaData.*;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.*;
-
-import java.sql.*;
-import java.util.Map;
-import java.util.Properties;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryOthers;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+
+import static net.snowflake.client.jdbc.DatabaseMetaDataIT.PI_PROCEDURE;
+import static net.snowflake.client.jdbc.DatabaseMetaDataIT.verifyResultSetMetaDataColumns;
+import static net.snowflake.client.jdbc.SnowflakeDatabaseMetaData.*;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.*;
 
 /**
  * DatabaseMetaData test for the latest JDBC driver. This doesn't work for the oldest supported
@@ -143,11 +145,14 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
       statement.execute(
           "create or replace table \"TESTTABLE_\"\"WITH_QUOTES\"\"\" (amount number)");
       statement.execute("create or replace table table20 (amount number, name string)");
+      statement.execute(PI_PROCEDURE);
       DatabaseMetaData metaData = con.getMetaData();
       ResultSet rs = metaData.getTables(database, querySchema, null, null);
       assertEquals(2, getSizeOfResultSet(rs));
       rs = metaData.getColumns(database, querySchema, null, "AMOUNT");
       assertEquals(2, getSizeOfResultSet(rs));
+      rs = metaData.getProcedures(database, querySchema, null);
+      assertEquals(1, getSizeOfResultSet(rs));
       rs.close();
       statement.close();
     }

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -3,19 +3,20 @@
  */
 package net.snowflake.client.jdbc;
 
-import static net.snowflake.client.jdbc.DatabaseMetaDataIT.verifyResultSetMetaDataColumns;
-import static net.snowflake.client.jdbc.SnowflakeDatabaseMetaData.*;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.*;
-
-import java.sql.*;
-import java.util.Map;
-import java.util.Properties;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryOthers;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+
+import static net.snowflake.client.jdbc.DatabaseMetaDataIT.verifyResultSetMetaDataColumns;
+import static net.snowflake.client.jdbc.SnowflakeDatabaseMetaData.*;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.*;
 
 /**
  * DatabaseMetaData test for the latest JDBC driver. This doesn't work for the oldest supported
@@ -137,19 +138,17 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
   public void testDoubleQuotedDatabaseAndSchema() throws SQLException {
     try (Connection con = getConnection()) {
       Statement statement = con.createStatement();
-      String queryDatabase = "TEST_DB_\"\"WITH_QUOTES\"\"";
+      String database = con.getCatalog();
       String querySchema = "TEST\\_SCHEMA\\_\"\"WITH\\_QUOTES\"\"";
-      statement.execute("create or replace database \"TEST_DB_\"\"WITH_QUOTES\"\"\"");
       statement.execute("create or replace schema \"TEST_SCHEMA_\"\"WITH_QUOTES\"\"\"");
       statement.execute(
           "create or replace table \"TESTTABLE_\"\"WITH_QUOTES\"\"\" (amount number)");
-      statement.execute("create table table20 (amount number, name string)");
+      statement.execute("create or replace table table20 (amount number, name string)");
       DatabaseMetaData metaData = con.getMetaData();
-      ResultSet rs = metaData.getTables(queryDatabase, querySchema, null, null);
+      ResultSet rs = metaData.getTables(database, querySchema, null, null);
       assertEquals(2, getSizeOfResultSet(rs));
-      rs = metaData.getColumns(queryDatabase, querySchema, null, "AMOUNT");
+      rs = metaData.getColumns(database, querySchema, null, "AMOUNT");
       assertEquals(2, getSizeOfResultSet(rs));
-      statement.execute("drop database \"" + queryDatabase + "\"");
       rs.close();
       statement.close();
     }


### PR DESCRIPTION
# Overview

SNOW-475617

There is an issue where when there are quotes inside an argument for any of the DatabaseMetadata get() functions (getColumns, getTables, getFunctionColumns, etc), the resultset always comes back as empty.

The reason this happens is that quotes must be escaped with another set of quotes, so a schema whose real name is
SCHEMA_"QUOTED" must be queried as SCHEMA_""QUOTED"". In these functions, we double-check that the returned schema/database/object name matches the original input. In this example, the returned schema would actually come back as SCHEMA_"QUOTED", lacking the escape quotes that were used in the function argument. This looks like a mismatch, so the function thinks the schema doesn't match and doesn't return and results from it.

The solution is to add the escape quotes back in to the return value prior to comparing the function argument with the returned data.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

