### PR TITLE
SNOW-159714

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SFAsyncResultSet.java
@@ -4,19 +4,18 @@
 
 package net.snowflake.client.jdbc;
 
-import com.google.api.client.util.Strings;
-import net.snowflake.client.core.QueryStatus;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFSession;
-import net.snowflake.common.core.SqlState;
+import static net.snowflake.client.core.QueryStatus.NO_DATA;
 
+import com.google.api.client.util.Strings;
 import java.math.BigDecimal;
 import java.sql.*;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
-
-import static net.snowflake.client.core.QueryStatus.NO_DATA;
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.common.core.SqlState;
 
 /** SFAsyncResultSet implementation */
 class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResultSet, ResultSet {
@@ -137,7 +136,9 @@ class SFAsyncResultSet extends SnowflakeBaseResultSet implements SnowflakeResult
             throw new SQLException(
                 "Status of query associated with resultSet is "
                     + qs.getDescription()
-                    + ". " + errorMessage + " Results not generated.");
+                    + ". "
+                    + errorMessage
+                    + " Results not generated.");
           }
           // if no data about the query is returned after about 2 minutes, give up
           if (qs == NO_DATA) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSet.java
@@ -4,9 +4,10 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.QueryStatus;
+
 import java.sql.SQLException;
 import java.util.List;
