### PR TITLE
Update Apache Arrow for OpenJDK 17 compatibility

### DIFF
--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <arrow.version>7.0.0</arrow.version>
+    <arrow.version>8.0.0</arrow.version>
     <slf4j.version>1.7.25</slf4j.version>
     <jsoup.version>1.14.2</jsoup.version>
     <tika.version>1.25</tika.version>

--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <arrow.version>7.0.0</arrow.version>
+    <arrow.version>8.0.0</arrow.version>
     <jacksondatabind.version>2.11.0</jacksondatabind.version>
     <jacoco.version>0.8.4</jacoco.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <arrow.version>7.0.0</arrow.version>
+    <arrow.version>8.0.0</arrow.version>
     <slf4j.version>1.7.25</slf4j.version>
     <jsoup.version>1.14.2</jsoup.version>
     <tika.version>1.25</tika.version>


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #589 and potentially #533


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Apache Arrow 8.0.0 fixes a problem running on OpenJDK >= 16 (see [ARROW-12747](https://issues.apache.org/jira/browse/ARROW-12747)).

   I was able to build the _snowflake-jdbc_ project with a shaded Apache Arrow 8.0.0, and it became usable under OpenJDK 17.
   It still requires the JVM argument `--add-opens java.base/java.nio=ALL-UNNAMED`.

## Pre-review checklist
- [ ] This change has passed pre-commit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))
