### PR TITLE
SNOW-760534 Added URLValidator and URLEncoder

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
@@ -57,6 +57,10 @@ public class SessionUtilExternalBrowser {
     public void openBrowser(String ssoUrl) throws SFException {
       try {
         // start web browser
+        if (!URLUtil.isValidURL(ssoUrl)) {
+          throw new SFException(ErrorCode.INVALID_CONNECTION_URL,
+                  "Invalid SSOUrl found - "+ssoUrl);
+        }
         if (java.awt.Desktop.isDesktopSupported()) {
           URI uri = new URI(ssoUrl);
           java.awt.Desktop.getDesktop().browse(uri);

--- a/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
@@ -58,8 +58,8 @@ public class SessionUtilExternalBrowser {
       try {
         // start web browser
         if (!URLUtil.isValidURL(ssoUrl)) {
-          throw new SFException(ErrorCode.INVALID_CONNECTION_URL,
-                  "Invalid SSOUrl found - "+ssoUrl);
+          throw new SFException(
+              ErrorCode.INVALID_CONNECTION_URL, "Invalid SSOUrl found - " + ssoUrl);
         }
         if (java.awt.Desktop.isDesktopSupported()) {
           URI uri = new URI(ssoUrl);

--- a/src/main/java/net/snowflake/client/core/URLUtil.java
+++ b/src/main/java/net/snowflake/client/core/URLUtil.java
@@ -3,11 +3,6 @@
  */
 package net.snowflake.client.core;
 
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.log.SFLogger;
-import net.snowflake.client.log.SFLoggerFactory;
-
-import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -17,42 +12,45 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import javax.annotation.Nullable;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 
 public class URLUtil {
 
-    static final SFLogger logger = SFLoggerFactory.getLogger(URLUtil.class);
-    static final String validURLPattern = "^http(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z@:])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\&\\(\\)\\/\\\\\\+&%\\$#_=@]*)?$";
-    static final Pattern pattern = Pattern.compile(validURLPattern);
+  static final SFLogger logger = SFLoggerFactory.getLogger(URLUtil.class);
+  static final String validURLPattern =
+      "^http(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z@:])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\&\\(\\)\\/\\\\\\+&%\\$#_=@]*)?$";
+  static final Pattern pattern = Pattern.compile(validURLPattern);
 
-    public static boolean isValidURL(String url) {
-        try {
-            Matcher matcher = pattern.matcher(url);
-            return matcher.find();
-        } catch (PatternSyntaxException pex) {
-            logger.debug("The URL REGEX is invalid. Falling back to basic sanity test");
-            try {
-                new URL(url).toURI();
-                return true;
-            } catch(MalformedURLException mex) {
-                logger.debug("The URL "+url+", is invalid");
-                return false;
-            } catch (URISyntaxException uex) {
-                logger.debug("The URL "+url+", is invalid");
-                return false;
-            }
-        }
+  public static boolean isValidURL(String url) {
+    try {
+      Matcher matcher = pattern.matcher(url);
+      return matcher.find();
+    } catch (PatternSyntaxException pex) {
+      logger.debug("The URL REGEX is invalid. Falling back to basic sanity test");
+      try {
+        new URL(url).toURI();
+        return true;
+      } catch (MalformedURLException mex) {
+        logger.debug("The URL " + url + ", is invalid");
+        return false;
+      } catch (URISyntaxException uex) {
+        logger.debug("The URL " + url + ", is invalid");
+        return false;
+      }
     }
+  }
 
-    @Nullable
-    public static String urlEncode(String target) throws UnsupportedEncodingException {
-        String encodedTarget;
-        try {
-            encodedTarget = URLEncoder.encode(target,
-                    StandardCharsets.UTF_8.toString());
-        } catch(UnsupportedEncodingException uex) {
-            logger.debug("The string to be encoded- "+target+", is invalid");
-            return null;
-        }
-        return encodedTarget;
+  @Nullable
+  public static String urlEncode(String target) throws UnsupportedEncodingException {
+    String encodedTarget;
+    try {
+      encodedTarget = URLEncoder.encode(target, StandardCharsets.UTF_8.toString());
+    } catch (UnsupportedEncodingException uex) {
+      logger.debug("The string to be encoded- " + target + ", is invalid");
+      return null;
     }
+    return encodedTarget;
+  }
 }

--- a/src/main/java/net/snowflake/client/core/URLUtil.java
+++ b/src/main/java/net/snowflake/client/core/URLUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ */
+package net.snowflake.client.core;
+
+import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class URLUtil {
+
+    static final SFLogger logger = SFLoggerFactory.getLogger(URLUtil.class);
+    public static boolean isValidURL(String url) {
+        try {
+            new URL(url).toURI();
+            return true;
+        } catch(MalformedURLException mex) {
+            logger.debug("Invalid URL found - ", url);
+            return false;
+        } catch (URISyntaxException uex) {
+            logger.debug("Invalid URL found - ", url);
+            return false;
+        }
+    }
+
+    @Nullable
+    public static String urlEncode(String url) throws UnsupportedEncodingException {
+        String encodedURL;
+        try {
+            encodedURL = URLEncoder.encode(url,
+                    StandardCharsets.UTF_8.toString());
+        } catch(UnsupportedEncodingException uex) {
+            return null;
+        }
+        return encodedURL;
+    }
+}

--- a/src/main/java/net/snowflake/client/core/URLUtil.java
+++ b/src/main/java/net/snowflake/client/core/URLUtil.java
@@ -14,32 +14,45 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public class URLUtil {
 
     static final SFLogger logger = SFLoggerFactory.getLogger(URLUtil.class);
+    static final String validURLPattern = "^http(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z@:])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\&\\(\\)\\/\\\\\\+&%\\$#_=@]*)?$";
+    static final Pattern pattern = Pattern.compile(validURLPattern);
+
     public static boolean isValidURL(String url) {
         try {
-            new URL(url).toURI();
-            return true;
-        } catch(MalformedURLException mex) {
-            logger.debug("Invalid URL found - ", url);
-            return false;
-        } catch (URISyntaxException uex) {
-            logger.debug("Invalid URL found - ", url);
-            return false;
+            Matcher matcher = pattern.matcher(url);
+            return matcher.find();
+        } catch (PatternSyntaxException pex) {
+            logger.debug("The URL REGEX is invalid. Falling back to basic sanity test");
+            try {
+                new URL(url).toURI();
+                return true;
+            } catch(MalformedURLException mex) {
+                logger.debug("The URL "+url+", is invalid");
+                return false;
+            } catch (URISyntaxException uex) {
+                logger.debug("The URL "+url+", is invalid");
+                return false;
+            }
         }
     }
 
     @Nullable
-    public static String urlEncode(String url) throws UnsupportedEncodingException {
-        String encodedURL;
+    public static String urlEncode(String target) throws UnsupportedEncodingException {
+        String encodedTarget;
         try {
-            encodedURL = URLEncoder.encode(url,
+            encodedTarget = URLEncoder.encode(target,
                     StandardCharsets.UTF_8.toString());
         } catch(UnsupportedEncodingException uex) {
+            logger.debug("The string to be encoded- "+target+", is invalid");
             return null;
         }
-        return encodedURL;
+        return encodedTarget;
     }
 }

--- a/src/test/java/net/snowflake/client/core/URLUtilTest.java
+++ b/src/test/java/net/snowflake/client/core/URLUtilTest.java
@@ -3,28 +3,28 @@
  */
 package net.snowflake.client.core;
 
-import org.junit.Test;
-
 import static org.junit.Assert.*;
+
+import org.junit.Test;
 
 public class URLUtilTest {
 
-    @Test
-    public void testValidURL() throws Exception {
-        assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com"));
-        assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com:8080"));
-        assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com/testpathvalue"));
-    }
+  @Test
+  public void testValidURL() throws Exception {
+    assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com"));
+    assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com:8080"));
+    assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com/testpathvalue"));
+  }
 
-    @Test
-    public void testInvalidURL() throws Exception {
-        assertFalse(URLUtil.isValidURL("-a Calculator"));
-        assertFalse(URLUtil.isValidURL("This is random text"));
-    }
+  @Test
+  public void testInvalidURL() throws Exception {
+    assertFalse(URLUtil.isValidURL("-a Calculator"));
+    assertFalse(URLUtil.isValidURL("This is random text"));
+  }
 
-    @Test
-    public void testEncodeURL() throws Exception {
-        assertEquals(URLUtil.urlEncode("Hello @World"), "Hello+%40World");
-        assertEquals(URLUtil.urlEncode("Test//String"), "Test%2F%2FString");
-    }
+  @Test
+  public void testEncodeURL() throws Exception {
+    assertEquals(URLUtil.urlEncode("Hello @World"), "Hello+%40World");
+    assertEquals(URLUtil.urlEncode("Test//String"), "Test%2F%2FString");
+  }
 }

--- a/src/test/java/net/snowflake/client/core/URLUtilTest.java
+++ b/src/test/java/net/snowflake/client/core/URLUtilTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ */
+package net.snowflake.client.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class URLUtilTest {
+
+    @Test
+    public void testValidURL() throws Exception {
+        assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com"));
+        assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com:8080"));
+        assertTrue(URLUtil.isValidURL("https://ssoTestURL.okta.com/testpathvalue"));
+    }
+
+    @Test
+    public void testInvalidURL() throws Exception {
+        assertFalse(URLUtil.isValidURL("-a Calculator"));
+        assertFalse(URLUtil.isValidURL("This is random text"));
+    }
+
+    @Test
+    public void testEncodeURL() throws Exception {
+        assertEquals(URLUtil.urlEncode("Hello @World"), "Hello+%40World");
+        assertEquals(URLUtil.urlEncode("Test//String"), "Test%2F%2FString");
+    }
+}

--- a/src/test/java/net/snowflake/client/core/URLUtilTest.java
+++ b/src/test/java/net/snowflake/client/core/URLUtilTest.java
@@ -20,6 +20,7 @@ public class URLUtilTest {
   public void testInvalidURL() throws Exception {
     assertFalse(URLUtil.isValidURL("-a Calculator"));
     assertFalse(URLUtil.isValidURL("This is random text"));
+    assertFalse(URLUtil.isValidURL("file://TestForFile"));
   }
 
   @Test


### PR DESCRIPTION
# Overview

SNOW-760534

Snowflake JDBC Driver does not validate SSO URL before executing it. Added a URLValidator utility to address that.
Also added URL Encoder to be used by OCSP Code to URL Encode the base64 encoded OCSP Request before sending it out on the wire. 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

