### PR TITLE
SNOW-748294 Fix test failures

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderLatestIT.java
@@ -125,7 +125,9 @@ public class FileUploaderLatestIT extends FileUploaderPrepIT {
   public void testGetObjectMetadataFileNotFoundWithGCS() throws Exception {
     Connection connection = null;
     try {
-      connection = getConnection("gcpaccount");
+      Properties paramProperties = new Properties();
+      paramProperties.put("GCS_USE_DOWNSCOPED_CREDENTIAL", true);
+      connection = getConnection("gcpaccount", paramProperties);
       Statement statement = connection.createStatement();
       statement.execute("CREATE OR REPLACE STAGE " + OBJ_META_STAGE);
 
@@ -151,6 +153,7 @@ public class FileUploaderLatestIT extends FileUploaderPrepIT {
       assertTrue(
           "Wrong type of exception. Message: " + ex.getMessage(),
           ex instanceof StorageProviderException);
+      assertTrue(ex.getMessage().matches(".*Blob.*not found in bucket.*"));
     } finally {
       if (connection != null) {
         connection.createStatement().execute("DROP STAGE if exists " + OBJ_META_STAGE);
@@ -164,7 +167,9 @@ public class FileUploaderLatestIT extends FileUploaderPrepIT {
   public void testGetObjectMetadataStorageExceptionWithGCS() throws Exception {
     Connection connection = null;
     try {
-      connection = getConnection("gcpaccount");
+      Properties paramProperties = new Properties();
+      paramProperties.put("GCS_USE_DOWNSCOPED_CREDENTIAL", true);
+      connection = getConnection("gcpaccount", paramProperties);
       Statement statement = connection.createStatement();
       statement.execute("CREATE OR REPLACE STAGE " + OBJ_META_STAGE);
 
@@ -189,6 +194,7 @@ public class FileUploaderLatestIT extends FileUploaderPrepIT {
       assertTrue(
           "Wrong type of exception. Message: " + ex.getMessage(),
           ex instanceof StorageProviderException);
+      assertTrue(ex.getMessage().matches(".*Permission.*denied.*"));
     } finally {
       if (connection != null) {
         connection.createStatement().execute("DROP STAGE if exists " + OBJ_META_STAGE);

--- a/src/test/java/net/snowflake/client/jdbc/StreamIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/StreamIT.java
@@ -3,7 +3,8 @@
  */
 package net.snowflake.client.jdbc;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.io.StringWriter;


### PR DESCRIPTION
# Overview

SNOW-748294

Fix failing StreamIT test by moving to LatestIT
Add GCS_DOWNSCOPING_CREDENTIAL=true for GCS stream download tests. Presigned URL is not set up for these tests. This param is false by default and must be set explicitly for jenkins testing (Note that Simba has this param set to true by default)

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

