### PR TITLE
Escape double quotes in catalog name for getColumns and getTables

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1315,13 +1315,14 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     } else if (catalog.isEmpty()) {
       return "";
     } else {
+      String catalogUnescaped = unescapeChars(catalog);
       if (schemaPattern == null || isSchemaNameWildcardPattern(schemaPattern)) {
-        showProcedureCommand += " in database \"" + catalog + "\"";
+        showProcedureCommand += " in database \"" + catalogUnescaped + "\"";
       } else if (schemaPattern.isEmpty()) {
         return "";
       } else {
         schemaPattern = unescapeChars(schemaPattern);
-        showProcedureCommand += " in schema \"" + catalog + "\".\"" + schemaPattern + "\"";
+        showProcedureCommand += " in schema \"" + catalogUnescaped + "\".\"" + schemaPattern + "\"";
       }
     }
     logger.debug("sql command to get column metadata: {}", showProcedureCommand);
@@ -1432,12 +1433,14 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
       // a schema if the current schema a user is connected to is different
       // given that we don't support show tables without a known schema.
       if (schemaPattern == null || isSchemaNameWildcardPattern(schemaPattern)) {
-        showCommand += " in database \"" + catalog + "\"";
+        String catalogUnescaped = unescapeChars(catalog);
+        showCommand += " in database \"" + catalogUnescaped + "\"";
       } else if (schemaPattern.isEmpty()) {
         return SnowflakeDatabaseMetaDataResultSet.getEmptyResultSet(GET_TABLES, statement);
       } else {
+        String catalogUnescaped = unescapeChars(catalog);
         String schemaUnescaped = unescapeChars(schemaPattern);
-        showCommand += " in schema \"" + catalog + "\".\"" + schemaUnescaped + "\"";
+        showCommand += " in schema \"" + catalogUnescaped + "\".\"" + schemaUnescaped + "\"";
       }
     }
 
@@ -1606,14 +1609,16 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           extendedSet ? GET_COLUMNS_EXTENDED_SET : GET_COLUMNS, statement);
     } else {
       if (schemaPattern == null || isSchemaNameWildcardPattern(schemaPattern)) {
-        showCommand += " in database \"" + catalog + "\"";
+        String catalogUnescaped = unescapeChars(catalog);
+        showCommand += " in database \"" + catalogUnescaped + "\"";
       } else if (schemaPattern.isEmpty()) {
         return SnowflakeDatabaseMetaDataResultSet.getEmptyResultSet(
             extendedSet ? GET_COLUMNS_EXTENDED_SET : GET_COLUMNS, statement);
       } else {
+        String catalogUnescaped = unescapeChars(catalog);
         String schemaUnescaped = unescapeChars(schemaPattern);
         if (tableNamePattern == null || Wildcard.isWildcardPatternStr(tableNamePattern)) {
-          showCommand += " in schema \"" + catalog + "\".\"" + schemaUnescaped + "\"";
+          showCommand += " in schema \"" + catalogUnescaped + "\".\"" + schemaUnescaped + "\"";
         } else if (tableNamePattern.isEmpty()) {
           return SnowflakeDatabaseMetaDataResultSet.getEmptyResultSet(
               extendedSet ? GET_COLUMNS_EXTENDED_SET : GET_COLUMNS, statement);
@@ -1621,7 +1626,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           String tableNameUnescaped = unescapeChars(tableNamePattern);
           showCommand +=
               " in table \""
-                  + catalog
+                  + catalogUnescaped
                   + "\".\""
                   + schemaUnescaped
                   + "\".\""

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -206,6 +206,42 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
     }
   }
 
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testDoubleQuotedDatabaseInGetTables() throws SQLException {
+    try (Connection con = getConnection()) {
+      Statement statement = con.createStatement();
+      // Create a database with double quotes inside the database name
+      statement.execute("create or replace database \"dbwith\"\"quotes\"");
+      statement.execute("create or replace schema \"dbwith\"\"quotes\".\"testschema\"");
+      statement.execute(
+          "create or replace table \"dbwith\"\"quotes\".\"testschema\".\"testtable\" (col1 string, col2 string)");
+      DatabaseMetaData metaData = con.getMetaData();
+      ResultSet rs = metaData.getTables("dbwith\"quotes", "testschema", null, null);
+      assertEquals(1, getSizeOfResultSet(rs));
+      rs.close();
+      statement.close();
+    }
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testDoubleQuotedDatabaseInGetColumns() throws SQLException {
+    try (Connection con = getConnection()) {
+      Statement statement = con.createStatement();
+      // Create a database with double quotes inside the database name
+      statement.execute("create or replace database \"dbwith\"\"quotes\"");
+      statement.execute("create or replace schema \"dbwith\"\"quotes\".\"testschema\"");
+      statement.execute(
+          "create or replace table \"dbwith\"\"quotes\".\"testschema\".\"testtable\"  (col1 string, col2 string)");
+      DatabaseMetaData metaData = con.getMetaData();
+      ResultSet rs = metaData.getColumns("dbwith\"quotes", "testschema", null, null);
+      assertEquals(2, getSizeOfResultSet(rs));
+      rs.close();
+      statement.close();
+    }
+  }
+
   /**
    * This tests that wildcards can be used for the schema name for getProcedureColumns().
    * Previously, only empty resultsets were returned.


### PR DESCRIPTION
This is a follow up to #681 . When using getColumns and getTables on a database name that contains quotes an empty result set is returned. 

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

