### PR TITLE
SNOW-414125 Refactor for stored proc put support

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseStatement.java
@@ -135,6 +135,20 @@ public abstract class SFBaseStatement {
     }
   }
 
+  /**
+   * A method to check if a sql is file upload statement with consideration for potential comments
+   * in front of put keyword.
+   *
+   * <p>
+   *
+   * @param sql sql statement
+   * @return true if the command is upload statement
+   */
+  public static boolean isFileTransfer(String sql) {
+    SFStatementType statementType = StmtUtil.checkStageManageCommand(sql);
+    return statementType == SFStatementType.PUT || statementType == SFStatementType.GET;
+  }
+
   /** If this is a multi-statement, i.e., has child results. */
   public abstract boolean hasChildren();
 

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -731,20 +731,6 @@ public class SFStatement extends SFBaseStatement {
   }
 
   /**
-   * A method to check if a sql is file upload statement with consideration for potential comments
-   * in front of put keyword.
-   *
-   * <p>
-   *
-   * @param sql sql statement
-   * @return true if the command is upload statement
-   */
-  private boolean isFileTransfer(String sql) {
-    SFStatementType statementType = StmtUtil.checkStageManageCommand(sql);
-    return statementType == SFStatementType.PUT || statementType == SFStatementType.GET;
-  }
-
-  /**
    * Execute sql
    *
    * @param sql sql statement.

--- a/src/main/java/net/snowflake/client/jdbc/SFBaseFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFBaseFileTransferAgent.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import net.snowflake.client.core.SFBaseSession;
 import net.snowflake.common.util.ClassUtil;
+import net.snowflake.common.util.FixedViewColumn;
 
 /**
  * Base class for file transfers: given a SnowflakeConnection, files may be uploaded or downloaded
@@ -30,6 +31,134 @@ import net.snowflake.common.util.ClassUtil;
  * default is false).
  */
 public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
+
+  /** A class for encapsulating the columns to return for the upload command */
+  public enum UploadColumns {
+    source,
+    target,
+    source_size,
+    target_size,
+    source_compression,
+    target_compression,
+    status,
+    encryption,
+    message
+  };
+
+  public class UploadCommandFacade {
+
+    @FixedViewColumn(name = "source", ordinal = 10)
+    private String srcFile;
+
+    @FixedViewColumn(name = "target", ordinal = 20)
+    private String destFile;
+
+    @FixedViewColumn(name = "source_size", ordinal = 30)
+    private long srcSize;
+
+    @FixedViewColumn(name = "target_size", ordinal = 40)
+    private long destSize = -1;
+
+    @FixedViewColumn(name = "source_compression", ordinal = 50)
+    private String srcCompressionType;
+
+    @FixedViewColumn(name = "target_compression", ordinal = 60)
+    private String destCompressionType;
+
+    @FixedViewColumn(name = "status", ordinal = 70)
+    private String resultStatus;
+
+    @FixedViewColumn(name = "message", ordinal = 80)
+    private String errorDetails;
+
+    public UploadCommandFacade(
+            String srcFile,
+            String destFile,
+            String resultStatus,
+            String errorDetails,
+            long srcSize,
+            long destSize,
+            String srcCompressionType,
+            String destCompressionType) {
+      this.srcFile = srcFile;
+      this.destFile = destFile;
+      this.resultStatus = resultStatus;
+      this.errorDetails = errorDetails;
+      this.srcSize = srcSize;
+      this.destSize = destSize;
+      this.srcCompressionType = srcCompressionType;
+      this.destCompressionType = destCompressionType;
+    }
+
+    public String getSrcFile() {
+      return srcFile;
+    }
+  }
+
+  public class UploadCommandEncryptionFacade extends UploadCommandFacade {
+    @FixedViewColumn(name = "encryption", ordinal = 75)
+    private String encryption;
+
+    public UploadCommandEncryptionFacade(
+            String srcFile,
+            String destFile,
+            String resultStatus,
+            String errorDetails,
+            long srcSize,
+            long destSize,
+            String srcCompressionType,
+            String destCompressionType,
+            boolean isEncrypted) {
+      super(
+              srcFile,
+              destFile,
+              resultStatus,
+              errorDetails,
+              srcSize,
+              destSize,
+              srcCompressionType,
+              destCompressionType);
+      this.encryption = isEncrypted ? "ENCRYPTED" : "";
+    }
+  }
+
+  /** A class for encapsulating the columns to return for the download command */
+  public class DownloadCommandFacade {
+    @FixedViewColumn(name = "file", ordinal = 10)
+    private String file;
+
+    @FixedViewColumn(name = "size", ordinal = 20)
+    private long size;
+
+    @FixedViewColumn(name = "status", ordinal = 30)
+    private String resultStatus;
+
+    @FixedViewColumn(name = "message", ordinal = 40)
+    private String errorDetails;
+
+    public DownloadCommandFacade(String file, String resultStatus, String errorDetails, long size) {
+      this.file = file;
+      this.resultStatus = resultStatus;
+      this.errorDetails = errorDetails;
+      this.size = size;
+    }
+
+    public String getFile() {
+      return file;
+    }
+  }
+
+  public class DownloadCommandEncryptionFacade extends DownloadCommandFacade {
+    @FixedViewColumn(name = "encryption", ordinal = 35)
+    private String encryption;
+
+    public DownloadCommandEncryptionFacade(
+            String file, String resultStatus, String errorDetails, long size, boolean isEncrypted) {
+      super(file, resultStatus, errorDetails, size);
+      this.encryption = isEncrypted ? "DECRYPTED" : "";
+    }
+  }
+
   protected boolean compressSourceFromStream;
   protected String destStagePath;
   protected String destFileNameForStreamSource;
