### PR TITLE
SNOW-577665: Wrong retry 403 logic

### DIFF
--- a/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
+++ b/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
@@ -27,6 +27,8 @@ import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.crypto.CryptoServicesRegistrar;
 import org.bouncycastle.crypto.fips.FipsStatus;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -102,8 +104,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   private static int JCE_PROVIDER_SUN_JCE_PROVIDER_POSITION;
   private static int JCE_PROVIDER_SUN_RSA_SIGN_PROVIDER_POSITION;
 
-  // TODO: temporarily disable the function to merge an urgent pr
-  // @BeforeClass
+  @BeforeClass
   public static void setup() throws Exception {
     System.setProperty("javax.net.debug", "ssl");
     // get keystore types for BouncyCastle libraries
@@ -163,8 +164,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     //connectToGoogle();
   }
 
-  // TODO: temporarily disable the function to merge an urgent pr
-  // @AfterClass
+  @AfterClass
   public static void teardown() throws Exception {
     // Remove BouncyCastle FIPS Provider
     Security.removeProvider(JCE_PROVIDER_BOUNCY_CASTLE_FIPS);
@@ -211,7 +211,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFips() throws SQLException {
     Connection con = getConnection();
     Statement statement = con.createStatement();
@@ -289,7 +288,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFipsAndQuery() throws SQLException {
     try (Connection con = getConnection()) {
       Statement statement = con.createStatement();
@@ -307,7 +305,6 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFipsAndPut() throws Exception {
     try (Connection con = getConnection()) {
       // put files

--- a/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
+++ b/FIPS/src/test/java/net/snowflake/client/jdbc/ConnectionFipsIT.java
@@ -27,8 +27,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.crypto.CryptoServicesRegistrar;
 import org.bouncycastle.crypto.fips.FipsStatus;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -104,7 +102,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   private static int JCE_PROVIDER_SUN_JCE_PROVIDER_POSITION;
   private static int JCE_PROVIDER_SUN_RSA_SIGN_PROVIDER_POSITION;
 
-  @BeforeClass
+  // TODO: temporarily disable the function to merge an urgent pr
+  // @BeforeClass
   public static void setup() throws Exception {
     System.setProperty("javax.net.debug", "ssl");
     // get keystore types for BouncyCastle libraries
@@ -164,7 +163,8 @@ public class ConnectionFipsIT extends AbstractDriverIT {
     //connectToGoogle();
   }
 
-  @AfterClass
+  // TODO: temporarily disable the function to merge an urgent pr
+  // @AfterClass
   public static void teardown() throws Exception {
     // Remove BouncyCastle FIPS Provider
     Security.removeProvider(JCE_PROVIDER_BOUNCY_CASTLE_FIPS);
@@ -211,6 +211,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFips() throws SQLException {
     Connection con = getConnection();
     Statement statement = con.createStatement();
@@ -288,6 +289,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFipsAndQuery() throws SQLException {
     try (Connection con = getConnection()) {
       Statement statement = con.createStatement();
@@ -305,6 +307,7 @@ public class ConnectionFipsIT extends AbstractDriverIT {
   }
 
   @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubActions.class)
   public void connectWithFipsAndPut() throws Exception {
     try (Connection con = getConnection()) {
       // put files

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -207,7 +207,7 @@ public class RestRequest {
        * If we got a response and the status code is not one of those
        * transient failures, no more retry
        */
-      if (isCertificateRevoked(savedEx) || isNonretryableHTTPCode(response, retryHTTP403)) {
+      if (isCertificateRevoked(savedEx) || isNonRetryableHTTPCode(response, retryHTTP403)) {
         String msg = "Unknown cause";
         if (response != null) {
           logger.debug("HTTP response code: {}", response.getStatusLine().getStatusCode());
@@ -439,8 +439,7 @@ public class RestRequest {
     return response;
   }
 
-  static boolean isNonretryableHTTPCode(CloseableHttpResponse response, boolean retryHTTP403) {
-    // TODO: this function is wrong
+  static boolean isNonRetryableHTTPCode(CloseableHttpResponse response, boolean retryHTTP403) {
     return response != null
         && (response.getStatusLine().getStatusCode() < 500
             || // service unavailable

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -440,6 +440,7 @@ public class RestRequest {
   }
 
   static boolean isNonretryableHTTPCode(CloseableHttpResponse response, boolean retryHTTP403) {
+    // TODO: this function is wrong
     return response != null
         && (response.getStatusLine().getStatusCode() < 500
             || // service unavailable
@@ -447,7 +448,7 @@ public class RestRequest {
         && // gateway timeout
         response.getStatusLine().getStatusCode() != 408
         && // request timeout
-        (retryHTTP403 || response.getStatusLine().getStatusCode() != 403);
+        (!retryHTTP403 || response.getStatusLine().getStatusCode() != 403);
   }
 
   private static boolean isCertificateRevoked(Exception ex) {

--- a/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
@@ -158,13 +158,12 @@ public class RestRequestTest {
   }
 
   @Test
-  public void testIsRetryableHTTPCode() throws Exception {
-    // TODO: this test is wrong
+  public void testIsNonRetryableHTTPCode() throws Exception {
     class TestCase {
       TestCase(int statusCode, boolean retryHTTP403, boolean result) {
         this.statusCode = statusCode;
         this.retryHTTP403 = retryHTTP403;
-        this.result = result; // expected result of calling isNonretryableHTTPCode()
+        this.result = result; // expected result of calling isNonRetryableHTTPCode()
       }
 
       public int statusCode;
@@ -280,24 +279,20 @@ public class RestRequestTest {
     testCases.add(new TestCase(510, true, false));
     testCases.add(new TestCase(511, true, false));
 
-    /*
-    testCases.add(new TestCase(403, false, true)); // no retry on HTTP 403
-    testCases.add(new TestCase(403, true, false)); // do retry on HTTP 403
-*/
     for (TestCase t : testCases) {
       if (t.result) {
         assertTrue(
             String.format(
                 "Result must be true but false: HTTP Code: %d, RetryHTTP403: %s",
                 t.statusCode, t.retryHTTP403),
-            RestRequest.isNonretryableHTTPCode(
+            RestRequest.isNonRetryableHTTPCode(
                 anyStatusCodeResponse(t.statusCode), t.retryHTTP403));
       } else {
         assertFalse(
             String.format(
                 "Result must be false but true: HTTP Code: %d, RetryHTTP403: %s",
                 t.statusCode, t.retryHTTP403),
-            RestRequest.isNonretryableHTTPCode(
+            RestRequest.isNonRetryableHTTPCode(
                 anyStatusCodeResponse(t.statusCode), t.retryHTTP403));
       }
     }

--- a/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
@@ -159,11 +159,12 @@ public class RestRequestTest {
 
   @Test
   public void testIsRetryableHTTPCode() throws Exception {
+    // TODO: this test is wrong
     class TestCase {
       TestCase(int statusCode, boolean retryHTTP403, boolean result) {
         this.statusCode = statusCode;
         this.retryHTTP403 = retryHTTP403;
-        this.result = result;
+        this.result = result; // expected result of calling isNonretryableHTTPCode()
       }
 
       public int statusCode;
@@ -172,6 +173,7 @@ public class RestRequestTest {
     }
     List<TestCase> testCases = new ArrayList<>();
     // no retry on HTTP 403 option
+
     testCases.add(new TestCase(100, false, true));
     testCases.add(new TestCase(101, false, true));
     testCases.add(new TestCase(103, false, true));
@@ -191,12 +193,12 @@ public class RestRequestTest {
     testCases.add(new TestCase(308, false, true));
     testCases.add(new TestCase(400, false, true));
     testCases.add(new TestCase(401, false, true));
-    testCases.add(new TestCase(403, false, false)); // no retry on HTTP 403
+    testCases.add(new TestCase(403, false, true)); // no retry on HTTP 403
     testCases.add(new TestCase(404, false, true));
     testCases.add(new TestCase(405, false, true));
     testCases.add(new TestCase(406, false, true));
     testCases.add(new TestCase(407, false, true));
-    testCases.add(new TestCase(408, false, false)); // no retry on HTTP 408
+    testCases.add(new TestCase(408, false, false)); // do retry on HTTP 408
     testCases.add(new TestCase(410, false, true));
     testCases.add(new TestCase(411, false, true));
     testCases.add(new TestCase(412, false, true));
@@ -244,12 +246,12 @@ public class RestRequestTest {
     testCases.add(new TestCase(308, true, true));
     testCases.add(new TestCase(400, true, true));
     testCases.add(new TestCase(401, true, true));
-    testCases.add(new TestCase(403, true, true)); // do retry on HTTP 403
+    testCases.add(new TestCase(403, true, false)); // do retry on HTTP 403
     testCases.add(new TestCase(404, true, true));
     testCases.add(new TestCase(405, true, true));
     testCases.add(new TestCase(406, true, true));
     testCases.add(new TestCase(407, true, true));
-    testCases.add(new TestCase(408, true, false)); // no retry on HTTP 408
+    testCases.add(new TestCase(408, true, false)); // do retry on HTTP 408
     testCases.add(new TestCase(410, true, true));
     testCases.add(new TestCase(411, true, true));
     testCases.add(new TestCase(412, true, true));
@@ -278,6 +280,10 @@ public class RestRequestTest {
     testCases.add(new TestCase(510, true, false));
     testCases.add(new TestCase(511, true, false));
 
+    /*
+    testCases.add(new TestCase(403, false, true)); // no retry on HTTP 403
+    testCases.add(new TestCase(403, true, false)); // do retry on HTTP 403
+*/
     for (TestCase t : testCases) {
       if (t.result) {
         assertTrue(


### PR DESCRIPTION
# Overview

SNOW-577665

Bug fix. The bug was introduced in https://github.com/snowflakedb/snowflake-jdbc/pull/241/commits/6594bc47b8480333b151b75d2dce2a4f24792113

The `isNonRetryableHttpCode` function returns wrong value for 403 http code. Please look at RestRequestTest.java for correct behavior on 403.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

