### PR TITLE
Moved PrintWriter to a try-with-resources block to avoid a resource leak

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -107,8 +107,7 @@ public class SnowflakeUtil {
         errorCode = ErrorCode.INTERNAL_ERROR.getMessageCode();
         errorMessage = "no_error_code_from_server";
 
-        try {
-          PrintWriter writer = new PrintWriter("output.json", "UTF-8");
+        try (PrintWriter writer = new PrintWriter("output.json", "UTF-8")) {
           writer.print(rootNode.toString());
         } catch (Exception ex) {
           logger.debug("{}", ex);


### PR DESCRIPTION
# Overview

SNOW-785336

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1351 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

By using the _try-with-resources_ pattern, the `PrintWriter` is automatically closed.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

