### PR TITLE
SNOW-760642 Change Default TTL From -1 to 60 seconds

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -65,7 +65,7 @@ public class HttpUtil {
   static final int DEFAULT_MAX_CONNECTIONS_PER_ROUTE = 300;
   static final int DEFAULT_CONNECTION_TIMEOUT = 60000;
   static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 300000; // ms
-  static final int DEFAULT_TTL = -1; // secs
+  static final int DEFAULT_TTL = 60; // secs
   static final int DEFAULT_IDLE_CONNECTION_TIMEOUT = 5; // secs
   static final int DEFAULT_DOWNLOADED_CONDITION_TIMEOUT = 3600; // secs
 

--- a/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
@@ -5,6 +5,7 @@
 package net.snowflake.client.core;
 
 import static net.snowflake.client.TestUtil.systemGetEnv;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
@@ -89,5 +90,17 @@ public class SessionUtilLatestIT {
     Map<SFSessionProperty, Object> connectionPropertiesMap = new HashMap<>();
     connectionPropertiesMap.put(SFSessionProperty.TRACING, "ALL");
     return connectionPropertiesMap;
+  }
+
+  @Test
+  public void testConvertSystemPropertyToIntValue() {
+    // SNOW-760642 - Test that new default for net.snowflake.jdbc.ttl is 60 seconds.
+    assertEquals(
+        60, HttpUtil.convertSystemPropertyToIntValue(HttpUtil.JDBC_TTL, HttpUtil.DEFAULT_TTL));
+
+    // Test that TTL can be disabled
+    System.setProperty(HttpUtil.JDBC_TTL, "-1");
+    assertEquals(
+        -1, HttpUtil.convertSystemPropertyToIntValue(HttpUtil.JDBC_TTL, HttpUtil.DEFAULT_TTL));
   }
 }


### PR DESCRIPTION
This is configured using the JVM argument -Dnet.snowflake.jdbc.ttl in order to ensure that idle connections were closed. The default now is to close those after 60 seconds if idle. The reasoning behind this change is that the load balancers across all the cloud providers have some idle timeout configuration so there's no reason for us to leave idle connections open indefinitely. This is referring to the Apache HttpClient's connection pool and is transparent to the user/developer.

# Overview

SNOW-760642


1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1294 


2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

