### PR TITLE
SNOW-573507 Supporting parsing otherParameters in JDBC

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1369,6 +1369,12 @@ public class SessionUtil {
       } else if (BOOLEAN_PARAMS.contains(paramName.toUpperCase())) {
         parameters.put(paramName, child.path("value").asBoolean());
       } else {
+        try {
+          // Value should only be boolean, int or string so we don't expect exceptions here.
+          parameters.put(paramName, mapper.treeToValue(child.path("value"), Object.class));
+        } catch (Exception e) {
+          logger.debug("Unknown Common Parameter Failed to Parse: {} -> {}. Exception: {}", paramName, child.path("value"), e.getMessage());
+        }
         logger.debug("Unknown Common Parameter: {}", paramName);
       }
 

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1373,7 +1373,11 @@ public class SessionUtil {
           // Value should only be boolean, int or string so we don't expect exceptions here.
           parameters.put(paramName, mapper.treeToValue(child.path("value"), Object.class));
         } catch (Exception e) {
-          logger.debug("Unknown Common Parameter Failed to Parse: {} -> {}. Exception: {}", paramName, child.path("value"), e.getMessage());
+          logger.debug(
+              "Unknown Common Parameter Failed to Parse: {} -> {}. Exception: {}",
+              paramName,
+              child.path("value"),
+              e.getMessage());
         }
         logger.debug("Unknown Common Parameter: {}", paramName);
       }

--- a/src/test/java/net/snowflake/client/jdbc/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SessionUtilTest.java
@@ -1,0 +1,50 @@
+package net.snowflake.client.jdbc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.snowflake.client.core.ObjectMapperFactory;
+import net.snowflake.client.core.SessionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class SessionUtilTest {
+    @Test
+    public void testGetCommonParams() throws Exception {
+        ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+
+        // Test unknown param name
+        Map<String, Object> result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": true}]"));
+        Assert.assertTrue((boolean) result.get("testParam"));
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": false}]"));
+        Assert.assertFalse((boolean) result.get("testParam"));
+
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": 0}]"));
+        Assert.assertEquals(0, (int) result.get("testParam"));
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": 1000}]"));
+        Assert.assertEquals(1000, (int) result.get("testParam"));
+
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": \"\"}]"));
+        Assert.assertEquals("", result.get("testParam"));
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": \"value\"}]"));
+        Assert.assertEquals("value", result.get("testParam"));
+
+        // Test known param name
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"CLIENT_DISABLE_INCIDENTS\", \"value\": true}]"));
+        Assert.assertTrue((boolean) result.get("CLIENT_DISABLE_INCIDENTS"));
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"CLIENT_DISABLE_INCIDENTS\", \"value\": false}]"));
+        Assert.assertFalse((boolean) result.get("CLIENT_DISABLE_INCIDENTS"));
+
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"CLIENT_STAGE_ARRAY_BINDING_THRESHOLD\", \"value\": 0}]"));
+        Assert.assertEquals(0, (int) result.get("CLIENT_STAGE_ARRAY_BINDING_THRESHOLD"));
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"CLIENT_STAGE_ARRAY_BINDING_THRESHOLD\", \"value\": 1000}]"));
+        Assert.assertEquals(1000, (int) result.get("CLIENT_STAGE_ARRAY_BINDING_THRESHOLD"));
+
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"TIMEZONE\", \"value\": \"\"}]"));
+        Assert.assertEquals("", result.get("TIMEZONE"));
+        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"TIMEZONE\", \"value\": \"value\"}]"));
+        Assert.assertEquals("value", result.get("TIMEZONE"));
+
+    }
+}

--- a/src/test/java/net/snowflake/client/jdbc/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SessionUtilTest.java
@@ -1,50 +1,71 @@
 package net.snowflake.client.jdbc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
 import net.snowflake.client.core.ObjectMapperFactory;
 import net.snowflake.client.core.SessionUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Map;
