### PR TITLE
Reset query status error code and error message after error

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -241,12 +241,17 @@ public class SFSession extends SFBaseSession {
     else if (isAnError(result)) {
       result.setErrorCode(ErrorCode.INTERNAL_ERROR.getMessageCode());
       result.setErrorMessage("no_error_code_from_server");
+    } else if (!isAnError(result)) {
+      result.setErrorCode(0);
+      result.setErrorMessage("No error reported");
     }
     // if an error message has been provided, set appropriate error message.
     // This should override the default error message displayed when there is
     // an error with no code.
     if (!Strings.isNullOrEmpty(errorMessage) && !errorMessage.equalsIgnoreCase("null")) {
       result.setErrorMessage(errorMessage);
+    } else {
+      result.setErrorMessage("No error reported");
     }
     return result;
   }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -291,6 +291,7 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     // called.
     status.setErrorMessage(QueryStatus.FAILED_WITH_ERROR.toString());
     status.setErrorCode(2003);
+    Thread.sleep(300);
     status = rs1.unwrap(SnowflakeResultSet.class).getStatus();
     // Assert status of query is a success
     assertEquals(QueryStatus.SUCCESS, status);


### PR DESCRIPTION
# Overview

SNOW-XXXXX

Description from #1005 
enum QueryStatus has setErrorMessage and setErrorCode methods [ref](https://github.com/snowflakedb/snowflake-jdbc/blob/master/src/main/java/net/snowflake/client/core/QueryStatus.java#L48-L54) to put error message and error code.
Since Java's enum has single instance, if we change error message and error code these values will maintain permanently unless we call setErrorMessage and setErrorCode again.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1005 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   If the query status is not an error, set the error code and error message back to default values so they don't retain the error code/message.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

