### PR TITLE
SNOW-591431: Fix ocsp wrong host name test failure

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/ConnectionWithOCSPModeIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionWithOCSPModeIT.java
@@ -5,6 +5,7 @@ package net.snowflake.client.jdbc;
 
 import static net.snowflake.client.jdbc.ErrorCode.NETWORK_ERROR;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
# Overview

SNOW-591431

## [Precommit]

https://ci70.int.snowflakecomputing.com/job/RT-LanguageJDBC2-PC/1309/ is green, which contains `testWrongHost`

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

