### PR TITLE
Fix priority collision corner case for QCC client side

### DIFF
--- a/src/test/java/net/snowflake/client/core/QueryContextCacheTest.java
+++ b/src/test/java/net/snowflake/client/core/QueryContextCacheTest.java
@@ -44,6 +44,7 @@ public class QueryContextCacheTest {
       expectedPriority[i] = BASE_PRIORITY + i;
       qcc.merge(expectedIDs[i], expectedReadTimestamp[i], expectedPriority[i], context);
     }
+    qcc.syncPriorityMap();
   }
 
   private void initCacheWithDataInRandomOrder() {
@@ -62,6 +63,7 @@ public class QueryContextCacheTest {
     qcc.merge(expectedIDs[4], expectedReadTimestamp[4], expectedPriority[4], CONTEXT);
     qcc.merge(expectedIDs[0], expectedReadTimestamp[0], expectedPriority[0], CONTEXT);
     qcc.merge(expectedIDs[1], expectedReadTimestamp[1], expectedPriority[1], CONTEXT);
+    qcc.syncPriorityMap();
   }
 
   /** Test for empty cache */
@@ -92,6 +94,7 @@ public class QueryContextCacheTest {
     // Add one more element at the end
     int i = MAX_CAPACITY;
     qcc.merge(BASE_ID + i, BASE_READ_TIMESTAMP + i, BASE_PRIORITY + i, CONTEXT);
+    qcc.syncPriorityMap();
     qcc.checkCacheCapacity();
 
     // Compare elements
@@ -107,6 +110,7 @@ public class QueryContextCacheTest {
     expectedReadTimestamp[updatedID] = BASE_READ_TIMESTAMP + updatedID + 10;
     qcc.merge(
         BASE_ID + updatedID, expectedReadTimestamp[updatedID], BASE_PRIORITY + updatedID, CONTEXT);
+    qcc.syncPriorityMap();
     qcc.checkCacheCapacity();
 
     // Compare elements
@@ -124,6 +128,7 @@ public class QueryContextCacheTest {
     expectedPriority[updatedID] = updatedPriority;
     qcc.merge(
         BASE_ID + updatedID, BASE_READ_TIMESTAMP + updatedID, expectedPriority[updatedID], CONTEXT);
+    qcc.syncPriorityMap();
     qcc.checkCacheCapacity();
 
     for (int i = updatedID; i < MAX_CAPACITY - 1; i++) {
@@ -147,8 +152,8 @@ public class QueryContextCacheTest {
     int i = MAX_CAPACITY;
     long UpdatedPriority = BASE_PRIORITY + 1;
     qcc.merge(BASE_ID + i, BASE_READ_TIMESTAMP + i, UpdatedPriority, CONTEXT);
+    qcc.syncPriorityMap();
     qcc.checkCacheCapacity();
-
     expectedIDs[1] = BASE_ID + i;
     expectedReadTimestamp[1] = BASE_READ_TIMESTAMP + i;
 
@@ -163,6 +168,7 @@ public class QueryContextCacheTest {
     // Add one more element with same priority
     int i = 2;
     qcc.merge(BASE_ID + i, BASE_READ_TIMESTAMP + i - 10, BASE_PRIORITY + i, CONTEXT);
+    qcc.syncPriorityMap();
     qcc.checkCacheCapacity();
 
     // Compare elements


### PR DESCRIPTION
# Overview

Consider a simple situation : 
```
current state:
<id, priority, timestamp, context>
<1, 1, 1, None>
<2,2,2, None>
```

incoming changes:
```
merge <1, 2,1, None> 
   call remove QCE(<1,1,1, None>) -> remove priorityMap(1, <1,1,1, None>)
   call add QCE(<1,2,1, None>) -> add priorityMap(2, <1,2,1, None>) this map insertion will fail due to collision of priority key(there are two priority keys of 2)
merge <2,1,1, None>
```

Although this bug does not affect the contents in `treeSet` in this simple example (this is also why I thought I fixed the issue before, I only checked the final QCC entries embedded into the HTTP request, and found the previous multi-db missing query context issue was gone. However, the priorityMap contents are not correctly maintained), it can trigger inconsistent QCC `treeSet` and `priorityMap` contents in following rounds.

I did not figure out how to fix this error without adding a new intermediate variable to store the partial changes and sync back to `priorityMap`. So I have to use `newPriorityMap` to store the priority changes in each round of `merge` operations, and do synchronization at the end of for loop of `merge` and clear the `newPriorityMap` for next round. If any clever fix is found, we should update it.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

