### PR TITLE
Add http.proxyProtocol property for JVM proxy settings

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -383,8 +383,8 @@ public abstract class SFBaseSession {
           combinedNonProxyHosts += noProxy;
         }
 
-        // It is possible that a user can have both http and https proxies in the
-        // default protocol is http
+        // It is possible that a user can have both http and https proxies specified in the JVM
+        // parameters. The default protocol is http.
         String proxyProtocol = "http";
         if (!Strings.isNullOrEmpty(httpProxyProtocol)) {
           proxyProtocol = httpProxyProtocol;
@@ -393,11 +393,6 @@ public abstract class SFBaseSession {
             && Strings.isNullOrEmpty(httpProxyHost)
             && Strings.isNullOrEmpty(httpProxyPort)) {
           proxyProtocol = "https";
-        } else if (Strings.isNullOrEmpty(httpsProxyHost)
-            && Strings.isNullOrEmpty(httpsProxyPort)
-            && !Strings.isNullOrEmpty(httpProxyHost)
-            && !Strings.isNullOrEmpty(httpProxyPort)) {
-          proxyProtocol = "http";
         }
 
         if (proxyProtocol.equals("https")


### PR DESCRIPTION
# Overview

SNOW-745310

The JDBC driver always defaults to HTTPS proxy protocol if:
- proxy params are not set in the connection url
- And both HTTPS and HTTP proxy parameters are set at the JVM level.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [#195
](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/195)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

 Add http.proxyProtocol that allows users to specify which proxy protocol they want to use if both https and http proxies are set in the JVM. The default will be http to match the default for proxyProtocol set through connection params. 

If only one proxy is specified on the JVM, the driver will default to the protocol that matches the settings:
http.proxyProtocol & http.proxyPort defaults to http.
https.proxyProtocol & https.proxyPort defaults to https.

If both are specified, the default will be http unless http.proxyProtocol is used.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

