### PR TITLE
Relocate bouncycastle files under META-INF/versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <jna.version>5.5.0</jna.version>
     <mockito.version>3.5.6</mockito.version>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>
+    <relocationBase>net/snowflake/client/jdbc/internal</relocationBase>
     <testCategory>net.snowflake.client.category.AllTestCategory</testCategory>
   </properties>
 
@@ -911,6 +912,37 @@
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                     </transformer>
                   </transformers>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <!-- relocate the META-INF/versions files manually due to the maven bug -->
+            <!-- https://issues.apache.org/jira/browse/MSHADE-406 -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>repack</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <unzip src="${project.build.directory}/${project.build.finalName}.jar" dest="${project.build.directory}/relocate" />
+                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}" />
+                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}" />
+                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/15/${relocationBase}" />
+                    <move file="${project.build.directory}/relocate/META-INF/versions/9/org" todir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}" />
+                    <move file="${project.build.directory}/relocate/META-INF/versions/11/org" todir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}" />
+                    <move file="${project.build.directory}/relocate/META-INF/versions/15/org" todir="${project.build.directory}/relocate/META-INF/versions/15/${relocationBase}" />
+                    <zip basedir="${project.build.directory}/relocate" destfile="${project.build.directory}/${project.build.finalName}.jar" />
+                    <delete dir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}" />
+                    <delete dir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}" />
+                    <delete dir="${project.build.directory}/relocate/META-INF/versions/15/${relocationBase}" />
+                  </target>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
# Overview

Simba ticket 00410526.
Fixes #1193. Bouncy castle was upgrade to 1.70 which has become a multi-release JAR (#914). The files under META-INF/versions are shaded but they were not relocated due to the maven bug: https://issues.apache.org/jira/browse/MSHADE-406
This PR manually relocates the shaded bouncycastle files under "META-INF/versions" to "META-INF/versions/<version_number>/net/snowflake/client/jdbc/internal"

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1193.

This is causing problems for applications which have a dependency on both the Snowflake JDBC driver and a direct dependency on Bouncy Castle, as now those applications are including two copies of Bouncy Castle.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR manually relocates the shaded bouncycastle files under "META-INF/versions" to "META-INF/versions/<version_number>/net/snowflake/client/jdbc/internal"

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

