### PR TITLE
SNOW-644887 Remove inactive async queries from active query list

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -52,7 +52,7 @@ public class SFSession extends SFBaseSession {
   // list of active asynchronous queries. Used to see if session should be closed when connection
   // closes
   private Set<String> activeAsyncQueries = ConcurrentHashMap.newKeySet();
-  // Map of all asynchronous queries and their status; used to cache status calls
+  // Map of completed, successful async queries to avoid unneccessary getStatus calls
   private Set<String> successfulAsyncQueries = ConcurrentHashMap.newKeySet();
   private boolean isClosed = true;
   private String sessionToken;
@@ -158,6 +158,16 @@ public class SFSession extends SFBaseSession {
    */
   public boolean hasQuerySucceeded(String queryID) {
     return successfulAsyncQueries.contains(queryID);
+  }
+
+  /**
+   * Function to retrieve size of successfulAsyncQueries set. Used for testing only.
+   *
+   * @return
+   */
+  @VisibleForTesting
+  public int getNumberOfSuccessfulAsyncQueriesInSession() {
+    return successfulAsyncQueries.size();
   }
 
   /**

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -52,8 +52,6 @@ public class SFSession extends SFBaseSession {
   // list of active asynchronous queries. Used to see if session should be closed when connection
   // closes
   private Set<String> activeAsyncQueries = ConcurrentHashMap.newKeySet();
-  // Map of completed, successful async queries to avoid unneccessary getStatus calls
-  private Set<String> successfulAsyncQueries = ConcurrentHashMap.newKeySet();
   private boolean isClosed = true;
   private String sessionToken;
   private String masterToken;
@@ -148,26 +146,6 @@ public class SFSession extends SFBaseSession {
    */
   public void addQueryToActiveQueryList(String queryID) {
     activeAsyncQueries.add(queryID);
-  }
-
-  /**
-   * Function to see if an async query has already finished and succeeded.
-   *
-   * @param queryID query ID
-   * @return true if QueryStatus == SUCCESS, false if not
-   */
-  public boolean hasQuerySucceeded(String queryID) {
-    return successfulAsyncQueries.contains(queryID);
-  }
-
-  /**
-   * Function to retrieve size of successfulAsyncQueries set. Used for testing only.
-   *
-   * @return
-   */
-  @VisibleForTesting
-  public int getNumberOfSuccessfulAsyncQueriesInSession() {
-    return successfulAsyncQueries.size();
   }
 
   /**
@@ -280,9 +258,6 @@ public class SFSession extends SFBaseSession {
     }
     if (!isStillRunning(result)) {
       activeAsyncQueries.remove(queryID);
-    }
-    if (result == SUCCESS) {
-      successfulAsyncQueries.add(queryID);
     }
     return result;
   }

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -4,7 +4,18 @@
 
 package net.snowflake.client.core;
 
+import static net.snowflake.client.core.SessionUtil.*;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.core.bind.BindException;
 import net.snowflake.client.core.bind.BindUploader;
@@ -17,18 +28,6 @@ import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 import org.apache.http.client.methods.HttpRequestBase;
-
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static net.snowflake.client.core.SessionUtil.*;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 /** Snowflake statement */
 public class SFStatement extends SFBaseStatement {
@@ -247,7 +246,7 @@ public class SFStatement extends SFBaseStatement {
     logger.debug("Done creating result set", false);
 
     if (asyncExec) {
-      session.activeAsyncQueriesMap.put(resultSet.getQueryId(), QueryStatus.NO_DATA);
+      session.addQueryToActiveQueryList(resultSet.getQueryId());
     }
     return resultSet;
   }

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -4,22 +4,7 @@
 
 package net.snowflake.client.core;
 
-import static net.snowflake.client.core.SessionUtil.*;
-import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.core.BasicEvent.QueryState;
 import net.snowflake.client.core.bind.BindException;
 import net.snowflake.client.core.bind.BindUploader;
@@ -32,6 +17,18 @@ import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.common.core.SqlState;
 import org.apache.http.client.methods.HttpRequestBase;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static net.snowflake.client.core.SessionUtil.*;
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 /** Snowflake statement */
 public class SFStatement extends SFBaseStatement {
@@ -250,7 +247,7 @@ public class SFStatement extends SFBaseStatement {
     logger.debug("Done creating result set", false);
 
     if (asyncExec) {
-      session.activeAsyncQueries.add(resultSet.getQueryId());
+      session.activeAsyncQueriesMap.put(resultSet.getQueryId(), QueryStatus.NO_DATA);
     }
     return resultSet;
   }

--- a/src/main/java/net/snowflake/client/core/StmtUtil.java
+++ b/src/main/java/net/snowflake/client/core/StmtUtil.java
@@ -292,7 +292,7 @@ public class StmtUtil {
           uriBuilder.addParameter(SF_QUERY_COMBINE_DESCRIBE_EXECUTE, Boolean.TRUE.toString());
         }
 
-        if (stmtInput.queryContext != null) {
+        if (!Strings.isNullOrEmpty(stmtInput.queryContext)) {
           uriBuilder.addParameter(SF_QUERY_CONTEXT, stmtInput.queryContext);
         }
 

--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -4,16 +4,17 @@
 
 package net.snowflake.client.jdbc;
 
-import java.math.BigDecimal;
-import java.sql.*;
-import java.util.List;
-import java.util.TimeZone;
-import java.util.regex.Pattern;
 import net.snowflake.client.core.QueryStatus;
 import net.snowflake.client.core.SFBaseResultSet;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.common.core.SqlState;
+
+import java.math.BigDecimal;
+import java.sql.*;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
 
 /** SFAsyncResultSet implementation */
 class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet {
@@ -113,7 +114,11 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
    */
   private void getRealResults() throws SQLException {
     if (!resultSetForNextInitialized) {
-      QueryStatus qs = this.getStatus();
+      QueryStatus qs = session.getAsyncQueryStatus(queryID);
+      if (qs == null)
+      {
+        qs = this.getStatus();
+      }
       int noDataRetry = 0;
       final int noDataMaxRetries = 30;
       final int[] retryPattern = {1, 1, 2, 3, 4, 8, 10};
@@ -149,6 +154,8 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
         }
         qs = this.getStatus();
       }
+
+      // add code
       resultSetForNext =
           extraStatement.executeQuery("select * from table(result_scan('" + this.queryID + "'))");
       resultSetForNextInitialized = true;

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -983,16 +983,10 @@ public class ConnectionLatestIT extends BaseJDBCTest {
           statement
               .unwrap(SnowflakeStatement.class)
               .executeAsyncQuery("select count(*) from table(generator(timeLimit => 4))");
-      String queryID = rs.unwrap(SnowflakeResultSet.class).getQueryID();
       // Assert that activeAsyncQueries is non-empty with running query. Session is async and not
       // safe to close
       assertTrue(con.unwrap(SnowflakeConnectionV1.class).getSfSession().isAsyncSession());
       assertFalse(con.unwrap(SnowflakeConnectionV1.class).getSfSession().isSafeToClose());
-      assertEquals(
-          0,
-          con.unwrap(SnowflakeConnectionV1.class)
-              .getSfSession()
-              .getNumberOfSuccessfulAsyncQueriesInSession());
       // Sleep 6 seconds to ensure query is finished running
       TimeUnit.SECONDS.sleep(6);
       // Assert that there are no longer any queries running.
@@ -1002,14 +996,6 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       // Next, assert session is no longer async (just fetches size of activeQueriesMap with no
       // other action)
       assertFalse(con.unwrap(SnowflakeConnectionV1.class).getSfSession().isAsyncSession());
-      // Assert query was successful and is placed in map of successful async queries.
-      assertTrue(con.unwrap(SnowflakeConnectionV1.class).getSfSession().hasQuerySucceeded(queryID));
-      assertEquals(
-          1,
-          statement
-              .unwrap(SnowflakeConnectionV1.class)
-              .getSfSession()
-              .getNumberOfSuccessfulAsyncQueriesInSession());
       rs.close();
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -973,4 +973,44 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     // Check that 404 was not retried
     assertTrue(endDownloadTime - startDownloadTime < 400000);
   }
+
+  @Test
+  public void testIsAsyncSession() throws SQLException, InterruptedException {
+    try (Connection con = getConnection();
+        Statement statement = con.createStatement()) {
+      // Run a query that takes 5 seconds to complete
+      ResultSet rs =
+          statement
+              .unwrap(SnowflakeStatement.class)
+              .executeAsyncQuery("select count(*) from table(generator(timeLimit => 4))");
+      String queryID = rs.unwrap(SnowflakeResultSet.class).getQueryID();
+      // Assert that activeAsyncQueries is non-empty with running query. Session is async and not
+      // safe to close
+      assertTrue(con.unwrap(SnowflakeConnectionV1.class).getSfSession().isAsyncSession());
+      assertFalse(con.unwrap(SnowflakeConnectionV1.class).getSfSession().isSafeToClose());
+      assertEquals(
+          0,
+          con.unwrap(SnowflakeConnectionV1.class)
+              .getSfSession()
+              .getNumberOfSuccessfulAsyncQueriesInSession());
+      // Sleep 6 seconds to ensure query is finished running
+      TimeUnit.SECONDS.sleep(6);
+      // Assert that there are no longer any queries running.
+      // First, assert session is safe to close. This iterates through active queries, fetches their
+      // status, and removes them from the activeQueriesMap if they are no longer active.
+      assertTrue(con.unwrap(SnowflakeConnectionV1.class).getSfSession().isSafeToClose());
+      // Next, assert session is no longer async (just fetches size of activeQueriesMap with no
+      // other action)
+      assertFalse(con.unwrap(SnowflakeConnectionV1.class).getSfSession().isAsyncSession());
+      // Assert query was successful and is placed in map of successful async queries.
+      assertTrue(con.unwrap(SnowflakeConnectionV1.class).getSfSession().hasQuerySucceeded(queryID));
+      assertEquals(
+          1,
+          statement
+              .unwrap(SnowflakeConnectionV1.class)
+              .getSfSession()
+              .getNumberOfSuccessfulAsyncQueriesInSession());
+      rs.close();
+    }
+  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncLatestIT.java
@@ -4,7 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
 import java.sql.*;


### PR DESCRIPTION
# Overview

SNOW-644887

Once async queries are added to the active async query list, they are not removed. With this PR, logic is added to the getStatus() function so that queries which are no longer running are removed from the active query list.

Note that since the queries are async, there is no way to remove queries from the active query list without first checking their status. **So the async query list will be out of date if no query status checking occurs.**

getQueryStatus() is called by SFSession.isSafeToClose(), and SFAsyncResultSet.getQueryStatus(queryId). Calling isSafeToClose() will iterate through all query IDs in the active async query list and remove queries that are not active. Calling SFAsyncResultSet.getQueryStatus(queryID) will only remove the query corresponding to its query ID if it is not active.

Additionally, this PR adds in a caching feature for successful completed async queries so that repeated getStatus() calls for an already-succeeded query will not invoke more calls to the server.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

