### PR TITLE
SNOW-520660 Fix for S3 Regional URL not being updated in stageInfo

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -991,7 +991,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
     overwrite = jsonNode.path("data").path("overwrite").asBoolean(false);
 
-    stageInfo = getStageInfo(jsonNode);
+    stageInfo = getStageInfo(jsonNode, this.session);
 
     if (logger.isDebugEnabled()) {
       logger.debug("Command type: {}", commandType);
@@ -1014,6 +1014,19 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           stageInfo.getEndPoint(),
           stageInfo.getStorageAccount());
     }
+  }
+
+  static StageInfo getStageInfo(JsonNode jsonNode, SFSession session) throws SnowflakeSQLException {
+
+    StageInfo stageInfo = getStageInfo(jsonNode);
+
+    // Update StageInfo to reflect use of S3 regional URL.
+    // This is required for connecting to S3 over privatelink when the
+    // target stage is in us-east-1
+    if (stageInfo.getStageType() == StageInfo.StageType.S3)
+      stageInfo.setUseS3RegionalUrl(session.getUseRegionalS3EndpointsForPresignedURL());
+
+    return stageInfo;
   }
 
   static StageInfo getStageInfo(JsonNode jsonNode) throws SnowflakeSQLException {

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderLatestIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All right reserved.
+ */
+package net.snowflake.client.jdbc;
+
+import static net.snowflake.client.AbstractDriverIT.getConnection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.jdbc.cloud.storage.StageInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for SnowflakeFileTransferAgent that require an active connection */
+public class FileUploaderLatestIT extends FileUploaderSessionlessTest {
+
+  /**
+   * This tests that getStageInfo(JsonNode, session) reflects the boolean value of UseS3RegionalUrl
+   * that has been set via the session.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testGetS3StageDataWithS3Session() throws SQLException {
+
+    Connection con = getConnection("s3testaccount");
+    SFSession sfSession = con.unwrap(SnowflakeConnectionV1.class).getSfSession();
+    // Set UseRegionalS3EndpointsForPresignedURL to true in session
+    sfSession.setUseRegionalS3EndpointsForPresignedURL(true);
+
+    // Get sample stage info with session
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleS3JsonNode, sfSession);
+    Assert.assertEquals(StageInfo.StageType.S3, stageInfo.getStageType());
+    // Assert that true value from session is reflected in StageInfo
+    Assert.assertEquals(true, stageInfo.getUseS3RegionalUrl());
+
+    // Set UseRegionalS3EndpointsForPresignedURL to false in session
+    sfSession.setUseRegionalS3EndpointsForPresignedURL(false);
+    stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleS3JsonNode, sfSession);
+    Assert.assertEquals(StageInfo.StageType.S3, stageInfo.getStageType());
+    // Assert that false value from session is reflected in StageInfo
+    Assert.assertEquals(false, stageInfo.getUseS3RegionalUrl());
+    con.close();
+  }
+
+  /**
+   * This tests that setting the value of UseS3RegionalUrl for a non-S3 account session has no
+   * effect on the function getStageInfo(JsonNode, session).
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testGetS3StageDataWithAzureSession() throws SQLException {
+    Connection con = getConnection("azureaccount");
+    SFSession sfSession = con.unwrap(SnowflakeConnectionV1.class).getSfSession();
+    // Set UseRegionalS3EndpointsForPresignedURL to true in session. This is redundant since session
+    // is Azure
+    sfSession.setUseRegionalS3EndpointsForPresignedURL(true);
+
+    // Get sample stage info with session
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleAzureJsonNode, sfSession);
+    Assert.assertEquals(StageInfo.StageType.AZURE, stageInfo.getStageType());
+    Assert.assertEquals("EXAMPLE_LOCATION/", stageInfo.getLocation());
+    // Assert that UseRegionalS3EndpointsForPresignedURL is false in StageInfo even if it was set to
+    // true.
+    // The value should always be false for non-S3 accounts
+    Assert.assertEquals(false, stageInfo.getUseS3RegionalUrl());
+    con.close();
+  }
+}

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
@@ -183,8 +183,8 @@ public class FileUploaderSessionlessTest {
           + "  \"success\": true\n"
           + "}";
 
-  private JsonNode exampleS3JsonNode;
-  private JsonNode exampleAzureJsonNode;
+  protected JsonNode exampleS3JsonNode;
+  protected JsonNode exampleAzureJsonNode;
   private JsonNode exampleGCSJsonNode;
   private List<JsonNode> exampleNodes;
 


### PR DESCRIPTION
Description
Kafka connector depends on stageInfo to be updated for it to perform sessionless
"blind" put to stages. JDBC driver was not udpating the stageInfo instance with
s3RegionalURL related information. KC would hence skip using s3regionalURL even
if it was explicitly requested via backend param.

Testing

# Overview

SNOW-520660

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

