### PR TITLE
Return an empty resultset for getProcedures() when connected with a reader account

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -3348,7 +3348,8 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
       resultSet = statement.executeQuery(sql);
     } catch (SnowflakeSQLException e) {
       if (e.getSQLState().equals(SqlState.NO_DATA)
-          || e.getSQLState().equals(SqlState.BASE_TABLE_OR_VIEW_NOT_FOUND)) {
+          || e.getSQLState().equals(SqlState.BASE_TABLE_OR_VIEW_NOT_FOUND)
+          || e.getMessage().contains("Operation is not supported in reader account")) {
         return SnowflakeDatabaseMetaDataResultSet.getEmptyResult(
             metadataType, statement, e.getQueryId());
       }

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryOthers;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -1325,6 +1326,19 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
       con.createStatement().execute("drop stream if exists " + targetStream);
       resultSet.close();
       statement.close();
+    }
+  }
+
+  /*
+   * This tests that an empty resultset will be returned for getProcedures when using a reader account.
+   */
+  @Test
+  @Ignore
+  public void testGetProceduresWithReaderAccount() throws SQLException {
+    try (Connection connection = getConnection()) {
+      DatabaseMetaData metadata = connection.getMetaData();
+      ResultSet rs = metadata.getProcedures(null, null, null);
+      assertEquals(0, getSizeOfResultSet(rs));
     }
   }
 }


### PR DESCRIPTION
Overview from Snowflake support:

The customer is connecting to the Snowflake reader account via JDBC driver using their tool (name: Rhapsody). This tool performs schema discovery and calls the getProcedures() function when it establishes connectivity but since the Snowflake reader account doesn’t support it, it gets the error: “Operation not supported in Snowflake reader account”. Since this is failing the schema discovery process is getting interrupted.

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  This change will return an empty result set instead of throwing an exception when calling getProcedures() with a reader account.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

