### PR TITLE
[SNOW-522301] Support for BigInteger in SnowflakePreparedStatementV1 setObject method

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatement.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatement.java
@@ -1,5 +1,6 @@
 package net.snowflake.client.jdbc;
 
+import java.math.BigInteger;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -14,4 +15,13 @@ public interface SnowflakePreparedStatement {
    * @throws SQLException
    */
   ResultSet executeAsyncQuery() throws SQLException;
+
+  /**
+   * Sets the designated parameter to the given BigInteger value.
+   *
+   * @param parameterIndex
+   * @param x
+   * @throws SQLException
+   */
+  void setBigInteger(int parameterIndex, BigInteger x) throws SQLException;
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -7,6 +7,7 @@ package net.snowflake.client.jdbc;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URL;
 import java.sql.*;
 import java.sql.Date;
@@ -218,6 +219,17 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
+  public void setBigInteger(int parameterIndex, BigInteger x) throws SQLException {
+    logger.debug("setBigInteger(parameterIndex: {}, BigInteger x)", parameterIndex);
+
+    ParameterBindingDTO binding =
+        new ParameterBindingDTO(
+            SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT, connection.getSFBaseSession()),
+            String.valueOf(x));
+    parameterBindings.put(String.valueOf(parameterIndex), binding);
+  }
+
+  @Override
   public void setFloat(int parameterIndex, float x) throws SQLException {
     logger.debug("setFloat(parameterIndex: {}, float x)", parameterIndex);
 
@@ -414,6 +426,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       setInt(parameterIndex, (Integer) x);
     } else if (x instanceof Long) {
       setLong(parameterIndex, (Long) x);
+    } else if (x instanceof BigInteger) {
+      setBigInteger(parameterIndex, (BigInteger) x);
     } else if (x instanceof Float) {
       setFloat(parameterIndex, (Float) x);
     } else if (x instanceof Double) {

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement1LatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement1LatestIT.java
@@ -6,6 +6,7 @@ package net.snowflake.client.jdbc;
 import static net.snowflake.client.jdbc.PreparedStatement1IT.bindOneParamSet;
 import static org.junit.Assert.*;
 
+import java.math.BigInteger;
 import java.sql.*;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
@@ -235,6 +236,35 @@ public class PreparedStatement1LatestIT extends PreparedStatement0IT {
           connection.prepareStatement("insert into test_binary(b) values (?)")) {
         prepStatement.setObject(1, "HELLO WORLD".getBytes());
         prepStatement.execute(); // shouldn't raise an error.
+      }
+    }
+  }
+
+  @Test
+  public void testSetObjectMethodWithBigIntegerColumn() throws SQLException {
+    try (Connection connection = init()) {
+      connection.createStatement().execute("create or replace table test_bigint(id NUMBER)");
+
+      try (PreparedStatement prepStatement =
+          connection.prepareStatement("insert into test_bigint(id) values(?)")) {
+        prepStatement.setObject(1, BigInteger.valueOf(9999));
+        int rows = prepStatement.executeUpdate();
+        assertTrue("Row count doesn't match", rows == 1);
+      }
+    }
+  }
+
+  @Test
+  public void testSetObjectMethodWithLargeBigIntegerColumn() throws SQLException {
+    try (Connection connection = init()) {
+      connection.createStatement().execute("create or replace table test_bigint(id NUMBER)");
+
+      try (PreparedStatement prepStatement =
+          connection.prepareStatement("insert into test_bigint(id) values(?)")) {
+        BigInteger largeBigInt = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TEN);
+        prepStatement.setObject(1, largeBigInt);
+        int rows = prepStatement.executeUpdate();
+        assertTrue("Row count doesn't match", rows == 1);
       }
     }
   }


### PR DESCRIPTION
# Overview

SNOW-522301

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [666 ](https://github.com/snowflakedb/snowflake-jdbc/issues/666)


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

