### PR TITLE
SNOW-618683 Add previous status code as parameter "retry", update tests

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -350,7 +350,7 @@ public class RestRequest {
 
         retryCount++;
         lastStatusCodeForRetry =
-            response == null ? "null" : String.valueOf(response.getStatusLine().getStatusCode());
+            response == null ? "0" : String.valueOf(response.getStatusLine().getStatusCode());
         // If the request failed with any other retry-able error and auth timeout is reached
         // increase the retry count and throw special exception to renew the token before retrying.
         if (authTimeout > 0) {

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -114,6 +114,8 @@ public class RestRequest {
     // label the reason to break retry
     String breakRetryReason = "";
 
+    String lastStatusCodeForRetry = "";
+
     // try request till we get a good response or retry timeout
     while (true) {
       logger.debug("Retry count: {}", retryCount);
@@ -154,6 +156,7 @@ public class RestRequest {
         }
         if (includeRetryParameters && retryCount > 0) {
           builder.setParameter("retryCount", String.valueOf(retryCount));
+          builder.setParameter("retry", lastStatusCodeForRetry);
           builder.setParameter("clientStartTime", String.valueOf(startTime));
         }
 
@@ -346,6 +349,8 @@ public class RestRequest {
         }
 
         retryCount++;
+        lastStatusCodeForRetry =
+            response == null ? "null" : String.valueOf(response.getStatusLine().getStatusCode());
         // If the request failed with any other retry-able error and auth timeout is reached
         // increase the retry count and throw special exception to renew the token before retrying.
         if (authTimeout > 0) {

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -56,7 +56,8 @@ public class RestRequest {
    * @param injectSocketTimeout : simulate socket timeout
    * @param canceling canceling flag
    * @param withoutCookies whether the cookie spec should be set to IGNORE or not
-   * @param includeRetryParameters whether to include retry parameters in retried requests
+   * @param includeRetryParameters whether to include retry parameters in retried requests. Only
+   *     needs to be true for JDBC statement execution (query requests to Snowflake server).
    * @param includeRequestGuid whether to include request_guid parameter
    * @param retryHTTP403 whether to retry on HTTP 403 or not
    * @return HttpResponse Object get from server
@@ -156,7 +157,7 @@ public class RestRequest {
         }
         if (includeRetryParameters && retryCount > 0) {
           builder.setParameter("retryCount", String.valueOf(retryCount));
-          builder.setParameter("retry", lastStatusCodeForRetry);
+          builder.setParameter("retryReason", lastStatusCodeForRetry);
           builder.setParameter("clientStartTime", String.valueOf(startTime));
         }
 

--- a/src/test/java/net/snowflake/client/jdbc/ChunkDownloaderS3RetryUrlLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ChunkDownloaderS3RetryUrlLatestIT.java
@@ -84,7 +84,7 @@ public class ChunkDownloaderS3RetryUrlLatestIT extends AbstractDriverIT {
         new ExecTimeTelemetryData()); // retry HTTP 403
 
     assertFalse(getRequest.containsHeader("retryCount"));
-    assertFalse(getRequest.containsHeader("retry"));
+    assertFalse(getRequest.containsHeader("retryReason"));
     assertFalse(getRequest.containsHeader("clientStartTime"));
     assertFalse(getRequest.containsHeader("request_guid"));
   }

--- a/src/test/java/net/snowflake/client/jdbc/ChunkDownloaderS3RetryUrlLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ChunkDownloaderS3RetryUrlLatestIT.java
@@ -84,6 +84,7 @@ public class ChunkDownloaderS3RetryUrlLatestIT extends AbstractDriverIT {
         new ExecTimeTelemetryData()); // retry HTTP 403
 
     assertFalse(getRequest.containsHeader("retryCount"));
+    assertFalse(getRequest.containsHeader("retry"));
     assertFalse(getRequest.containsHeader("clientStartTime"));
     assertFalse(getRequest.containsHeader("request_guid"));
   }

--- a/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
@@ -100,10 +100,12 @@ public class RestRequestTest {
 
                 if (callCount == 0) {
                   assertFalse(params.contains("retryCount="));
+                  assertFalse(params.contains("retry="));
                   assertFalse(params.contains("clientStartTime="));
                   assertTrue(params.contains("request_guid="));
                 } else {
                   assertTrue(params.contains("retryCount=" + callCount));
+                  assertTrue(params.contains("retry=503"));
                   assertTrue(params.contains("clientStartTime="));
                   assertTrue(params.contains("request_guid="));
                 }
@@ -134,6 +136,7 @@ public class RestRequestTest {
                 String params = arg.getURI().getQuery();
 
                 assertFalse(params.contains("retryCount="));
+                assertFalse(params.contains("retry="));
                 assertFalse(params.contains("clientStartTime="));
                 assertTrue(params.contains("request_guid="));
 

--- a/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -51,6 +52,16 @@ public class RestRequestTest {
     return successResponse;
   }
 
+  private CloseableHttpResponse socketTimeoutResponse() throws SocketTimeoutException {
+    StatusLine successStatusLine = mock(StatusLine.class);
+    when(successStatusLine.getStatusCode()).thenThrow(new SocketTimeoutException("Read timed out"));
+
+    CloseableHttpResponse successResponse = mock(CloseableHttpResponse.class);
+    when(successStatusLine.getStatusCode()).thenThrow(new SocketTimeoutException("Read timed out"));
+
+    return successResponse;
+  }
+
   private void execute(
       CloseableHttpClient client,
       String uri,
@@ -58,7 +69,7 @@ public class RestRequestTest {
       int authTimeout,
       int socketTimeout,
       boolean includeRetryParameters)
-      throws IOException, SnowflakeSQLException {
+      throws SnowflakeSQLException {
 
     RequestConfig.Builder builder =
         RequestConfig.custom()
@@ -100,12 +111,12 @@ public class RestRequestTest {
 
                 if (callCount == 0) {
                   assertFalse(params.contains("retryCount="));
-                  assertFalse(params.contains("retry="));
+                  assertFalse(params.contains("retryReason="));
                   assertFalse(params.contains("clientStartTime="));
                   assertTrue(params.contains("request_guid="));
                 } else {
                   assertTrue(params.contains("retryCount=" + callCount));
-                  assertTrue(params.contains("retry=503"));
+                  assertTrue(params.contains("retryReason=503"));
                   assertTrue(params.contains("clientStartTime="));
                   assertTrue(params.contains("request_guid="));
                 }
@@ -136,7 +147,7 @@ public class RestRequestTest {
                 String params = arg.getURI().getQuery();
 
                 assertFalse(params.contains("retryCount="));
-                assertFalse(params.contains("retry="));
+                assertFalse(params.contains("retryReason="));
                 assertFalse(params.contains("clientStartTime="));
                 assertTrue(params.contains("request_guid="));
 
@@ -315,5 +326,50 @@ public class RestRequestTest {
       assertThat(
           ex.getErrorCode(), equalTo(ErrorCode.AUTHENTICATOR_REQUEST_TIMEOUT.getMessageCode()));
     }
+  }
+
+  /**
+   * Test that after socket timeout, retryReason parameter is set for queries and is set to 0 for
+   * null response.
+   *
+   * @throws SnowflakeSQLException
+   * @throws IOException
+   */
+  @Test
+  public void testRetryParametersWithSocketTimeout() throws SnowflakeSQLException, IOException {
+
+    CloseableHttpClient client = mock(CloseableHttpClient.class);
+    when(client.execute(any(HttpUriRequest.class)))
+        .thenAnswer(
+            new Answer<CloseableHttpResponse>() {
+              int callCount = 0;
+
+              @Override
+              public CloseableHttpResponse answer(InvocationOnMock invocation) throws Throwable {
+                HttpUriRequest arg = (HttpUriRequest) invocation.getArguments()[0];
+                String params = arg.getURI().getQuery();
+
+                if (callCount == 0) {
+                  assertFalse(params.contains("retryCount="));
+                  assertFalse(params.contains("retryReason="));
+                  assertFalse(params.contains("clientStartTime="));
+                  assertTrue(params.contains("request_guid="));
+                } else {
+                  assertTrue(params.contains("retryCount=" + callCount));
+                  assertTrue(params.contains("retryReason=0"));
+                  assertTrue(params.contains("clientStartTime="));
+                  assertTrue(params.contains("request_guid="));
+                }
+
+                callCount += 1;
+                if (callCount >= 2) {
+                  return successResponse();
+                } else {
+                  return socketTimeoutResponse();
+                }
+              }
+            });
+
+    execute(client, "fakeurl.com/?requestId=abcd-1234", 0, 0, 0, true);
   }
 }


### PR DESCRIPTION
# Overview

SNOW-618683

I have read the CLA Document and I hereby sign the CLA

If the driver issues a retry, the query parameter "retry" is now added. "Retry" contains the value of the HTTP status code from the server's previous response. If the response or the status code is null, then the value is set as "0" (as a string value). The parameter "retryCount" is already added.

Note that neither "retry" nor "retryCount" parameters will be included when:
1.) The driver is fetching using a AWS presigned URL because this causes a bug
2.) The driver is issuing a login request. I am not sure if there's any real reason not to include these query parameters for the login request so they could be added back in if needed.

Link to dummy PR (merge to master) so that precommit jobs run: https://github.com/snowflakedb/snowflake-jdbc/pull/1225

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

