### PR TITLE
SNOW-475617 SNOW-494684 Fix DatabaseMetadata bugs -double quotes and wildcards

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
@@ -1133,7 +1133,7 @@ public class DatabaseMetaDataIT extends BaseJDBCTest {
       assertFalse(resultSet.next());
       /* Call getProcedureColumns with specified procedure name and column name. This will return 2 rows: 1 for the
       result values of the procedure, and 1 for the parameter values for the specified parameter. */
-      resultSet = metaData.getProcedureColumns(null, null, "stproc1", "param2");
+      resultSet = metaData.getProcedureColumns(null, null, "STPROC1", "PARAM2");
       assertEquals(20, resultSet.getMetaData().getColumnCount());
       assertEquals(2, getSizeOfResultSet(resultSet));
       connection.createStatement().execute("drop procedure if exists stproc1(float, string)");

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -25,6 +25,16 @@ import org.junit.experimental.categories.Category;
  */
 @Category(TestCategoryOthers.class)
 public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
+  private static final String TEST_PROC =
+      "create or replace procedure testproc(param1 float, param2 string)\n"
+          + "    returns table(retval varchar)\n"
+          + "    language javascript\n"
+          + "    as\n"
+          + "    $$\n"
+          + "    var sql_command = \"Hello, world!\"\n"
+          + "    $$\n"
+          + "    ;";
+
   /**
    * Tests for getFunctions
    *
@@ -124,6 +134,73 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
 
       resultSet = databaseMetaData.getCrossReference(null, null, null, null, null, null);
       assertThat(getSizeOfResultSet(resultSet), greaterThanOrEqualTo(2));
+    }
+  }
+
+  /**
+   * This tests the ability to have quotes inside a schema or database. This fixes a bug where
+   * double-quoted function arguments like schemas, databases, etc were returning empty resultsets.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testDoubleQuotedDatabaseAndSchema() throws SQLException {
+    try (Connection con = getConnection()) {
+      Statement statement = con.createStatement();
+      String database = con.getCatalog();
+      // To query the schema and table, we can use a normal java escaped quote. Wildcards are also
+      // escaped here
+      String querySchema = "TEST\\_SCHEMA\\_\"WITH\\_QUOTES\"";
+      String queryTable = "TESTTABLE\\_\"WITH\\_QUOTES\"";
+      // Create the schema and table. With SQL commands, double quotes must be escaped with another
+      // quote
+      statement.execute("create or replace schema \"TEST_SCHEMA_\"\"WITH_QUOTES\"\"\"");
+      statement.execute(
+          "create or replace table \"TESTTABLE_\"\"WITH_QUOTES\"\"\" (AMOUNT number, \"COL_\"\"QUOTED\"\"\" string)");
+      DatabaseMetaData metaData = con.getMetaData();
+      ResultSet rs = metaData.getTables(database, querySchema, queryTable, null);
+      // Assert 1 row returned for the testtable_"with_quotes"
+      assertEquals(1, getSizeOfResultSet(rs));
+      rs = metaData.getColumns(database, querySchema, queryTable, null);
+      // Assert 2 rows returned for the 2 rows in testtable_"with_quotes"
+      assertEquals(2, getSizeOfResultSet(rs));
+      rs = metaData.getColumns(database, querySchema, queryTable, "COL\\_\"QUOTED\"");
+      // Assert 1 row returned for the column col_"quoted"
+      assertEquals(1, getSizeOfResultSet(rs));
+      rs = metaData.getSchemas(database, querySchema);
+      // Assert 1 row returned for the schema test_schema_"with_quotes"
+      assertEquals(1, getSizeOfResultSet(rs));
+      rs.close();
+      statement.close();
+    }
+  }
+
+  /**
+   * This tests that wildcards can be used for the schema name for getProcedureColumns().
+   * Previously, only empty resultsets were returned.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testGetProcedureColumnsWildcards() throws SQLException {
+    try (Connection con = getConnection()) {
+      Statement statement = con.createStatement();
+      String database = con.getCatalog();
+      String schema1 = "SCH1";
+      String schema2 = "SCH2";
+      // Create 2 schemas, each with the same stored procedure declared in them
+      statement.execute("create or replace schema " + schema1);
+      statement.execute(TEST_PROC);
+      statement.execute("create or replace schema " + schema2);
+      statement.execute(TEST_PROC);
+      DatabaseMetaData metaData = con.getMetaData();
+      ResultSet rs = metaData.getProcedureColumns(database, "SCH_", "TESTPROC", "PARAM1");
+      // Assert 4 rows returned for the param PARAM1 that's present in each of the 2 identical
+      // stored procs in different schemas. A result row is returned for each procedure, making the
+      // total rowcount 4
+      assertEquals(4, getSizeOfResultSet(rs));
+      rs.close();
+      statement.close();
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -27,7 +27,7 @@ import org.junit.experimental.categories.Category;
 public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
   private static final String TEST_PROC =
       "create or replace procedure testproc(param1 float, param2 string)\n"
-          + "    returns table(retval varchar)\n"
+          + "    returns varchar\n"
           + "    language javascript\n"
           + "    as\n"
           + "    $$\n"


### PR DESCRIPTION
# Overview

SNOW-475617 SNOW-494684

This PR addresses 2 customer bugs:

1. Customers are attempting call getTables() and getColumns() with a schema that contains double quotes inside the name (for example, a name such as TEST_SCHEMA_"WITH_QHOTES"). This should be supported, but empty results were coming back for double quoted schemas. Now, that is fixed.
2. Customers were attempting to call getProcedureColumns() with a schema input containing wildcards (for example, a name like TEST%). Empty results were being returned there also. This is now fixed so getProcedureColumns() supports wildcards in the schema name.
## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

