### PR TITLE
Clear batchOfVectors list when freeing chunk data to fix memory issue

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -115,6 +115,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
   @Override
   public void freeData() {
     batchOfVectors.forEach(list -> list.forEach(ValueVector::close));
+    this.batchOfVectors.clear();
     if (firstResultChunkSortedIndices != null) {
       firstResultChunkSortedIndices.close();
     }


### PR DESCRIPTION
# Overview

When using arrow format, the driver stores a 2-D array of arrow ValueVectors for each chunk. 

`private final ArrayList<List<ValueVector>> batchOfVectors;`

When freeData() is called on the chunk once it is no longer needed, the list of ValueVectors is cleared but the outer list of record batches is not. This is causing the memory to be retained in the heap and for larger datasets a 'java.lang.OutOfMemoryError: GC overhead limit exceeded' error can be thrown.

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   When freeData() is called on the arrow chunk, clear the batchOfVectors array list so that it can be garbage collected.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

