### PR TITLE
Snow 755302 change non critical msg to warning

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -225,7 +225,7 @@ public class RestRequest {
         savedEx = ex;
         // if the request took more than 5 min (socket timeout) log an error
         if ((System.currentTimeMillis() - startTimePerRequest) > 300000) {
-          logger.error(
+          logger.warn(
               "HTTP request took longer than 5 min: {} sec",
               (System.currentTimeMillis() - startTimePerRequest) / 1000);
         }


### PR DESCRIPTION
# Overview

SNOW-755302

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [#228](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/228)


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

   The message "SEVERE: HTTP request took longer than 5 min: 302 sec" in the driver logs is not show-stopper or critical. Customer requested changing it from SEVERE to WARNING.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

