### PR TITLE
Implement executeLargeBatch() for SnowflakePreparedStatementV1

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -787,17 +787,16 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   @Override
   public int[] executeBatch() throws SQLException {
     logger.debug("executeBatch()", false);
-    return executeBatchInternal(false).intArr;
+    return executeBatchInternalWithArrayBind(false).intArr;
   }
 
   @Override
   public long[] executeLargeBatch() throws SQLException {
     logger.debug("executeLargeBatch()", false);
-    return executeBatchInternal(true).longArr;
+    return executeBatchInternalWithArrayBind(true).longArr;
   }
 
-  @Override
-  VariableTypeArray executeBatchInternal(boolean isLong) throws SQLException {
+  VariableTypeArray executeBatchInternalWithArrayBind(boolean isLong) throws SQLException {
     raiseSQLExceptionIfStatementIsClosed();
 
     describeSqlIfNotTried();
@@ -853,6 +852,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
           }
         }
       } else {
+        // Array binding is not supported
         if (isLong) {
           updateCounts.longArr = executeBatchInternal(false).longArr;
 

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
@@ -8,10 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryStatement;
@@ -187,6 +184,31 @@ public class PreparedStatement2LatestIT extends PreparedStatement0IT {
         prepStatement.setInt(1, 2);
         try (ResultSet resultSet = prepStatement.executeQuery()) {
           assertEquals(2, getSizeOfResultSet(resultSet));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testExecuteLargeBatch() throws SQLException {
+    try (Connection con = init()) {
+      try (Statement statement = con.createStatement()) {
+        statement.execute("create or replace table mytab(id int)");
+        try (PreparedStatement pstatement =
+            con.prepareStatement("insert into mytab(id) values (?)")) {
+          pstatement.setLong(1, 4);
+          pstatement.addBatch();
+          pstatement.setLong(1, 5);
+          pstatement.addBatch();
+          pstatement.setLong(1, 6);
+          pstatement.addBatch();
+          pstatement.executeLargeBatch();
+          con.commit();
+          try (ResultSet resultSet = statement.executeQuery("select * from mytab")) {
+            resultSet.next();
+            assertEquals(4, resultSet.getInt(1));
+          }
+          statement.execute("drop table if exists mytab");
         }
       }
     }


### PR DESCRIPTION
# Overview

When calling executeLargeBatch() for prepared statements, no rows were being inserted. 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1006 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add implementation for array binding with executeLargeBatch, similar to executeBatch(), for prepared statements.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

