### PR TITLE
setReadOnly() is unsupported

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -358,8 +358,7 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
     logger.debug("void setReadOnly(boolean readOnly)");
     raiseSQLExceptionIfConnectionIsClosed();
     if (readOnly) {
-
-      throw new SnowflakeLoggedFeatureNotSupportedException(sfSession);
+      logger.debug("setReadOnly not supported.");
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -672,23 +672,6 @@ public class ConnectionIT extends BaseJDBCTest {
   }
 
   @Test
-  public void testReadOnly() throws Throwable {
-    try (Connection connection = getConnection()) {
-
-      try {
-        connection.setReadOnly(true);
-        fail("must raise SQLFeatureNotSupportedException");
-      } catch (SQLFeatureNotSupportedException ex) {
-        // nop
-      }
-      connection.setReadOnly(false);
-      connection.createStatement().execute("create or replace table readonly_test(c1 int)");
-      assertFalse(connection.isReadOnly());
-      connection.createStatement().execute("drop table if exists readonly_test");
-    }
-  }
-
-  @Test
   public void testNativeSQL() throws Throwable {
     try (Connection connection = getConnection()) {
       // today returning the source SQL.

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -674,12 +674,9 @@ public class ConnectionIT extends BaseJDBCTest {
   @Test
   public void testReadOnly() throws Throwable {
     try (Connection connection = getConnection()) {
-      try {
-        connection.setReadOnly(true);
-        fail("must raise SQLFeatureNotSupportedException");
-      } catch (SQLFeatureNotSupportedException ex) {
-        // nop
-      }
+
+      connection.setReadOnly(true);
+      assertEquals(connection.isReadOnly(), false);
 
       connection.setReadOnly(false);
       connection.createStatement().execute("create or replace table readonly_test(c1 int)");

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -675,9 +675,12 @@ public class ConnectionIT extends BaseJDBCTest {
   public void testReadOnly() throws Throwable {
     try (Connection connection = getConnection()) {
 
-      connection.setReadOnly(true);
-      assertEquals(connection.isReadOnly(), false);
-
+      try {
+        connection.setReadOnly(true);
+        fail("must raise SQLFeatureNotSupportedException");
+      } catch (SQLFeatureNotSupportedException ex) {
+        // nop
+      }
       connection.setReadOnly(false);
       connection.createStatement().execute("create or replace table readonly_test(c1 int)");
       assertFalse(connection.isReadOnly());

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -939,4 +939,18 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     assertEquals(
         "{\"data\":null,\"code\":null,\"message\":null,\"success\":true}", jsonNode.toString());
   }
+
+  @Test
+  public void testReadOnly() throws Throwable {
+    try (Connection connection = getConnection()) {
+
+      connection.setReadOnly(true);
+      assertEquals(connection.isReadOnly(), false);
+
+      connection.setReadOnly(false);
+      connection.createStatement().execute("create or replace table readonly_test(c1 int)");
+      assertFalse(connection.isReadOnly());
+      connection.createStatement().execute("drop table if exists readonly_test");
+    }
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

 A customer is using the jdbc driver with an application which calls the JDBC setReadOnly method. They are getting an exception since the driver does not support the method. This change is to log a message instead of throw an exception when setReadOnly is called so we can ignore it. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

