### PR TITLE
Fix excessive logging by allowing commons-logging (JCL) to initialize Log4j properly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -706,6 +706,9 @@
                      <relocation>
                        <pattern>org.apache</pattern>
                        <shadedPattern>${shadeBase}.apache</shadedPattern>
+                       <excludes>
+                         <exclude>org.apache.log4j.*</exclude>
+                       </excludes>
                      </relocation>
                      <relocation>
                        <pattern>com.amazonaws</pattern>


### PR DESCRIPTION
# Overview

NO-SNOW

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

We use Log4j for logging in my project. We could see the following messages in our logs:
```
May 30, 2022 3:18:59 PM net.snowflake.client.jdbc.internal.amazonaws.http.apache.client.impl.ApacheHttpClientFactory addProxyConfig
INFO: Configuring Proxy. Proxy Host: some.proxy Proxy Port: 8080
```
Our initial thought was that we need to set up appropriate log level for `net.snowflake.client.jdbc.internal.amazonaws.http.apache.client.impl.ApacheHttpClientFactory` but it did not work. This class uses shaded Apache Commons Logging (JCL) as logging abstraction, supporting Log4j as logging implementation. The issue is the Log4j presence recognition does not work. 
If you following the chain of calls from `LogFactory.getLog(AmazonHttpClient.class)` you’ll see that in `net.snowflake.client.jdbc.internal.apache.commons.logging.impl.LogFactoryImpl#createLogFromClass` there is a code that is trying to instantiate Log4j JCL wrapper `net.snowflake.client.jdbc.internal.apache.commons.logging.impl.Log4JLogger` and fails because of `java.lang.NoClassDefFoundError: net.snowflake.client.jdbc.internal.apache.log4j.Priority`. 
This class indeed does not exists in `snowflake-jdbc` and should not. This class comes with Log4j, but the package is different:  `org.apache.log4j.Priority`. It is different because when you shade libraries (relocate packages) you change the imports inside `org.apache.commons.logging.impl.Log4JLogger`  - you try to import `net.snowflake.client.jdbc.internal.apache.log4j.Priority` instead of `import org.apache.log4j.Priority`, which does not exist. Changing imports causes JCL not to recognize Log4j presence. Hence all JCL logs will go to default implementation -> `Jdk14Logger`. We could mitigate it by using `Log4jBridgeHandler` (or `SLF4JBridgeHandler` in case of `SLF4J`), but I think this is not an ideal solution. 
I create this PR to make everyone's life easier and repackage log4j correctly. 

TL;DR;
This PR changes imports inside shaded `org.apache.commons.logging.impl.Log4JLogger` (`net.snowflake.client.jdbc.internal.apache.commons.logging.impl.Log4JLogger` and `net.snowflake.client.jdbc.internal.io.netty.util.internal.logging.Log4J2Logger`) to correctly point to Log4j packages. 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

