### PR TITLE
bug fix for stage binding with TIMESTAMP_INPUT_FORMAT

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -418,6 +418,7 @@ public class SFStatement extends SFBaseStatement {
         stmtInput.setBindValues(null).setBindStage(bindStagePath);
         // use the new SQL format for this query so dates/timestamps are parsed correctly
         setUseNewSqlFormat(true);
+        statementParametersMap.put("TIMESTAMP_INPUT_FORMAT", "AUTO");
       } else {
         stmtInput.setBindValues(bindValues).setBindStage(null);
       }


### PR DESCRIPTION
Changing TIMESTAMP_INPUT_FORMAT could change the expected format for stage binding as well but the driver is using default format to generate the input file.
Set TIMESTAMP_INPUT_FORMAT to default value in parameters for the query request so the default format is always used for stage binding.

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

