### PR TITLE
Remove double decoding on arrow result sets

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -14,7 +14,6 @@ import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.util.Base64;
 import java.util.TimeZone;
 import net.snowflake.client.core.arrow.ArrowVectorConverter;
 import net.snowflake.client.jdbc.*;
@@ -194,11 +193,11 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
         }
 
         this.currentChunkIterator =
-            getSortedFirstResultChunk(resultSetSerializable.getFirstChunkStringData())
+            getSortedFirstResultChunk(resultSetSerializable.getFirstChunkByteData())
                 .getIterator(this);
       } else {
         this.currentChunkIterator =
-            buildFirstChunk(resultSetSerializable.getFirstChunkStringData()).getIterator(this);
+            buildFirstChunk(resultSetSerializable.getFirstChunkByteData()).getIterator(this);
       }
     }
   }
@@ -278,12 +277,11 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
   /**
    * Decode rowset returned in query response the load data into arrow vectors
    *
-   * @param rowsetBase64 first chunk of rowset in arrow format and base64 encoded
+   * @param firstChunk first chunk of rowset in arrow format
    * @return result chunk with arrow data already being loaded
    */
-  private ArrowResultChunk buildFirstChunk(String rowsetBase64) throws SQLException {
-    byte[] bytes = Base64.getDecoder().decode(rowsetBase64);
-    ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+  private ArrowResultChunk buildFirstChunk(byte[] firstChunk) throws SQLException {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(firstChunk);
 
     // create a result chunk
     ArrowResultChunk resultChunk = new ArrowResultChunk("", 0, 0, 0, rootAllocator, session);
@@ -303,11 +301,11 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
   /**
    * Decode rowset returned in query response the load data into arrow vectors and sort data
    *
-   * @param rowsetBase64 first chunk of rowset in arrow format and base64 encoded
+   * @param firstChunk first chunk of rowset in arrow format
    * @return result chunk with arrow data already being loaded
    */
-  private ArrowResultChunk getSortedFirstResultChunk(String rowsetBase64) throws SQLException {
-    ArrowResultChunk resultChunk = buildFirstChunk(rowsetBase64);
+  private ArrowResultChunk getSortedFirstResultChunk(byte[] firstChunk) throws SQLException {
+    ArrowResultChunk resultChunk = buildFirstChunk(firstChunk);
 
     // enable sorted chunk, the sorting happens when the result chunk is ready to consume
     resultChunk.enableSortFirstResultChunk();

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -577,7 +577,7 @@ public class SnowflakeResultSetSerializableV1
           || resultSetSerializable.firstChunkRowset.isMissingNode()) {
         resultSetSerializable.firstChunkRowCount = 0;
         resultSetSerializable.firstChunkStringData = null;
-        resultSetSerializable.firstChunkByteData = null;
+        resultSetSerializable.firstChunkByteData = new byte[0];
       } else {
         resultSetSerializable.firstChunkRowCount = resultSetSerializable.firstChunkRowset.size();
         resultSetSerializable.firstChunkStringData =
@@ -953,7 +953,7 @@ public class SnowflakeResultSetSerializableV1
         curResultSetSerializable.firstChunkStringData = null;
         curResultSetSerializable.firstChunkRowCount = 0;
         curResultSetSerializable.firstChunkRowset = null;
-        curResultSetSerializable.firstChunkByteData = null;
+        curResultSetSerializable.firstChunkByteData = new byte[0];
       }
 
       // Append this chunk file to result serializable object
@@ -1064,11 +1064,11 @@ public class SnowflakeResultSetSerializableV1
   // Set the row count for first result chunk by parsing the chunk data.
   private void setFirstChunkRowCountForArrow() throws SnowflakeSQLException {
     firstChunkRowCount = 0;
-    firstChunkByteData = null;
+    firstChunkByteData = new byte[0];
     // If the first chunk doesn't exist or empty, set it as 0
     if (firstChunkStringData == null || firstChunkStringData.isEmpty()) {
       firstChunkRowCount = 0;
-      firstChunkByteData = null;
+      firstChunkByteData = new byte[0];
     }
     // Parse the Arrow result chunk
     else if (getQueryResultFormat().equals(QueryResultFormat.ARROW)) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -104,6 +104,7 @@ public class SnowflakeResultSetSerializableV1
   int firstChunkRowCount;
   int chunkFileCount;
   List<ChunkFileMetadata> chunkFileMetadatas = new ArrayList<>();
+  byte[] firstChunkByteData;
 
   // below fields are used for building a ChunkDownloader which
   // uses http client to download chunk files
@@ -178,6 +179,7 @@ public class SnowflakeResultSetSerializableV1
     this.firstChunkRowCount = toCopy.firstChunkRowCount;
     this.chunkFileCount = toCopy.chunkFileCount;
     this.chunkFileMetadatas = toCopy.chunkFileMetadatas;
+    this.firstChunkByteData = toCopy.firstChunkByteData;
 
     // below fields are used for building a ChunkDownloader
     this.resultPrefetchThreads = toCopy.resultPrefetchThreads;
@@ -251,6 +253,10 @@ public class SnowflakeResultSetSerializableV1
 
   public void setFristChunkStringData(String firstChunkStringData) {
     this.firstChunkStringData = firstChunkStringData;
+  }
+
+  public void setFirstChunkByteData(byte[] firstChunkByteData) {
+    this.firstChunkByteData = firstChunkByteData;
   }
 
   public void setChunkDownloader(ChunkDownloader chunkDownloader) {
@@ -447,6 +453,10 @@ public class SnowflakeResultSetSerializableV1
     return firstChunkStringData;
   }
 
+  public byte[] getFirstChunkByteData() {
+    return firstChunkByteData;
+  }
+
   public boolean getTreatNTZAsUTC() {
     return treatNTZAsUTC;
   }
@@ -567,6 +577,7 @@ public class SnowflakeResultSetSerializableV1
           || resultSetSerializable.firstChunkRowset.isMissingNode()) {
         resultSetSerializable.firstChunkRowCount = 0;
         resultSetSerializable.firstChunkStringData = null;
+        resultSetSerializable.firstChunkByteData = null;
       } else {
         resultSetSerializable.firstChunkRowCount = resultSetSerializable.firstChunkRowset.size();
         resultSetSerializable.firstChunkStringData =
@@ -942,6 +953,7 @@ public class SnowflakeResultSetSerializableV1
         curResultSetSerializable.firstChunkStringData = null;
         curResultSetSerializable.firstChunkRowCount = 0;
         curResultSetSerializable.firstChunkRowset = null;
+        curResultSetSerializable.firstChunkByteData = null;
       }
 
       // Append this chunk file to result serializable object
@@ -1052,16 +1064,18 @@ public class SnowflakeResultSetSerializableV1
   // Set the row count for first result chunk by parsing the chunk data.
   private void setFirstChunkRowCountForArrow() throws SnowflakeSQLException {
     firstChunkRowCount = 0;
-
+    firstChunkByteData = null;
     // If the first chunk doesn't exist or empty, set it as 0
     if (firstChunkStringData == null || firstChunkStringData.isEmpty()) {
       firstChunkRowCount = 0;
+      firstChunkByteData = null;
     }
     // Parse the Arrow result chunk
     else if (getQueryResultFormat().equals(QueryResultFormat.ARROW)) {
       // Below code is developed based on SFArrowResultSet.buildFirstChunk
       // and ArrowResultChunk.readArrowStream()
       byte[] bytes = Base64.getDecoder().decode(firstChunkStringData);
+      firstChunkByteData = bytes;
       VectorSchemaRoot root = null;
       RootAllocator localRootAllocator =
           (rootAllocator != null) ? rootAllocator : new RootAllocator(Long.MAX_VALUE);

--- a/src/test/java/net/snowflake/client/core/SFArrowResultSetIT.java
+++ b/src/test/java/net/snowflake/client/core/SFArrowResultSetIT.java
@@ -76,6 +76,7 @@ public class SFArrowResultSetIT {
     SnowflakeResultSetSerializableV1 resultSetSerializable = new SnowflakeResultSetSerializableV1();
     resultSetSerializable.setRootAllocator(new RootAllocator(Long.MAX_VALUE));
     resultSetSerializable.setFristChunkStringData(Base64.getEncoder().encodeToString(dataBytes));
+    resultSetSerializable.setFirstChunkByteData(dataBytes);
     resultSetSerializable.setChunkFileCount(0);
 
     SFArrowResultSet resultSet =
@@ -198,6 +199,7 @@ public class SFArrowResultSetIT {
 
     SnowflakeResultSetSerializableV1 resultSetSerializable = new SnowflakeResultSetSerializableV1();
     resultSetSerializable.setFristChunkStringData(Base64.getEncoder().encodeToString(dataBytes));
+    resultSetSerializable.setFirstChunkByteData(dataBytes);
     resultSetSerializable.setChunkFileCount(chunkCount);
     resultSetSerializable.setRootAllocator(new RootAllocator(Long.MAX_VALUE));
     // build chunk downloader


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 

Snowflake backend returns query result in Arrow Format. Since Arrow format is in binary and it needs to be embedded in JSON message from GS, GS encodes the arrow format result set into Base64 format.

JDBC in order to process result first gathers some metadata about the result set - number of rows in the current chunk, for example. This happens before any processing on the data can happen. For this JDBC driver decodes the result set from base64 to arrow native, calculates the number of rows but then discards the decoded result set. While processing the result later it again decodes the arrow result set from base64.

This double decoding is quite CPU intensive and should be removed.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

When the result set is first decoded to get the metadata, store the decoded firstChunkByteData in the resultSetSerializable object. That way it can be accessed when later processing the result without having to repeat the decoding again. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

