### PR TITLE
SNOW-579524: Test negative with chunk file not exist taking too long

### DIFF
--- a/src/test/java/net/snowflake/client/AbstractDriverIT.java
+++ b/src/test/java/net/snowflake/client/AbstractDriverIT.java
@@ -3,18 +3,17 @@
  */
 package net.snowflake.client;
 
-import com.google.common.base.Strings;
-import org.junit.Rule;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import javax.annotation.Nullable;
+import com.google.common.base.Strings;
 import java.net.URL;
-import java.sql.Date;
 import java.sql.*;
+import java.sql.Date;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static org.hamcrest.MatcherAssert.assertThat;
+import javax.annotation.Nullable;
+import org.junit.Rule;
 
 /** Base test class with common constants, data structures and methods */
 public class AbstractDriverIT {

--- a/src/test/java/net/snowflake/client/AbstractDriverIT.java
+++ b/src/test/java/net/snowflake/client/AbstractDriverIT.java
@@ -3,16 +3,18 @@
  */
 package net.snowflake.client;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import com.google.common.base.Strings;
+import org.junit.Rule;
+
+import javax.annotation.Nullable;
 import java.net.URL;
-import java.sql.*;
 import java.sql.Date;
+import java.sql.*;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.junit.Rule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Base test class with common constants, data structures and methods */
 public class AbstractDriverIT {
@@ -242,7 +244,7 @@ public class AbstractDriverIT {
    */
   public static Connection getConnection(
       int injectSocketTimeout,
-      Properties paramProperties,
+      @Nullable Properties paramProperties,
       boolean isAdmin,
       boolean usesCom,
       String accountName)

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
@@ -632,7 +632,7 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
   public void testNegativeWithChunkFileNotExist() throws Throwable {
     // This test takes about (download worker retry times * networkTimeout) long to finish
     Properties properties = new Properties();
-    properties.put("networkTimeout", 15000); // 150000 millisec
+    properties.put("networkTimeout", 10000); // 10000 millisec
     try (Connection connection = init(properties)) {
       Statement statement = connection.createStatement();
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
@@ -1,5 +1,14 @@
 package net.snowflake.client.jdbc;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import javax.annotation.Nullable;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryResultSet;
@@ -8,16 +17,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
-
-import javax.annotation.Nullable;
-import java.io.*;
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.*;
 
 /** SnowflakeResultSetSerializable tests */
 @Category(TestCategoryResultSet.class)
@@ -43,6 +42,7 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
   public Connection init() throws SQLException {
     return init(null);
   }
+
   public Connection init(@Nullable Properties properties) throws SQLException {
     Connection conn = BaseJDBCTest.getConnection(properties);
     Statement stmt = conn.createStatement();
@@ -628,11 +628,11 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
   }
 
   @Test
-  // TODO: This test is taking longer than expected
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testNegativeWithChunkFileNotExist() throws Throwable {
+    // This test takes about (download worker retry times * networkTimeout) long to finish
     Properties properties = new Properties();
-    properties.put("networkTimeout", 30000); // millisec
+    properties.put("networkTimeout", 15000); // 150000 millisec
     try (Connection connection = init(properties)) {
       Statement statement = connection.createStatement();
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableIT.java
@@ -1,13 +1,5 @@
 package net.snowflake.client.jdbc;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.*;
-
-import java.io.*;
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryResultSet;
@@ -16,6 +8,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nullable;
+import java.io.*;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.*;
 
 /** SnowflakeResultSetSerializable tests */
 @Category(TestCategoryResultSet.class)
@@ -39,7 +41,10 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
   }
 
   public Connection init() throws SQLException {
-    Connection conn = BaseJDBCTest.getConnection();
+    return init(null);
+  }
+  public Connection init(@Nullable Properties properties) throws SQLException {
+    Connection conn = BaseJDBCTest.getConnection(properties);
     Statement stmt = conn.createStatement();
     stmt.execute("alter session set jdbc_query_result_format = '" + queryResultFormat + "'");
 
@@ -623,9 +628,12 @@ public class SnowflakeResultSetSerializableIT extends BaseJDBCTest {
   }
 
   @Test
+  // TODO: This test is taking longer than expected
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testNegativeWithChunkFileNotExist() throws Throwable {
-    try (Connection connection = init()) {
+    Properties properties = new Properties();
+    properties.put("networkTimeout", 30000); // millisec
+    try (Connection connection = init(properties)) {
       Statement statement = connection.createStatement();
 
       statement.execute(


### PR DESCRIPTION
# Overview

SNOW-579524
The test manually hacked the result chunk URL, which results in a dead loop on retry 403. The fix is adding networkTimeout in the test.

https://ci70.int.snowflakecomputing.com/job/RT-LanguageJDBC1-PC/1280/ running time has back to normal.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

