### PR TITLE
SNOW-797605 bug fix for case where qsmk and fileKey have different lengths, updat…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 - repo: git@github.com:snowflakedb/casec_precommit.git
-  rev: v1.7
+  rev: v1.11
   hooks:
   - id: secret-scanner

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/EncryptionProvider.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/EncryptionProvider.java
@@ -96,6 +96,14 @@ public class EncryptionProvider {
       SecretKey queryStageMasterKey = new SecretKeySpec(qsmkBytes, 0, qsmkBytes.length, AES);
       keyCipher.init(Cipher.DECRYPT_MODE, queryStageMasterKey);
       byte[] fileKeyBytes = keyCipher.doFinal(keyBytes);
+
+      // previous version: fileKey = new SecretKeySpec(fileKeyBytes, offset = 0, len = qsmk.length,
+      // AES);
+      // This incorrectly assumes fileKey is always same length as qsmk. If we perform put from
+      // jdbc, fileKey and qsmk are same length,
+      // but in the case of AwsStorageClient.putObjectInternal() in GS code, they are not. This
+      // leads to some decryption bugs.
+      // See: SnowflakeDriverLatestIt.testS3PutInGs
       fileKey = new SecretKeySpec(fileKeyBytes, AES);
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/EncryptionProvider.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/EncryptionProvider.java
@@ -96,10 +96,7 @@ public class EncryptionProvider {
       SecretKey queryStageMasterKey = new SecretKeySpec(qsmkBytes, 0, qsmkBytes.length, AES);
       keyCipher.init(Cipher.DECRYPT_MODE, queryStageMasterKey);
       byte[] fileKeyBytes = keyCipher.doFinal(keyBytes);
-
-      // NB: we assume qsmk.length == fileKey.length
-      //     (fileKeyBytes.length may be bigger due to padding)
-      fileKey = new SecretKeySpec(fileKeyBytes, 0, qsmkBytes.length, AES);
+      fileKey = new SecretKeySpec(fileKeyBytes, AES);
     }
 
     // Decrypt file


### PR DESCRIPTION
# Overview

SNOW-797605
In JDBC when we encrypt files we use a 128 bit (16 byte) key. The file key is generated to match the length of the qsmk
[here](https://github.com/snowflakedb/snowflake-jdbc/blob/78ba1f0cf952c43e92022bb6059ea19c0538e191/src/main/java/net/snowflake/client/jdbc/cloud/storage/EncryptionProvider.java#L164).

We [decrypt](https://github.com/snowflakedb/snowflake-jdbc/blob/78ba1f0cf952c43e92022bb6059ea19c0538e191/src/main/java/net/snowflake/client/jdbc/cloud/storage/EncryptionProvider.java#L102) following this assumption that the fileKey length matches qsmk length. However, there are cases where this is untrue (encrypting in GS), which leads to some bugs like the one referenced by the JIRA tagged. This PR changes the decrypt logic so we do not truncate the key to the size of the qsmk.


## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-797605


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   See overview above.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

