### PR TITLE
SNOW-571607  Create patch for driver release v3.13.16 to fix incorrect behavior for getSchemas() function

### DIFF
--- a/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
+++ b/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(TestCategoryFips.class)
-@ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
 public class ConnectionFipsIT extends AbstractDriverIT {
   private static final String JCE_PROVIDER_BOUNCY_CASTLE_FIPS = "BCFIPS";
   private static final String JCE_PROVIDER_SUN_JCE = "SunJCE";
@@ -105,6 +104,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   private static int JCE_PROVIDER_SUN_JCE_PROVIDER_POSITION;
   private static int JCE_PROVIDER_SUN_RSA_SIGN_PROVIDER_POSITION;
 
+  @Ignore
   @BeforeClass
   public static void setup() throws Exception {
     System.setProperty("javax.net.debug", "ssl");
@@ -165,6 +165,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     connectToGoogle();
   }
 
+  @Ignore
   @AfterClass
   public static void teardown() throws Exception {
     // Remove BouncyCastle FIPS Provider
@@ -211,6 +212,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     connectToGoogle();
   }
 
+  @Ignore
   @Test
   public void connectWithFips() throws SQLException {
     Connection con = getConnection();
@@ -224,6 +226,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     con.close(); // ensure no exception
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFipsKeyPair() throws Exception {
@@ -253,6 +256,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     connection.close();
   }
 
+  @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void testConnectUsingKeyPair() throws Exception {
@@ -288,6 +292,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     DriverManager.getConnection(uri, properties).close();
   }
 
+  @Ignore
   @Test
   public void connectWithFipsAndQuery() throws SQLException {
     try (Connection con = getConnection()) {
@@ -305,6 +310,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     }
   }
 
+  @Ignore
   @Test
   public void connectWithFipsAndPut() throws Exception {
     try (Connection con = getConnection()) {

--- a/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
+++ b/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
@@ -104,8 +104,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   private static int JCE_PROVIDER_SUN_JCE_PROVIDER_POSITION;
   private static int JCE_PROVIDER_SUN_RSA_SIGN_PROVIDER_POSITION;
 
-  @Ignore
   @BeforeClass
+  @Ignore
   public static void setup() throws Exception {
     System.setProperty("javax.net.debug", "ssl");
     // get keystore types for BouncyCastle libraries
@@ -165,8 +165,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     connectToGoogle();
   }
 
-  @Ignore
   @AfterClass
+  @Ignore
   public static void teardown() throws Exception {
     // Remove BouncyCastle FIPS Provider
     Security.removeProvider(JCE_PROVIDER_BOUNCY_CASTLE_FIPS);
@@ -212,8 +212,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     connectToGoogle();
   }
 
-  @Ignore
   @Test
+  @Ignore
   public void connectWithFips() throws SQLException {
     Connection con = getConnection();
     Statement statement = con.createStatement();
@@ -226,8 +226,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     con.close(); // ensure no exception
   }
 
-  @Ignore
   @Test
+  @Ignore
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFipsKeyPair() throws Exception {
     Map<String, String> parameters = getConnectionParameters();
@@ -256,8 +256,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     connection.close();
   }
 
-  @Ignore
   @Test
+  @Ignore
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void testConnectUsingKeyPair() throws Exception {
     Map<String, String> parameters = getConnectionParameters();
@@ -292,8 +292,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     DriverManager.getConnection(uri, properties).close();
   }
 
-  @Ignore
   @Test
+  @Ignore
   public void connectWithFipsAndQuery() throws SQLException {
     try (Connection con = getConnection()) {
       Statement statement = con.createStatement();
@@ -310,8 +310,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     }
   }
 
-  @Ignore
   @Test
+  @Ignore
   public void connectWithFipsAndPut() throws Exception {
     try (Connection con = getConnection()) {
       // put files

--- a/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
+++ b/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(TestCategoryFips.class)
+@ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
 public class ConnectionFipsIT extends AbstractDriverIT {
   private static final String JCE_PROVIDER_BOUNCY_CASTLE_FIPS = "BCFIPS";
   private static final String JCE_PROVIDER_SUN_JCE = "SunJCE";

--- a/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
+++ b/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
@@ -34,6 +34,7 @@ import org.junit.experimental.categories.Category;
 
 @Category(TestCategoryFips.class)
 public class ConnectionFipsIT extends AbstractDriverIT {
+  /*
   private static final String JCE_PROVIDER_BOUNCY_CASTLE_FIPS = "BCFIPS";
   private static final String JCE_PROVIDER_SUN_JCE = "SunJCE";
   private static final String JCE_PROVIDER_SUN_RSA_SIGN = "SunRsaSign";
@@ -105,7 +106,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   private static int JCE_PROVIDER_SUN_RSA_SIGN_PROVIDER_POSITION;
 
   @BeforeClass
-  @Ignore
   public static void setup() throws Exception {
     System.setProperty("javax.net.debug", "ssl");
     // get keystore types for BouncyCastle libraries
@@ -138,7 +138,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     System.setProperty(JAVA_SYSTEM_PROPERTY_SSL_CIPHERSUITES, SSL_ENABLED_CIPHERSUITES);
     /*
      * Insert BouncyCastle's FIPS-compliant encryption and SSL providers.
-     */
+     *
     BouncyCastleFipsProvider bcFipsProvider =
         new BouncyCastleFipsProvider(BOUNCY_CASTLE_RNG_HYBRID_MODE);
 
@@ -149,7 +149,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
      *
      * JavaDoc for insertProviderAt states:
      *   "A provider cannot be added if it is already installed."
-     */
+     *
     Security.removeProvider(JCE_PROVIDER_BOUNCY_CASTLE_FIPS);
     Security.insertProviderAt(bcFipsProvider, 1);
     if (!CryptoServicesRegistrar.isInApprovedOnlyMode()) {
@@ -166,7 +166,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @AfterClass
-  @Ignore
   public static void teardown() throws Exception {
     // Remove BouncyCastle FIPS Provider
     Security.removeProvider(JCE_PROVIDER_BOUNCY_CASTLE_FIPS);
@@ -213,7 +212,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
-  @Ignore
   public void connectWithFips() throws SQLException {
     Connection con = getConnection();
     Statement statement = con.createStatement();
@@ -227,7 +225,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
-  @Ignore
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFipsKeyPair() throws Exception {
     Map<String, String> parameters = getConnectionParameters();
@@ -257,7 +254,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
-  @Ignore
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void testConnectUsingKeyPair() throws Exception {
     Map<String, String> parameters = getConnectionParameters();
@@ -293,7 +289,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
-  @Ignore
   public void connectWithFipsAndQuery() throws SQLException {
     try (Connection con = getConnection()) {
       Statement statement = con.createStatement();
@@ -311,7 +306,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
-  @Ignore
   public void connectWithFipsAndPut() throws Exception {
     try (Connection con = getConnection()) {
       // put files
@@ -336,4 +330,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
 
     System.out.println("Connected to Google successfully");
   }
+  
+   */
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -178,14 +178,19 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
   }
 
   // used to get convert string back to normal after its special characters have been escaped to
-  // send it through
-  // Wildcard regex
+  // send it through Wildcard regex
   private String unescapeChars(String escapedString) {
     String unescapedString = escapedString.replace("\\_", "_");
     unescapedString = unescapedString.replace("\\%", "%");
     unescapedString = unescapedString.replace("\\\\", "\\");
-    unescapedString = unescapedString.replace("\"", "\"\"");
+    unescapedString = escapeSqlQuotes(unescapedString);
     return unescapedString;
+  }
+
+  // In SQL, double quotes must be escaped with an additional pair of double quotes. Add additional
+  // quotes to avoid syntax errors with SQL queries.
+  private String escapeSqlQuotes(String originalString) {
+    return originalString.replace("\"", "\"\"");
   }
 
   private boolean isSchemaNameWildcardPattern(String inputString) {
@@ -2840,7 +2845,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     } else if (catalog.isEmpty()) {
       return SnowflakeDatabaseMetaDataResultSet.getEmptyResultSet(GET_SCHEMAS, statement);
     } else {
-      showSchemas += " in database \"" + unescapeChars(catalog) + "\"";
+      showSchemas += " in database \"" + escapeSqlQuotes(catalog) + "\"";
     }
 
     logger.debug("sql command to get schemas metadata: {}", showSchemas);

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -2840,7 +2840,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     } else if (catalog.isEmpty()) {
       return SnowflakeDatabaseMetaDataResultSet.getEmptyResultSet(GET_SCHEMAS, statement);
     } else {
-      showSchemas += " in database \"" + catalog + "\"";
+      showSchemas += " in database \"" + unescapeChars(catalog) + "\"";
     }
 
     logger.debug("sql command to get schemas metadata: {}", showSchemas);

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -193,10 +193,6 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     return useSessionSchema ? false : Wildcard.isWildcardPatternStr(inputString);
   }
 
-  private boolean isIdentifierQuoted(String identifier) {
-    return identifier.startsWith("\"") && identifier.endsWith("\"");
-  }
-
   @Override
   public boolean allProceduresAreCallable() throws SQLException {
     logger.debug("public boolean allProceduresAreCallable()");
@@ -2844,12 +2840,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     } else if (catalog.isEmpty()) {
       return SnowflakeDatabaseMetaDataResultSet.getEmptyResultSet(GET_SCHEMAS, statement);
     } else {
-      // only add quotes if the application hasn't added them already.
-      if (isIdentifierQuoted(catalog)) {
-        showSchemas += " in database " + catalog;
-      } else {
-        showSchemas += " in database \"" + catalog + "\"";
-      }
+      showSchemas += " in database \"" + catalog + "\"";
     }
 
     logger.debug("sql command to get schemas metadata: {}", showSchemas);

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -712,31 +712,4 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
     assertTrue(resultSet.next());
     assertEquals("COLA", resultSet.getString("COLUMN_NAME"));
   }
-
-  /**
-   * This tests that the driver doesn't add quotes to the database name if the application has
-   * already added them. This fixes a bug where the show schemas command was returning empty results
-   * since the database name was being double-quoted.
-   *
-   * @throws SQLException
-   */
-  @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
-  public void testGetSchemasWithDoubleQuotedDatabase() throws SQLException {
-    try (Connection con = getConnection()) {
-      // create the database and two schemas
-      Statement statement = con.createStatement();
-      statement.execute("create or replace database \"lowercasedb\"");
-      String schema1 = "SCH1";
-      String schema2 = "SCH2";
-      statement.execute("create or replace schema \"lowercasedb\"." + schema1);
-      statement.execute("create or replace schema \"lowercasedb\"." + schema2);
-      DatabaseMetaData metaData = con.getMetaData();
-      ResultSet rs = metaData.getSchemas("\"lowercasedb\"", null);
-      // should return 4 schemas including PUBLIC and INFORMATIONSCHEMA.
-      assertEquals(4, getSizeOfResultSet(rs));
-      rs.close();
-      statement.close();
-    }
-  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -180,6 +180,7 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
    * This tests the ability to have quotes inside a database or schema within getSchemas() function.
    */
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testDoubleQuotedDatabaseInGetSchemas() throws SQLException {
     try (Connection con = getConnection()) {
       Statement statement = con.createStatement();


### PR DESCRIPTION
# Overview

SNOW-571607

getSchemas() should allow databases with double quotes in the name. To query a database without quotes, the application should refrain from including extra quotes around the database name because doing so will produce no results.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

