### PR TITLE
[SNOW-540328] Excessive logging by StreamLoader

### DIFF
--- a/src/main/java/net/snowflake/client/loader/StreamLoader.java
+++ b/src/main/java/net/snowflake/client/loader/StreamLoader.java
@@ -706,7 +706,6 @@ public class StreamLoader implements Loader, Runnable {
   // If operation changes, existing stage needs to be scheduled for processing.
   @Override
   public void resetOperation(Operation op) {
-    LOGGER.debug("Reset Loader", false);
 
     if (op.equals(_op)) {
       // no-op


### PR DESCRIPTION
After enabling debugging for the JDBC driver to look into a problem, I noticed the following message being logged a lot, making it very difficult to go through the logs:

2022-02-01 14:17:03.931 n.s.c.loader.StreamLoader FINE resetOperation:709 - Reset Loader

This was logged 15,894,396 times in comparison to the following log message which was only logged 8 times:

2022-02-01 10:55:43.107 n.s.c.loader.StreamLoader FINE resetOperation:716 - Operation is changing from INSERT to MODIFY

The latter offers some kind of information, but I believe we can do without the first log message. 

# Overview

SNOW-540328
GitHub Issue #694 