### PR TITLE
SNOW-538708: Unsafe warning segfault

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -4,13 +4,14 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.common.core.ResourceBundleManager;
+import net.snowflake.common.core.SqlState;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.sql.*;
 import java.util.List;
 import java.util.Properties;
-import net.snowflake.common.core.ResourceBundleManager;
-import net.snowflake.common.core.SqlState;
 
 /**
  * JDBC Driver implementation of Snowflake for production. To use this driver, specify the following
@@ -78,10 +79,13 @@ public class SnowflakeDriver implements Driver {
           unsafeClass.getDeclaredMethod(
               "putObjectVolatile", Object.class, long.class, Object.class);
       Method staticFieldOffset = unsafeClass.getDeclaredMethod("staticFieldOffset", Field.class);
+      //Method staticFieldBase = unsafeClass.getDeclaredMethod("staticFieldBase", Field.class);
 
       Class loggerClass = Class.forName("jdk.internal.module.IllegalAccessLogger");
       Field loggerField = loggerClass.getDeclaredField("logger");
       Long offset = (Long) staticFieldOffset.invoke(unsafe, loggerField);
+      //Object loggerBase = staticFieldBase.invoke(unsafe, loggerField);
+      //putObjectVolatile.invoke(unsafe, loggerBase, offset, null);
       putObjectVolatile.invoke(unsafe, loggerClass, offset, null);
     } catch (Throwable ex) {
       // If failed to eliminate warnings, do nothing


### PR DESCRIPTION
# Overview

SNOW-538708
There is a bug with the current solution to depress illegal access warning.

Follow the repro steps mentioned in the ticket (https://github.com/oracle/graal/issues/4149 ) with the new jdbc jar, the test can finish successfully.
```
+ : Running native app
+ echo '[INFO] Running native app'
[INFO] Running native app
+ ./target/graalvm-segfault-bug
com.snowflake.client.jdbc.SnowflakeDriver@2d9d3270       <<< the correct output instead of getting a segfault
```
Also verified that the new logic can still depress the illegal access warning by running arrow result set IT.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

