### PR TITLE
SNOW-752232: change warn level log to debug/info level in SnowflakeConnectString parse

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -154,7 +154,7 @@ public class SnowflakeConnectString implements Serializable {
 
       return new SnowflakeConnectString(scheme, host, port, parameters, account);
     } catch (Exception ex) {
-      logger.info("Exception thrown while parsing Snowflake connect string", ex);
+      logger.warn("Exception thrown while parsing Snowflake connect string", ex);
       return INVALID_CONNECT_STRING;
     }
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -31,12 +31,12 @@ public class SnowflakeConnectString implements Serializable {
 
   public static SnowflakeConnectString parse(String url, Properties info) {
     if (url == null) {
-      logger.warn("Connect strings must be non-null");
+      logger.debug("Connect strings must be non-null");
       return INVALID_CONNECT_STRING;
     }
     int pos = url.indexOf(PREFIX);
     if (pos != 0) {
-      logger.warn("Connect strings must start with jdbc:snowflake://");
+      logger.debug("Connect strings must start with jdbc:snowflake://");
       return INVALID_CONNECT_STRING; // not start with jdbc:snowflake://
     }
     String afterPrefix = url.substring(pos + PREFIX.length());
@@ -64,11 +64,11 @@ public class SnowflakeConnectString implements Serializable {
       String queryData = uri.getRawQuery();
 
       if (!scheme.equals("snowflake") && !scheme.equals("http") && !scheme.equals("https")) {
-        logger.warn("Connect strings must have a valid scheme: 'snowflake' or 'http' or 'https'");
+        logger.debug("Connect strings must have a valid scheme: 'snowflake' or 'http' or 'https'");
         return INVALID_CONNECT_STRING;
       }
       if (Strings.isNullOrEmpty(host)) {
-        logger.warn("Connect strings must have a valid host: found null or empty host");
+        logger.debug("Connect strings must have a valid host: found null or empty host");
         return INVALID_CONNECT_STRING;
       }
       if (port == -1) {
@@ -76,7 +76,7 @@ public class SnowflakeConnectString implements Serializable {
       }
       String path = uri.getPath();
       if (!Strings.isNullOrEmpty(path) && !"/".equals(path)) {
-        logger.warn("Connect strings must have no path: expecting empty or null or '/'");
+        logger.debug("Connect strings must have no path: expecting empty or null or '/'");
         return INVALID_CONNECT_STRING;
       }
       String account = null;
@@ -154,7 +154,7 @@ public class SnowflakeConnectString implements Serializable {
 
       return new SnowflakeConnectString(scheme, host, port, parameters, account);
     } catch (Exception ex) {
-      logger.warn("Exception thrown while parsing Snowflake connect string", ex);
+      logger.info("Exception thrown while parsing Snowflake connect string", ex);
       return INVALID_CONNECT_STRING;
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
@@ -359,6 +359,7 @@ public class SnowflakeDriverTest {
     assertFalse(snowflakeDriver.acceptsURL("jdbc:snowflake://testaccount.com?proxyHost=%%"));
     assertFalse(
         snowflakeDriver.acceptsURL("jdbc:snowflake://testaccount.com?proxyHost=%b&proxyPort="));
+    assertFalse(snowflakeDriver.acceptsURL("jdbc:mysql://localhost:3306/dbname"));
   }
 
   @Test


### PR DESCRIPTION
# Overview

SNOW-752232
Some of the logs in SnowflakeConnectString are warn level, which sometimes cause unnecessary concerns, e.g. `SnowflakeDriver.acceptsURL`. Change the log level to either debug or info to mitigate the issue.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

