### PR TITLE
map timestamp_tz to java.sql.Type TIMESTAMP_WITH_TIMEZONE

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
@@ -349,11 +349,12 @@ public class SFResultSetMetaData {
 
     int externalColumnType = internalColumnType;
 
-    if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ
-        || internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ) {
+    if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ) {
       externalColumnType = Types.TIMESTAMP;
     }
-
+    if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ) {
+      externalColumnType = Types.TIMESTAMP_WITH_TIMEZONE;
+    }
     return externalColumnType;
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1722,9 +1722,11 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
             int internalColumnType = columnMetadata.getType();
             int externalColumnType = internalColumnType;
 
-            if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ
-                || internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ) {
+            if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_LTZ) {
               externalColumnType = Types.TIMESTAMP;
+            }
+            if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ) {
+              externalColumnType = Types.TIMESTAMP_WITH_TIMEZONE;
             }
 
             nextRow[4] = externalColumnType;

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -742,4 +742,19 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
     assertTrue(resultSet.next());
     assertEquals("COLA", resultSet.getString("COLUMN_NAME"));
   }
+
+  @Test
+  public void testTimestampWithTimezoneDataType() throws SQLException {
+    try (Connection connection = getConnection()) {
+      Statement statement = connection.createStatement();
+      statement.executeQuery("create or replace table ts_test(ts timestamp_tz)");
+      String database = connection.getCatalog();
+      String schema = connection.getSchema();
+      DatabaseMetaData metaData = connection.getMetaData();
+      ResultSet resultSet = metaData.getColumns(database, schema, "TS_TEST", "TS");
+      resultSet.next();
+      // Assert that TIMESTAMP_TZ type matches java.sql.TIMESTAMP_WITH_TIMEZONE
+      assertEquals(resultSet.getObject("DATA_TYPE"), 2014);
+    }
+  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -531,4 +531,16 @@ public class ResultSetLatestIT extends ResultSet0IT {
     assertEquals(bigDecimal.setScale(5, RoundingMode.HALF_UP), resultSet.getBigDecimal(1, 5));
     assertEquals(bigDecimal.setScale(5, RoundingMode.HALF_UP), resultSet.getBigDecimal("COLA", 5));
   }
+
+  @Test
+  public void testGetDataTypeWithTimestampTz() throws SQLException {
+    try (Connection connection = getConnection()) {
+      Statement statement = connection.createStatement();
+      statement.executeQuery("create or replace table ts_test(ts timestamp_tz)");
+      ResultSet resultSet = statement.executeQuery("select * from ts_test");
+      ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+      // Assert that TIMESTAMP_TZ type matches java.sql.TIMESTAMP_WITH_TIMEZONE
+      assertEquals(resultSetMetaData.getColumnType(1), 2014);
+    }
+  }
 }


### PR DESCRIPTION
Description provided by Snowflake support:
For Timestamp_with_timezone columns, Snowflake JDBC drivers report datatype as 93.
However, Oracle java documentation recommends setting Timestamp_with_timezone datatype as 2014.
https://docs.oracle.com/javase/8/docs/api/constant-values.html#java.sql.Types.TIME_WITH_TIMEZONE

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   This change maps timestamp_tz columns to java.sql.Type TIMESTAMP_WITH_TIMEZONE instead of TIMESTAMP for column metadata. 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

