### PR TITLE
Implement DatabaseMetadata.getSQLStateType()

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -2962,8 +2962,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
   @Override
   public int getSQLStateType() throws SQLException {
     logger.debug("public int getSQLStateType()", false);
-
-    throw new SnowflakeLoggedFeatureNotSupportedException(session);
+    return sqlStateSQL;
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
@@ -935,7 +935,6 @@ public class DatabaseMetaDataIT extends BaseJDBCTest {
       expectFeatureNotSupportedException(() -> metaData.getSuperTypes(null, null, null));
       expectFeatureNotSupportedException(() -> metaData.getSuperTables(null, null, null));
       expectFeatureNotSupportedException(() -> metaData.getAttributes(null, null, null, null));
-      expectFeatureNotSupportedException(metaData::getSQLStateType);
       expectFeatureNotSupportedException(metaData::locatorsUpdateCopy);
       expectFeatureNotSupportedException(metaData::getRowIdLifetime);
       expectFeatureNotSupportedException(metaData::autoCommitFailureClosesAllResultSets);


### PR DESCRIPTION
# Overview

A customer is facing an issue where the application is calling getSQLStateType() while retrieving the database metadata. The current implementation throws a SnowflakeLoggedFeatureNotSupportedException. 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The driver uses SQLState codes that are not listed under sqlStateXOpen, so return sqlStateSQL when getSQLStateType() is called. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

