### PR TITLE
Handle 'java.io.IOException: No space left on device' instead of retrying

### DIFF
--- a/src/main/java/net/snowflake/client/core/Constants.java
+++ b/src/main/java/net/snowflake/client/core/Constants.java
@@ -22,6 +22,9 @@ public final class Constants {
   // Error code for all invalid id token cases during login request
   public static final int ID_TOKEN_INVALID_LOGIN_REQUEST_GS_CODE = 390195;
 
+  // Error message for IOException when no space is left for GET
+  public static final String NO_SPACE_LEFT_ON_DEVICE_ERR = "No space left on device";
+
   public enum OS {
     WINDOWS,
     LINUX,

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -651,6 +651,17 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
+    // If there is no space left in the download location, java.io.IOException is thrown.
+    // Don't retry.
+    if (SnowflakeUtil.getRootCause(ex).getMessage().equals("No space left on device")) {
+      throw new SnowflakeSQLLoggedException(
+              session,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              ex,
+              "Encountered exception during " + operation + ": " + ex.getMessage());
+    }
+
     if (ex instanceof StorageException) {
       StorageException se = (StorageException) ex;
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -4,6 +4,7 @@
 package net.snowflake.client.jdbc.cloud.storage;
 
 import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
+import static net.snowflake.client.core.Constants.NO_SPACE_LEFT_ON_DEVICE_ERR;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.fasterxml.jackson.core.JsonFactory;
@@ -653,13 +654,14 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
 
     // If there is no space left in the download location, java.io.IOException is thrown.
     // Don't retry.
-    if (SnowflakeUtil.getRootCause(ex).getMessage().equals("No space left on device")) {
+    String exMessage = SnowflakeUtil.getRootCause(ex).getMessage();
+    if (exMessage != null && exMessage.equals(NO_SPACE_LEFT_ON_DEVICE_ERR)) {
       throw new SnowflakeSQLLoggedException(
-              session,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              ex,
-              "Encountered exception during " + operation + ": " + ex.getMessage());
+          session,
+          SqlState.SYSTEM_ERROR,
+          ErrorCode.IO_ERROR.getMessageCode(),
+          ex,
+          "Encountered exception during " + operation + ": " + ex.getMessage());
     }
 
     if (ex instanceof StorageException) {

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -4,6 +4,7 @@
 package net.snowflake.client.jdbc.cloud.storage;
 
 import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
+import static net.snowflake.client.core.Constants.NO_SPACE_LEFT_ON_DEVICE_ERR;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.fasterxml.jackson.core.JsonFactory;
@@ -894,13 +895,14 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
 
     // If there is no space left in the download location, java.io.IOException is thrown.
     // Don't retry.
-    if (SnowflakeUtil.getRootCause(ex).getMessage().equals("No space left on device")) {
+    String exMessage = SnowflakeUtil.getRootCause(ex).getMessage();
+    if (exMessage != null && exMessage.equals(NO_SPACE_LEFT_ON_DEVICE_ERR)) {
       throw new SnowflakeSQLLoggedException(
-              session,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              ex,
-              "Encountered exception during " + operation + ": " + ex.getMessage());
+          session,
+          SqlState.SYSTEM_ERROR,
+          ErrorCode.IO_ERROR.getMessageCode(),
+          ex,
+          "Encountered exception during " + operation + ": " + ex.getMessage());
     }
 
     if (ex instanceof StorageException) {

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -892,6 +892,17 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
+    // If there is no space left in the download location, java.io.IOException is thrown.
+    // Don't retry.
+    if (SnowflakeUtil.getRootCause(ex).getMessage().equals("No space left on device")) {
+      throw new SnowflakeSQLLoggedException(
+              session,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              ex,
+              "Encountered exception during " + operation + ": " + ex.getMessage());
+    }
+
     if (ex instanceof StorageException) {
       // NOTE: this code path only handle Access token based operation,
       // presigned URL is not covered. Presigned Url do not raise

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -4,7 +4,6 @@
 package net.snowflake.client.jdbc.cloud.storage;
 
 import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
-import static net.snowflake.client.core.Constants.NO_SPACE_LEFT_ON_DEVICE_ERR;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.fasterxml.jackson.core.JsonFactory;
@@ -895,14 +894,8 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
 
     // If there is no space left in the download location, java.io.IOException is thrown.
     // Don't retry.
-    String exMessage = SnowflakeUtil.getRootCause(ex).getMessage();
-    if (exMessage != null && exMessage.equals(NO_SPACE_LEFT_ON_DEVICE_ERR)) {
-      throw new SnowflakeSQLLoggedException(
-          session,
-          SqlState.SYSTEM_ERROR,
-          ErrorCode.IO_ERROR.getMessageCode(),
-          ex,
-          "Encountered exception during " + operation + ": " + ex.getMessage());
+    if (SnowflakeUtil.getRootCause(ex) instanceof IOException) {
+      SnowflakeFileTransferAgent.throwNoSpaceLeftError(session, operation, ex);
     }
 
     if (ex instanceof StorageException) {

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -688,6 +688,17 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       SnowflakeFileTransferAgent.throwJCEMissingError(operation, ex);
     }
 
+    // If there is no space left in the download location, java.io.IOException is thrown.
+    // Don't retry.
+    if (SnowflakeUtil.getRootCause(ex).getMessage().equals("No space left on device")) {
+      throw new SnowflakeSQLLoggedException(
+              session,
+              SqlState.SYSTEM_ERROR,
+              ErrorCode.IO_ERROR.getMessageCode(),
+              ex,
+              "Encountered exception during " + operation + ": " + ex.getMessage());
+    }
+
     if (ex instanceof AmazonClientException) {
       if (retryCount > s3Client.getMaxRetries() || s3Client.isClientException404(ex)) {
         String extendedRequestId = "none";

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -5,6 +5,7 @@
 package net.snowflake.client.jdbc.cloud.storage;
 
 import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
+import static net.snowflake.client.core.Constants.NO_SPACE_LEFT_ON_DEVICE_ERR;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.AmazonClientException;
@@ -690,13 +691,14 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
     // If there is no space left in the download location, java.io.IOException is thrown.
     // Don't retry.
-    if (SnowflakeUtil.getRootCause(ex).getMessage().equals("No space left on device")) {
+    String exMessage = SnowflakeUtil.getRootCause(ex).getMessage();
+    if (exMessage != null && exMessage.equals(NO_SPACE_LEFT_ON_DEVICE_ERR)) {
       throw new SnowflakeSQLLoggedException(
-              session,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.IO_ERROR.getMessageCode(),
-              ex,
-              "Encountered exception during " + operation + ": " + ex.getMessage());
+          session,
+          SqlState.SYSTEM_ERROR,
+          ErrorCode.IO_ERROR.getMessageCode(),
+          ex,
+          "Encountered exception during " + operation + ": " + ex.getMessage());
     }
 
     if (ex instanceof AmazonClientException) {

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -5,7 +5,6 @@
 package net.snowflake.client.jdbc.cloud.storage;
 
 import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
-import static net.snowflake.client.core.Constants.NO_SPACE_LEFT_ON_DEVICE_ERR;
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 
 import com.amazonaws.AmazonClientException;
@@ -691,14 +690,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
     // If there is no space left in the download location, java.io.IOException is thrown.
     // Don't retry.
-    String exMessage = SnowflakeUtil.getRootCause(ex).getMessage();
-    if (exMessage != null && exMessage.equals(NO_SPACE_LEFT_ON_DEVICE_ERR)) {
-      throw new SnowflakeSQLLoggedException(
-          session,
-          SqlState.SYSTEM_ERROR,
-          ErrorCode.IO_ERROR.getMessageCode(),
-          ex,
-          "Encountered exception during " + operation + ": " + ex.getMessage());
+    if (SnowflakeUtil.getRootCause(ex) instanceof IOException) {
+      SnowflakeFileTransferAgent.throwNoSpaceLeftError(session, operation, ex);
     }
 
     if (ex instanceof AmazonClientException) {

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeGcsClientHandleExceptionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeGcsClientHandleExceptionLatestIT.java
@@ -1,6 +1,9 @@
 package net.snowflake.client.jdbc;
 
 import com.google.cloud.storage.StorageException;
+
+import java.io.File;
+import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.security.InvalidKeyException;
 import java.sql.Connection;
@@ -14,17 +17,16 @@ import net.snowflake.client.category.TestCategoryOthers;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.cloud.storage.SnowflakeGCSClient;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 /** Test for SnowflakeGcsClient handle exception function, only work with latest driver */
 @Category(TestCategoryOthers.class)
 public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT {
-
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
   private Connection connection;
   private SFStatement sfStatement;
   private SFSession sfSession;
@@ -149,6 +151,16 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
   public void errorWithNullSession() throws SQLException {
     spyingClient.handleStorageException(
         new StorageException(401, "Unauthenticated"), 0, "upload", null, command);
+  }
+
+  @Test(expected = SnowflakeSQLException.class)
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void errorNoSpaceLeftOnDevice() throws SQLException, IOException {
+    File destFolder = tmpFolder.newFolder();
+    String destFolderCanonicalPath = destFolder.getCanonicalPath();
+    String getCommand = "get @testPutGet_stage/" + TEST_DATA_FILE + " 'file://" + destFolderCanonicalPath + "'";
+    spyingClient.handleStorageException(
+            new StorageException(0, "No space left on device", new IOException("No space left on device")), 0, "download", null, getCommand);
   }
 
   @After

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeGcsClientHandleExceptionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeGcsClientHandleExceptionLatestIT.java
@@ -1,7 +1,6 @@
 package net.snowflake.client.jdbc;
 
 import com.google.cloud.storage.StorageException;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -14,6 +13,7 @@ import net.snowflake.client.AbstractDriverIT;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryOthers;
+import net.snowflake.client.core.Constants;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.cloud.storage.SnowflakeGCSClient;
@@ -25,8 +25,7 @@ import org.mockito.Mockito;
 /** Test for SnowflakeGcsClient handle exception function, only work with latest driver */
 @Category(TestCategoryOthers.class)
 public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT {
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
   private Connection connection;
   private SFStatement sfStatement;
   private SFSession sfSession;
@@ -158,9 +157,17 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
   public void errorNoSpaceLeftOnDevice() throws SQLException, IOException {
     File destFolder = tmpFolder.newFolder();
     String destFolderCanonicalPath = destFolder.getCanonicalPath();
-    String getCommand = "get @testPutGet_stage/" + TEST_DATA_FILE + " 'file://" + destFolderCanonicalPath + "'";
+    String getCommand =
+        "get @testPutGet_stage/" + TEST_DATA_FILE + " 'file://" + destFolderCanonicalPath + "'";
     spyingClient.handleStorageException(
-            new StorageException(0, "No space left on device", new IOException("No space left on device")), 0, "download", null, getCommand);
+        new StorageException(
+            maxRetry,
+            Constants.NO_SPACE_LEFT_ON_DEVICE_ERR,
+            new IOException(Constants.NO_SPACE_LEFT_ON_DEVICE_ERR)),
+        0,
+        "download",
+        null,
+        getCommand);
   }
 
   @After


### PR DESCRIPTION
# Overview

SNOW-741463
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/180

When a GET is issued on a file which when downloaded, cannot fit the target filesystem, the driver retries with backoff 25 times causing a delay.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-741463


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Catch and throw the exception instead of retrying when the error is "No space left on device"

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

