### PR TITLE
#550 fix the special case for procedure parameters reading

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1157,7 +1157,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
       // Procedure name column check must occur later when columns are parsed.
       if ((compiledProcedurePattern != null
               && !compiledProcedurePattern.matcher(procedureNameNoArgs).matches())
-          || !isSchemaNameMatch) {
+          || (compiledSchemaPattern != null && !isSchemaNameMatch)) {
         continue;
       }
       String catalogName = resultSetStepOne.getString("catalog_name");

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1142,17 +1142,21 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
       String schemaName = resultSetStepOne.getString("schema_name");
       // Check that schema name match the original input
       // And check special case - schema with special name in quotes
-      boolean isSchemaNameMatch = compiledSchemaPattern != null && (compiledSchemaPattern.matcher(schemaName).matches()
-          || (schemaName.startsWith("\"") && schemaName.endsWith("\"")
-          && compiledSchemaPattern.matcher(schemaName).region(1, schemaName.length() - 1).matches()
-      )
-      );
+      boolean isSchemaNameMatch =
+          compiledSchemaPattern != null
+              && (compiledSchemaPattern.matcher(schemaName).matches()
+                  || (schemaName.startsWith("\"")
+                      && schemaName.endsWith("\"")
+                      && compiledSchemaPattern
+                          .matcher(schemaName)
+                          .region(1, schemaName.length() - 1)
+                          .matches()));
 
       // Check that procedure name and schema name match the original input in case wildcards have
       // been used.
       // Procedure name column check must occur later when columns are parsed.
       if ((compiledProcedurePattern != null
-          && !compiledProcedurePattern.matcher(procedureNameNoArgs).matches())
+              && !compiledProcedurePattern.matcher(procedureNameNoArgs).matches())
           || !isSchemaNameMatch) {
         continue;
       }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1140,17 +1140,25 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
       String procedureNameUnparsed = resultSetStepOne.getString("arguments").trim();
       String procedureNameNoArgs = resultSetStepOne.getString("name");
       String schemaName = resultSetStepOne.getString("schema_name");
+      // Check that schema name match the original input
+      // And check special case - schema with special name in quotes
+      boolean isSchemaNameMatch = compiledSchemaPattern != null && (compiledSchemaPattern.matcher(schemaName).matches()
+          || (schemaName.startsWith("\"") && schemaName.endsWith("\"")
+          && compiledSchemaPattern.matcher(schemaName).region(1, schemaName.length() - 1).matches()
+      )
+      );
+
       // Check that procedure name and schema name match the original input in case wildcards have
       // been used.
       // Procedure name column check must occur later when columns are parsed.
       if ((compiledProcedurePattern != null
-              && !compiledProcedurePattern.matcher(procedureNameNoArgs).matches())
-          || (compiledSchemaPattern != null
-              && !compiledSchemaPattern.matcher(schemaName).matches())) {
+          && !compiledProcedurePattern.matcher(procedureNameNoArgs).matches())
+          || !isSchemaNameMatch) {
         continue;
       }
+      String catalogName = resultSetStepOne.getString("catalog_name");
       String showProcedureColCommand =
-          getSecondResultSetCommand(catalog, schemaName, procedureNameUnparsed, "procedure");
+          getSecondResultSetCommand(catalogName, schemaName, procedureNameUnparsed, "procedure");
 
       ResultSet resultSetStepTwo =
           executeAndReturnEmptyResultIfNotFound(


### PR DESCRIPTION
 - then catalog or schema are quoted

# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #550

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

 Hello! We use your excellent driver in DBeaver to connect to Snowflake and read some metadata. We found an issue with procedures columns reading for special cases. For catalogs or schemas with quoted names (lowercase as an example).
Then I used the catalog name in `getProcedureColumns` like "test" - I had an empty resultset even though my procedure had columns. It's because `getFirstResultSetCommand` set my catalog name in quotes, but getSecondResultSetCommand created statement without quotes around catalog name.
I checked the `getFunctionsColumns` method and I think, that we can read catalog names from resultSet in `getProcedureColumns` too.

The second case is with the `schemaPattern`. As in the first case, the schema name gets quotes in the `getFirstResultSetCommand` method. And after that schema name is read and used in getSecondResultSetCommand - which means, that quotes will be around the schema name if the schema has been quoted. But compiledSchemaPattern doesn't know anything about quotes. And the pattern doesn't match. For these reasons, I added special conditions about quotes around schemaName.

I hope this PR will help to solve this issue. Any advice will be also very beneficial for me. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

