### PR TITLE
SNOW-540172 Reduce test execution time

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -676,7 +676,11 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
                     networkTimeoutInMilli,
                     session));
         downloaderFutures.put(nextChunkToDownload, downloaderFuture);
-        nextChunkToDownload = nextChunkToConsume + 1;
+        // Only when prefetch fails due to internal memory limitation, nextChunkToDownload
+        // equals nextChunkToConsume. In that case we need to increment nextChunkToDownload
+        if (nextChunkToDownload == nextChunkToConsume) {
+          nextChunkToDownload = nextChunkToConsume + 1;
+        }
       }
     }
     if (currentChunk.getDownloadState() == DownloadState.SUCCESS) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -675,7 +675,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
                     chunkHeadersMap,
                     networkTimeoutInMilli,
                     session));
-        downloaderFutures.put(nextChunkToConsume, downloaderFuture);
+        downloaderFutures.put(nextChunkToDownload, downloaderFuture);
         nextChunkToDownload = nextChunkToConsume + 1;
       }
     }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import net.snowflake.client.category.TestCategoryResultSet;
 import net.snowflake.client.core.SFBaseSession;
+import net.snowflake.client.core.SessionUtil;
 import net.snowflake.client.jdbc.telemetry.*;
 import net.snowflake.common.core.SFBinary;
 import org.apache.arrow.vector.Float8Vector;
@@ -129,7 +130,11 @@ public class ResultSetLatestIT extends ResultSet0IT {
     connection
         .unwrap(SnowflakeConnectionV1.class)
         .getSFBaseSession()
-        .setMemoryLimitForTesting(2 * 1024 * 1024);
+        .setMemoryLimitForTesting(1 * 1024 * 1024);
+    connection
+        .unwrap(SnowflakeConnectionV1.class)
+        .getSFBaseSession()
+        .setOtherParameter(SessionUtil.JDBC_CHUNK_DOWNLOADER_MAX_RETRY, 1);
     // Set memory limit to low number
     // open multiple statements concurrently to overwhelm current memory allocation
     for (int i = 0; i < stmtCount; ++i) {
@@ -143,6 +148,11 @@ public class ResultSetLatestIT extends ResultSet0IT {
       }
       assertTrue(Pattern.matches("[a-zA-Z0-9]{100}", resultSet.getString(1)));
     }
+    // reset retry to MAX_NUM_OF_RETRY, which is 10
+    connection
+        .unwrap(SnowflakeConnectionV1.class)
+        .getSFBaseSession()
+        .setOtherParameter(SessionUtil.JDBC_CHUNK_DOWNLOADER_MAX_RETRY, 10);
     // set memory limit back to default invalid value so it does not get used
     connection
         .unwrap(SnowflakeConnectionV1.class)


### PR DESCRIPTION
# Overview

SNOW-540172 
Two changes:
1. Reduced test time of testChunkDownloaderSetRetry from 20 minutes to 40 seconds. Total run time reduced from 1.5 hours to 1 hour.
2. Only when prefetch fails due to internal memory limitation, nextChunkToDownload equals nextChunkToConsume. In that case we need to increment nextChunkToDownload. For all other cases we want to follow the old JDBC path to not increase the value of nextChunkToDownload.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

