### PR TITLE
SNOW-749517: NullPointerException when trying to read a null Clob

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -794,7 +794,9 @@ public abstract class SnowflakeBaseResultSet implements ResultSet {
   @Override
   public Clob getClob(int columnIndex) throws SQLException {
     logger.debug("public Clob getClob(int columnIndex)", false);
-    return new SnowflakeClob(getString(columnIndex));
+    String columnValue = getString(columnIndex);
+
+    return columnValue == null ? null : new SnowflakeClob(columnValue);
   }
 
   @Override
@@ -829,8 +831,9 @@ public abstract class SnowflakeBaseResultSet implements ResultSet {
   @Override
   public Clob getClob(String columnLabel) throws SQLException {
     logger.debug("public Clob getClob(String columnLabel)", false);
+    String columnValue = getString(columnLabel);
 
-    return new SnowflakeClob(getString(columnLabel));
+    return columnValue == null ? null : new SnowflakeClob(columnValue);
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -535,7 +535,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
   @Override
   public void setClob(int parameterIndex, Clob x) throws SQLException {
-    setString(parameterIndex, x.toString());
+    setString(parameterIndex, x == null ? null : x.toString());
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetAsyncIT.java
@@ -179,10 +179,16 @@ public class ResultSetAsyncIT extends BaseJDBCTest {
   public void testWasNull() throws SQLException {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
-    statement.execute("create or replace table test_null(colA number, colB string)");
-    PreparedStatement prepst = connection.prepareStatement("insert into test_null values (?, ?)");
+    Clob emptyClob = connection.createClob();
+    emptyClob.setString(1, "");
+    statement.execute(
+        "create or replace table test_null(colA number, colB string, colNull string, emptyClob string)");
+    PreparedStatement prepst =
+        connection.prepareStatement("insert into test_null values (?, ?, ?, ?)");
     prepst.setNull(1, Types.INTEGER);
     prepst.setString(2, "hello");
+    prepst.setString(3, null);
+    prepst.setClob(4, emptyClob);
     prepst.execute();
 
     ResultSet resultSet =
@@ -192,6 +198,9 @@ public class ResultSetAsyncIT extends BaseJDBCTest {
     assertTrue(resultSet.wasNull()); // integer value is null
     resultSet.getString(2);
     assertFalse(resultSet.wasNull()); // string value is not null
+    assertNull(resultSet.getClob(3));
+    assertNull(resultSet.getClob("COLNULL"));
+    assertEquals("", resultSet.getClob("EMPTYCLOB").toString());
   }
 
   @Test


### PR DESCRIPTION
getClob() methods didn't account for null values resulting in a NullPointerException raised by StringBuffer. The methods will now return a null if the column holds a SQL NULL.

# Overview

SNOW-749517

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1247 


2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

We simply check if the value in a given column is null or not. If so, we return a Java null in order to avoid passing a null String to the StringBuffer's constructor. 

The JDK documentation for ResultSet didn't mention anything about how nulls should be treated:
https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html#getClob-int-

It explicitly mentions what other methods should do when a null value is encountered, so it was a bit ambiguous on how we should handle nulls in getClob(). However, the documentation for other classes like CallableStatement mentions that a null should be returned:
https://docs.oracle.com/javase/8/docs/api/java/sql/CallableStatement.html#getClob-int-

I also browsed around on GitHub for other JDBC driver implementations of their ResultSet::getClob(x) methods  and found several that handled nulls in the same manner.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

