### PR TITLE
SNOW-759147 Do Not Retry Requests That Fail With SSLHandshakeException

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -8,7 +8,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.net.ssl.SSLException;
+import javax.net.ssl.*;
 import net.snowflake.client.core.Event;
 import net.snowflake.client.core.EventUtil;
 import net.snowflake.client.core.HttpUtil;
@@ -211,7 +211,10 @@ public class RestRequest {
         throw new SnowflakeSQLLoggedException(
             null, ErrorCode.INVALID_STATE, ex, /* session = */ ex.getMessage());
 
-      } catch (SSLException ex) {
+      } catch (SSLHandshakeException
+          | SSLKeyException
+          | SSLPeerUnverifiedException
+          | SSLProtocolException ex) {
         // if an SSL issue occurs like an SSLHandshakeException then fail
         // immediately and stop retrying the requests
         throw new SnowflakeSQLLoggedException(


### PR DESCRIPTION
HTTP requests will now fail immediately after an SSLHandshakeException occurs and the error will be redirected to the standard error stream.

# Overview

SNOW-759147

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

