### PR TITLE
Add the ability to set a custom key pair auth signing implementation

### DIFF
--- a/src/main/java/net/snowflake/client/PrivateKeySigner.java
+++ b/src/main/java/net/snowflake/client/PrivateKeySigner.java
@@ -1,0 +1,21 @@
+package net.snowflake.client;
+
+import java.security.PublicKey;
+
+/**
+ * Interface for customer signer implementations for key pair authentication.
+ */
+public interface PrivateKeySigner {
+    /**
+     * Returns a signature for the given input.
+     *
+     * The signature must be compatible with the "RS256" JWT signing algorithm,
+     * a.k.a. "RSASSA-PKCS1-v1_5 using SHA-256"
+     */
+    byte[] sign(byte[] input);
+
+    /**
+     * Returns the public key associated with the private key used by the sign() method.
+     */
+    PublicKey publicKey();
+}

--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -47,6 +47,7 @@ public class SFLoginInput {
   private HttpClientSettingsKey httpClientKey;
   private String privateKeyFile;
   private String privateKeyFilePwd;
+  private String privateKeySignerClass;
 
   SFLoginInput() {}
 
@@ -294,6 +295,11 @@ public class SFLoginInput {
     return this;
   }
 
+  SFLoginInput setPrivateKeySignerClass(String privateKeySignerClass) {
+    this.privateKeySignerClass = privateKeySignerClass;
+    return this;
+  }
+
   String getPrivateKeyFile() {
     return privateKeyFile;
   }
@@ -301,6 +307,8 @@ public class SFLoginInput {
   String getPrivateKeyFilePwd() {
     return privateKeyFilePwd;
   }
+
+  String getPrivateKeySignerClass() { return privateKeySignerClass; }
 
   public String getApplication() {
     return application;

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -61,6 +61,7 @@ public class SFSession extends SFBaseSession {
   private String mfaToken;
   private String privateKeyFileLocation;
   private String privateKeyPassword;
+  private String privateKeySignerClass;
   private PrivateKey privateKey;
 
   /**
@@ -334,6 +335,12 @@ public class SFSession extends SFBaseSession {
           }
           break;
 
+        case PRIVATE_KEY_SIGNER_CLASS:
+          if (propertyValue != null) {
+            privateKeySignerClass = (String) propertyValue;
+          }
+          break;
+
         default:
           break;
       }
@@ -450,6 +457,7 @@ public class SFSession extends SFBaseSession {
         .setPrivateKeyFile((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE))
         .setPrivateKeyFilePwd(
             (String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
+            .setPrivateKeySignerClass((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_SIGNER_CLASS))
         .setApplication((String) connectionPropertiesMap.get(SFSessionProperty.APPLICATION))
         .setServiceName(getServiceName())
         .setOCSPMode(getOCSPMode())
@@ -532,7 +540,7 @@ public class SFSession extends SFBaseSession {
     Map<SFSessionProperty, Object> connectionPropertiesMap = getConnectionPropertiesMap();
     String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
     PrivateKey privateKey = (PrivateKey) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY);
-    return (authenticator == null && privateKey == null && privateKeyFileLocation == null)
+    return (authenticator == null && privateKey == null && privateKeyFileLocation == null && privateKeySignerClass == null)
         || ClientAuthnDTO.AuthenticatorType.SNOWFLAKE.name().equalsIgnoreCase(authenticator);
   }
 

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -55,6 +55,7 @@ public enum SFSessionProperty {
   INJECT_WAIT_IN_PUT("inject_wait_in_put", false, Integer.class),
   PRIVATE_KEY_FILE("private_key_file", false, String.class),
   PRIVATE_KEY_FILE_PWD("private_key_file_pwd", false, String.class),
+  PRIVATE_KEY_SIGNER_CLASS("private_key_signer_class", false, String.class),
   CLIENT_INFO("snowflakeClientInfo", false, String.class),
   ALLOW_UNDERSCORES_IN_HOST("allowUnderscoresInHost", false, Boolean.class);
 

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -221,7 +221,7 @@ public class SessionUtil {
     // authenticator is null, then jdbc will decide authenticator depends on
     // if privateKey is specified or not. If yes, authenticator type will be
     // SNOWFLAKE_JWT, otherwise it will use SNOWFLAKE.
-    return (loginInput.getPrivateKey() != null || loginInput.getPrivateKeyFile() != null)
+    return (loginInput.getPrivateKey() != null || loginInput.getPrivateKeyFile() != null || loginInput.getPrivateKeySignerClass() != null)
         ? ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT
         : ClientAuthnDTO.AuthenticatorType.SNOWFLAKE;
   }
@@ -384,6 +384,7 @@ public class SessionUtil {
                 loginInput.getPrivateKey(),
                 loginInput.getPrivateKeyFile(),
                 loginInput.getPrivateKeyFilePwd(),
+                loginInput.getPrivateKeySignerClass(),
                 loginInput.getAccountName(),
                 loginInput.getUserName());
 
@@ -1545,12 +1546,13 @@ public class SessionUtil {
       PrivateKey privateKey,
       String privateKeyFile,
       String privateKeyFilePwd,
+      String privateKeySignerClass,
       String accountName,
       String userName)
       throws SFException {
     SessionUtilKeyPair s =
         new SessionUtilKeyPair(
-            privateKey, privateKeyFile, privateKeyFilePwd, accountName, userName);
+            privateKey, privateKeyFile, privateKeyFilePwd, privateKeySignerClass, accountName, userName);
     return s.issueJwtToken();
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -179,7 +179,7 @@ public class TelemetryIT extends AbstractDriverIT {
     Map<String, String> parameters = getConnectionParameters();
     String jwtToken =
         SessionUtil.generateJWTToken(
-            null, privateKeyLocation, null, parameters.get("account"), parameters.get("user"));
+            null, privateKeyLocation, null, null, parameters.get("account"), parameters.get("user"));
 
     CloseableHttpClient httpClient = HttpUtil.buildHttpClient(null, null, false);
     TelemetryClient telemetry =


### PR DESCRIPTION
# Overview

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #909


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [X] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Allows library users to create their own implementation of PrivateKeySigner which calls KMS to do the required operations. Here is the implementation I'm using (it's Kotlin but I could convert to Java if it's needed for docs or whatever):

```
class KMSPrivateKeySigner(private val kmsClient: KmsClient, private val keyAlias: String) :
    PrivateKeySigner {
  val keyId: String = run {
    val describeRequest = DescribeKeyRequest.builder().keyId("alias/$keyAlias").build()
    kmsClient.describeKey(describeRequest).keyMetadata().keyId()
  }

  val publicKey: PublicKey = run {
    val request = GetPublicKeyRequest.builder().keyId(keyId).build()
    val response = kmsClient.getPublicKey(request)
    val spec = X509EncodedKeySpec(response.publicKey().asByteArray())
    val keyFactory = KeyFactory.getInstance("RSA")
    keyFactory.generatePublic(spec)
  }

  override fun sign(bytes: ByteArray): ByteArray {
    val request =
        SignRequest.builder()
            .keyId(keyId)
            .signingAlgorithm(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256)
            .messageType(MessageType.RAW)
            .message(SdkBytes.fromByteArray(bytes))
            .build()
    return kmsClient.sign(request).signature().asByteArray()
  }

  override fun publicKey() = publicKey
}
```

Another option would be that I could just contribute this KMS support directly to this library, but that seems probably undesirable because it adds new dependencies.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

