### PR TITLE
Implement fast fail for Amazon S3 404 exception

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -790,12 +790,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     }
   }
 
-  /**
-   * Checks the status code of the exception to see if it's a 404
-   *
-   * @param ex the Exception
-   * @return
-   */
+  /** Checks the status code of the exception to see if it's a 404 */
   public boolean isClientException404(Exception ex) {
     if (ex instanceof AmazonServiceException) {
       AmazonServiceException asEx = (AmazonServiceException) (ex);

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -51,6 +51,7 @@ import net.snowflake.client.util.SFPair;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 import net.snowflake.common.core.SqlState;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLInitializationException;
 
@@ -691,7 +692,7 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     }
 
     if (ex instanceof AmazonClientException) {
-      if (retryCount > s3Client.getMaxRetries()) {
+      if (retryCount > s3Client.getMaxRetries() || s3Client.isClientException404(ex)) {
         String extendedRequestId = "none";
 
         if (ex instanceof AmazonS3Exception) {
@@ -787,6 +788,22 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
             "Encountered exception during " + operation + ": " + ex.getMessage());
       }
     }
+  }
+
+  /**
+   * Checks the status code of the exception to see if it's a 404
+   *
+   * @param ex the Exception
+   * @return
+   */
+  public boolean isClientException404(Exception ex) {
+    if (ex instanceof AmazonServiceException) {
+      AmazonServiceException asEx = (AmazonServiceException) (ex);
+      if (asEx.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Returns the material descriptor key */


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

An issue was reported for downloadStreams() where the driver would hang for 5 minutes when trying to retry the downloading of a file from S3 that doesn't exist before throwing the file not found error. This change is to check whether the status code of AmazonServiceException is 404 and not retry if true. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

