### PR TITLE
Use parallelism parameter for PUT/GET with Azure

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -999,6 +999,84 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
     }
   }
 
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testPutGetLargeFileAzure() throws Throwable {
+    Properties paramProperties = new Properties();
+    Connection connection = getConnection("azureaccount", paramProperties);
+    Statement statement = connection.createStatement();
+
+    File destFolder = tmpFolder.newFolder();
+    String destFolderCanonicalPath = destFolder.getCanonicalPath();
+    String destFolderCanonicalPathWithSeparator = destFolderCanonicalPath + File.separator;
+
+    File largeTempFile = tmpFolder.newFile("largeFile.csv");
+    BufferedWriter bw = new BufferedWriter(new FileWriter(largeTempFile));
+    bw.write("Creating large test file for Azure PUT/GET test");
+    bw.write(System.lineSeparator());
+    bw.write("Creating large test file for Azure PUT/GET test");
+    bw.write(System.lineSeparator());
+    bw.close();
+    File largeTempFile2 = tmpFolder.newFile("largeFile2.csv");
+
+    String sourceFilePath = largeTempFile.getCanonicalPath();
+
+    try {
+      // copy info from 1 file to another and continue doubling file size until we reach ~1.5GB,
+      // which is a large file
+      for (int i = 0; i < 12; i++) {
+        copyContentFrom(largeTempFile, largeTempFile2);
+        copyContentFrom(largeTempFile2, largeTempFile);
+      }
+
+      // create a stage to put the file in
+      statement.execute("CREATE OR REPLACE STAGE largefile_stage");
+      assertTrue(
+          "Failed to put a file",
+          statement.execute("PUT file://" + sourceFilePath + " @largefile_stage"));
+
+      // check that file exists in stage after PUT
+      findFile(statement, "ls @largefile_stage/");
+
+      // create a new table with columns matching CSV file
+      statement.execute("create or replace table large_table (colA string)");
+      // copy rows from file into table
+      statement.execute("copy into large_table from @largefile_stage/largeFile.csv.gz");
+      // copy back from table into different stage
+      statement.execute("create or replace stage extra_stage");
+      statement.execute("copy into @extra_stage/bigFile.csv.gz from large_table single=true");
+
+      // get file from new stage
+      assertTrue(
+          "Failed to get files",
+          statement.execute(
+              "GET @extra_stage 'file://" + destFolderCanonicalPath + "' parallel=8"));
+
+      // Make sure that the downloaded file exists; it should be gzip compressed
+      File downloaded = new File(destFolderCanonicalPathWithSeparator + "bigFile.csv.gz");
+      assert (downloaded.exists());
+
+      // unzip the file
+      Process p =
+          Runtime.getRuntime()
+              .exec("gzip -d " + destFolderCanonicalPathWithSeparator + "bigFile.csv.gz");
+      p.waitFor();
+
+      // compare the original file with the file that's been uploaded, copied into a table, copied
+      // back into a stage,
+      // downloaded, and unzipped
+      File unzipped = new File(destFolderCanonicalPathWithSeparator + "bigFile.csv");
+      assert (largeTempFile.length() == unzipped.length());
+      assert (FileUtils.contentEquals(largeTempFile, unzipped));
+    } finally {
+      statement.execute("DROP STAGE IF EXISTS largefile_stage");
+      statement.execute("DROP STAGE IF EXISTS extra_stage");
+      statement.execute("DROP TABLE IF EXISTS large_table");
+      statement.close();
+      connection.close();
+    }
+  }
+
   /**
    * helper function for creating large file in Java. Copies info from 1 file to another
    *


### PR DESCRIPTION
# Overview

The Snowflake JDBC driver provides upload method that a customer is using to upload files to internal stages within their Azure Snowflake accounts. The JDBC driver has an internal threshold ("big file" threshold) defined as 200MB. 

For small files, we upload files in parallel, so we don't want the remote store uploader to upload parts in parallel for each file. For large files, we upload them in serial, and we want remote store uploader to upload parts in parallel for each file. This is the reason for the parallel value.

For files over 200MB the JDBC driver relies on the object store provider to do the splitting and parallel uploading, and that because Azure does not provide this capability, the result is that the JDBC driver serializes (does not parallelize) uploads for any files exceeding 200MB. The threshold is not configurable. Customer cannot control size of files to be uploaded.

Customer impact: Upload performance is much faster when multiple files are uploaded in parallel, which is entirely disabled for files >200MB. Customer would like parallelism to either work as designed (splitting of large files) or to have a way to disable or control the "big file" threshold.

(Salesforce ticket 00387680)

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The azure-storage library has BlobRequestOptions for Blob uploads that has a setConcurrentRequestCount() option. This sets the concurrent number of simultaneous requests per operation. 

For big file uploads, the concurrent request count will be set to the parallelism parameter (default 4 if not in the command). For small file uploads, it will be set to 1 since parallelism is handled by the driver.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

