### PR TITLE
[#589] Upgrading netty to enable JDK17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <jsoup.version>1.14.2</jsoup.version>
     <tika.version>1.22</tika.version>
     <jackson.version>2.12.1</jackson.version>
+    <netty.version>4.1.72.Final</netty.version>
     <jacksondatabind.version>2.12.1</jacksondatabind.version>
     <!-- Caution: version 4.5.12 and onward of apache httpclient causes a regression in recognizing S3 certificates (SNOW-259063) -->
     <httpclient.version>4.5.11</httpclient.version>
@@ -78,6 +79,22 @@
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
       <version>8.0</version>
+      <exclusions>
+        <exclusion>  <!-- exclude earlier versions of json-smart due to multiple vulnerabilities -->
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
@@ -189,7 +206,7 @@
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.4.5</version>
+      <version>2.4.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -289,6 +306,14 @@
         <exclusion>  <!-- Exclude early version of commons-codec to avoid whitesource vulnerability -->
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-buffer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
# Overview

Fixes #589, may fix #484 by upgrading Netty (and json-smart)

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #589 which relates directly to #484, both of which are the result of Project Jigsaw encapsulation.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Netty (`netty-common`) is ultimately at fault for the JDK17 illegal access reported in both tickets. Arrow depends on that machinery by simple dependency. `snowflake-jdbc` pulls in and shades both arrow and netty components. This makes it impossible for users of `snowflake-jdbc` to directly override the packaged dependency and run a newer (fixed) netty.

Per the netty maintainers 4.1.52+ has fixes for JDK17 access restrictions. In my testing rolling a snowflake-jdbc jar which forces netty-* to 4.1.72.Final (latest) resolves these issues.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

