### PR TITLE
Fix SNOW-669337

### DIFF
--- a/ci/_init.sh
+++ b/ci/_init.sh
@@ -25,8 +25,9 @@ declare -A BUILD_IMAGE_NAMES=(
 )
 export BUILD_IMAGE_NAMES
 
-declare -A TEST_IMAGE_NAMES=(
-    [$DRIVER_NAME-centos6-default]=$DOCKER_REGISTRY_NAME/client-$DRIVER_NAME-centos6-default-test:$BUILD_IMAGE_VERSION
-)
-export TEST_IMAGE_NAMES
+declare TEST_IMAGE_NAME=$DRIVER_NAME-centos7-default
+declare TEST_IMAGE_VAL=$DOCKER_REGISTRY_NAME/client-$DRIVER_NAME-centos7-default-test:$TEST_IMAGE_VERSION
+
+export TEST_IMAGE_NAME
+export TEST_IMAGE_VAL
 

--- a/ci/image/Dockerfile.jdbc-centos7-default-test
+++ b/ci/image/Dockerfile.jdbc-centos7-default-test
@@ -1,0 +1,73 @@
+FROM centos:7
+
+# update OS
+RUN yum -y update && \
+    yum -y install epel-release && \
+    yum -y install centos-release-scl
+
+# python
+RUN yum -y install rh-python38
+COPY scripts/python3.8.sh /usr/local/bin/python3.8
+COPY scripts/python3.8.sh /usr/local/bin/python3
+RUN chmod a+x /usr/local/bin/python3.8 /usr/local/bin/python3
+COPY scripts/pip.sh /usr/local/bin/pip
+RUN chmod a+x /usr/local/bin/pip
+RUN pip install -U pip
+RUN pip install -U snowflake-connector-python
+
+# aws
+RUN pip install -U awscli
+COPY scripts/aws.sh /usr/local/bin/aws
+RUN chmod a+x /usr/local/bin/aws
+
+# install Development tools
+RUN yum -y groupinstall "Development Tools" && \
+    yum -y install zlib-devel
+
+# git
+RUN curl -o - https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.26.0.tar.gz | tar xfz - && \
+    cd git-2.26.0 && \
+    ./configure --prefix=/opt/git && make && make install && \
+    ln -s /opt/git/bin/git /usr/local/bin/git
+
+# zstd
+RUN yum -y install zstd
+
+# jq
+RUN yum -y install jq
+
+# gosu
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64"
+RUN chmod +x /usr/local/bin/gosu
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Java
+RUN yum -y install java-1.8.0-openjdk-devel
+
+# Maven
+RUN curl -o - https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xfz - -C /opt && \
+    ln -s /opt/apache-maven-3.6.3/bin/mvn /usr/local/bin/mvn
+
+# workspace
+RUN mkdir -p /home/user && \
+    chmod 777 /home/user
+WORKDIR /home/user
+
+COPY pom.xml /root
+COPY dependencies /root/dependencies
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
+RUN export JAVA_HOME
+RUN echo $JAVA_HOME
+RUN ls /usr/lib/jvm
+
+
+RUN cd /root && \
+    mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+        -Dnot-self-contained-jar \
+        --batch-mode --fail-never compile && \
+    mv $HOME/.m2 /home/user && \
+    chmod -R 777 /home/user/.m2
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/image/build.sh
+++ b/ci/image/build.sh
@@ -7,7 +7,8 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $THIS_DIR/../_init.sh
 
 cp -p $THIS_DIR/../../pom.xml $THIS_DIR
-cp -rp $THIS_DIR/../../dependencies/ $THIS_DIR
+cp -rp $THIS_DIR/../../dependencies/ $THIS_DIR/dependencies
+#export DOCKER_BUILDKIT=0
 
 for name in "${!BUILD_IMAGE_NAMES[@]}"; do
     docker build \
@@ -18,11 +19,12 @@ for name in "${!BUILD_IMAGE_NAMES[@]}"; do
         --tag ${BUILD_IMAGE_NAMES[$name]} .
 done
 
-for name in "${!TEST_IMAGE_NAMES[@]}"; do
-    docker build \
+
+docker build \
         --pull \
-        --file $THIS_DIR/Dockerfile.$name-test \
+        --file $THIS_DIR/Dockerfile.$TEST_IMAGE_NAME-test \
         --label snowflake \
         --label $DRIVER_NAME \
-        --tag ${TEST_IMAGE_NAMES[$name]} .
-done
+        --tag $TEST_IMAGE_VAL .
+
+

--- a/ci/image/readme
+++ b/ci/image/readme
@@ -1,0 +1,14 @@
+1. Build image on Mac. DevVm has network issue and build will fail.
+2. To build on Mac, clone the driver code from github
+3. Then run sh build.sh from this directory.
+4. It will create image with name like:
+   nexus.int.snowflakecomputing.com:8086/docker/client-jdbc-centos7-default-test:1
+5. You can login to Nexus, if you don't have credentials then request using LDAP JIRA bug format.
+   e.g https://snowflakecomputing.atlassian.net/browse/SNOW-672513
+
+   docker login nexus.int.snowflakecomputing.com:8086
+6. Once login successful, push the image:
+   docker push nexus.int.snowflakecomputing.com:8086/docker/client-jdbc-centos7-default-test:1
+7. You can brwose the docker image:
+   https://nexus.int.snowflakecomputing.com/#browse/browse:docker-internal
+

--- a/ci/image/scripts/pip.sh
+++ b/ci/image/scripts/pip.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source /opt/rh/rh-python36/enable
+source /opt/rh/rh-python38/enable
 pip "$@"

--- a/ci/image/scripts/python3.8.sh
+++ b/ci/image/scripts/python3.8.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+
 source /opt/rh/rh-python38/enable
-aws "$@"
+python3.8 "$@"


### PR DESCRIPTION
# Overview

SNOW-669337: Docker image of JDBC driver for CentOS7
The previous image for centos6. We don't know when we created this image last time. Now DPE needs image with Centos7 support. Change the script to use centos7 and also change other stuff found for dependencies upgrades.
Created a readme file, so one can create image easily in future.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

