### PR TITLE
Removing disableIllegalReflectiveAccessWarning()

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
@@ -398,10 +398,4 @@ public class SnowflakeDriverTest {
     String[] args = {"--version"};
     snowflakeDriver.main(args);
   }
-
-  @Test
-  public void testSuppressIllegalReflectiveAccessWarning() {
-    // Just to make sure this function won't break anything
-    SnowflakeDriver.disableIllegalReflectiveAccessWarning();
-  }
 }


### PR DESCRIPTION
# Overview

SNOW-752403

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1270


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

By removing the `SnowflakeDriver.disableIllegalReflectiveAccessWarning()` method, `IllegalAccessLogger` won't be suppressed and we would see the warning messages as expected. In case these warnings are to be avoided, we can add the jvm option `illegal-access=permit`.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

