### PR TITLE
Upgrade commons-text library from 1.6 to 1.10.0

### DIFF
--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -188,7 +188,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.6</version>
+      <version>1.10.0</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>

--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.6</version>
+      <version>1.10.0</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.6</version>
+      <version>1.10.0</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
# Overview

Simba ticket 00406750.

Description provided by Snowflake Support:
https://nvd.nist.gov/vuln/detail/CVE-2022-42889
apache:commons_text: Up to (excluding) 1.10.0

------------------------------------------------------------------------------------------------------------------------

The JDBC driver uses commons-text library version version 1.6 in test scope that is vulnerable to CVE-2022-42889. This is a critical vulnerability that must be patched ASAP to version 1.10.0. Can you please assign a resource to bump up the dependency version to 1.10.0 in snowflake-jdbc/pom.xml at master · snowflakedb/snowflake-jdbc

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Upgrade to version 1.10.0 which doesn't have this vulnerability.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

