### PR TITLE
Fix issue where database name is double quoted in catalog function

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -193,6 +193,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     return useSessionSchema ? false : Wildcard.isWildcardPatternStr(inputString);
   }
 
+  private boolean isIdentifierQuoted(String identifier) {
+    return identifier.startsWith("\"") && identifier.endsWith("\"");
+  }
+
   @Override
   public boolean allProceduresAreCallable() throws SQLException {
     logger.debug("public boolean allProceduresAreCallable()");
@@ -2840,7 +2844,12 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     } else if (catalog.isEmpty()) {
       return SnowflakeDatabaseMetaDataResultSet.getEmptyResultSet(GET_SCHEMAS, statement);
     } else {
-      showSchemas += " in database \"" + catalog + "\"";
+      // only add quotes if the application hasn't added them already.
+      if (isIdentifierQuoted(catalog)) {
+        showSchemas += " in database " + catalog;
+      } else {
+        showSchemas += " in database \"" + catalog + "\"";
+      }
     }
 
     logger.debug("sql command to get schemas metadata: {}", showSchemas);

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -712,4 +712,30 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
     assertTrue(resultSet.next());
     assertEquals("COLA", resultSet.getString("COLUMN_NAME"));
   }
+
+  /**
+   * This tests that the driver doesn't add quotes to the database name if the application has
+   * already added them. This fixes a bug where the show schemas command was returning empty results
+   * since the database name was being double-quoted.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testGetSchemasWithDoubleQuotedDatabase() throws SQLException {
+    try (Connection con = getConnection()) {
+      // create the database and two schemas
+      Statement statement = con.createStatement();
+      statement.execute("create or replace database \"lowercasedb\"");
+      String schema1 = "SCH1";
+      String schema2 = "SCH2";
+      statement.execute("create or replace schema \"lowercasedb\"." + schema1);
+      statement.execute("create or replace schema \"lowercasedb\"." + schema2);
+      DatabaseMetaData metaData = con.getMetaData();
+      ResultSet rs = metaData.getSchemas("\"lowercasedb\"", null);
+      // should return 4 schemas including PUBLIC and INFORMATIONSCHEMA.
+      assertEquals(4, getSizeOfResultSet(rs));
+      rs.close();
+      statement.close();
+    }
+  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -721,6 +721,7 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
    * @throws SQLException
    */
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testGetSchemasWithDoubleQuotedDatabase() throws SQLException {
     try (Connection con = getConnection()) {
       // create the database and two schemas


### PR DESCRIPTION
# Overview

SNOW-263598

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes [#432  ](https://github.com/snowflakedb/snowflake-jdbc/issues/432)


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Some users are trying to integrate the driver with Collibra application which adds double quotes around database name for getSchemas() function. The driver also adds quotes around the database name, which was leading to is being double quoted and returning empty result sets. This change will only add quotes to the database name if the application hasn't done so first.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

