### PR TITLE
Debugging logger issue causing failing tests

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -431,7 +431,6 @@ public class TelemetryService {
         post.setEntity(new StringEntity(payload));
         post.setHeader("Content-type", "application/json");
         post.setHeader("x-api-key", instance.serverDeployment.getApiKey());
-
         try (CloseableHttpClient httpClient =
             HttpClientBuilder.create().setDefaultRequestConfig(config).build()) {
           response = httpClient.execute(post);
@@ -462,7 +461,12 @@ public class TelemetryService {
         if (response != null) {
           res = response.toString();
         }
-        instance.lastClientError = "Response: " + res + "; Error: " + e.getMessage();
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        String stacktrace = sw.toString();
+        instance.lastClientError =
+            "Response: " + res + "; Error: " + e.getMessage() + "; Stacktrace: " + stacktrace;
         instance.clientFailureCnt.incrementAndGet();
         success = false;
       } finally {

--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -437,13 +437,13 @@ public class TelemetryService {
           int statusCode = response.getStatusLine().getStatusCode();
 
           if (statusCode == 200) {
-            logger.debug("telemetry server request success: " + response, true);
+            logger.debug("telemetry server request success: {}", response, true);
             instance.count();
           } else if (statusCode == 429) {
-            logger.debug("telemetry server request hit server cap on response: " + response);
+            logger.debug("telemetry server request hit server cap on response: {}", response);
             instance.serverFailureCnt.incrementAndGet();
           } else {
-            logger.debug("telemetry server request error: " + response, true);
+            logger.debug("telemetry server request error: {}", response, true);
             instance.lastClientError = response.toString();
             instance.clientFailureCnt.incrementAndGet();
             success = false;
@@ -461,12 +461,7 @@ public class TelemetryService {
         if (response != null) {
           res = response.toString();
         }
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        e.printStackTrace(pw);
-        String stacktrace = sw.toString();
-        instance.lastClientError =
-            "Response: " + res + "; Error: " + e.getMessage() + "; Stacktrace: " + stacktrace;
+        instance.lastClientError = "Response: " + res + "; Error: " + e.getMessage();
         instance.clientFailureCnt.incrementAndGet();
         success = false;
       } finally {


### PR DESCRIPTION
# Overview

When recording logging messages, the following string concatenation for messages is causing an issue:
`logger.debug("telemetry server request hit server cap on response: " + response);`

but the error disappears when the logging message is changed so that the additional string is put as an argument to the debug function instead, like so:
`logger.debug("telemetry server request hit server cap on response: {}", response);`

The odd part is that these logging messages have been the same for quite some time but the tests just started failing now. Fixing the ones I see for now, still trying to find the root cause of why the issue just now is popping up.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