@@ -63,11 +192,11 @@ public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
       return ClassUtil.getFixedViewObjectAsRow(
           commandType == CommandType.UPLOAD
               ? (showEncryptionParameter
-                  ? SnowflakeFileTransferAgent.UploadCommandEncryptionFacade.class
-                  : SnowflakeFileTransferAgent.UploadCommandFacade.class)
+                  ? UploadCommandEncryptionFacade.class
+                  : UploadCommandFacade.class)
               : (showEncryptionParameter
-                  ? SnowflakeFileTransferAgent.DownloadCommandEncryptionFacade.class
-                  : SnowflakeFileTransferAgent.DownloadCommandFacade.class),
+                  ? DownloadCommandEncryptionFacade.class
+                  : DownloadCommandFacade.class),
           statusRows.get(currentRowIndex++));
     } else {
       return null;
@@ -85,11 +214,11 @@ public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
     return SnowflakeUtil.describeFixedViewColumns(
         commandType == CommandType.UPLOAD
             ? (showEncryptionParameter
-                ? SnowflakeFileTransferAgent.UploadCommandEncryptionFacade.class
-                : SnowflakeFileTransferAgent.UploadCommandFacade.class)
+                ? UploadCommandEncryptionFacade.class
+                : UploadCommandFacade.class)
             : (showEncryptionParameter
-                ? SnowflakeFileTransferAgent.DownloadCommandEncryptionFacade.class
-                : SnowflakeFileTransferAgent.DownloadCommandFacade.class),
+                ? DownloadCommandEncryptionFacade.class
+                : DownloadCommandFacade.class),
         session);
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SFBaseFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFBaseFileTransferAgent.java
@@ -72,14 +72,14 @@ public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
     private String errorDetails;
 
     public UploadCommandFacade(
-            String srcFile,
-            String destFile,
-            String resultStatus,
-            String errorDetails,
-            long srcSize,
-            long destSize,
-            String srcCompressionType,
-            String destCompressionType) {
+        String srcFile,
+        String destFile,
+        String resultStatus,
+        String errorDetails,
+        long srcSize,
+        long destSize,
+        String srcCompressionType,
+        String destCompressionType) {
       this.srcFile = srcFile;
       this.destFile = destFile;
       this.resultStatus = resultStatus;
@@ -100,24 +100,24 @@ public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
     private String encryption;
 
     public UploadCommandEncryptionFacade(
-            String srcFile,
-            String destFile,
-            String resultStatus,
-            String errorDetails,
-            long srcSize,
-            long destSize,
-            String srcCompressionType,
-            String destCompressionType,
-            boolean isEncrypted) {
+        String srcFile,
+        String destFile,
+        String resultStatus,
+        String errorDetails,
+        long srcSize,
+        long destSize,
+        String srcCompressionType,
+        String destCompressionType,
+        boolean isEncrypted) {
       super(
-              srcFile,
-              destFile,
-              resultStatus,
-              errorDetails,
-              srcSize,
-              destSize,
-              srcCompressionType,
-              destCompressionType);
+          srcFile,
+          destFile,
+          resultStatus,
+          errorDetails,
+          srcSize,
+          destSize,
+          srcCompressionType,
+          destCompressionType);
       this.encryption = isEncrypted ? "ENCRYPTED" : "";
     }
   }
