### PR TITLE
Fix SNOW-683245 and format the file

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -296,7 +296,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
           }
 
           logger.debug("Starting download without presigned URL", false);
-          blob.downloadTo(localFile.toPath());
+          blob.downloadTo(
+              localFile.toPath(), Blob.BlobSourceOption.shouldReturnRawInputStream(true));
           logger.debug("Download successful", false);
 
           // Get the user-defined BLOB metadata

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -857,7 +857,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
    * @throws Throwable
    */
   @Test
-  @Ignore
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPutGetGcsDownscopedCredential() throws Throwable {
     Connection connection = null;
     Statement statement = null;


### PR DESCRIPTION
# Overview

SNOW-683245: Bug fix in JDBC for GET command when GCS_USE_DOWNSCOPED_CREDENTIAL in GS is true

When code was added not to use presigned url and use GCS API to download the file, it was using GCS GUNZIP stuff. In pre-signed URL logic the driver download the file as is i.e. in GZIP format. So added same logic when use the GCS API to get file without decompression i.e. in RAW format of the file.  This optimize the data transfer on the wire.

Sent the new JDBC Jar to Timothy as he has setup already. He confirm the change works fine.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

