### PR TITLE
nonProxyHosts Parameter is Not Honored

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -306,7 +306,9 @@ public class HttpUtil {
               .setConnectionRequestTimeout(DEFAULT_CONNECTION_TIMEOUT)
               .setSocketTimeout(DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT);
       // only set the proxy settings if they are not null
-      if (proxy != null) builder.setProxy(proxy);
+      // but no value has been specified for nonProxyHosts
+      // the route planner will determine whether to use a proxy based on nonProxyHosts value.
+      if (proxy != null && Strings.isNullOrEmpty(key.getNonProxyHosts())) builder.setProxy(proxy);
       DefaultRequestConfig = builder.build();
     }
 


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

nonProxyHosts value is not being honored from JVM properties or connection properties when proxy is set in the DefaultRequestConfig. This proxy object does not keep track of nonProxyHosts value.

The DefaultRoutePlanner.determineRoute() will use the DefaultRequestConfig proxy if it is available. If it is null it will call on SDKProxyRoutePlanner.java to determine if a proxy should be used. SDKProxyRoutePlanner.determineProxy() checks if the target matches the nonProxyHosts.

This change will not set the proxy in the default configuration when nonProxyHosts is used, so the route planner can determine whether to use a proxy or not based on the proxyHost and nonProxyHosts values.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