-
 public class SessionUtilTest {
-    @Test
-    public void testGetCommonParams() throws Exception {
-        ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+  @Test
+  public void testGetCommonParams() throws Exception {
+    ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
 
-        // Test unknown param name
-        Map<String, Object> result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": true}]"));
-        Assert.assertTrue((boolean) result.get("testParam"));
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": false}]"));
-        Assert.assertFalse((boolean) result.get("testParam"));
+    // Test unknown param name
+    Map<String, Object> result =
+        SessionUtil.getCommonParams(
+            mapper.readTree("[{\"name\": \"testParam\", \"value\": true}]"));
+    Assert.assertTrue((boolean) result.get("testParam"));
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree("[{\"name\": \"testParam\", \"value\": false}]"));
+    Assert.assertFalse((boolean) result.get("testParam"));
 
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": 0}]"));
-        Assert.assertEquals(0, (int) result.get("testParam"));
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": 1000}]"));
-        Assert.assertEquals(1000, (int) result.get("testParam"));
+    result =
+        SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": 0}]"));
+    Assert.assertEquals(0, (int) result.get("testParam"));
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree("[{\"name\": \"testParam\", \"value\": 1000}]"));
+    Assert.assertEquals(1000, (int) result.get("testParam"));
 
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": \"\"}]"));
-        Assert.assertEquals("", result.get("testParam"));
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"testParam\", \"value\": \"value\"}]"));
-        Assert.assertEquals("value", result.get("testParam"));
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree("[{\"name\": \"testParam\", \"value\": \"\"}]"));
+    Assert.assertEquals("", result.get("testParam"));
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree("[{\"name\": \"testParam\", \"value\": \"value\"}]"));
+    Assert.assertEquals("value", result.get("testParam"));
 
-        // Test known param name
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"CLIENT_DISABLE_INCIDENTS\", \"value\": true}]"));
-        Assert.assertTrue((boolean) result.get("CLIENT_DISABLE_INCIDENTS"));
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"CLIENT_DISABLE_INCIDENTS\", \"value\": false}]"));
-        Assert.assertFalse((boolean) result.get("CLIENT_DISABLE_INCIDENTS"));
+    // Test known param name
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree("[{\"name\": \"CLIENT_DISABLE_INCIDENTS\", \"value\": true}]"));
+    Assert.assertTrue((boolean) result.get("CLIENT_DISABLE_INCIDENTS"));
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree("[{\"name\": \"CLIENT_DISABLE_INCIDENTS\", \"value\": false}]"));
+    Assert.assertFalse((boolean) result.get("CLIENT_DISABLE_INCIDENTS"));
 
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"CLIENT_STAGE_ARRAY_BINDING_THRESHOLD\", \"value\": 0}]"));
-        Assert.assertEquals(0, (int) result.get("CLIENT_STAGE_ARRAY_BINDING_THRESHOLD"));
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"CLIENT_STAGE_ARRAY_BINDING_THRESHOLD\", \"value\": 1000}]"));
-        Assert.assertEquals(1000, (int) result.get("CLIENT_STAGE_ARRAY_BINDING_THRESHOLD"));
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree(
+                "[{\"name\": \"CLIENT_STAGE_ARRAY_BINDING_THRESHOLD\", \"value\": 0}]"));
+    Assert.assertEquals(0, (int) result.get("CLIENT_STAGE_ARRAY_BINDING_THRESHOLD"));
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree(
+                "[{\"name\": \"CLIENT_STAGE_ARRAY_BINDING_THRESHOLD\", \"value\": 1000}]"));
+    Assert.assertEquals(1000, (int) result.get("CLIENT_STAGE_ARRAY_BINDING_THRESHOLD"));
 
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"TIMEZONE\", \"value\": \"\"}]"));
-        Assert.assertEquals("", result.get("TIMEZONE"));
-        result = SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"TIMEZONE\", \"value\": \"value\"}]"));
-        Assert.assertEquals("value", result.get("TIMEZONE"));
-
-    }
+    result =
+        SessionUtil.getCommonParams(mapper.readTree("[{\"name\": \"TIMEZONE\", \"value\": \"\"}]"));
+    Assert.assertEquals("", result.get("TIMEZONE"));
+    result =
+        SessionUtil.getCommonParams(
+            mapper.readTree("[{\"name\": \"TIMEZONE\", \"value\": \"value\"}]"));
+    Assert.assertEquals("value", result.get("TIMEZONE"));
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-573507 Supporting parsing otherParameters in JDBC

Initially JDBC only support parsing parameters defined in `SessionUtil.STRING_PARAMS`, `SessionUtil.INT_PARAMS` and `SessionUtil.BOOLEAN_PARAMS`. This is a limitation for Snowpark client because if we want to add a new server side parameter in for Snowpark client, we need to also change JDBC to recognize the new parameter.

As a result we added a new API in Session called getOtherParameter to get parameters that are not in the three lists. We had a PR to add support to that, https://github.com/snowflakedb/snowflake-jdbc/pull/474. But it is missing the change in getCommonParams. This PR will fix this issue. Without this PR, parameters that are not listed in `SessionUtil.STRING_PARAMS`, `SessionUtil.INT_PARAMS` and `SessionUtil.BOOLEAN_PARAMS` will still be dropped by JDBC.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [x] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

