### PR TITLE
SNOW-521194 Fix account name breakage and update host url

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -124,7 +124,7 @@ public class SnowflakeConnectString implements Serializable {
         // if it's a global url
         parameters.put("ACCOUNT", account);
         if (account.contains("_")) {
-          // Update the Host URL to remove underscores if there are any 
+          // Update the Host URL to remove underscores if there are any
           String account_wo_uscores = account.replaceAll("_", "-");
           host = host.replaceFirst(account, account_wo_uscores);
         }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -116,15 +116,18 @@ public class SnowflakeConnectString implements Serializable {
 
       if (parameters.get("ACCOUNT") == null && account == null && host.indexOf(".") > 0) {
         account = host.substring(0, host.indexOf("."));
-
         // If this is a global URL, then extract out the external ID part
         if (host.contains(".global.")) {
           account = account.substring(0, account.lastIndexOf('-'));
         }
-        if (account.contains("_")) {
-          account = account.replaceAll("_", "-");
-        }
+        // Account names should not be altered. Set it to a value without org name
+        // if it's a global url
         parameters.put("ACCOUNT", account);
+        if (account.contains("_")) {
+          // Update the Host URL to remove underscores if there are any 
+          String account_wo_uscores = account.replaceAll("_", "-");
+          host = host.replaceFirst(account, account_wo_uscores);
+        }
       }
 
       return new SnowflakeConnectString(scheme, host, port, parameters, account);


### PR DESCRIPTION
Description

Account names were incorrectly updated to replace underscores with hyphens. Host names on the contrary were not updated. This PR fixes the account names and updates host names to not have underscores in them.

Testing
Manually tested to confirm that both global URLs and URLs with underscores in them are correctly updated with no impact on account names.

# Overview

SNOW-521194

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

