### PR TITLE
Fix memory leak by checking isClosed() before adding resultset to openResultSets

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -207,7 +207,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     } finally {
-      if (resultSet != null) {
+      if (resultSet != null && !resultSet.isClosed()) {
         openResultSets.add(resultSet);
       }
       resultSet = null;
@@ -268,7 +268,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
 
-    if (resultSet != null) {
+    if (resultSet != null && !resultSet.isClosed()) {
       openResultSets.add(resultSet);
     }
 
@@ -317,7 +317,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
               sfResultSet.isArrayBindSupported(),
               sfResultSet.getMetaDataOfBinds(),
               true); // valid metadata
-      if (resultSet != null) {
+      if (resultSet != null && !resultSet.isClosed()) {
         openResultSets.add(resultSet);
       }
       resultSet = connection.getHandler().createResultSet(sfResultSet, this);
@@ -330,7 +330,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       if (!sfResultSet.getStatementType().isGenerateResultSet()
           && (!connection.getSFBaseSession().isSfSQLMode() || sfBaseStatement.hasChildren())) {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
-        if (resultSet != null) {
+        if (resultSet != null && !resultSet.isClosed()) {
           openResultSets.add(resultSet);
         }
         resultSet = null;
@@ -360,6 +360,11 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   /** @return the child query IDs for the multiple statements query. */
   public String[] getChildQueryIds(String queryID) throws SQLException {
     return sfBaseStatement.getChildQueryIds(queryID);
+  }
+
+  /** @return the open resultSets from this statement */
+  public Set<ResultSet> getOpenResultSets() {
+    return openResultSets;
   }
 
   /**
@@ -611,7 +616,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     if (hasResultSet) // result set returned
     {
       sfResultSet.setSession(this.connection.getSFBaseSession());
-      if (resultSet != null) {
+      if (resultSet != null && !resultSet.isClosed()) {
         openResultSets.add(resultSet);
       }
       resultSet = connection.getHandler().createResultSet(sfResultSet, this);
@@ -619,7 +624,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       return true;
     } else if (sfResultSet != null) // update count returned
     {
-      if (resultSet != null) {
+      if (resultSet != null && !resultSet.isClosed()) {
         openResultSets.add(resultSet);
       }
       resultSet = null;

--- a/src/test/java/net/snowflake/client/jdbc/StatementLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/StatementLatestIT.java
@@ -152,4 +152,36 @@ public class StatementLatestIT extends BaseJDBCTest {
     statement.close();
     connection.close();
   }
+
+  /**
+   * Tests that resultsets that have been closed are not added to the set of openResultSets.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testExecuteOpenResultSets() throws SQLException {
+    Connection con = getConnection();
+    Statement statement = con.createStatement();
+    ResultSet resultSet;
+
+    for (int i = 0; i < 10; i++) {
+      statement.execute("select 1");
+      statement.getResultSet();
+    }
+
+    assertEquals(9, statement.unwrap(SnowflakeStatementV1.class).getOpenResultSets().size());
+    statement.close();
+
+    statement = con.createStatement();
+    for (int i = 0; i < 10; i++) {
+      statement.execute("select 1");
+      resultSet = statement.getResultSet();
+      resultSet.close();
+    }
+
+    assertEquals(0, statement.unwrap(SnowflakeStatementV1.class).getOpenResultSets().size());
+
+    statement.close();
+    con.close();
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-755712

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1219 https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/234


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Check resultset.isClosed() before adding the resultset to the set of openResultSets.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

