### PR TITLE
Add warnings for errors while parsing a SnowflakeConnectString

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -31,10 +31,12 @@ public class SnowflakeConnectString implements Serializable {
 
   public static SnowflakeConnectString parse(String url, Properties info) {
     if (url == null) {
+      logger.warn("Connect strings must be non-null");
       return INVALID_CONNECT_STRING;
     }
     int pos = url.indexOf(PREFIX);
     if (pos != 0) {
+      logger.warn("Connect strings must start with jdbc:snowflake://");
       return INVALID_CONNECT_STRING; // not start with jdbc:snowflake://
     }
     String afterPrefix = url.substring(pos + PREFIX.length());
@@ -62,9 +64,11 @@ public class SnowflakeConnectString implements Serializable {
       String queryData = uri.getRawQuery();
 
       if (!scheme.equals("snowflake") && !scheme.equals("http") && !scheme.equals("https")) {
+        logger.warn("Connect strings must have a valid scheme: 'snowflake' or 'http' or 'https'");
         return INVALID_CONNECT_STRING;
       }
       if (Strings.isNullOrEmpty(host)) {
+        logger.warn("Connect strings must have a valid host: found null or empty host");
         return INVALID_CONNECT_STRING;
       }
       if (port == -1) {
@@ -72,6 +76,7 @@ public class SnowflakeConnectString implements Serializable {
       }
       String path = uri.getPath();
       if (!Strings.isNullOrEmpty(path) && !"/".equals(path)) {
+        logger.warn("Connect strings must have no path: expecting empty or null or '/'");
         return INVALID_CONNECT_STRING;
       }
       String account = null;
@@ -147,6 +152,7 @@ public class SnowflakeConnectString implements Serializable {
 
       return new SnowflakeConnectString(scheme, host, port, parameters, account);
     } catch (Exception ex) {
+      logger.warn("Exception thrown while parsing Snowflake connect string", ex);
       return INVALID_CONNECT_STRING;
     }
   }


### PR DESCRIPTION
# Overview

Add log warnings for each of the error return paths of `SnowflakeConnectString.parse`.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowflake-jdbc/issues/1165


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [X] I am adding new logging messages
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This code adds additional logging for each of the error return paths of `SnowflakeConnectString.parse`.  This helps users who see the errors determine what is wrong with their provided connection string.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

