### PR TITLE
SNOW-622919: Check empty result set for get procedure columns

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1189,7 +1189,9 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
       ResultSet resultSetStepTwo =
           executeAndReturnEmptyResultIfNotFound(
               statement, showProcedureColCommand, GET_PROCEDURE_COLUMNS);
-      resultSetStepTwo.next();
+      if (resultSetStepTwo.next() == false) {
+        continue;
+      }
       // Retrieve the procedure arguments and procedure return values.
       String args = resultSetStepTwo.getString("value");
       resultSetStepTwo.next();


### PR DESCRIPTION
# Overview

SNOW-622919

In some rare cases, the resultSetStepTwo result set can be empty result set. This PR adds a check. However, I haven't figure out a reasonable way to add an exact test for the it (hard to repro empty result set).

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