-import net.snowflake.client.core.QueryStatus;
 
 /** This interface defines Snowflake specific APIs for ResultSet */
 public interface SnowflakeResultSet {
@@ -24,6 +25,13 @@ public interface SnowflakeResultSet {
    * @throws SQLException
    */
   QueryStatus getStatus() throws SQLException;
+
+  /**
+   * This function retrieves the error message recorded from the error status of an asynchronous query. If there is no error or no error is returned by the server, an empty string will be returned.
+   * @return String value of query's error message
+   * @throws SQLException
+   */
+  String getQueryErrorMessage() throws SQLException;
 
   /**
    * Get a list of ResultSetSerializables for the ResultSet in order to parallel processing

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSet.java
@@ -4,10 +4,9 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.QueryStatus;
-
 import java.sql.SQLException;
 import java.util.List;
+import net.snowflake.client.core.QueryStatus;
 
 /** This interface defines Snowflake specific APIs for ResultSet */
 public interface SnowflakeResultSet {
@@ -27,7 +26,10 @@ public interface SnowflakeResultSet {
   QueryStatus getStatus() throws SQLException;
 
   /**
-   * This function retrieves the error message recorded from the error status of an asynchronous query. If there is no error or no error is returned by the server, an empty string will be returned.
+   * This function retrieves the error message recorded from the error status of an asynchronous
+   * query. If there is no error or no error is returned by the server, an empty string will be
+   * returned.
+   *
    * @return String value of query's error message
    * @throws SQLException
    */

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -4,10 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.core.QueryStatus;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -17,6 +13,9 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
 
 /** Snowflake ResultSet implementation */
 public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
@@ -61,7 +60,6 @@ public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
   public String getQueryErrorMessage() throws SQLException {
     throw new SnowflakeLoggedFeatureNotSupportedException(session);
   }
-
 
   /**
    * Constructor takes a result set serializable object to create a sessionless result set.

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -4,6 +4,10 @@
 
 package net.snowflake.client.jdbc;
 
+import net.snowflake.client.core.QueryStatus;
+import net.snowflake.client.core.SFBaseResultSet;
+import net.snowflake.client.core.SFException;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -13,9 +17,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-import net.snowflake.client.core.QueryStatus;
-import net.snowflake.client.core.SFBaseResultSet;
-import net.snowflake.client.core.SFException;
 
 /** Snowflake ResultSet implementation */
 public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
@@ -49,6 +50,18 @@ public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
   public QueryStatus getStatus() throws SQLException {
     throw new SnowflakeLoggedFeatureNotSupportedException(session);
   }
+
+  /**
+   * This function is not supported for synchronous queries
+   *
+   * @return no return value; exception is always thrown
+   * @throws SQLFeatureNotSupportedException
+   */
+  @Override
+  public String getQueryErrorMessage() throws SQLException {
+    throw new SnowflakeLoggedFeatureNotSupportedException(session);
+  }
+
 
   /**
    * Constructor takes a result set serializable object to create a sessionless result set.

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -3,8 +3,27 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
+import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
+import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.*;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryConnection;
@@ -22,26 +41,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.sql.*;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
-
-import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static net.snowflake.client.jdbc.ConnectionIT.INVALID_CONNECTION_INFO_CODE;
-import static net.snowflake.client.jdbc.ConnectionIT.WAIT_FOR_TELEMETRY_REPORT_IN_MILLISECS;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
 /**
  * Connection integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -225,30 +224,38 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     if (status != QueryStatus.NO_DATA) {
       assertEquals(QueryStatus.FAILED_WITH_ERROR, status);
       assertEquals(2003, status.getErrorCode());
-      assertEquals("SQL compilation error:\n" +
-              "Object 'NONEXISTENTTABLE' does not exist or not authorized.", status.getErrorMessage());
+      assertEquals(
+          "SQL compilation error:\n"
+              + "Object 'NONEXISTENTTABLE' does not exist or not authorized.",
+          status.getErrorMessage());
     }
     statement.close();
     con.close();
   }
 
   @Test
-  public void testGetErrorMessageFromAsyncQuery() throws SQLException, InterruptedException {
+  public void testGetErrorMessageFromAsyncQuery() throws SQLException {
     Connection con = getConnection();
     Statement statement = con.createStatement();
     // Create another query that will not be successful (querying table that does not exist)
-    ResultSet rs1 =
-            statement
-                    .unwrap(SnowflakeStatement.class)
-                    .executeAsyncQuery("select * from nonexistentTable2");
+    ResultSet rs1 = statement.unwrap(SnowflakeStatement.class).executeAsyncQuery("bad query!");
     try {
       rs1.next();
     } catch (SQLException ex) {
-      assertEquals("", ex.getMessage());
-      assertEquals("SQL compilation error:\nObject 'NONEXISTENTTABLE' does not exist or not authorized.", rs1.unwrap(SnowflakeResultSet.class).getQueryErrorMessage());
+      assertEquals(
+          "Status of query associated with resultSet is FAILED_WITH_ERROR. SQL compilation error:\n"
+              + "syntax error line 1 at position 0 unexpected 'bad'. Results not generated.",
+          ex.getMessage());
+      assertEquals(
+          "SQL compilation error:\n" + "syntax error line 1 at position 0 unexpected 'bad'.",
+          rs1.unwrap(SnowflakeResultSet.class).getQueryErrorMessage());
     }
-    statement.close();
+    rs1 = statement.unwrap(SnowflakeStatement.class).executeAsyncQuery("select 1");
+    rs1.next();
+    // Assert there is no error message when query is successful
+    assertEquals("No error reported", rs1.unwrap(SnowflakeResultSet.class).getQueryErrorMessage());
     rs1.close();
+    statement.close();
     con.close();
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetFeatureNotSupportedIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetFeatureNotSupportedIT.java
@@ -1,7 +1,14 @@
 package net.snowflake.client.jdbc;
 
 import java.math.BigDecimal;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.Collections;
 import net.snowflake.client.category.TestCategoryResultSet;
 import org.junit.Test;

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetFeatureNotSupportedIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetFeatureNotSupportedIT.java
@@ -1,14 +1,7 @@
 package net.snowflake.client.jdbc;
 
 import java.math.BigDecimal;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.Date;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Time;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.Collections;
 import net.snowflake.client.category.TestCategoryResultSet;
 import org.junit.Test;

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -739,4 +739,21 @@ public class ResultSetLatestIT extends ResultSet0IT {
       }
     }
   }
+
+  /**
+   * Test that new query error message function for checking async query error messages is not
+   * implemented for synchronous queries *
+   */
+  @Test
+  public void testNewFeaturesNotSupported() throws SQLException {
+    Connection con = init();
+    ResultSet rs = con.createStatement().executeQuery("select 1");
+    try {
+      rs.unwrap(SnowflakeResultSet.class).getQueryErrorMessage();
+    } catch (SQLFeatureNotSupportedException ex) {
+      // catch SQLFeatureNotSupportedException
+    }
+    rs.close();
+    con.close();
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-159714

This exposes the SQL error message in the exception message for when asynchronous query calls result in a failed query and exception.

It also adds a function to SFAsyncResultSet to check the query error message if it exists. There is already a function for checking this in the QueryStatus class, but customers seemed to not like this approach as much.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

