### PR TITLE
SNOW-524708: Adding streaming ingest related metadata for streaming ingest billing

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -352,7 +352,8 @@ public abstract class SFBaseSession {
       // log the JVM parameters that are being used
       if (httpUseProxy) {
         logger.debug(
-            "http.useProxy={}, http.proxyHost={}, http.proxyPort={}, https.proxyHost={}, https.proxyPort={}, http.nonProxyHosts={}, NO_PROXY={}",
+            "http.useProxy={}, http.proxyHost={}, http.proxyPort={}, https.proxyHost={},"
+                + " https.proxyPort={}, http.nonProxyHosts={}, NO_PROXY={}",
             httpUseProxy,
             httpProxyHost,
             httpProxyPort,

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -364,12 +364,12 @@ public class SFSession extends SFBaseSession {
     performSanityCheckOnProperties();
     Map<SFSessionProperty, Object> connectionPropertiesMap = getConnectionPropertiesMap();
     logger.debug(
-        "input: server={}, account={}, user={}, password={}, role={}, "
-            + "database={}, schema={}, warehouse={}, validate_default_parameters={}, authenticator={}, ocsp_mode={}, "
-            + "passcode_in_password={}, passcode={}, private_key={}, disable_socks_proxy={}, "
-            + "application={}, app_id={}, app_version={}, "
-            + "login_timeout={}, network_timeout={}, query_timeout={}, tracing={}, private_key_file={}, private_key_file_pwd={}. "
-            + "session_parameters: client_store_temporary_credential={}",
+        "input: server={}, account={}, user={}, password={}, role={}, database={}, schema={},"
+            + " warehouse={}, validate_default_parameters={}, authenticator={}, ocsp_mode={},"
+            + " passcode_in_password={}, passcode={}, private_key={}, disable_socks_proxy={},"
+            + " application={}, app_id={}, app_version={}, login_timeout={}, network_timeout={},"
+            + " query_timeout={}, tracing={}, private_key_file={}, private_key_file_pwd={}."
+            + " session_parameters: client_store_temporary_credential={}",
         connectionPropertiesMap.get(SFSessionProperty.SERVER_URL),
         connectionPropertiesMap.get(SFSessionProperty.ACCOUNT),
         connectionPropertiesMap.get(SFSessionProperty.USER),
@@ -407,7 +407,8 @@ public class SFSession extends SFBaseSession {
 
     HttpClientSettingsKey httpClientSettingsKey = getHttpClientKey();
     logger.debug(
-        "connection proxy parameters: use_proxy={}, proxy_host={}, proxy_port={}, proxy_user={}, proxy_password={}, non_proxy_hosts={}, proxy_protocol={}",
+        "connection proxy parameters: use_proxy={}, proxy_host={}, proxy_port={}, proxy_user={},"
+            + " proxy_password={}, non_proxy_hosts={}, proxy_protocol={}",
         httpClientSettingsKey.usesProxy(),
         httpClientSettingsKey.getProxyHost(),
         httpClientSettingsKey.getProxyPort(),

--- a/src/main/java/net/snowflake/client/jdbc/DefaultSFConnectionHandler.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultSFConnectionHandler.java
@@ -182,7 +182,8 @@ public class DefaultSFConnectionHandler implements SFConnectionHandler {
       throws SQLNonTransientConnectionException, SnowflakeSQLException {
     if (!(statement instanceof SFStatement)) {
       throw new SnowflakeSQLException(
-          "getFileTransferAgent() called with an incompatible SFBaseStatement type. Requires an SFStatement.");
+          "getFileTransferAgent() called with an incompatible SFBaseStatement type. Requires an"
+              + " SFStatement.");
     }
     return new SnowflakeFileTransferAgent(command, sfSession, (SFStatement) statement);
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -334,7 +334,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
               || (nextChunkToDownload == 0 && nextChunkToConsume == 0))) {
         // cancel the reserved memory and this downloader too
         logger.debug(
-            "Not enough memory available for prefetch. Cancel reserved memory. MemoryLimit: {}, curMem: {}, nextChunkToDownload: {}, nextChunkToConsume: {}, retry: {}",
+            "Not enough memory available for prefetch. Cancel reserved memory. MemoryLimit: {},"
+                + " curMem: {}, nextChunkToDownload: {}, nextChunkToConsume: {}, retry: {}",
             memoryLimit,
             curMem,
             nextChunkToDownload,
@@ -387,7 +388,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         curMem = currentMemoryUsage.addAndGet(-neededChunkMemory);
         if (getPrefetchMemRetry > prefetchMaxRetry) {
           logger.debug(
-              "Retry limit for prefetch has been reached. Cancel reserved memory and prefetch attempt.");
+              "Retry limit for prefetch has been reached. Cancel reserved memory and prefetch"
+                  + " attempt.");
           break;
         }
       }
@@ -401,8 +403,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         getPrefetchMemRetry++;
         if (logger.isDebugEnabled()) {
           logger.debug(
-              "Thread {} waiting for {}s: currentMemoryUsage in MB: {}, neededChunkMemory in MB: {}, "
-                  + "nextChunkToDownload: {}, nextChunkToConsume: {}, retry: {}",
+              "Thread {} waiting for {}s: currentMemoryUsage in MB: {}, neededChunkMemory in MB:"
+                  + " {}, nextChunkToDownload: {}, nextChunkToConsume: {}, retry: {}",
               (ArgSupplier) () -> Thread.currentThread().getId(),
               waitingTime / 1000.0,
               curMem / MB,
@@ -693,9 +695,10 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
             + "Several suggestions to try to resolve the OOM issue:\n"
             + "1. increase the JVM heap size if you have more space; or \n"
             + "2. use CLIENT_MEMORY_LIMIT to reduce the memory usage by the JDBC driver "
-            + "(https://docs.snowflake.net/manuals/sql-reference/parameters.html#client-memory-limit)"
-            + "3. please make sure 2 * CLIENT_PREFETCH_THREADS * CLIENT_RESULT_CHUNK_SIZE < CLIENT_MEMORY_LIMIT. "
-            + "If not, please reduce CLIENT_PREFETCH_THREADS and CLIENT_RESULT_CHUNK_SIZE too.",
+            + "(https://docs.snowflake.net/manuals/sql-reference/parameters.html#client-memory-limit)3."
+            + " please make sure 2 * CLIENT_PREFETCH_THREADS * CLIENT_RESULT_CHUNK_SIZE <"
+            + " CLIENT_MEMORY_LIMIT. If not, please reduce CLIENT_PREFETCH_THREADS and"
+            + " CLIENT_RESULT_CHUNK_SIZE too.",
         numberMillisWaitingForChunks,
         Runtime.getRuntime().totalMemory(),
         Runtime.getRuntime().maxMemory(),

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -687,7 +687,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
                   parallel,
                   fileToUpload,
                   (fileToUpload == null),
-                  encMat);
+                  encMat,
+                  null,
+                  null);
               metadata.isEncrypted = encMat != null;
               break;
           }
@@ -1903,7 +1905,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
       int parallel,
       File srcFile,
       boolean uploadFromStream,
-      RemoteStoreFileEncryptionMaterial encMat)
+      RemoteStoreFileEncryptionMaterial encMat,
+      String streamingIngestClientName,
+      String streamingIngestClientKey)
       throws SQLException, IOException {
     remoteLocation remoteLocation = extractLocationAndPath(stage.getLocation());
 
@@ -1929,6 +1933,11 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
     if (compressionType != null && compressionType.isSupported()) {
       meta.setContentEncoding(compressionType.name().toLowerCase());
+    }
+
+    if (streamingIngestClientName != null && streamingIngestClientKey != null) {
+      initialClient.addStreamingIngestMetadata(
+          meta, streamingIngestClientName, streamingIngestClientKey);
     }
 
     try {
@@ -1983,6 +1992,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     int networkTimeoutInMilli = config.getNetworkTimeoutInMilli();
     OCSPMode ocspMode = config.getOcspMode();
     Properties proxyProperties = config.getProxyProperties();
+    String streamingIngestClientName = config.getStreamingIngestClientName();
+    String streamingIngestClientKey = config.getStreamingIngestClientKey();
 
     // Create HttpClient key
     HttpClientSettingsKey key =
@@ -2069,7 +2080,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
               1,
               fileToUpload,
               (fileToUpload == null),
-              encMat);
+              encMat,
+              streamingIngestClientName,
+              streamingIngestClientKey);
           break;
         case GCS:
           pushFileToRemoteStoreWithPresignedUrl(
@@ -2087,7 +2100,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
               null,
               true,
               encMat,
-              metadata.getPresignedUrl());
+              metadata.getPresignedUrl(),
+              streamingIngestClientName,
+              streamingIngestClientKey);
           break;
       }
     } catch (Exception ex) {
@@ -2125,7 +2140,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
       File srcFile,
       boolean uploadFromStream,
       RemoteStoreFileEncryptionMaterial encMat,
-      String presignedUrl)
+      String presignedUrl,
+      String streamingIngestClientName,
+      String streamingIngestClientKey)
       throws SQLException, IOException {
     remoteLocation remoteLocation = extractLocationAndPath(stage.getLocation());
 
@@ -2151,6 +2168,11 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
     if (compressionType != null && compressionType.isSupported()) {
       meta.setContentEncoding(compressionType.name().toLowerCase());
+    }
+
+    if (streamingIngestClientName != null && streamingIngestClientKey != null) {
+      initialClient.addStreamingIngestMetadata(
+          meta, streamingIngestClientName, streamingIngestClientKey);
     }
 
     try {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferConfig.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferConfig.java
@@ -190,11 +190,16 @@ public class SnowflakeFileTransferConfig {
       return this;
     }
 
+    /** Streaming ingest client name, used to calculate streaming ingest billing per client */
     public Builder setStreamingIngestClientName(String streamingIngestClientName) {
       this.streamingIngestClientName = streamingIngestClientName;
       return this;
     }
 
+    /**
+     * Streaming ingest client key provided by Snowflake, used to calculate streaming ingest billing
+     * per client
+     */
     public Builder setStreamingIngestClientKey(String streamingIngestClientKey) {
       this.streamingIngestClientKey = streamingIngestClientKey;
       return this;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferConfig.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferConfig.java
@@ -24,6 +24,8 @@ public class SnowflakeFileTransferConfig {
   private SFSession session; // Optional, added for S3 and Azure
   private String command; // Optional, added for S3 and Azure
   private boolean useS3RegionalUrl; // only for S3 us-east-1 private link deployments
+  private String streamingIngestClientName;
+  private String streamingIngestClientKey;
 
   public SnowflakeFileTransferConfig(Builder builder) {
     this.metadata = builder.metadata;
@@ -37,6 +39,8 @@ public class SnowflakeFileTransferConfig {
     this.session = builder.session;
     this.command = builder.command;
     this.useS3RegionalUrl = builder.useS3RegionalUrl;
+    this.streamingIngestClientKey = builder.streamingIngestClientKey;
+    this.streamingIngestClientName = builder.streamingIngestClientName;
   }
 
   public SnowflakeFileTransferMetadata getSnowflakeFileTransferMetadata() {
@@ -83,6 +87,14 @@ public class SnowflakeFileTransferConfig {
     return useS3RegionalUrl;
   }
 
+  public String getStreamingIngestClientName() {
+    return this.streamingIngestClientName;
+  }
+
+  public String getStreamingIngestClientKey() {
+    return this.streamingIngestClientKey;
+  }
+
   // Builder class
   public static class Builder {
     private SnowflakeFileTransferMetadata metadata = null;
@@ -96,6 +108,8 @@ public class SnowflakeFileTransferConfig {
     private SFSession session = null;
     private String command = null;
     private boolean useS3RegionalUrl = false; // only for S3 us-east-1 private link deployments
+    private String streamingIngestClientName;
+    private String streamingIngestClientKey;
 
     public static Builder newInstance() {
       return new Builder();
@@ -173,6 +187,16 @@ public class SnowflakeFileTransferConfig {
 
     public Builder setUseS3RegionalUrl(boolean useS3RegUrl) {
       this.useS3RegionalUrl = useS3RegUrl;
+      return this;
+    }
+
+    public Builder setStreamingIngestClientName(String streamingIngestClientName) {
+      this.streamingIngestClientName = streamingIngestClientName;
+      return this;
+    }
+
+    public Builder setStreamingIngestClientKey(String streamingIngestClientKey) {
+      this.streamingIngestClientKey = streamingIngestClientKey;
       return this;
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -41,6 +41,8 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
 
   private static final String localFileSep = systemGetProperty("file.separator");
   private static final String AZ_ENCRYPTIONDATAPROP = "encryptiondata";
+  private static final String AZ_STREAMING_INGEST_CLIENT_NAME = "ingestclientname";
+  private static final String AZ_STREAMING_INGEST_CLIENT_KEY = "ingestclientkey";
 
   private int encryptionKeySize = 0; // used for PUTs
   private StageInfo stageInfo;
@@ -865,11 +867,26 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
     return meta.getUserMetadata().get("sfcdigest");
   }
 
-  /** Adds streaming ingest metadata to the StorageObjectMetadata object */
+  /**
+   * Adds streaming ingest metadata to the StorageObjectMetadata object, used for streaming ingest
+   * per client billing calculation
+   */
   @Override
   public void addStreamingIngestMetadata(
       StorageObjectMetadata meta, String clientName, String clientKey) {
-    meta.addUserMetadata("clientname", clientName);
-    meta.addUserMetadata("clientkey", clientKey);
+    meta.addUserMetadata(AZ_STREAMING_INGEST_CLIENT_NAME, clientName);
+    meta.addUserMetadata(AZ_STREAMING_INGEST_CLIENT_KEY, clientKey);
+  }
+
+  /** Gets streaming ingest client name to the StorageObjectMetadata object */
+  @Override
+  public String getStreamingIngestClientName(StorageObjectMetadata meta) {
+    return meta.getUserMetadata().get(AZ_STREAMING_INGEST_CLIENT_NAME);
+  }
+
+  /** Gets streaming ingest client key to the StorageObjectMetadata object */
+  @Override
+  public String getStreamingIngestClientKey(StorageObjectMetadata meta) {
+    return meta.getUserMetadata().get(AZ_STREAMING_INGEST_CLIENT_KEY);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -864,4 +864,12 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
   public String getDigestMetadata(StorageObjectMetadata meta) {
     return meta.getUserMetadata().get("sfcdigest");
   }
+
+  /** Adds streaming ingest metadata to the StorageObjectMetadata object */
+  @Override
+  public void addStreamingIngestMetadata(
+      StorageObjectMetadata meta, String clientName, String clientKey) {
+    meta.addUserMetadata("client-name", clientName);
+    meta.addUserMetadata("client-key", clientKey);
+  }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -869,7 +869,7 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
   @Override
   public void addStreamingIngestMetadata(
       StorageObjectMetadata meta, String clientName, String clientKey) {
-    meta.addUserMetadata("client-name", clientName);
-    meta.addUserMetadata("client-key", clientKey);
+    meta.addUserMetadata("clientname", clientName);
+    meta.addUserMetadata("clientkey", clientKey);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -1092,4 +1092,12 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
   private static boolean isSuccessStatusCode(int code) {
     return code < 300 && code >= 200;
   }
+
+  /** Adds streaming ingest metadata to the StorageObjectMetadata object */
+  @Override
+  public void addStreamingIngestMetadata(
+      StorageObjectMetadata meta, String clientName, String clientKey) {
+    meta.addUserMetadata("client-name", clientName);
+    meta.addUserMetadata("client-key", clientKey);
+  }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -56,6 +56,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
   private static final String GCS_ENCRYPTIONDATAPROP = "encryptiondata";
   private static final String localFileSep = systemGetProperty("file.separator");
   private static final String GCS_METADATA_PREFIX = "x-goog-meta-";
+  private static final String GCS_STREAMING_INGEST_CLIENT_NAME = "ingestclientname";
+  private static final String GCS_STREAMING_INGEST_CLIENT_KEY = "ingestclientkey";
 
   private int encryptionKeySize = 0; // used for PUTs
   private StageInfo stageInfo;
@@ -1093,11 +1095,26 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
     return code < 300 && code >= 200;
   }
 
-  /** Adds streaming ingest metadata to the StorageObjectMetadata object */
+  /**
+   * Adds streaming ingest metadata to the StorageObjectMetadata object, used for streaming ingest
+   * per client billing calculation
+   */
   @Override
   public void addStreamingIngestMetadata(
       StorageObjectMetadata meta, String clientName, String clientKey) {
-    meta.addUserMetadata("client-name", clientName);
-    meta.addUserMetadata("client-key", clientKey);
+    meta.addUserMetadata(GCS_STREAMING_INGEST_CLIENT_NAME, clientName);
+    meta.addUserMetadata(GCS_STREAMING_INGEST_CLIENT_KEY, clientKey);
+  }
+
+  /** Gets streaming ingest client name to the StorageObjectMetadata object */
+  @Override
+  public String getStreamingIngestClientName(StorageObjectMetadata meta) {
+    return meta.getUserMetadata().get(GCS_STREAMING_INGEST_CLIENT_NAME);
+  }
+
+  /** Gets streaming ingest client key to the StorageObjectMetadata object */
+  @Override
+  public String getStreamingIngestClientKey(StorageObjectMetadata meta) {
+    return meta.getUserMetadata().get(GCS_STREAMING_INGEST_CLIENT_KEY);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -837,4 +837,12 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
     return s3ConnectionSocketFactory;
   }
+
+  /** Adds streaming ingest metadata to the StorageObjectMetadata object */
+  @Override
+  public void addStreamingIngestMetadata(
+      StorageObjectMetadata meta, String clientName, String clientKey) {
+    meta.addUserMetadata("client-name", clientName);
+    meta.addUserMetadata("client-key", clientKey);
+  }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -65,6 +65,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
   private static final String AES = "AES";
   private static final String AMZ_KEY = "x-amz-key";
   private static final String AMZ_IV = "x-amz-iv";
+  private static final String S3_STREAMING_INGEST_CLIENT_NAME = "ingestclientname";
+  private static final String S3_STREAMING_INGEST_CLIENT_KEY = "ingestclientkey";
 
   // expired AWS token error code
   private static final String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
@@ -838,11 +840,26 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     return s3ConnectionSocketFactory;
   }
 
-  /** Adds streaming ingest metadata to the StorageObjectMetadata object */
+  /**
+   * Adds streaming ingest metadata to the StorageObjectMetadata object, used for streaming ingest
+   * per client billing calculation
+   */
   @Override
   public void addStreamingIngestMetadata(
       StorageObjectMetadata meta, String clientName, String clientKey) {
-    meta.addUserMetadata("client-name", clientName);
-    meta.addUserMetadata("client-key", clientKey);
+    meta.addUserMetadata(S3_STREAMING_INGEST_CLIENT_NAME, clientName);
+    meta.addUserMetadata(S3_STREAMING_INGEST_CLIENT_KEY, clientKey);
+  }
+
+  /** Gets streaming ingest client name to the StorageObjectMetadata object */
+  @Override
+  public String getStreamingIngestClientName(StorageObjectMetadata meta) {
+    return meta.getUserMetadata().get(S3_STREAMING_INGEST_CLIENT_NAME);
+  }
+
+  /** Gets streaming ingest client key to the StorageObjectMetadata object */
+  @Override
+  public String getStreamingIngestClientKey(StorageObjectMetadata meta) {
+    return meta.getUserMetadata().get(S3_STREAMING_INGEST_CLIENT_KEY);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
@@ -259,11 +259,18 @@ public interface SnowflakeStorageClient {
   String getDigestMetadata(StorageObjectMetadata meta);
 
   /**
-   * Adds streaming ingest metadata to the StorageObjectMetadata object
+   * Adds streaming ingest metadata to the StorageObjectMetadata object, used for streaming ingest
+   * per client billing calculation
    *
    * @param meta the storage metadata object to add the digest to
    * @param clientName streaming ingest client name
    * @param clientKey streaming ingest client key, provided by Snowflake
    */
   void addStreamingIngestMetadata(StorageObjectMetadata meta, String clientName, String clientKey);
+
+  /** Gets streaming ingest client name to the StorageObjectMetadata object */
+  String getStreamingIngestClientName(StorageObjectMetadata meta);
+
+  /** Gets streaming ingest client key to the StorageObjectMetadata object */
+  String getStreamingIngestClientKey(StorageObjectMetadata meta);
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
@@ -257,4 +257,13 @@ public interface SnowflakeStorageClient {
    * @return the digest metadata value
    */
   String getDigestMetadata(StorageObjectMetadata meta);
+
+  /**
+   * Adds streaming ingest metadata to the StorageObjectMetadata object
+   *
+   * @param meta the storage metadata object to add the digest to
+   * @param clientName streaming ingest client name
+   * @param clientKey streaming ingest client key, provided by Snowflake
+   */
+  void addStreamingIngestMetadata(StorageObjectMetadata meta, String clientName, String clientKey);
 }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -892,7 +892,8 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       assertTrue(
           ex.getMessage()
               .contains(
-                  "Uncaught Execution of multiple statements failed on statement \"select to_date('not_date')\""));
+                  "Uncaught Execution of multiple statements failed on statement \"select"
+                      + " to_date('not_date')\""));
     } finally {
       statement.close();
       connection.close();

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
@@ -46,8 +46,9 @@ public class DatabaseMetaDataInternalIT extends BaseJDBCTest {
       st.execute("create or replace schema JDBC_SCHEMA12");
       st.execute("create or replace table JDBC_TBL121(colA varchar)");
       st.execute(
-          "create or replace table JDBC_TBL122(colA NUMBER(20, 2) AUTOINCREMENT comment "
-              + "'cmt colA', colB NUMBER(20, 2) DEFAULT(3) NOT NULL, colC NUMBER(20,2) IDENTITY(20, 2))");
+          "create or replace table JDBC_TBL122(colA NUMBER(20, 2) AUTOINCREMENT comment 'cmt"
+              + " colA', colB NUMBER(20, 2) DEFAULT(3) NOT NULL, colC NUMBER(20,2) IDENTITY(20,"
+              + " 2))");
       st.execute("create or replace database JDBC_DB2");
       st.execute("create or replace schema JDBC_SCHEMA21");
       st.execute("create or replace table JDBC_TBL211(colA string)");
@@ -168,8 +169,8 @@ public class DatabaseMetaDataInternalIT extends BaseJDBCTest {
         "create or replace function JDBC_DB2.JDBC_SCHEMA21.JDBCFUNCTEST211 "
             + "(a number, b number) RETURNS NUMBER COMMENT='mutiply numbers' as 'a*b'");
     statement.execute(
-        "create or replace function JDBC_DB2.JDBC_SCHEMA21.JDBCFUNCTEST212 "
-            + "() RETURNS TABLE(colA varchar) as 'select COLA from JDBC_DB2.JDBC_SCHEMA21.JDBC_TBL211'");
+        "create or replace function JDBC_DB2.JDBC_SCHEMA21.JDBCFUNCTEST212 () RETURNS TABLE(colA"
+            + " varchar) as 'select COLA from JDBC_DB2.JDBC_SCHEMA21.JDBC_TBL211'");
     databaseMetaData = connection.getMetaData();
 
     // test each column return the right value

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetMultiTimeZoneLatestIT.java
@@ -76,7 +76,8 @@ public class ResultSetMultiTimeZoneLatestIT extends BaseJDBCTest {
     String timestampStringValue = "1970-01-01 " + timeStringValue;
     int length = timestampStringValue.length();
     statement.execute(
-        "create or replace table SRC_DATE_TIME (C2_TIME_3 TIME(3), C3_TIME_5 TIME(5), C4_TIME TIME(9))");
+        "create or replace table SRC_DATE_TIME (C2_TIME_3 TIME(3), C3_TIME_5 TIME(5), C4_TIME"
+            + " TIME(9))");
     statement.execute(
         "insert into SRC_DATE_TIME values ('"
             + timeStringValue
@@ -220,7 +221,8 @@ public class ResultSetMultiTimeZoneLatestIT extends BaseJDBCTest {
     Statement statement = connection.createStatement();
     // create table with all timestamp types, time, and date
     statement.execute(
-        "create or replace table datetimetypes(colA timestamp_ltz, colB timestamp_ntz, colC timestamp_tz, colD time, colE date)");
+        "create or replace table datetimetypes(colA timestamp_ltz, colB timestamp_ntz, colC"
+            + " timestamp_tz, colD time, colE date)");
     // Enable session parameter JDBC_USE_SESSION_TIMEZONE
     statement.execute("alter session set JDBC_USE_SESSION_TIMEZONE=true");
     if (!useDefaultParamSettings) {


### PR DESCRIPTION
# Overview

SNOW-524708

Adding streaming ingest client name and client key as part of the file metadata to support per client streaming ingest billing. 

Two things to note:
1. This PR contains a few changes made by automatic google java format
2. I spent a long time trying to add a test for GCP but failed, it always complains about no permission access stage object (errors below), let me know if you know how to fix it (i believe the problem is related to presigned URL)
`net.snowflake.client.jdbc.cloud.storage.StorageProviderException: com.google.cloud.storage.StorageException: Anonymous caller does not have storage.objects.get access to the Google Cloud Storage object
`
 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

