### PR TITLE
SNOW-685100 Add enable timestamp with timezone parameter

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -801,9 +801,4 @@ public abstract class SFBaseSession {
   public boolean getEnableReturnTimestampWithTimeZone() {
     return enableReturnTimestampWithTimeZone;
   }
-
-  /** only used for tests */
-  private void setEnableReturnTimestampWithTimeZoneForTesting(boolean value) {
-    enableReturnTimestampWithTimeZone = value;
-  }
 }

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -802,7 +802,8 @@ public abstract class SFBaseSession {
     return enableReturnTimestampWithTimeZone;
   }
 
-  public void setEnableReturnTimestampWithTimeZoneForTesting(boolean value) {
+  /** only used for tests */
+  private void setEnableReturnTimestampWithTimeZoneForTesting(boolean value) {
     enableReturnTimestampWithTimeZone = value;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -795,7 +795,7 @@ public abstract class SFBaseSession {
    * have any behavior change. Stored proc JDBC will override this function to return the value of
    * SP_JDBC_ENABLE_TIMESTAMP_WITH_TIMEZONE from server for backward compatibility.
    */
-  public boolean getEnableTimestampReturnType() {
+  public boolean getEnableReturnTimestampWithTimeZone() {
     return true;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -788,4 +788,14 @@ public abstract class SFBaseSession {
   public void setQueryContext(String queryContext) {
     this.queryContext = queryContext;
   }
+
+  /**
+   * If true, JDBC will enable returning TIMESTAMP_WITH_TIMEZONE as column type, otherwise it will
+   * not. This function will always return true for JDBC client, so that the client JDBC will not
+   * have any behavior change. Stored proc JDBC will override this function to return the value of
+   * SP_JDBC_ENABLE_TIMESTAMP_WITH_TIMEZONE from server for backward compatibility.
+   */
+  public boolean getEnableTimestampReturnType() {
+    return true;
+  }
 }

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -117,6 +117,9 @@ public abstract class SFBaseSession {
   // Query context for current session
   private String queryContext;
 
+  // Whether enable returning timestamp with timezone as data type
+  private boolean enableReturnTimestampWithTimeZone = true;
+
   protected SFBaseSession(SFConnectionHandler sfConnectionHandler) {
     this.sfConnectionHandler = sfConnectionHandler;
   }
@@ -796,6 +799,10 @@ public abstract class SFBaseSession {
    * SP_JDBC_ENABLE_TIMESTAMP_WITH_TIMEZONE from server for backward compatibility.
    */
   public boolean getEnableReturnTimestampWithTimeZone() {
-    return true;
+    return enableReturnTimestampWithTimeZone;
+  }
+
+  public void setEnableReturnTimestampWithTimeZoneForTesting(boolean value) {
+    enableReturnTimestampWithTimeZone = value;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
@@ -354,7 +354,9 @@ public class SFResultSetMetaData {
     }
     if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ) {
       externalColumnType =
-          session.getEnableTimestampReturnType() ? Types.TIMESTAMP_WITH_TIMEZONE : Types.TIMESTAMP;
+          session.getEnableReturnTimestampWithTimeZone()
+              ? Types.TIMESTAMP_WITH_TIMEZONE
+              : Types.TIMESTAMP;
     }
     return externalColumnType;
   }

--- a/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
@@ -353,7 +353,8 @@ public class SFResultSetMetaData {
       externalColumnType = Types.TIMESTAMP;
     }
     if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ) {
-      externalColumnType = Types.TIMESTAMP_WITH_TIMEZONE;
+      externalColumnType =
+          session.getEnableTimestampReturnType() ? Types.TIMESTAMP_WITH_TIMEZONE : Types.TIMESTAMP;
     }
     return externalColumnType;
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1733,7 +1733,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
             }
             if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ) {
               externalColumnType =
-                  session.getEnableTimestampReturnType()
+                  session.getEnableReturnTimestampWithTimeZone()
                       ? Types.TIMESTAMP_WITH_TIMEZONE
                       : Types.TIMESTAMP;
             }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1732,7 +1732,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
               externalColumnType = Types.TIMESTAMP;
             }
             if (internalColumnType == SnowflakeUtil.EXTRA_TYPES_TIMESTAMP_TZ) {
-              externalColumnType = Types.TIMESTAMP_WITH_TIMEZONE;
+              externalColumnType =
+                  session.getEnableTimestampReturnType()
+                      ? Types.TIMESTAMP_WITH_TIMEZONE
+                      : Types.TIMESTAMP;
             }
 
             nextRow[4] = externalColumnType;

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -8,7 +8,7 @@ import static net.snowflake.client.jdbc.SnowflakeDatabaseMetaData.*;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.*;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
 import java.sql.*;
 import java.util.HashSet;
 import java.util.Map;
@@ -886,11 +886,9 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
       assertEquals(resultSet.getObject("DATA_TYPE"), 2014);
 
       SFBaseSession baseSession = connection.unwrap(SnowflakeConnectionV1.class).getSFBaseSession();
-      Method method =
-          SFBaseSession.class.getDeclaredMethod(
-              "setEnableReturnTimestampWithTimeZoneForTesting", boolean.class);
-      method.setAccessible(true);
-      method.invoke(baseSession, false);
+      Field field = SFBaseSession.class.getDeclaredField("enableReturnTimestampWithTimeZone");
+      field.setAccessible(true);
+      field.set(baseSession, false);
 
       metaData = connection.getMetaData();
       resultSet = metaData.getColumns(database, schema, "TS_TEST", "TS");

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -888,6 +888,7 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
           .getSFBaseSession()
           .setEnableReturnTimestampWithTimeZoneForTesting(false);
 
+      metaData = connection.getMetaData();
       resultSet = metaData.getColumns(database, schema, "TS_TEST", "TS");
       resultSet.next();
       // Assert that TIMESTAMP_TZ type matches java.sql.TIMESTAMP when

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -882,6 +882,17 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
       resultSet.next();
       // Assert that TIMESTAMP_TZ type matches java.sql.TIMESTAMP_WITH_TIMEZONE
       assertEquals(resultSet.getObject("DATA_TYPE"), 2014);
+
+      connection
+          .unwrap(SnowflakeConnectionV1.class)
+          .getSFBaseSession()
+          .setEnableReturnTimestampWithTimeZoneForTesting(false);
+
+      resultSet = metaData.getColumns(database, schema, "TS_TEST", "TS");
+      resultSet.next();
+      // Assert that TIMESTAMP_TZ type matches java.sql.TIMESTAMP when
+      // enableReturnTimestampWithTimeZone is false.
+      assertEquals(resultSet.getObject("DATA_TYPE"), Types.TIMESTAMP);
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -533,7 +534,7 @@ public class ResultSetLatestIT extends ResultSet0IT {
   }
 
   @Test
-  public void testGetDataTypeWithTimestampTz() throws SQLException {
+  public void testGetDataTypeWithTimestampTz() throws Exception {
     try (Connection connection = getConnection()) {
       Statement statement = connection.createStatement();
       statement.executeQuery("create or replace table ts_test(ts timestamp_tz)");
@@ -544,10 +545,12 @@ public class ResultSetLatestIT extends ResultSet0IT {
       // Assert that TIMESTAMP_TZ column returns Timestamp class name
       assertEquals(resultSetMetaData.getColumnClassName(1), Timestamp.class.getName());
 
-      connection
-          .unwrap(SnowflakeConnectionV1.class)
-          .getSFBaseSession()
-          .setEnableReturnTimestampWithTimeZoneForTesting(false);
+      SFBaseSession baseSession = connection.unwrap(SnowflakeConnectionV1.class).getSFBaseSession();
+      Method method =
+          SFBaseSession.class.getDeclaredMethod(
+              "setEnableReturnTimestampWithTimeZoneForTesting", boolean.class);
+      method.setAccessible(true);
+      method.invoke(baseSession, false);
 
       statement = connection.createStatement();
       resultSet = statement.executeQuery("select * from ts_test");

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -543,6 +543,17 @@ public class ResultSetLatestIT extends ResultSet0IT {
       assertEquals(resultSetMetaData.getColumnType(1), 2014);
       // Assert that TIMESTAMP_TZ column returns Timestamp class name
       assertEquals(resultSetMetaData.getColumnClassName(1), Timestamp.class.getName());
+
+      connection
+          .unwrap(SnowflakeConnectionV1.class)
+          .getSFBaseSession()
+          .setEnableReturnTimestampWithTimeZoneForTesting(false);
+
+      resultSet = statement.executeQuery("select * from ts_test");
+      resultSet.next();
+      // Assert that TIMESTAMP_TZ type matches java.sql.TIMESTAMP when
+      // enableReturnTimestampWithTimeZone is false.
+      assertEquals(resultSet.getObject("DATA_TYPE"), Types.TIMESTAMP);
     }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -549,11 +549,12 @@ public class ResultSetLatestIT extends ResultSet0IT {
           .getSFBaseSession()
           .setEnableReturnTimestampWithTimeZoneForTesting(false);
 
+      statement = connection.createStatement();
       resultSet = statement.executeQuery("select * from ts_test");
-      resultSet.next();
+      resultSetMetaData = resultSet.getMetaData();
       // Assert that TIMESTAMP_TZ type matches java.sql.TIMESTAMP when
       // enableReturnTimestampWithTimeZone is false.
-      assertEquals(resultSet.getObject("DATA_TYPE"), Types.TIMESTAMP);
+      assertEquals(resultSetMetaData.getColumnType(1), Types.TIMESTAMP);
     }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -8,7 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -546,11 +546,9 @@ public class ResultSetLatestIT extends ResultSet0IT {
       assertEquals(resultSetMetaData.getColumnClassName(1), Timestamp.class.getName());
 
       SFBaseSession baseSession = connection.unwrap(SnowflakeConnectionV1.class).getSFBaseSession();
-      Method method =
-          SFBaseSession.class.getDeclaredMethod(
-              "setEnableReturnTimestampWithTimeZoneForTesting", boolean.class);
-      method.setAccessible(true);
-      method.invoke(baseSession, false);
+      Field field = SFBaseSession.class.getDeclaredField("enableReturnTimestampWithTimeZone");
+      field.setAccessible(true);
+      field.set(baseSession, false);
 
       statement = connection.createStatement();
       resultSet = statement.executeQuery("select * from ts_test");


### PR DESCRIPTION
# Overview

SNOW-685100 Add enable timestamp with timezone parameter. This change is a no op for JDBC client, because on client side we never want to disable the timestamp with timezone feature. We only want to disable the timestamp with timezone feature in stored proc JDBC on server side. server side test here: https://github.com/snowflakedb/snowflake/pull/76365 . Client side test should be covered by the tests added in this PR: https://github.com/snowflakedb/snowflake-jdbc/commit/15e0c18984b5820e4c6d85d361b7ac416857e3cb 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

