### PR TITLE
Update QueryStatus.BLOCKED to no be classified as an ERROR

### DIFF
--- a/src/main/java/net/snowflake/client/core/QueryStatus.java
+++ b/src/main/java/net/snowflake/client/core/QueryStatus.java
@@ -54,13 +54,14 @@ public enum QueryStatus {
   }
 
   public static boolean isStillRunning(QueryStatus status) {
-    switch (status.getValue()) {
-      case 0: // "RUNNING"
-      case 5: // "QUEUED"
-      case 8: // "RESUMING_WAREHOUSE"
-      case 9: // "QUEUED_REPAIRING_WAREHOUSE"
-      case 11: // "BLOCKED"
-      case 12: // "NO_DATA"
+    switch(status) {
+      case RUNNING:
+      case QUEUED:
+      case RESUMING_WAREHOUSE:
+      case QUEUED_REPAIRING_WAREHOUSE:
+      case BLOCKED:
+      case NO_DATA:
+      case RESTARTED:
         return true;
       default:
         return false;
@@ -68,13 +69,12 @@ public enum QueryStatus {
   }
 
   public static boolean isAnError(QueryStatus status) {
-    switch (status.getValue()) {
-      case 1: // Aborting
-      case 3: // Failed with error
-      case 4: // Aborted
-      case 6: // Failed with incident
-      case 7: // disconnected
-      case 11: // blocked
+    switch(status) {
+      case ABORTING:
+      case FAILED_WITH_ERROR:
+      case ABORTED:
+      case FAILED_WITH_INCIDENT:
+      case DISCONNECTED:
         return true;
       default:
         return false;

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -332,7 +332,7 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     QueryStatus[] errorStatuses = {
       QueryStatus.ABORTED, QueryStatus.ABORTING,
       QueryStatus.FAILED_WITH_ERROR, QueryStatus.FAILED_WITH_INCIDENT,
-      QueryStatus.DISCONNECTED, QueryStatus.BLOCKED
+      QueryStatus.DISCONNECTED
     };
 
     for (QueryStatus qs : errorStatuses) {


### PR DESCRIPTION
# Overview

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowflake-jdbc/issues/717

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   (Updated existing unit test)

   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

QueryStatus.BLOCKED is the only status categorized as both RUNNING and an ERROR. But since BLOCKED just means the query is waiting for a lock, technically no error has occurred. This status seems nearly equivalent to QUEUED since both statuses are waiting for warehouse to start the query.

This also adds RESTARTED to the list of RUNNING states.

This also updates the switch case logic to use the enum names rather than hard coded integers which makes the code self-documenting.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

