### PR TITLE
Support resultset columns in getProcedureColumns() and getFunctionColumns()

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1188,11 +1188,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           nextRow[3] = paramNames[i]; // column/parameter name
           // column type
           if (i == 0) {
-            if (paramTypes[i].substring(0, 5).equalsIgnoreCase("table")) {
-              nextRow[4] = procedureColumnOut;
-            } else {
-              nextRow[4] = procedureColumnReturn;
-            }
+            nextRow[4] = procedureColumnReturn;
           } else {
             nextRow[4] = procedureColumnIn; // kind of column/parameter
           }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -107,6 +107,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
 
   private boolean stringsQuoted = false;
 
+  // The number of columns for the result set returned from the current procedure. A value of -1
+  // means the procedure doesn't return a result set
+  private int procedureResultsetColumnNum;
+
   SnowflakeDatabaseMetaData(Connection connection) throws SQLException {
     logger.debug("public SnowflakeDatabaseMetaData(SnowflakeConnection connection)", false);
 
@@ -116,6 +120,7 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     this.metadataRequestUseSessionDatabase = session.getMetadataRequestUseSessionDatabase();
     this.stringsQuoted = session.isStringQuoted();
     this.ibInstance = session.getTelemetryClient();
+    this.procedureResultsetColumnNum = -1;
   }
 
   private void raiseSQLExceptionIfConnectionIsClosed() throws SQLException {
@@ -1161,22 +1166,24 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           executeAndReturnEmptyResultIfNotFound(
               statement, showProcedureColCommand, GET_PROCEDURE_COLUMNS);
       resultSetStepTwo.next();
-      String[] params = parseParams(resultSetStepTwo.getString("value"));
+      // Retrieve the procedure arguments and procedure return values.
+      String args = resultSetStepTwo.getString("value");
       resultSetStepTwo.next();
       String res = resultSetStepTwo.getString("value");
-      String paramNames[] = new String[params.length / 2 + 1];
-      String paramTypes[] = new String[params.length / 2 + 1];
-      if (params.length > 1) {
-        for (int i = 0; i < params.length; i++) {
+      // parse procedure arguments and return values into a list of columns
+      // result value(s) will be at the top of the list, followed by any arguments
+      List<String> procedureCols = parseColumns(res, args);
+      String paramNames[] = new String[procedureCols.size() / 2];
+      String paramTypes[] = new String[procedureCols.size() / 2];
+      if (procedureCols.size() > 1) {
+        for (int i = 0; i < procedureCols.size(); i++) {
           if (i % 2 == 0) {
-            paramNames[i / 2 + 1] = params[i];
+            paramNames[i / 2] = procedureCols.get(i);
           } else {
-            paramTypes[i / 2 + 1] = params[i];
+            paramTypes[i / 2] = procedureCols.get(i);
           }
         }
       }
-      paramNames[0] = "";
-      paramTypes[0] = res;
       for (int i = 0; i < paramNames.length; i++) {
         // if it's the 1st in for loop, it's the result
         if (i == 0 || paramNames[i].equalsIgnoreCase(columnNamePattern) || addAllRows) {
@@ -1187,8 +1194,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           nextRow[2] = procedureNameNoArgs; // procedure name
           nextRow[3] = paramNames[i]; // column/parameter name
           // column type
-          if (i == 0) {
+          if (i == 0 && procedureResultsetColumnNum < 0) {
             nextRow[4] = procedureColumnReturn;
+          } else if (procedureResultsetColumnNum >= 0 && i < procedureResultsetColumnNum) {
+            nextRow[4] = procedureColumnResult;
           } else {
             nextRow[4] = procedureColumnIn; // kind of column/parameter
           }
@@ -1197,6 +1206,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           // don't include nullability in type name, such as NUMBER NOT NULL. Just include NUMBER.
           if (typeName.contains(" NOT NULL")) {
             typeNameTrimmed = typeName.substring(0, typeName.indexOf(' '));
+          }
+          // don't include column size in type name
+          if (typeNameTrimmed.contains("(") && typeNameTrimmed.contains(")")) {
+            typeNameTrimmed = typeNameTrimmed.substring(0, typeNameTrimmed.indexOf('('));
           }
           int type = convertStringToType(typeName);
           nextRow[5] = type; // data type
@@ -1266,7 +1279,18 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           } else {
             nextRow[16] = null;
           }
-          nextRow[17] = i; // ordinal position.
+          // the ordinal position is 0 for a return value.
+          // for result set columns, the ordinal position is of the column in the result set
+          // starting at 1
+          if (procedureResultsetColumnNum >= 0) {
+            if (i < procedureResultsetColumnNum) {
+              nextRow[17] = i + 1;
+            } else {
+              nextRow[17] = i - procedureResultsetColumnNum + 1;
+            }
+          } else {
+            nextRow[17] = i; // ordinal position.
+          }
           nextRow[19] = procedureNameUnparsed; // specific name
           rows.add(nextRow);
         }
@@ -3143,14 +3167,36 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
   }
 
   /**
-   * This is a function that takes in a string containing a function name, its parameter names, and
-   * its parameter types, and splits the string into a list of parameter names and types. The names
-   * will be every odd index and the types will be every even index.
+   * This is a function that takes in a string of return types and a string of parameter names and
+   * types. It splits both strings in a list of column names and column types. The names will be
+   * every odd index and the types will be every even index.
    */
-  private String[] parseParams(String args) {
-    String chopped = args.substring(args.indexOf('(') + 1, args.lastIndexOf(')'));
-    String[] params = chopped.split("\\s+|, ");
-    return params;
+  private List<String> parseColumns(String retType, String args) {
+    List<String> columns = new ArrayList<>();
+    if (retType.substring(0, 5).equalsIgnoreCase("table")) {
+      // if return type is a table there will be a result set
+      String typeStr = retType.substring(retType.indexOf('(') + 1, retType.lastIndexOf(')'));
+      String[] types = typeStr.split("\\s+|, ");
+      if (types.length != 1) {
+        for (int i = 0; i < types.length; i++) {
+          columns.add(types[i]);
+        }
+        procedureResultsetColumnNum = columns.size() / 2;
+      }
+    } else {
+      // otherwise it will be a return value
+      columns.add(""); // there is no name for this column
+      columns.add(retType);
+      procedureResultsetColumnNum = -1;
+    }
+    String argStr = args.substring(args.indexOf('(') + 1, args.lastIndexOf(')'));
+    String arguments[] = argStr.split("\\s+|, ");
+    if (arguments.length != 1) {
+      for (int i = 0; i < arguments.length; i++) {
+        columns.add(arguments[i]);
+      }
+    }
+    return columns;
   }
 
   @Override
@@ -3202,22 +3248,24 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
       if (resultSetStepTwo.next() == false) {
         continue;
       }
-      String[] params = parseParams(resultSetStepTwo.getString("value"));
+      // Retrieve the function arguments and function return values.
+      String args = resultSetStepTwo.getString("value");
       resultSetStepTwo.next();
       String res = resultSetStepTwo.getString("value");
-      String paramNames[] = new String[params.length / 2 + 1];
-      String paramTypes[] = new String[params.length / 2 + 1];
-      if (params.length > 1) {
-        for (int i = 0; i < params.length; i++) {
+      // parse function arguments and return values into a list of columns
+      // result value(s) will be at the top of the list, followed by any arguments
+      List<String> functionCols = parseColumns(res, args);
+      String paramNames[] = new String[functionCols.size() / 2];
+      String paramTypes[] = new String[functionCols.size() / 2];
+      if (functionCols.size() > 1) {
+        for (int i = 0; i < functionCols.size(); i++) {
           if (i % 2 == 0) {
-            paramNames[i / 2 + 1] = params[i];
+            paramNames[i / 2] = functionCols.get(i);
           } else {
-            paramTypes[i / 2 + 1] = params[i];
+            paramTypes[i / 2] = functionCols.get(i);
           }
         }
       }
-      paramNames[0] = "";
-      paramTypes[0] = res;
       for (int i = 0; i < paramNames.length; i++) {
         // if it's the 1st in for loop, it's the result
         if (i == 0 || paramNames[i].equalsIgnoreCase(columnNamePattern) || addAllRows) {
@@ -3227,12 +3275,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           nextRow[1] = schemaPattern; // function schema. Can be null.
           nextRow[2] = functionNameNoArgs; // function name
           nextRow[3] = paramNames[i]; // column/parameter name
-          if (i == 0) {
-            if (paramTypes[i].substring(0, 5).equalsIgnoreCase("table")) {
-              nextRow[4] = functionColumnOut;
-            } else {
-              nextRow[4] = functionReturn;
-            }
+          if (i == 0 && procedureResultsetColumnNum < 0) {
+            nextRow[4] = functionReturn;
+          } else if (procedureResultsetColumnNum >= 0 && i < procedureResultsetColumnNum) {
+            nextRow[4] = functionColumnResult;
           } else {
             nextRow[4] = functionColumnIn; // kind of column/parameter
           }
@@ -3286,7 +3332,18 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
           } else {
             nextRow[13] = null;
           }
-          nextRow[14] = i; // ordinal position.
+          // the ordinal position is 0 for a return value.
+          // for result set columns, the ordinal position is of the column in the result set
+          // starting at 1
+          if (procedureResultsetColumnNum >= 0) {
+            if (i < procedureResultsetColumnNum) {
+              nextRow[14] = i + 1;
+            } else {
+              nextRow[14] = i - procedureResultsetColumnNum + 1;
+            }
+          } else {
+            nextRow[14] = i; // ordinal position.
+          }
           nextRow[15] = ""; // nullability again. Not supported.
           nextRow[16] = functionNameUnparsed;
           rows.add(nextRow);

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalIT.java
@@ -583,4 +583,117 @@ public class DatabaseMetaDataInternalIT extends BaseJDBCTest {
     }
     return objectCount;
   }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testGetFunctionColumns() throws SQLException {
+    Connection connection = getConnection();
+    Statement statement = connection.createStatement();
+    statement.execute(
+        "create or replace function JDBC_DB1.JDBC_SCHEMA11.FUNC111 "
+            + "(a number, b number) RETURNS NUMBER COMMENT='multiply numbers' as 'a*b'");
+    statement.execute(
+        "create or replace table JDBC_DB1.JDBC_SCHEMA11.BIN_TABLE(bin1 binary, bin2 binary(100), "
+            + "sharedCol decimal)");
+    // statement.execute("create or replace table JDBC_TBL111(colA string, colB decimal, colC
+    // timestamp)");
+    statement.execute(
+        "create or replace function JDBC_DB1.JDBC_SCHEMA11.FUNC112 "
+            + "() RETURNS TABLE(colA string, colB decimal, bin2 binary, sharedCol decimal) COMMENT= 'returns "
+            + "table of 4 columns'"
+            + " as 'select JDBC_DB1.JDBC_SCHEMA11.JDBC_TBL111.colA, JDBC_DB1.JDBC_SCHEMA11.JDBC_TBL111.colB, "
+            + "JDBC_DB1.JDBC_SCHEMA11.BIN_TABLE.bin2, JDBC_DB1.JDBC_SCHEMA11.BIN_TABLE.sharedCol from JDBC_DB1"
+            + ".JDBC_SCHEMA11.JDBC_TBL111 inner join JDBC_DB1.JDBC_SCHEMA11.BIN_TABLE on JDBC_DB1.JDBC_SCHEMA11"
+            + ".JDBC_TBL111.colB = JDBC_DB1.JDBC_SCHEMA11.BIN_TABLE.sharedCol'");
+    DatabaseMetaData databaseMetaData = connection.getMetaData();
+    // test each column return the right value
+    ResultSet resultSet =
+        databaseMetaData.getFunctionColumns("JDBC_DB1", "JDBC_SCHEMA11", "FUNC111", "%");
+    resultSet.next();
+    assertEquals("JDBC_DB1", resultSet.getString("FUNCTION_CAT"));
+    assertEquals("JDBC_SCHEMA11", resultSet.getString("FUNCTION_SCHEM"));
+    assertEquals("FUNC111", resultSet.getString("FUNCTION_NAME"));
+    assertEquals("", resultSet.getString("COLUMN_NAME"));
+    assertEquals(DatabaseMetaData.functionReturn, resultSet.getInt("COLUMN_TYPE"));
+    assertEquals(Types.NUMERIC, resultSet.getInt("DATA_TYPE"));
+    assertEquals("NUMBER(38,0)", resultSet.getString("TYPE_NAME"));
+    assertEquals(38, resultSet.getInt("PRECISION"));
+    assertEquals(0, resultSet.getInt("LENGTH"));
+    assertEquals(0, resultSet.getShort("SCALE"));
+    assertEquals(10, resultSet.getInt("RADIX"));
+    assertEquals(DatabaseMetaData.functionNullableUnknown, resultSet.getInt("NULLABLE"));
+    assertEquals("multiply numbers", resultSet.getString("REMARKS"));
+    assertEquals(0, resultSet.getInt("CHAR_OCTET_LENGTH"));
+    assertEquals(0, resultSet.getInt("ORDINAL_POSITION"));
+    assertEquals("", resultSet.getString("IS_NULLABLE"));
+    assertEquals("FUNC111(NUMBER, NUMBER) RETURN NUMBER", resultSet.getString("SPECIFIC_NAME"));
+    resultSet.next();
+    assertEquals("JDBC_DB1", resultSet.getString("FUNCTION_CAT"));
+    assertEquals("JDBC_SCHEMA11", resultSet.getString("FUNCTION_SCHEM"));
+    assertEquals("FUNC111", resultSet.getString("FUNCTION_NAME"));
+    assertEquals("A", resultSet.getString("COLUMN_NAME"));
+    assertEquals(1, resultSet.getInt("COLUMN_TYPE"));
+    assertEquals(Types.NUMERIC, resultSet.getInt("DATA_TYPE"));
+    assertEquals("NUMBER", resultSet.getString("TYPE_NAME"));
+    assertEquals(38, resultSet.getInt("PRECISION"));
+    assertEquals(0, resultSet.getInt("LENGTH"));
+    assertEquals(0, resultSet.getShort("SCALE"));
+    assertEquals(10, resultSet.getInt("RADIX"));
+    assertEquals(DatabaseMetaData.functionNullableUnknown, resultSet.getInt("NULLABLE"));
+    assertEquals("multiply numbers", resultSet.getString("REMARKS"));
+    assertEquals(0, resultSet.getInt("CHAR_OCTET_LENGTH"));
+    assertEquals(1, resultSet.getInt("ORDINAL_POSITION"));
+    assertEquals("", resultSet.getString("IS_NULLABLE"));
+    assertEquals("FUNC111(NUMBER, NUMBER) RETURN NUMBER", resultSet.getString("SPECIFIC_NAME"));
+    resultSet.next();
+    assertEquals("JDBC_DB1", resultSet.getString("FUNCTION_CAT"));
+    assertEquals("JDBC_SCHEMA11", resultSet.getString("FUNCTION_SCHEM"));
+    assertEquals("FUNC111", resultSet.getString("FUNCTION_NAME"));
+    assertEquals("B", resultSet.getString("COLUMN_NAME"));
+    assertEquals(1, resultSet.getInt("COLUMN_TYPE"));
+    assertEquals(Types.NUMERIC, resultSet.getInt("DATA_TYPE"));
+    assertEquals("NUMBER", resultSet.getString("TYPE_NAME"));
+    assertEquals(38, resultSet.getInt("PRECISION"));
+    assertEquals(0, resultSet.getInt("LENGTH"));
+    assertEquals(0, resultSet.getShort("SCALE"));
+    assertEquals(10, resultSet.getInt("RADIX"));
+    assertEquals(DatabaseMetaData.functionNullableUnknown, resultSet.getInt("NULLABLE"));
+    assertEquals("multiply numbers", resultSet.getString("REMARKS"));
+    assertEquals(0, resultSet.getInt("CHAR_OCTET_LENGTH"));
+    assertEquals(2, resultSet.getInt("ORDINAL_POSITION"));
+    assertEquals("", resultSet.getString("IS_NULLABLE"));
+    assertEquals("FUNC111(NUMBER, NUMBER) RETURN NUMBER", resultSet.getString("SPECIFIC_NAME"));
+    assertFalse(resultSet.next());
+    resultSet = databaseMetaData.getFunctionColumns("JDBC_DB1", "JDBC_SCHEMA11", "FUNC112", "%");
+    resultSet.next();
+    assertEquals("JDBC_DB1", resultSet.getString("FUNCTION_CAT"));
+    assertEquals("JDBC_SCHEMA11", resultSet.getString("FUNCTION_SCHEM"));
+    assertEquals("FUNC112", resultSet.getString("FUNCTION_NAME"));
+    assertEquals("", resultSet.getString("COLUMN_NAME"));
+    assertEquals(DatabaseMetaData.functionColumnOut, resultSet.getInt("COLUMN_TYPE"));
+    assertEquals(Types.OTHER, resultSet.getInt("DATA_TYPE"));
+    assertEquals(
+        "TABLE (COLA VARCHAR, COLB NUMBER, BIN2 BINARY, SHAREDCOL NUMBER)",
+        resultSet.getString("TYPE_NAME"));
+    assertEquals(0, resultSet.getInt("PRECISION"));
+    assertEquals(0, resultSet.getInt("LENGTH"));
+    assertEquals(0, resultSet.getInt("SCALE"));
+    assertEquals(10, resultSet.getInt("RADIX"));
+    assertEquals(DatabaseMetaData.functionNullableUnknown, resultSet.getInt("NULLABLE"));
+    assertEquals("returns table of 4 columns", resultSet.getString("REMARKS"));
+    assertEquals(0, resultSet.getInt("CHAR_OCTET_LENGTH"));
+    assertEquals(0, resultSet.getInt("ORDINAL_POSITION"));
+    assertEquals("", resultSet.getString("IS_NULLABLE"));
+    assertEquals(
+        "FUNC112() RETURN TABLE (COLA VARCHAR, COLB NUMBER, BIN2 BINARY, SHAREDCOL NUMBER)",
+        resultSet.getString("SPECIFIC_NAME"));
+    assertFalse(resultSet.next());
+    resultSet = databaseMetaData.getFunctionColumns(null, "%", "%", "%");
+    // we have 81 columns returned
+    assertEquals(4, getSizeOfResultSet(resultSet));
+    // setting catalog to % will result in 0 columns. % does not apply for catalog, only for other
+    // params
+    resultSet = databaseMetaData.getFunctionColumns("%", "%", "%", "%");
+    assertEquals(0, getSizeOfResultSet(resultSet));
+  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataInternalLatestIT.java
@@ -155,25 +155,82 @@ public class DatabaseMetaDataInternalLatestIT extends BaseJDBCTest {
     assertEquals("JDBC_DB1", resultSet.getString("FUNCTION_CAT"));
     assertEquals("JDBC_SCHEMA11", resultSet.getString("FUNCTION_SCHEM"));
     assertEquals("FUNC112", resultSet.getString("FUNCTION_NAME"));
-    assertEquals("", resultSet.getString("COLUMN_NAME"));
-    assertEquals(DatabaseMetaData.functionColumnOut, resultSet.getInt("COLUMN_TYPE"));
-    assertEquals(Types.OTHER, resultSet.getInt("DATA_TYPE"));
-    assertEquals(
-        "TABLE (COLA VARCHAR, COLB NUMBER, BIN2 BINARY, SHAREDCOL NUMBER)",
-        resultSet.getString("TYPE_NAME"));
+    assertEquals("COLA", resultSet.getString("COLUMN_NAME"));
+    assertEquals(DatabaseMetaData.functionColumnResult, resultSet.getInt("COLUMN_TYPE"));
+    assertEquals(Types.VARCHAR, resultSet.getInt("DATA_TYPE"));
+    assertEquals("VARCHAR", resultSet.getString("TYPE_NAME"));
     assertEquals(0, resultSet.getInt("PRECISION"));
     assertEquals(0, resultSet.getInt("LENGTH"));
     assertEquals(0, resultSet.getInt("SCALE"));
     assertEquals(10, resultSet.getInt("RADIX"));
     assertEquals(DatabaseMetaData.functionNullableUnknown, resultSet.getInt("NULLABLE"));
     assertEquals("returns table of 4 columns", resultSet.getString("REMARKS"));
-    assertEquals(0, resultSet.getInt("CHAR_OCTET_LENGTH"));
-    assertEquals(0, resultSet.getInt("ORDINAL_POSITION"));
+    assertEquals(16777216, resultSet.getInt("CHAR_OCTET_LENGTH"));
+    assertEquals(1, resultSet.getInt("ORDINAL_POSITION"));
     assertEquals("", resultSet.getString("IS_NULLABLE"));
     assertEquals(
         "FUNC112() RETURN TABLE (COLA VARCHAR, COLB NUMBER, BIN2 BINARY, SHAREDCOL NUMBER)",
         resultSet.getString("SPECIFIC_NAME"));
-    assertFalse(resultSet.next());
+    resultSet.next();
+    assertEquals("JDBC_DB1", resultSet.getString("FUNCTION_CAT"));
+    assertEquals("JDBC_SCHEMA11", resultSet.getString("FUNCTION_SCHEM"));
+    assertEquals("FUNC112", resultSet.getString("FUNCTION_NAME"));
+    assertEquals("COLB", resultSet.getString("COLUMN_NAME"));
+    assertEquals(DatabaseMetaData.functionColumnResult, resultSet.getInt("COLUMN_TYPE"));
+    assertEquals(Types.NUMERIC, resultSet.getInt("DATA_TYPE"));
+    assertEquals("NUMBER", resultSet.getString("TYPE_NAME"));
+    assertEquals(38, resultSet.getInt("PRECISION"));
+    assertEquals(0, resultSet.getInt("LENGTH"));
+    assertEquals(0, resultSet.getInt("SCALE"));
+    assertEquals(10, resultSet.getInt("RADIX"));
+    assertEquals(DatabaseMetaData.functionNullableUnknown, resultSet.getInt("NULLABLE"));
+    assertEquals("returns table of 4 columns", resultSet.getString("REMARKS"));
+    assertEquals(0, resultSet.getInt("CHAR_OCTET_LENGTH"));
+    assertEquals(2, resultSet.getInt("ORDINAL_POSITION"));
+    assertEquals("", resultSet.getString("IS_NULLABLE"));
+    assertEquals(
+        "FUNC112() RETURN TABLE (COLA VARCHAR, COLB NUMBER, BIN2 BINARY, SHAREDCOL NUMBER)",
+        resultSet.getString("SPECIFIC_NAME"));
+    resultSet.next();
+    assertEquals("JDBC_DB1", resultSet.getString("FUNCTION_CAT"));
+    assertEquals("JDBC_SCHEMA11", resultSet.getString("FUNCTION_SCHEM"));
+    assertEquals("FUNC112", resultSet.getString("FUNCTION_NAME"));
+    assertEquals("BIN2", resultSet.getString("COLUMN_NAME"));
+    assertEquals(DatabaseMetaData.functionColumnResult, resultSet.getInt("COLUMN_TYPE"));
+    assertEquals(Types.BINARY, resultSet.getInt("DATA_TYPE"));
+    assertEquals("BINARY", resultSet.getString("TYPE_NAME"));
+    assertEquals(38, resultSet.getInt("PRECISION"));
+    assertEquals(0, resultSet.getInt("LENGTH"));
+    assertEquals(0, resultSet.getInt("SCALE"));
+    assertEquals(10, resultSet.getInt("RADIX"));
+    assertEquals(DatabaseMetaData.functionNullableUnknown, resultSet.getInt("NULLABLE"));
+    assertEquals("returns table of 4 columns", resultSet.getString("REMARKS"));
+    assertEquals(8388608, resultSet.getInt("CHAR_OCTET_LENGTH"));
+    assertEquals(3, resultSet.getInt("ORDINAL_POSITION"));
+    assertEquals("", resultSet.getString("IS_NULLABLE"));
+    assertEquals(
+        "FUNC112() RETURN TABLE (COLA VARCHAR, COLB NUMBER, BIN2 BINARY, SHAREDCOL NUMBER)",
+        resultSet.getString("SPECIFIC_NAME"));
+    resultSet.next();
+    assertEquals("JDBC_DB1", resultSet.getString("FUNCTION_CAT"));
+    assertEquals("JDBC_SCHEMA11", resultSet.getString("FUNCTION_SCHEM"));
+    assertEquals("FUNC112", resultSet.getString("FUNCTION_NAME"));
+    assertEquals("SHAREDCOL", resultSet.getString("COLUMN_NAME"));
+    assertEquals(DatabaseMetaData.functionColumnResult, resultSet.getInt("COLUMN_TYPE"));
+    assertEquals(Types.NUMERIC, resultSet.getInt("DATA_TYPE"));
+    assertEquals("NUMBER", resultSet.getString("TYPE_NAME"));
+    assertEquals(38, resultSet.getInt("PRECISION"));
+    assertEquals(0, resultSet.getInt("LENGTH"));
+    assertEquals(0, resultSet.getInt("SCALE"));
+    assertEquals(10, resultSet.getInt("RADIX"));
+    assertEquals(DatabaseMetaData.functionNullableUnknown, resultSet.getInt("NULLABLE"));
+    assertEquals("returns table of 4 columns", resultSet.getString("REMARKS"));
+    assertEquals(0, resultSet.getInt("CHAR_OCTET_LENGTH"));
+    assertEquals(4, resultSet.getInt("ORDINAL_POSITION"));
+    assertEquals("", resultSet.getString("IS_NULLABLE"));
+    assertEquals(
+        "FUNC112() RETURN TABLE (COLA VARCHAR, COLB NUMBER, BIN2 BINARY, SHAREDCOL NUMBER)",
+        resultSet.getString("SPECIFIC_NAME"));
     resultSet = databaseMetaData.getFunctionColumns(null, "%", "%", "%");
     // we have 81 columns returned
     assertEquals(4, getSizeOfResultSet(resultSet));

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -40,6 +40,26 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
           + "    $$\n"
           + "    ;";
 
+  private static final String PI_PROCEDURE =
+      "create or replace procedure GETPI()\n"
+          + "    returns float not null\n"
+          + "    language javascript\n"
+          + "    as\n"
+          + "    $$\n"
+          + "    return 3.1415926;\n"
+          + "    $$\n"
+          + "    ;";
+
+  private static final String MESSAGE_PROCEDURE =
+      "create or replace procedure MESSAGE_PROC(message varchar)\n"
+          + "    returns varchar not null\n"
+          + "    language javascript\n"
+          + "    as\n"
+          + "    $$\n"
+          + "    return message;\n"
+          + "    $$\n"
+          + "    ;";
+
   /** Create catalog and schema for tests with double quotes */
   public void createDoubleQuotedSchemaAndCatalog(Statement statement) throws SQLException {
     statement.execute("create or replace database \"dbwith\"\"quotes\"");
@@ -1356,12 +1376,13 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
   }
 
   @Test
-  public void testGetProceduresColumnsWithReturnTypeTable() throws SQLException {
+  public void testGetProcedureColumnsReturnsResultSet() throws SQLException {
     try (Connection con = getConnection()) {
       Statement statement = con.createStatement();
-      statement.execute("create table testtable (id int, name varchar(20), address varchar(20));");
       statement.execute(
-          "create or replace procedure proctest ()\n"
+          "create or replace table testtable (id int, name varchar(20), address varchar(20));");
+      statement.execute(
+          "create or replace procedure PROCTEST()\n"
               + "returns table (\"id\" number(38,0), \"name\" varchar(20), \"address\" varchar(20))\n"
               + "language sql\n"
               + "execute as owner\n"
@@ -1370,13 +1391,106 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
               + "  begin\n"
               + "    return table(res);\n"
               + "  end';");
-
       DatabaseMetaData metaData = con.getMetaData();
       ResultSet res = metaData.getProcedureColumns(con.getCatalog(), null, "PROCTEST", "%");
       res.next();
-      assertEquals("5", res.getString("COLUMN_TYPE"));
+      assertEquals("PROCTEST", res.getString("PROCEDURE_NAME"));
+      assertEquals("id", res.getString("COLUMN_NAME"));
+      assertEquals(
+          DatabaseMetaData.procedureColumnResult,
+          res.getInt("COLUMN_TYPE")); // procedureColumnResult
+      assertEquals(Types.NUMERIC, res.getInt("DATA_TYPE"));
+      assertEquals("NUMBER", res.getString("TYPE_NAME"));
+      assertEquals(1, res.getInt("ORDINAL_POSITION")); // result set column 1
+      res.next();
+      assertEquals("name", res.getString("COLUMN_NAME"));
+      assertEquals(DatabaseMetaData.procedureColumnResult, res.getInt("COLUMN_TYPE"));
+      assertEquals(Types.VARCHAR, res.getInt("DATA_TYPE"));
+      assertEquals("VARCHAR", res.getString("TYPE_NAME"));
+      assertEquals(2, res.getInt("ORDINAL_POSITION")); // result set column 2
+      res.next();
+      assertEquals("address", res.getString("COLUMN_NAME"));
+      assertEquals(DatabaseMetaData.procedureColumnResult, res.getInt("COLUMN_TYPE"));
+      assertEquals(Types.VARCHAR, res.getInt("DATA_TYPE"));
+      assertEquals("VARCHAR", res.getString("TYPE_NAME"));
+      assertEquals(3, res.getInt("ORDINAL_POSITION")); // result set column 3
+
+      res.close();
+      statement.execute("drop table if exists testtable");
+      statement.close();
+    }
+  }
+
+  @Test
+  public void testGetProcedureColumnsReturnsValue() throws SQLException {
+    try (Connection con = getConnection()) {
+      Statement statement = con.createStatement();
+      DatabaseMetaData metaData = con.getMetaData();
+      // create a procedure with no parameters that has a return value
+      statement.execute(PI_PROCEDURE);
+      ResultSet res = metaData.getProcedureColumns(con.getCatalog(), null, "GETPI", "%");
+      res.next();
+      assertEquals("GETPI", res.getString("PROCEDURE_NAME"));
+      assertEquals("", res.getString("COLUMN_NAME"));
+      assertEquals(5, res.getInt("COLUMN_TYPE")); // procedureColumnReturn
+      assertEquals(Types.FLOAT, res.getInt("DATA_TYPE"));
+      assertEquals("FLOAT", res.getString("TYPE_NAME"));
+      assertEquals(0, res.getInt("ORDINAL_POSITION"));
+
+      // create a procedure that returns the value of the argument that is passed in
+      statement.execute(MESSAGE_PROCEDURE);
+      res = metaData.getProcedureColumns(con.getCatalog(), null, "MESSAGE_PROC", "%");
+      res.next();
+      assertEquals("MESSAGE_PROC", res.getString("PROCEDURE_NAME"));
+      assertEquals("", res.getString("COLUMN_NAME"));
+      assertEquals(
+          DatabaseMetaData.procedureColumnReturn,
+          res.getInt("COLUMN_TYPE")); // procedureColumnReturn
+      assertEquals(Types.VARCHAR, res.getInt("DATA_TYPE"));
+      assertEquals("VARCHAR", res.getString("TYPE_NAME"));
+      assertEquals(0, res.getInt("ORDINAL_POSITION"));
+      res.next();
+      assertEquals("MESSAGE", res.getString("COLUMN_NAME"));
+      assertEquals(
+          DatabaseMetaData.procedureColumnIn, res.getInt("COLUMN_TYPE")); // procedureColumnIn
+      assertEquals(Types.VARCHAR, res.getInt("DATA_TYPE"));
+      assertEquals("VARCHAR", res.getString("TYPE_NAME"));
+      assertEquals(1, res.getInt("ORDINAL_POSITION"));
+
       res.close();
       statement.close();
+    }
+  }
+
+  @Test
+  public void testGetProcedureColumnsReturnsNull() throws SQLException {
+    try (Connection con = getConnection()) {
+      Statement statement = con.createStatement();
+      DatabaseMetaData metaData = con.getMetaData();
+      // The CREATE PROCEDURE statement must include a RETURNS clause that defines a return type,
+      // even
+      // if the procedure does not explicitly return anything.
+      statement.execute(
+          "create or replace table testtable (id int, name varchar(20), address varchar(20));");
+      statement.execute(
+          "create or replace procedure insertproc() \n"
+              + "returns varchar \n"
+              + "language javascript as \n"
+              + "'var sqlcommand = \n"
+              + "`insert into testtable (id, name, address) values (1, \\'Tom\\', \\'Pacific Avenue\\');` \n"
+              + "snowflake.execute({sqlText: sqlcommand}); \n"
+              + "';");
+      ResultSet res = metaData.getProcedureColumns(con.getCatalog(), null, "INSERTPROC", "%");
+      res.next();
+      // the procedure will return null as the value but column type will be varchar.
+      assertEquals("INSERTPROC", res.getString("PROCEDURE_NAME"));
+      assertEquals("", res.getString("COLUMN_NAME"));
+      assertEquals(
+          DatabaseMetaData.procedureColumnReturn,
+          res.getInt("COLUMN_TYPE")); // procedureColumnReturn
+      assertEquals(Types.VARCHAR, res.getInt("DATA_TYPE"));
+      assertEquals("VARCHAR", res.getString("TYPE_NAME"));
+      assertEquals(0, res.getInt("ORDINAL_POSITION"));
     }
   }
 }


### PR DESCRIPTION
# Overview
(https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/110)

getProcedureColumns() and getFunctionColumns() are returning procedureColumnOut/functionColumnOut for column_type when the stored procedure or function returns a resultset.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/110


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Add support for stored procedures and functions that return a result set. Return procedureColumnResult for resultset columns in procedures and functionColumnResult for resultset columns in functions. Iterate through the result set and return each column and its metadata. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

