### PR TITLE
Change properties to protected so it can be accessed in subclasses

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
@@ -30,7 +30,7 @@ public class SnowflakeBasicDataSource implements DataSource, Serializable {
 
   private String authenticator;
 
-  private Properties properties = new Properties();
+  protected Properties properties = new Properties();
 
   static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeBasicDataSource.class);
 


### PR DESCRIPTION
This pull request is a simple change so that a custom data-source class that extends `SnowflakeBasicDataSource` can access `properties` and not have to override all the methods that use it.