@@ -153,7 +153,7 @@ public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
     private String encryption;
 
     public DownloadCommandEncryptionFacade(
-            String file, String resultStatus, String errorDetails, long size, boolean isEncrypted) {
+        String file, String resultStatus, String errorDetails, long size, boolean isEncrypted) {
       super(file, resultStatus, errorDetails, size);
       this.encryption = isEncrypted ? "DECRYPTED" : "";
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -38,7 +38,6 @@ import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.FileCompressionType;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 import net.snowflake.common.core.SqlState;
-import net.snowflake.common.util.FixedViewColumn;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -246,125 +245,6 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     public remoteLocation(String remoteStorageLocation, String remotePath) {
       location = remoteStorageLocation;
       path = remotePath;
-    }
-  }
-
-  /** A class for encapsulating the columns to return for the upload command */
-  public enum UploadColumns {
-    source,
-    target,
-    source_size,
-    target_size,
-    source_compression,
-    target_compression,
-    status,
-    encryption,
-    message
-  };
-
-  public class UploadCommandFacade {
-
-    @FixedViewColumn(name = "source", ordinal = 10)
-    private String srcFile;
-
-    @FixedViewColumn(name = "target", ordinal = 20)
-    private String destFile;
-
-    @FixedViewColumn(name = "source_size", ordinal = 30)
-    private long srcSize;
-
-    @FixedViewColumn(name = "target_size", ordinal = 40)
-    private long destSize = -1;
-
-    @FixedViewColumn(name = "source_compression", ordinal = 50)
-    private String srcCompressionType;
-
-    @FixedViewColumn(name = "target_compression", ordinal = 60)
-    private String destCompressionType;
-
-    @FixedViewColumn(name = "status", ordinal = 70)
-    private String resultStatus;
-
-    @FixedViewColumn(name = "message", ordinal = 80)
-    private String errorDetails;
-
-    public UploadCommandFacade(
-        String srcFile,
-        String destFile,
-        String resultStatus,
-        String errorDetails,
-        long srcSize,
-        long destSize,
-        String srcCompressionType,
-        String destCompressionType) {
-      this.srcFile = srcFile;
-      this.destFile = destFile;
-      this.resultStatus = resultStatus;
-      this.errorDetails = errorDetails;
-      this.srcSize = srcSize;
-      this.destSize = destSize;
-      this.srcCompressionType = srcCompressionType;
-      this.destCompressionType = destCompressionType;
-    }
-  }
-
-  public class UploadCommandEncryptionFacade extends UploadCommandFacade {
-    @FixedViewColumn(name = "encryption", ordinal = 75)
-    private String encryption;
-
-    public UploadCommandEncryptionFacade(
-        String srcFile,
-        String destFile,
-        String resultStatus,
-        String errorDetails,
-        long srcSize,
-        long destSize,
-        String srcCompressionType,
-        String destCompressionType,
-        boolean isEncrypted) {
-      super(
-          srcFile,
-          destFile,
-          resultStatus,
-          errorDetails,
-          srcSize,
-          destSize,
-          srcCompressionType,
-          destCompressionType);
-      this.encryption = isEncrypted ? "ENCRYPTED" : "";
-    }
-  }
-
-  /** A class for encapsulating the columns to return for the download command */
-  public class DownloadCommandFacade {
-    @FixedViewColumn(name = "file", ordinal = 10)
-    private String file;
-
-    @FixedViewColumn(name = "size", ordinal = 20)
-    private long size;
-
-    @FixedViewColumn(name = "status", ordinal = 30)
-    private String resultStatus;
-
-    @FixedViewColumn(name = "message", ordinal = 40)
-    private String errorDetails;
-
-    public DownloadCommandFacade(String file, String resultStatus, String errorDetails, long size) {
-      this.file = file;
-      this.resultStatus = resultStatus;
-      this.errorDetails = errorDetails;
-      this.size = size;
-    }
-  }
-
-  public class DownloadCommandEncryptionFacade extends DownloadCommandFacade {
-    @FixedViewColumn(name = "encryption", ordinal = 35)
-    private String encryption;
-
-    public DownloadCommandEncryptionFacade(
-        String file, String resultStatus, String errorDetails, long size, boolean isEncrypted) {
-      super(file, resultStatus, errorDetails, size);
-      this.encryption = isEncrypted ? "DECRYPTED" : "";
     }
   }
 
@@ -3065,16 +2945,16 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           (commandType == CommandType.UPLOAD)
               ? new Comparator<Object>() {
                 public int compare(Object a, Object b) {
-                  String srcFileNameA = ((UploadCommandFacade) a).srcFile;
-                  String srcFileNameB = ((UploadCommandFacade) b).srcFile;
+                  String srcFileNameA = ((UploadCommandFacade) a).getSrcFile();
+                  String srcFileNameB = ((UploadCommandFacade) b).getSrcFile();
 
                   return srcFileNameA.compareTo(srcFileNameB);
                 }
               }
               : new Comparator<Object>() {
                 public int compare(Object a, Object b) {
-                  String srcFileNameA = ((DownloadCommandFacade) a).file;
-                  String srcFileNameB = ((DownloadCommandFacade) b).file;
+                  String srcFileNameA = ((DownloadCommandFacade) a).getFile();
+                  String srcFileNameB = ((DownloadCommandFacade) b).getFile();
 
                   return srcFileNameA.compareTo(srcFileNameB);
                 }


### PR DESCRIPTION
# Overview

SNOW-414125

Making a few refactors to avoid duplication in jdbc-stored-procs
- Refactor the upload/download command facade classes and their related code from `SnowflakeFileTransferAgent` into `SFBaseFileTransferAgent`.
- Refactor `SFStatement.isFileTransfer` into `SFBaseStatement`.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

