### PR TITLE
fix getColumnClassName() for timestamp_tz column

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeType.java
@@ -450,6 +450,7 @@ public enum SnowflakeType {
         return Double.class.getName();
 
       case Types.TIMESTAMP:
+      case Types.TIMESTAMP_WITH_TIMEZONE:
         return Timestamp.class.getName();
 
       case Types.DATE:

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -541,6 +541,8 @@ public class ResultSetLatestIT extends ResultSet0IT {
       ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
       // Assert that TIMESTAMP_TZ type matches java.sql.TIMESTAMP_WITH_TIMEZONE
       assertEquals(resultSetMetaData.getColumnType(1), 2014);
+      // Assert that TIMESTAMP_TZ column returns Timestamp class name
+      assertEquals(resultSetMetaData.getColumnClassName(1), Timestamp.class.getName());
     }
   }
 }


### PR DESCRIPTION
# Overview

SNOW-XXXXX

Method getColumnClassName (for ResultSetMetaData object type) throws exception if the column type is TIMEZONETZ

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add a case for TIMESTAMP_WITH_TIMEZONE to SnowflakeType.javaTypeToClassName()

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

