### PR TITLE
Set statement for async result set to fix memory leak

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/DefaultSFConnectionHandler.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultSFConnectionHandler.java
@@ -159,7 +159,7 @@ public class DefaultSFConnectionHandler implements SFConnectionHandler {
 
   @Override
   public ResultSet createResultSet(String queryID, Statement statement) throws SQLException {
-    SFAsyncResultSet rs = new SFAsyncResultSet(queryID);
+    SFAsyncResultSet rs = new SFAsyncResultSet(queryID, statement);
     rs.setSession(sfSession);
     rs.setStatement(statement);
     return rs;

--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -76,7 +76,8 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
     }
   }
 
-  public SFAsyncResultSet(String queryID) throws SQLException {
+  public SFAsyncResultSet(String queryID, Statement statement) throws SQLException {
+    super(statement);
     this.sfBaseResultSet = null;
     queryID.trim();
     if (!Pattern.matches("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}", queryID)) {

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncITLatest.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncITLatest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.client.jdbc;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.*;
+import net.snowflake.client.category.TestCategoryResultSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/** Test AsyncResultSet */
+@Category(TestCategoryResultSet.class)
+public class ResultSetAsyncITLatest extends BaseJDBCTest {
+  @Test
+  public void testAsyncResultSet() throws SQLException {
+    String queryID;
+    Connection connection = getConnection();
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("create or replace table test_rsmd(colA number(20, 5), colB string)");
+      statement.execute("insert into test_rsmd values(1.00, 'str'),(2.00, 'str2')");
+      String createTableSql = "select * from test_rsmd";
+      ResultSet rs = statement.unwrap(SnowflakeStatement.class).executeAsyncQuery(createTableSql);
+      queryID = rs.unwrap(SnowflakeResultSet.class).getQueryID();
+      statement.execute("drop table if exists test_rsmd");
+      rs.close();
+    }
+    // Close and reopen connection
+    connection.close();
+    connection = getConnection();
+    // open a new connection and create a result set
+    ResultSet resultSet = connection.unwrap(SnowflakeConnection.class).createResultSet(queryID);
+    // Process result set
+    ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+    SnowflakeResultSetMetaData secretMetaData =
+        resultSetMetaData.unwrap(SnowflakeResultSetMetaData.class);
+    assertEquals(
+        secretMetaData.getQueryID(), resultSet.unwrap(SnowflakeResultSet.class).getQueryID());
+    // Close statement and resultset
+    resultSet.getStatement().close();
+    resultSet.close();
+    connection.close();
+  }
+}

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncLatestIT.java
@@ -14,7 +14,7 @@ import org.junit.experimental.categories.Category;
 
 /** Test AsyncResultSet */
 @Category(TestCategoryResultSet.class)
-public class ResultSetAsyncITLatest extends BaseJDBCTest {
+public class ResultSetAsyncLatestIT extends BaseJDBCTest {
   @Test
   public void testAsyncResultSet() throws SQLException {
     String queryID;


### PR DESCRIPTION
# Overview
Description provided in #1034 :
When calling the createResultSet method of the Snowflake connection to get the result of an async query, the Snowflake connection creates a statement for us, but there is no accessible reference to it, making it impossible to close.

https://github.com/snowflakedb/snowflake-jdbc/blob/master/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java#L169

ResultSet rs = sfConnectionHandler.createResultSet(queryID, createStatement());
This results in a memory leak in the connection's openStatement object, because this open statement will never be removed for as long as the connection stays opened.

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1034 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  When SFAsyncResultSet is created, pass in the statement object that is created during createResultSet(), instead of assigning the SFAsyncResultSet a different NoOpSnowflakeStatementV1 statement. This will allow the user to access the statement and close it using resultSet.getStatement().close().

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

