### PR TITLE
Fix bug with proxyHost and proxyPort JVM parameters

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -406,15 +406,28 @@ public abstract class SFBaseSession {
           logger.debug(
               "http.useProxy={} but valid host and port were not provided. No proxy in use.",
               httpUseProxy);
+          unsetInvalidProxyHostAndPort();
           ocspAndProxyKey = new HttpClientSettingsKey(getOCSPMode());
         }
       } else {
         // If no proxy is used or JVM http proxy is used, no need for setting parameters
         logger.debug("http.useProxy={}. JVM proxy not used.", httpUseProxy);
+        unsetInvalidProxyHostAndPort();
         ocspAndProxyKey = new HttpClientSettingsKey(getOCSPMode());
       }
     }
     return ocspAndProxyKey;
+  }
+
+  public void unsetInvalidProxyHostAndPort() {
+    // If proxyHost and proxyPort are used without http or https unset them, so they are not used
+    // later by the ProxySelector.
+    if (!Strings.isNullOrEmpty(systemGetProperty("proxyHost"))) {
+      System.clearProperty("proxyHost");
+    }
+    if (!Strings.isNullOrEmpty(systemGetProperty("proxyPort"))) {
+      System.clearProperty("proxyPort");
+    }
   }
 
   public OCSPMode getOCSPMode() {


### PR DESCRIPTION
Setting JVM proxy values like " -DproxyHost=localhost -DproxyPort=3128" attempts to connect through proxy. The driver format for connecting through proxy is  -Dhttp.proxyHost=localhost -Dhttp.proxyPort=3128.

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

If proxy JVM parameters are set as "-DproxyHost" and "-DproxyPort" the route planner will set these in the http request even if the driver ignores them. This change is to ensure the proxy is only used when "-Dhttp.useProxy", "-Dhttp.proxyHost" and "-Dhttp.proxyPort" parameters are used. If we unset the invalid values from system properties, the route planner will return a NO_PROXY entry. This will keep consistency with how to use the JVM properties for proxies.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

