### PR TITLE
Add a Snowflake specific isOpen() function to check if a connection is open or not

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -55,6 +55,7 @@ public abstract class SFBaseSession {
   protected List<SFException> sqlWarnings = new ArrayList<>();
   // Unique Session ID
   private String sessionId;
+  private String sessionToken;
   // Database versions
   private String databaseVersion = null;
   private int databaseMajorVersion = 0;
@@ -160,6 +161,14 @@ public abstract class SFBaseSession {
    */
   public void setSessionId(String sessionId) {
     this.sessionId = sessionId;
+  }
+
+  public String getSessionToken() {
+    return sessionToken;
+  }
+
+  public void setSessionToken(String sessionToken) {
+    this.sessionToken = sessionToken;
   }
 
   public boolean isSfSQLMode() {

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -616,6 +616,15 @@ public class SFSession extends SFBaseSession {
   }
 
   /**
+   * set the session token
+   *
+   * @param sessionToken
+   */
+  public void setSessionToken(String sessionToken) {
+    this.sessionToken = sessionToken;
+  }
+
+  /**
    * Close the connection
    *
    * @throws SnowflakeSQLException if failed to close the connection

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnection.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnection.java
@@ -64,4 +64,5 @@ public interface SnowflakeConnection {
 
   /** Returns the SnowflakeConnectionImpl from the connection object. */
   SFConnectionHandler getHandler();
+
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnection.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnection.java
@@ -64,5 +64,4 @@ public interface SnowflakeConnection {
 
   /** Returns the SnowflakeConnectionImpl from the connection object. */
   SFConnectionHandler getHandler();
-
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -745,6 +745,13 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
     return sfConnectionHandler;
   }
 
+  public boolean isOpen() {
+    if (isClosed || (sfSession.getSessionToken() == null)) {
+      return false;
+    }
+    return true;
+  }
+
   /**
    * Method to put data from a stream at a stage location. The data will be uploaded as one file. No
    * splitting is done in this method.

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -953,4 +953,13 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       connection.createStatement().execute("drop table if exists readonly_test");
     }
   }
+
+  @Test
+  public void testIsOpen() throws SQLException {
+    Connection connection = getConnection();
+    SnowflakeConnectionV1 sfConnection = connection.unwrap(SnowflakeConnectionV1.class);
+    assertTrue(sfConnection.isOpen());
+    sfConnection.getSfSession().setSessionToken(null);
+    assertFalse(sfConnection.isOpen());
+  }
 }


### PR DESCRIPTION
The isValid() method in the Snowflake JDBC driver issues a select 1 statement to check for session validity. This is accruing costs for some customers. A new Snowflake-specific function was requested to check whether a connection is open or not depending on the session token.

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

