### PR TITLE
Set ALLOW_UNDERSCORES_IN_HOST to false by default

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -130,21 +130,23 @@ public class SnowflakeConnectString implements Serializable {
         // if it's a global url
         parameters.put("ACCOUNT", account);
       }
-
-      if (account.contains("_")
-          && parameters.containsKey(
-              SFSessionProperty.ALLOW_UNDERSCORES_IN_HOST.getPropertyKey().toUpperCase())
-          && "false"
-              .equalsIgnoreCase(
-                  (String)
-                      parameters.get(
-                          SFSessionProperty.ALLOW_UNDERSCORES_IN_HOST
-                              .getPropertyKey()
-                              .toUpperCase()))
-          && host.startsWith(account)) {
+      // By default, don't allow underscores in host name unless the property is set to true via
+      // connection properties.
+      boolean allowUnderscoresInHost = false;
+      if ("true"
+          .equalsIgnoreCase(
+              (String)
+                  parameters.get(
+                      SFSessionProperty.ALLOW_UNDERSCORES_IN_HOST
+                          .getPropertyKey()
+                          .toUpperCase()))) {
+        allowUnderscoresInHost = true;
+      }
+      if (account.contains("_") && !allowUnderscoresInHost && host.startsWith(account)) {
         // The account needs to have underscores in it and the host URL needs to start
         // with the account name. There are cases where the host URL might not have the
         // the account name in it, ex - ip address instead of host name.
+        // The property allowUnderscoresInHost needs to be set to false.
         // Update the Host URL to remove underscores if there are any
         String account_wo_uscores = account.replaceAll("_", "-");
         host = host.replaceFirst(account, account_wo_uscores);

--- a/src/test/java/net/snowflake/client/jdbc/ConnectStringParseTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectStringParseTest.java
@@ -18,13 +18,13 @@ public class ConnectStringParseTest {
         cstring.getParameters().get(SFSessionProperty.ACCOUNT.getPropertyKey().toUpperCase()),
         is("abc"));
 
-    // Hostname should remain unchanged by default.
+    // Hostname should be updated by default.
     jdbcConnectString = "jdbc:snowflake://abc_test.us-east-1.snowflakecomputing.com";
     cstring = SnowflakeConnectString.parse(jdbcConnectString, info);
     assertThat(
         cstring.getParameters().get(SFSessionProperty.ACCOUNT.getPropertyKey().toUpperCase()),
         is("abc_test"));
-    assertThat(cstring.getHost(), is("abc_test.us-east-1.snowflakecomputing.com"));
+    assertThat(cstring.getHost(), is("abc-test.us-east-1.snowflakecomputing.com"));
 
     jdbcConnectString = "jdbc:snowflake://abc-test.us-east-1.snowflakecomputing.com";
     cstring = SnowflakeConnectString.parse(jdbcConnectString, info);


### PR DESCRIPTION
# Overview

JDBC Driver HTTP library does not allow URLs with underscores in them. This creates a problem for customers that have account names that have underscores in them. In order to resolve this problem we added ALLOW_UNDERSCORES_IN_HOST parameter that was suppose to trigger the change of all underscores to hyphens and all the hyphenated URLs were supported by Snowflake.

Only there is a bug in the driver that the parameter is not set by default leading to the conversion not happening till the said parameter is added to the connection properties. The expected behavior is that this conversion should happen by default.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

