### PR TITLE
SNOW-500881 Fix nullptr exception for sessionless GCS client

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -47,7 +47,7 @@ public class SFSession extends SFBaseSession {
       "CLIENT_STORE_TEMPORARY_CREDENTIAL";
   private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
   private static final int MAX_SESSION_PARAMETERS = 1000;
-  private static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 300000; // millisec
+  public static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 300000; // millisec
   private final AtomicInteger sequenceId = new AtomicInteger(0);
   private final List<DriverPropertyInfo> missingProperties = new ArrayList<>();
   // list of active asynchronous queries. Used to see if session should be closed when connection

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -557,6 +557,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
     logger.debug("Starting upload");
     uploadWithPresignedUrl(
         networkTimeoutInMilli,
+        0, // auth timeout
+        SFSession.DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT, // socket timeout
         meta.getContentEncoding(),
         meta.getUserMetadata(),
         uploadStreamInfo.left,
@@ -623,6 +625,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
       logger.debug("Starting upload", false);
       uploadWithPresignedUrl(
           session.getNetworkTimeoutInMilli(),
+          session.getAuthTimeout(),
+          session.getHttpClientSocketTimeout(),
           meta.getContentEncoding(),
           meta.getUserMetadata(),
           uploadStreamInfo.left,
@@ -706,6 +710,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
    */
   private void uploadWithPresignedUrl(
       int networkTimeoutInMilli,
+      int authTimeout,
+      int httpClientSocketTimeout,
       String contentEncoding,
       Map<String, String> metadata,
       InputStream content,
@@ -743,8 +749,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
               httpClient,
               httpRequest,
               networkTimeoutInMilli / 1000, // retry timeout
-              session.getAuthTimeout(),
-              session.getHttpClientSocketTimeout(),
+              authTimeout, // auth timeout
+              httpClientSocketTimeout, // socket timeout in ms
               0,
               0, // no socketime injection
               null, // no canceling


### PR DESCRIPTION
# Overview

SNOW-500881 This is a fix for the previous PR https://github.com/snowflakedb/snowflake-jdbc/pull/715 for when the GCS client is session-less.


## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

