### PR TITLE
SNOW-782480 Misleading SAML2 Assertion Error Message When Hostnames Mismatch

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1093,11 +1093,17 @@ public class SessionUtil {
       // step 5
       String postBackUrl = getPostBackUrlFromHTML(responseHtml);
       if (!isPrefixEqual(postBackUrl, loginInput.getServerUrl())) {
-        logger.debug(
-            "The specified authenticator {} and the destination URL "
-                + "in the SAML assertion {} do not match.",
-            loginInput.getAuthenticator(),
-            postBackUrl);
+        URL idpDestinationUrl = new URL(postBackUrl);
+        URL clientDestinationUrl = new URL(loginInput.getServerUrl());
+        String idpDestinationHostName = idpDestinationUrl.getHost();
+        String clientDestinationHostName = clientDestinationUrl.getHost();
+
+        logger.error(
+            "The Snowflake hostname specified in the client connection {} does not match "
+                + "the destination hostname in the SAML response returned by the IdP: {}",
+            clientDestinationHostName,
+            idpDestinationHostName);
+
         // Session is in process of getting created, so exception constructor takes in null session
         // value
         throw new SnowflakeSQLLoggedException(


### PR DESCRIPTION
Improved error message related to SAML2 assertion failures due to a mismatch between the hostname the driver is trying to connect to and the hostname in the SAML response returned by the IdP. This error is very common for users that have underscore characters in the account name and upgrade to JDBC driver 3.13.25 where we set allowUnderscoresInHost to false by default.

# Overview

SNOW-782480

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1341 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [X] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Before this change we just threw the following error to the standard error stream:
```
Exception in thread "main" net.snowflake.client.jdbc.SnowflakeSQLLoggedException: Identity provider configuration for the specified authenticator does not match with your Snowflake account configuration (destination URL mismatch).  Please contact your local system administrator.
```
To get more details you would need to enable debugging but the message was confusing and inaccurate:
```
DEBUG SessionUtil: The specified authenticator https://<okta_account>.okta.com and the destination URL in the SAML assertion https://<snowflake_account>.snowflakecomputing.com/fed/login do not match.
```

With this change we additionally throw the following to stderr which is more meaningful:
```
The Snowflake hostname specified in the client connection your-account-name.snowflakecomputing.com does not match the destination hostname in the SAML response returned by the IdP: your_account_name.snowflakecomputing.com
```
We also changed the log level to ERROR instead of DEBUG when printing the following:
```
ERROR SessionUtil: The Snowflake hostname specified in the client connection your-account-name.snowflakecomputing.com does not match the destination hostname in the SAML response returned by the IdP: your_account_name.snowflakecomputing.com
```

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

