### PR TITLE
Remove maven-failsafe-plugin, exec-maven-plugin, plexus-archiver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,6 @@
       <version>9.21</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-failsafe-plugin</artifactId>
-      <version>3.0.0-M1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
@@ -214,18 +208,6 @@
       <version>1.10.0</version>
       <type>jar</type>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>exec-maven-plugin</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-archiver</artifactId>
-      <version>4.3.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1213


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency
   - [X] I am modifying an existing dependency

3. Please describe how your code solves the related issue.
- Remove exec-maven-plugin dependency for hygiene/security. In as both a dependency and plugin, and vulnerable to [CVE-2017-1000487](https://github.com/advisories/GHSA-8vhq-qq4p-grq3).
- Remove maven-failsafe-plugin dependency for hygiene. In as both a dependency and plugin.
- Remove plexus-archiver dependency for hygiene. Not needed on its own.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

