### PR TITLE
SNOW-719164 Escape quotes for 'like' commands in DatabaseMetadata to protect against SqlInjections

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -198,6 +198,9 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
    * @return
    */
   private String escapeSingleQuoteForLikeCommand(String arg) {
+    if (arg == null) {
+      return null;
+    }
     int i = 0;
     int index = arg.indexOf("'", i);
     while (index != -1) {

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -335,6 +335,30 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
       statement.close();
     }
   }
+
+  /**
+   * Test against sql injection, ensure resultset is empty. Not done yet, just trying to see if this
+   * breaks anything
+   *
+   * @throws Throwable
+   */
+  @Test
+  public void testGetSchemasInjection() throws Throwable {
+    Connection con = getSnowflakeAdminConnection();
+    con.createStatement().execute("alter user testaccount.snowman set MULTI_STATEMENT_COUNT=0");
+    String schemaQuoted = "TESTSCHEMA\\'WITH\\'QUOTES";
+    con.close();
+    try (Connection connection = getConnection()) {
+      DatabaseMetaData metaData = connection.getMetaData();
+      String schema = "%' in database testwh; select 11 as bar; show databases like '%";
+      ResultSet resultSet = metaData.getSchemas(null, schema);
+      while (resultSet.next()) {
+        System.out.println(resultSet.getString(1));
+        System.out.println(resultSet.getString(2));
+      }
+    }
+  }
+
   /**
    * This tests that wildcards can be used for the schema name for getProcedureColumns().
    * Previously, only empty resultsets were returned.


### PR DESCRIPTION
# Overview

SNOW-719164

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

