### PR TITLE
Propagate error for 404 resource not found instead of retry for Azure client

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -674,7 +674,9 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
         }
       }
       // If we have exceeded the max number of retries, propagate the error
-      if (retryCount > azClient.getMaxRetries()) {
+      // no need for back off and retry if the file does not exist
+      if (retryCount > azClient.getMaxRetries()
+          || ((StorageException) ex).getHttpStatusCode() == 404) {
         throw new SnowflakeSQLLoggedException(
             session,
             SqlState.SYSTEM_ERROR,

--- a/src/test/java/net/snowflake/client/jdbc/StreamIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/StreamIT.java
@@ -10,7 +10,6 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnTestaccount;
@@ -150,29 +149,6 @@ public class StreamIT extends BaseJDBCTest {
         statement.close();
       }
       closeSQLObjects(resultSet, statement, connection);
-    }
-  }
-
-  @Test
-  public void testDownloadToStreamBlobNotFoundGCS() throws SQLException {
-    final String DEST_PREFIX = TEST_UUID + "/testUploadStream";
-    Connection connection = null;
-    Statement statement = null;
-    try {
-      connection = getConnection("gcpaccount");
-      statement = connection.createStatement();
-      connection
-          .unwrap(SnowflakeConnection.class)
-          .downloadStream("~", DEST_PREFIX + "/abc.gz", true);
-      fail("should throw a storage provider exception for blob not found");
-    } catch (Exception ex) {
-      System.out.println("Negative test to hit expected exception: " + ex.getMessage());
-    } finally {
-      if (statement != null) {
-        statement.execute("rm @~/" + DEST_PREFIX);
-        statement.close();
-      }
-      closeSQLObjects(statement, connection);
     }
   }
 }


### PR DESCRIPTION
# Overview

Azure client retries with backoff on 404 resource not found exception.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Throw exception when the resource is not found instead of retying with a backoff.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

