### PR TITLE
SNOW 50081 JWT expiration issue

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -541,17 +541,19 @@ public class HttpUtil {
    *
    * @param httpRequest HttpRequestBase
    * @param retryTimeout retry timeout
+   * @param authTimeout authenticator specific timeout
    * @param ocspAndProxyKey OCSP mode and proxy settings for httpclient
    * @return response
    * @throws SnowflakeSQLException if Snowflake error occurs
    * @throws IOException raises if a general IO error occurs
    */
   public static String executeGeneralRequest(
-      HttpRequestBase httpRequest, int retryTimeout, HttpClientSettingsKey ocspAndProxyKey)
+      HttpRequestBase httpRequest, int retryTimeout, int authTimeout, HttpClientSettingsKey ocspAndProxyKey)
       throws SnowflakeSQLException, IOException {
     return executeRequest(
         httpRequest,
         retryTimeout,
+        authTimeout,
         0, // no inject socket timeout
         null, // no canceling
         false, // no retry parameter
@@ -589,6 +591,7 @@ public class HttpUtil {
    *
    * @param httpRequest HttpRequestBase
    * @param retryTimeout retry timeout
+   * @param authTimeout authenticator timeout
    * @param injectSocketTimeout injecting socket timeout
    * @param canceling canceling?
    * @param includeRetryParameters whether to include retry parameters in retried requests
@@ -601,6 +604,7 @@ public class HttpUtil {
   public static String executeRequest(
       HttpRequestBase httpRequest,
       int retryTimeout,
+      int authTimeout,
       int injectSocketTimeout,
       AtomicBoolean canceling,
       boolean includeRetryParameters,
@@ -610,6 +614,7 @@ public class HttpUtil {
     return executeRequestInternal(
         httpRequest,
         retryTimeout,
+        authTimeout,
         injectSocketTimeout,
         canceling,
         false, // with cookie (do we need cookie?)
@@ -628,6 +633,7 @@ public class HttpUtil {
    *
    * @param httpRequest request object contains all the information
    * @param retryTimeout retry timeout (in seconds)
+   * @param authTimeout authenticator specific timeout (in seconds)
    * @param injectSocketTimeout simulate socket timeout
    * @param canceling canceling flag
    * @param withoutCookies whether this request should ignore cookies
@@ -642,6 +648,7 @@ public class HttpUtil {
   private static String executeRequestInternal(
       HttpRequestBase httpRequest,
       int retryTimeout,
+      int authTimeout,
       int injectSocketTimeout,
       AtomicBoolean canceling,
       boolean withoutCookies,
@@ -666,6 +673,7 @@ public class HttpUtil {
               httpClient,
               httpRequest,
               retryTimeout,
+              authTimeout,
               injectSocketTimeout,
               canceling,
               withoutCookies,

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -574,17 +574,21 @@ public class HttpUtil {
    *
    * @param httpRequest HttpRequestBase
    * @param retryTimeout retry timeout
+   * @param authTimeout authenticator specific timeout
+   * @param retryCount : retry count for the request
    * @param httpClient client object used to communicate with other machine
    * @return response
    * @throws SnowflakeSQLException if Snowflake error occurs
    * @throws IOException raises if a general IO error occurs
    */
   public static String executeGeneralRequest(
-      HttpRequestBase httpRequest, int retryTimeout, CloseableHttpClient httpClient)
+      HttpRequestBase httpRequest, int retryTimeout, int authTimeout, int retryCount, CloseableHttpClient httpClient)
       throws SnowflakeSQLException, IOException {
     return executeRequestInternal(
         httpRequest,
         retryTimeout,
+        authTimeout,
+        retryCount,
         0, // no inject socket timeout
         null, // no canceling
         false, // with cookie

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.core;
@@ -510,6 +510,8 @@ public class HttpUtil {
    *
    * @param httpRequest HttpRequestBase
    * @param retryTimeout retry timeout
+   * @param authTimeout authenticator specific timeout
+   * @param retryCount : retry count for the request
    * @param injectSocketTimeout injecting socket timeout
    * @param canceling canceling?
    * @param ocspAndProxyKey OCSP mode and proxy settings for httpclient
@@ -520,6 +522,8 @@ public class HttpUtil {
   static String executeRequestWithoutCookies(
       HttpRequestBase httpRequest,
       int retryTimeout,
+      int authTimeout,
+      int retryCount,
       int injectSocketTimeout,
       AtomicBoolean canceling,
       HttpClientSettingsKey ocspAndProxyKey)
@@ -527,6 +531,8 @@ public class HttpUtil {
     return executeRequestInternal(
         httpRequest,
         retryTimeout,
+        authTimeout,
+        retryCount,
         injectSocketTimeout,
         canceling,
         true, // no cookie
@@ -542,18 +548,20 @@ public class HttpUtil {
    * @param httpRequest HttpRequestBase
    * @param retryTimeout retry timeout
    * @param authTimeout authenticator specific timeout
+   * @param retryCount : retry count for the request
    * @param ocspAndProxyKey OCSP mode and proxy settings for httpclient
    * @return response
    * @throws SnowflakeSQLException if Snowflake error occurs
    * @throws IOException raises if a general IO error occurs
    */
   public static String executeGeneralRequest(
-      HttpRequestBase httpRequest, int retryTimeout, int authTimeout, HttpClientSettingsKey ocspAndProxyKey)
+      HttpRequestBase httpRequest, int retryTimeout, int authTimeout, int retryCount, HttpClientSettingsKey ocspAndProxyKey)
       throws SnowflakeSQLException, IOException {
     return executeRequest(
         httpRequest,
         retryTimeout,
         authTimeout,
+        retryCount,
         0, // no inject socket timeout
         null, // no canceling
         false, // no retry parameter
@@ -592,6 +600,7 @@ public class HttpUtil {
    * @param httpRequest HttpRequestBase
    * @param retryTimeout retry timeout
    * @param authTimeout authenticator timeout
+   * @param retryCount : retry count for the request
    * @param injectSocketTimeout injecting socket timeout
    * @param canceling canceling?
    * @param includeRetryParameters whether to include retry parameters in retried requests
@@ -605,6 +614,7 @@ public class HttpUtil {
       HttpRequestBase httpRequest,
       int retryTimeout,
       int authTimeout,
+      int retryCount,
       int injectSocketTimeout,
       AtomicBoolean canceling,
       boolean includeRetryParameters,
@@ -615,6 +625,7 @@ public class HttpUtil {
         httpRequest,
         retryTimeout,
         authTimeout,
+        retryCount,
         injectSocketTimeout,
         canceling,
         false, // with cookie (do we need cookie?)
@@ -634,6 +645,7 @@ public class HttpUtil {
    * @param httpRequest request object contains all the information
    * @param retryTimeout retry timeout (in seconds)
    * @param authTimeout authenticator specific timeout (in seconds)
+   * @param retryCount : retry count for the request
    * @param injectSocketTimeout simulate socket timeout
    * @param canceling canceling flag
    * @param withoutCookies whether this request should ignore cookies
@@ -649,6 +661,7 @@ public class HttpUtil {
       HttpRequestBase httpRequest,
       int retryTimeout,
       int authTimeout,
+      int retryCount,
       int injectSocketTimeout,
       AtomicBoolean canceling,
       boolean withoutCookies,
@@ -674,6 +687,7 @@ public class HttpUtil {
               httpRequest,
               retryTimeout,
               authTimeout,
+              retryCount,
               injectSocketTimeout,
               canceling,
               withoutCookies,

--- a/src/main/java/net/snowflake/client/core/Incident.java
+++ b/src/main/java/net/snowflake/client/core/Incident.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2019-2022 Snowflake Computing Inc. All rights reserved.
  */
 package net.snowflake.client.core;
 
@@ -232,6 +232,8 @@ public class Incident extends Event {
           HttpUtil.executeGeneralRequest(
               postRequest,
               1000,
+              0,
+              0,
               ocspAndProxyKey != null
                   ? ocspAndProxyKey
                   : new HttpClientSettingsKey(OCSPMode.FAIL_OPEN));

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.core;
@@ -764,6 +764,8 @@ public abstract class SFBaseSession {
   }
 
   public abstract int getNetworkTimeoutInMilli();
+
+  public abstract int getAuthTimeout();
 
   public abstract SnowflakeConnectString getSnowflakeConnectionString();
 }

--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -25,6 +25,7 @@ public class SFLoginInput {
   private String oktaUserName;
   private String accountName;
   private int loginTimeout = -1; // default is invalid
+  private int authTimeout = 0;
   private String userName;
   private String password;
   private boolean passcodeInPassword;
@@ -136,6 +137,15 @@ public class SFLoginInput {
 
   SFLoginInput setLoginTimeout(int loginTimeout) {
     this.loginTimeout = loginTimeout;
+    return this;
+  }
+
+  int getAuthTimeout() {
+    return authTimeout;
+  }
+
+  SFLoginInput setAuthTimeout(int authTimeout) {
+    this.authTimeout = authTimeout;
     return this;
   }
 

--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.core;

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.core;
@@ -80,6 +80,7 @@ public class SFSession extends SFBaseSession {
    */
   private int networkTimeoutInMilli = 0; // in milliseconds
 
+  private int authTimeout = 0;
   private boolean enableCombineDescribe = false;
   private int httpClientConnectionTimeout = 60000; // milliseconds
   private int httpClientSocketTimeout = DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT; // milliseconds
@@ -166,7 +167,7 @@ public class SFSession extends SFBaseSession {
       try {
         get.setHeader("Content-type", "application/json");
         get.setHeader("Authorization", "Snowflake Token=\"" + this.sessionToken + "\"");
-        response = HttpUtil.executeGeneralRequest(get, loginTimeout, getHttpClientKey());
+        response = HttpUtil.executeGeneralRequest(get, loginTimeout, authTimeout, 0, getHttpClientKey());
         jsonNode = OBJECT_MAPPER.readTree(response);
       } catch (Exception e) {
         throw new SnowflakeSQLLoggedException(
@@ -432,6 +433,7 @@ public class SFSession extends SFBaseSession {
         .setOKTAUserName((String) connectionPropertiesMap.get(SFSessionProperty.OKTA_USERNAME))
         .setAccountName((String) connectionPropertiesMap.get(SFSessionProperty.ACCOUNT))
         .setLoginTimeout(loginTimeout)
+        .setAuthTimeout(authTimeout)
         .setUserName((String) connectionPropertiesMap.get(SFSessionProperty.USER))
         .setPassword((String) connectionPropertiesMap.get(SFSessionProperty.PASSWORD))
         .setToken((String) connectionPropertiesMap.get(SFSessionProperty.TOKEN))
@@ -457,6 +459,7 @@ public class SFSession extends SFBaseSession {
         SessionUtil.openSession(loginInput, connectionPropertiesMap, tracingLevel.toString());
     isClosed = false;
 
+    authTimeout = loginInput.getAuthTimeout();
     sessionToken = loginOutput.getSessionToken();
     masterToken = loginOutput.getMasterToken();
     idToken = loginOutput.getIdToken();
@@ -716,7 +719,7 @@ public class SFSession extends SFBaseSession {
         // per https://support-snowflake.zendesk.com/agent/tickets/6629
         int SF_HEARTBEAT_TIMEOUT = 300;
         String theResponse =
-            HttpUtil.executeGeneralRequest(postRequest, SF_HEARTBEAT_TIMEOUT, getHttpClientKey());
+            HttpUtil.executeGeneralRequest(postRequest, SF_HEARTBEAT_TIMEOUT, authTimeout, 0, getHttpClientKey());
 
         JsonNode rootNode;
 
@@ -787,6 +790,10 @@ public class SFSession extends SFBaseSession {
 
   public int getNetworkTimeoutInMilli() {
     return networkTimeoutInMilli;
+  }
+
+  public int getAuthTimeout() {
+    return authTimeout;
   }
 
   public boolean isClosed() {

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -184,6 +184,8 @@ public class SessionUtil {
               ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1,
               "SNOWPARK_LAZY_ANALYSIS"));
 
+  private static final int DEFAULT_AUTH_TIMEOUT = 0;
+
   /**
    * Returns Authenticator type
    *
@@ -346,8 +348,8 @@ public class SessionUtil {
     Map<String, Object> commonParams;
 
     try {
-      uriBuilder = new URIBuilder(loginInput.getServerUrl());
 
+      uriBuilder = new URIBuilder(loginInput.getServerUrl());
       // add database name and schema name as query parameters
       if (loginInput.getDatabaseName() != null) {
         uriBuilder.addParameter(SF_QUERY_DATABASE, loginInput.getDatabaseName());
@@ -388,6 +390,7 @@ public class SessionUtil {
                 loginInput.getUserName());
 
         loginInput.setToken(s.issueJwtToken());
+        loginInput.setAuthTimeout(SessionUtilKeyPair.getTimeout());
       }
 
       uriBuilder.addParameter(SFSession.SF_QUERY_REQUEST_ID, UUID.randomUUID().toString());
@@ -584,9 +587,28 @@ public class SessionUtil {
 
       setServiceNameHeader(loginInput, postRequest);
 
-      String theString =
-          HttpUtil.executeGeneralRequest(
-              postRequest, loginInput.getLoginTimeout(), loginInput.getHttpClientSettingsKey());
+      try {
+        String theString =
+                HttpUtil.executeGeneralRequest(
+                        postRequest, loginInput.getLoginTimeout(), loginInput.getAuthTimeout(), loginInput.getHttpClientSettingsKey());
+      } catch (SnowflakeSQLException ex) {
+        if(ex.getMessage().contains("Authenticator Timeout")) {
+          if(authenticatorType == ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT) {
+            SessionUtilKeyPair s =
+                    new SessionUtilKeyPair(
+                            loginInput.getPrivateKey(),
+                            loginInput.getPrivateKeyFile(),
+                            loginInput.getPrivateKeyFilePwd(),
+                            loginInput.getAccountName(),
+                            loginInput.getUserName());
+
+            data.put(ClientAuthnParameter.TOKEN.name(), s.issueJwtToken());
+          }
+          String theString =
+                  HttpUtil.executeGeneralRequest(
+                          postRequest, loginInput.getLoginTimeout(), loginInput.getAuthTimeout(), loginInput.getHttpClientSettingsKey());
+        }
+      }
 
       // general method, same as with data binding
       JsonNode jsonNode = mapper.readTree(theString);
@@ -1442,6 +1464,7 @@ public class SessionUtil {
     }
   }
 
+<<<<<<< HEAD
   /**
    * Helper function to generate a JWT token
    *
@@ -1461,8 +1484,13 @@ public class SessionUtil {
       String userName)
       throws SFException {
     SessionUtilKeyPair s =
-        new SessionUtilKeyPair(
-            privateKey, privateKeyFile, privateKeyFilePwd, accountName, userName);
+            new SessionUtilKeyPair(
+                    privateKey, privateKeyFile, privateKeyFilePwd, accountName, userName);
     return s.issueJwtToken();
+  }
+
+  public static void defaultAuthTimeoutResponse()
+  {
+    logger.debug("Default auth timeout response was triggered. This is a no op");
   }
 }

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1464,7 +1464,6 @@ public class SessionUtil {
     }
   }
 
-<<<<<<< HEAD
   /**
    * Helper function to generate a JWT token
    *

--- a/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 package net.snowflake.client.core;
 
@@ -179,7 +179,7 @@ public class SessionUtilExternalBrowser {
 
       String theString =
           HttpUtil.executeGeneralRequest(
-              postRequest, loginInput.getLoginTimeout(), loginInput.getHttpClientSettingsKey());
+              postRequest, loginInput.getLoginTimeout(), loginInput.getAuthTimeout(), 0, loginInput.getHttpClientSettingsKey());
 
       logger.debug("authenticator-request response: {}", theString);
 

--- a/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
@@ -30,6 +30,8 @@ import net.snowflake.client.log.SFLoggerFactory;
 import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.util.io.pem.PemReader;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetEnv;
+
 /** Class used to compute jwt token for key pair authentication Created by hyu on 1/16/18. */
 class SessionUtilKeyPair {
 
@@ -54,6 +56,8 @@ class SessionUtilKeyPair {
   private static final String ISSUER_FMT = "%s.%s.%s";
 
   private static final String SUBJECT_FMT = "%s.%s";
+
+  private static final int JWT_DEFAULT_AUTH_TIMEOUT = 10;
 
   SessionUtilKeyPair(
       PrivateKey privateKey,
@@ -103,6 +107,8 @@ class SessionUtilKeyPair {
           "Use java.security.interfaces.RSAPrivateCrtKey.class for the private key");
     }
   }
+
+
 
   private KeyFactory getKeyFactoryInstance() throws NoSuchAlgorithmException {
     if (isFipsMode) {
@@ -201,5 +207,13 @@ class SessionUtilKeyPair {
     } catch (NoSuchAlgorithmException e) {
       throw new SFException(e, ErrorCode.INTERNAL_ERROR, "Error when calculating fingerprint");
     }
+  }
+  public static int getTimeout()  {
+    String jwtAuthTimeoutStr = systemGetEnv("JWT_AUTH_TIMEOUT");
+    int jwtAuthTimeout = JWT_DEFAULT_AUTH_TIMEOUT;
+    if(jwtAuthTimeoutStr != null) {
+      jwtAuthTimeout = Integer.parseInt(jwtAuthTimeoutStr);
+    }
+    return jwtAuthTimeout;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 package net.snowflake.client.core;
 
@@ -208,6 +208,7 @@ class SessionUtilKeyPair {
       throw new SFException(e, ErrorCode.INTERNAL_ERROR, "Error when calculating fingerprint");
     }
   }
+
   public static int getTimeout()  {
     String jwtAuthTimeoutStr = systemGetEnv("JWT_AUTH_TIMEOUT");
     int jwtAuthTimeout = JWT_DEFAULT_AUTH_TIMEOUT;

--- a/src/main/java/net/snowflake/client/core/StmtUtil.java
+++ b/src/main/java/net/snowflake/client/core/StmtUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.core;
@@ -335,6 +335,8 @@ public class StmtUtil {
             HttpUtil.executeRequest(
                 httpRequest,
                 stmtInput.networkTimeoutInMillis / 1000,
+                0,
+                0,
                 stmtInput.injectSocketTimeout,
                 stmtInput.canceling,
                 true, // include retry parameters
@@ -574,6 +576,8 @@ public class StmtUtil {
           httpRequest,
           stmtInput.networkTimeoutInMillis / 1000,
           0,
+          0,
+          0,
           stmtInput.canceling,
           false, // no retry parameter
           false, // no retry on HTTP 403
@@ -685,6 +689,8 @@ public class StmtUtil {
           HttpUtil.executeRequest(
               httpRequest,
               SF_CANCELING_RETRY_TIMEOUT_IN_MILLIS,
+              0,
+              0,
               0,
               null,
               false, // no retry parameter

--- a/src/main/java/net/snowflake/client/jdbc/ChunkDownloadContext.java
+++ b/src/main/java/net/snowflake/client/jdbc/ChunkDownloadContext.java
@@ -35,6 +35,10 @@ public class ChunkDownloadContext {
     return networkTimeoutInMilli;
   }
 
+  public int getAuthTimeout() {
+    return authTimeout;
+  }
+
   public SFBaseSession getSession() {
     return session;
   }
@@ -44,6 +48,7 @@ public class ChunkDownloadContext {
   private final int chunkIndex;
   private final Map<String, String> chunkHeadersMap;
   private final int networkTimeoutInMilli;
+  private final int authTimeout;
   private final SFBaseSession session;
 
   public ChunkDownloadContext(
@@ -53,6 +58,7 @@ public class ChunkDownloadContext {
       int chunkIndex,
       Map<String, String> chunkHeadersMap,
       int networkTimeoutInMilli,
+      int authTimeout,
       SFBaseSession session) {
     this.chunkDownloader = chunkDownloader;
     this.resultChunk = resultChunk;
@@ -60,6 +66,7 @@ public class ChunkDownloadContext {
     this.chunkIndex = chunkIndex;
     this.chunkHeadersMap = chunkHeadersMap;
     this.networkTimeoutInMilli = networkTimeoutInMilli;
+    this.authTimeout = authTimeout;
     this.session = session;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
@@ -122,6 +122,8 @@ public class DefaultResultStreamProvider implements ResultStreamProvider {
             httpClient,
             httpRequest,
             context.getNetworkTimeoutInMilli() / 1000, // retry timeout
+            context.getAuthTimeout(),
+            0,
             0, // no socketime injection
             null, // no canceling
             false, // no cookie

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -268,8 +268,6 @@ public class RestRequest {
                 elapsedMilliForTransientIssues,
                 retryTimeoutInMilliseconds);
 
-            // check if it's a login request
-            String hostname = httpRequest.getURI().getHost();
             breakRetryReason = "retry timeout";
             TelemetryService.getInstance()
                 .logHttpRequestTelemetryEvent(
@@ -411,7 +409,6 @@ public class RestRequest {
             "Exception encountered for HTTP request: " + savedEx.getMessage());
       }
     }
-
 
     return response;
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeChunkDownloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.jdbc;
@@ -83,6 +83,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
   private Map<String, String> chunkHeadersMap;
 
   private final int networkTimeoutInMilli;
+
+  private final int authTimeout;
 
   private long memoryLimit;
 
@@ -190,6 +192,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
     this.ocspModeAndProxyKey = resultSetSerializable.getHttpClientKey();
     this.qrmk = resultSetSerializable.getQrmk();
     this.networkTimeoutInMilli = resultSetSerializable.getNetworkTimeoutInMilli();
+    this.authTimeout = resultSetSerializable.getAuthTimeout();
     this.prefetchSlots = resultSetSerializable.getResultPrefetchThreads() * 2;
     this.queryResultFormat = resultSetSerializable.getQueryResultFormat();
     logger.debug("qrmk = {}", this.qrmk);
@@ -380,6 +383,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
                     nextChunkToDownload,
                     chunkHeadersMap,
                     networkTimeoutInMilli,
+                    authTimeout,
                     this.session));
         downloaderFutures.put(nextChunkToDownload, downloaderFuture);
         // increment next chunk to download
@@ -674,6 +678,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
                     nextChunkToConsume,
                     chunkHeadersMap,
                     networkTimeoutInMilli,
+                    authTimeout,
                     session));
         downloaderFutures.put(nextChunkToDownload, downloaderFuture);
         // Only when prefetch fails due to internal memory limitation, nextChunkToDownload
@@ -827,6 +832,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
       final int chunkIndex,
       final Map<String, String> chunkHeadersMap,
       final int networkTimeoutInMilli,
+      final int authTimeout,
       final SFBaseSession session) {
     ChunkDownloadContext downloadContext =
         new ChunkDownloadContext(
@@ -836,6 +842,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
             chunkIndex,
             chunkHeadersMap,
             networkTimeoutInMilli,
+            authTimeout,
             session);
 
     return new Callable<Void>() {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.jdbc;
@@ -115,6 +115,7 @@ public class SnowflakeResultSetSerializableV1
   OCSPMode ocspMode;
   HttpClientSettingsKey httpClientKey;
   int networkTimeoutInMilli;
+  int authTimeout;
   boolean isResultColumnCaseInsensitive;
   int resultSetType;
   int resultSetConcurrency;
@@ -187,6 +188,7 @@ public class SnowflakeResultSetSerializableV1
     this.ocspMode = toCopy.ocspMode;
     this.httpClientKey = toCopy.httpClientKey;
     this.networkTimeoutInMilli = toCopy.networkTimeoutInMilli;
+    this.authTimeout = toCopy.authTimeout;
     this.isResultColumnCaseInsensitive = toCopy.isResultColumnCaseInsensitive;
     this.resultSetType = toCopy.resultSetType;
     this.resultSetConcurrency = toCopy.resultSetConcurrency;
@@ -296,6 +298,8 @@ public class SnowflakeResultSetSerializableV1
   public int getNetworkTimeoutInMilli() {
     return networkTimeoutInMilli;
   }
+
+  public int getAuthTimeout() { return authTimeout; }
 
   public int getResultPrefetchThreads() {
     return resultPrefetchThreads;
@@ -616,6 +620,7 @@ public class SnowflakeResultSetSerializableV1
     resultSetSerializable.httpClientKey = sfSession.getHttpClientKey();
     resultSetSerializable.snowflakeConnectionString = sfSession.getSnowflakeConnectionString();
     resultSetSerializable.networkTimeoutInMilli = sfSession.getNetworkTimeoutInMilli();
+    resultSetSerializable.authTimeout = sfSession.getAuthTimeout();
     resultSetSerializable.isResultColumnCaseInsensitive = sfSession.isResultColumnCaseInsensitive();
     resultSetSerializable.treatNTZAsUTC = sfSession.getTreatNTZAsUTC();
     resultSetSerializable.formatDateWithTimezone = sfSession.getFormatDateWithTimezone();

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.jdbc;
@@ -20,6 +20,7 @@ public class SnowflakeSQLException extends SQLException {
       ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
 
   private String queryId = "unknown";
+  private int retryCount = 0;
 
   /**
    * This constructor should only be used for error from Global service. Since Global service has
@@ -115,6 +116,15 @@ public class SnowflakeSQLException extends SQLException {
         errorCode.getMessageCode());
   }
 
+  public SnowflakeSQLException(ErrorCode errorCode, int retryCount, String reason) {
+    super(
+            errorResourceBundleManager.getLocalizedMessage(
+                    String.valueOf(errorCode.getMessageCode()), reason),
+            errorCode.getSqlState(),
+            errorCode.getMessageCode());
+    this.retryCount = retryCount;
+  }
+
   public SnowflakeSQLException(SFException e) {
     this(e.getQueryId(), e.getMessage(), e.getSqlState(), e.getVendorCode());
   }
@@ -125,5 +135,9 @@ public class SnowflakeSQLException extends SQLException {
 
   public String getQueryId() {
     return queryId;
+  }
+
+  public int getRetryCount() {
+    return retryCount;
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 package net.snowflake.client.jdbc.cloud.storage;
 
@@ -233,6 +233,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
                   httpClient,
                   httpRequest,
                   session.getNetworkTimeoutInMilli() / 1000, // retry timeout
+                  0,
+                  0,
                   0, // no socketime injection
                   null, // no canceling
                   false, // no cookie
@@ -395,6 +397,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
                   httpClient,
                   httpRequest,
                   session.getNetworkTimeoutInMilli() / 1000, // retry timeout
+                  0,
+                  0,
                   0, // no socketime injection
                   null, // no canceling
                   false, // no cookie
@@ -737,6 +741,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
               httpClient,
               httpRequest,
               networkTimeoutInMilli / 1000, // retry timeout
+              0,
+              0,
               0, // no socketime injection
               null, // no canceling
               false, // no cookie

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -327,10 +327,9 @@ public class TelemetryClient implements Telemetry {
         response =
             this.session == null
                 ? HttpUtil.executeGeneralRequest(
-                    post, TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC, this.httpClient)
+                    post, TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC, this.session.getAuthTimeout(), 0, this.httpClient)
                 : HttpUtil.executeGeneralRequest(
-                    post, TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC, this.session.getHttpClientKey());
-        response = HttpUtil.executeGeneralRequest(post, 1000, 0, 0, this.session.getHttpClientKey());
+                    post, TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC, this.session.getAuthTimeout(), 0, this.session.getHttpClientKey());
       } catch (SnowflakeSQLException e) {
         disableTelemetry(); // when got error like 404 or bad request, disable telemetry in this
         // telemetry instance

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -330,6 +330,7 @@ public class TelemetryClient implements Telemetry {
                     post, TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC, this.httpClient)
                 : HttpUtil.executeGeneralRequest(
                     post, TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC, this.session.getHttpClientKey());
+        response = HttpUtil.executeGeneralRequest(post, 1000, 0, 0, this.session.getHttpClientKey());
       } catch (SnowflakeSQLException e) {
         disableTelemetry(); // when got error like 404 or bad request, disable telemetry in this
         // telemetry instance

--- a/src/test/java/net/snowflake/client/core/SessionUtilExternalBrowserTest.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilExternalBrowserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.core;
@@ -137,6 +137,8 @@ public class SessionUtilExternalBrowserTest {
                   HttpUtil.executeGeneralRequest(
                       Mockito.any(HttpRequestBase.class),
                       Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
                       Mockito.nullable(HttpClientSettingsKey.class)))
           .thenReturn(
               "{\"success\":\"true\",\"data\":{\"proofKey\":\""
@@ -172,6 +174,8 @@ public class SessionUtilExternalBrowserTest {
               () ->
                   HttpUtil.executeGeneralRequest(
                       Mockito.any(HttpRequestBase.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
                       Mockito.anyInt(),
                       Mockito.nullable(HttpClientSettingsKey.class)))
           .thenReturn("{\"success\":\"false\",\"code\":\"123456\",\"message\":\"errormes\"}");

--- a/src/test/java/net/snowflake/client/core/SessionUtilIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.client.core;
+
+import static net.snowflake.client.TestUtil.systemGetEnv;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.common.core.ClientAuthnDTO;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class SessionUtilIT {
+
+    /**
+     * Tests the JWT renew functionality when retrying login requests.
+     * To run, update environment variables to use connect with JWT authentication.
+     *
+     * @throws SFException
+     * @throws SnowflakeSQLException
+     */
+    @Ignore
+    @Test
+    public void testJwtAuthTimeoutRetry() throws SFException, SnowflakeSQLException {
+        final SFLoginInput loginInput = initMockLoginInput();
+        Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
+        MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class);
+        SnowflakeSQLException ex =
+                new SnowflakeSQLException(ErrorCode.NETWORK_ERROR, 0, "Authenticator Request Timeout");
+
+        mockedHttpUtil
+                .when(
+                        () ->
+                                HttpUtil.executeGeneralRequest(
+                                        Mockito.any(HttpRequestBase.class),
+                                        Mockito.anyInt(),
+                                        Mockito.anyInt(),
+                                        Mockito.anyInt(),
+                                        Mockito.nullable(HttpClientSettingsKey.class)))
+                .thenThrow(ex) // fail first
+                .thenReturn(
+                        "{\"data\":null,\"code\":null,\"message\":null,\"success\":true}"); // succeed on retry
+
+        SessionUtil.openSession(loginInput, connectionPropertiesMap, "ALL");
+    }
+
+    /**
+     * Mock SFLoginInput
+     *
+     * @return a mock object for SFLoginInput
+     */
+    private SFLoginInput initMockLoginInput() {
+        // mock SFLoginInput
+        SFLoginInput loginInput = mock(SFLoginInput.class);
+        when(loginInput.getServerUrl()).thenReturn(systemGetEnv("SNOWFLAKE_TEST_HOST"));
+        when(loginInput.getAuthenticator())
+                .thenReturn(ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT.name());
+        when(loginInput.getPrivateKeyFile())
+                .thenReturn(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"));
+        when(loginInput.getPrivateKeyFilePwd())
+                .thenReturn(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE_PWD"));
+        when(loginInput.getUserName()).thenReturn(systemGetEnv("SNOWFLAKE_TEST_USER"));
+        when(loginInput.getAccountName()).thenReturn("testaccount");
+        when(loginInput.getAppId()).thenReturn("testid");
+        when(loginInput.getOCSPMode()).thenReturn(OCSPMode.FAIL_OPEN);
+        when(loginInput.getHttpClientSettingsKey())
+                .thenReturn(new HttpClientSettingsKey(OCSPMode.FAIL_OPEN));
+        return loginInput;
+    }
+
+    /**
+     * Initialize the connection properties map.
+     *
+     * @return connectionPropertiesMap
+     */
+    private Map<SFSessionProperty, Object> initConnectionPropertiesMap() {
+        Map<SFSessionProperty, Object> connectionPropertiesMap = new HashMap<>();
+        connectionPropertiesMap.put(SFSessionProperty.TRACING, "ALL");
+        return connectionPropertiesMap;
+    }
+}

--- a/src/test/java/net/snowflake/client/core/SnowflakeMFACacheTest.java
+++ b/src/test/java/net/snowflake/client/core/SnowflakeMFACacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.core;
@@ -101,7 +101,7 @@ public class SnowflakeMFACacheTest {
           .when(
               () ->
                   HttpUtil.executeGeneralRequest(
-                      any(HttpPost.class), anyInt(), any(HttpClientSettingsKey.class)))
+                      any(HttpPost.class), anyInt(), anyInt(), anyInt(), any(HttpClientSettingsKey.class)))
           .thenAnswer(
               new Answer<String>() {
                 int callCount = 0;
@@ -245,7 +245,7 @@ public class SnowflakeMFACacheTest {
           .when(
               () ->
                   HttpUtil.executeGeneralRequest(
-                      any(HttpPost.class), anyInt(), any(HttpClientSettingsKey.class)))
+                      any(HttpPost.class), anyInt(), anyInt(), anyInt(), any(HttpClientSettingsKey.class)))
           .thenAnswer(
               new Answer<String>() {
                 int callCount = 0;

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All right reserved.
  */
 package net.snowflake.client.jdbc;
 
@@ -933,7 +933,7 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     postRequest.addHeader("accept", "application/json");
 
     String theString =
-        HttpUtil.executeGeneralRequest(postRequest, 60, new HttpClientSettingsKey(null));
+        HttpUtil.executeGeneralRequest(postRequest, 60, 0, 0, new HttpClientSettingsKey(null));
 
     JsonNode jsonNode = mapper.readTree(theString);
     assertEquals(

--- a/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
@@ -701,6 +701,8 @@ public class MockConnectionTest extends BaseJDBCTest {
       return 0;
     }
 
+    public int getAuthTimeout() { return 0; }
+
     public SnowflakeConnectString getSnowflakeConnectionString() {
       return null;
     }

--- a/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
@@ -49,7 +49,8 @@ public class RestRequestTest {
         client,
         new HttpGet(uri),
         retryTimeout, // retry timeout
-            authTimeout,
+        authTimeout,
+        0,
         0, // inject socket timeout
         new AtomicBoolean(false), // canceling
         false, // without cookie
@@ -282,8 +283,8 @@ public class RestRequestTest {
     expectedException.expectMessage("Authenticator Request Timeout");
     CloseableHttpClient client = mock(CloseableHttpClient.class);
     when(client.execute(any(HttpUriRequest.class)))
-            .thenAnswer(retryResponse());
+            .thenAnswer((Answer<CloseableHttpResponse>) invocation -> retryResponse());
 
-    execute(client, "login-request.com/?requestId=abcd-1234",0,1, true);
+    execute(client, "login-request.com/?requestId=abcd-1234", 0, 1, true);
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.client.jdbc;
@@ -217,10 +217,11 @@ public class SSOConnectionTest {
         .when(
             () ->
                 HttpUtil.executeGeneralRequest(
-                    any(HttpPost.class), anyInt(), nullable(HttpClientSettingsKey.class)))
+                    any(HttpPost.class), anyInt(), anyInt(), anyInt(), nullable(HttpClientSettingsKey.class)))
         .thenAnswer(
             new Answer<String>() {
               int callCount = 0;
+
 
               @Override
               public String answer(InvocationOnMock invocation) throws IOException {

--- a/src/test/java/net/snowflake/client/jdbc/ServiceNameTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/ServiceNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
  */
 package net.snowflake.client.jdbc;
 
@@ -99,6 +99,8 @@ public class ServiceNameTest {
                   HttpUtil.executeGeneralRequest(
                       Mockito.any(HttpRequestBase.class),
                       Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
                       Mockito.any(HttpClientSettingsKey.class)))
           .thenReturn(responseLogin());
       mockedHttpUtil
@@ -106,6 +108,8 @@ public class ServiceNameTest {
               () ->
                   HttpUtil.executeRequest(
                       Mockito.any(HttpRequestBase.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
                       Mockito.anyInt(),
                       Mockito.anyInt(),
                       Mockito.any(AtomicBoolean.class),


### PR DESCRIPTION
# Overview

SNOW-50081

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

If a retriable network error happens during login the driver could retry on an expired JWT token. This change is to add an auth timeout property so each authenticator can use a custom handler for authentication timeouts. If the authentication timeout is hit during the retry, a custom exception is thrown and caught by the connection layer. Authenticators that don't implement a custom handler will use the default value of 0. For JWT authentication, we use a default of 10. If the authentication timeout is hit for JWT auth, the driver will renew the token before retrying the request.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

