### PR TITLE
SNOW-807489: use LocalDateTime for getTime() when useSessionTimezone is enabled

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
@@ -11,8 +11,6 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.TimeZone;
 import net.snowflake.client.core.arrow.ArrowResultUtil;
 import net.snowflake.client.jdbc.*;
@@ -430,15 +428,12 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
           new Time(
               sfTime.getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS));
       if (resultSetSerializable.getUseSessionTimezone()) {
-        LocalDateTime lcd =
-            LocalDateTime.ofEpochSecond(
+        ts =
+            SnowflakeUtil.getTimeInSessionTimezone(
                 SnowflakeUtil.getSecondsFromMillis(ts.getTime()),
-                sfTime.getNanosecondsWithinSecond(),
-                ZoneOffset.UTC);
-        return Time.valueOf(lcd.toLocalTime());
-      } else {
-        return ts;
+                sfTime.getNanosecondsWithinSecond());
       }
+      return ts;
     } else if (Types.TIMESTAMP == columnType || Types.TIMESTAMP_WITH_TIMEZONE == columnType) {
       Timestamp ts = getTimestamp(columnIndex);
       if (ts == null) {

--- a/src/main/java/net/snowflake/client/core/arrow/BigIntToTimeConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BigIntToTimeConverter.java
@@ -6,6 +6,7 @@ package net.snowflake.client.core.arrow;
 import java.nio.ByteBuffer;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.*;
 import java.util.TimeZone;
 import net.snowflake.client.core.DataConversionContext;
 import net.snowflake.client.core.ResultUtil;
@@ -45,10 +46,19 @@ public class BigIntToTimeConverter extends AbstractArrowVectorConverter {
       if (sfTime == null) {
         return null;
       }
-      return new SnowflakeTimeWithTimezone(
-          sfTime.getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS),
-          sfTime.getNanosecondsWithinSecond(),
-          useSessionTimezone);
+      Time ts =
+          new Time(
+              sfTime.getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS));
+      if (useSessionTimezone) {
+        LocalDateTime lcd =
+            LocalDateTime.ofEpochSecond(
+                SnowflakeUtil.getSecondsFromMillis(ts.getTime()),
+                sfTime.getNanosecondsWithinSecond(),
+                ZoneOffset.UTC);
+        return Time.valueOf(lcd.toLocalTime());
+      } else {
+        return ts;
+      }
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/arrow/BigIntToTimeConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BigIntToTimeConverter.java
@@ -50,15 +50,12 @@ public class BigIntToTimeConverter extends AbstractArrowVectorConverter {
           new Time(
               sfTime.getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS));
       if (useSessionTimezone) {
-        LocalDateTime lcd =
-            LocalDateTime.ofEpochSecond(
+        ts =
+            SnowflakeUtil.getTimeInSessionTimezone(
                 SnowflakeUtil.getSecondsFromMillis(ts.getTime()),
-                sfTime.getNanosecondsWithinSecond(),
-                ZoneOffset.UTC);
-        return Time.valueOf(lcd.toLocalTime());
-      } else {
-        return ts;
+                sfTime.getNanosecondsWithinSecond());
       }
+      return ts;
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/arrow/IntToTimeConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/IntToTimeConverter.java
@@ -6,8 +6,6 @@ package net.snowflake.client.core.arrow;
 import java.nio.ByteBuffer;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.TimeZone;
 import net.snowflake.client.core.DataConversionContext;
 import net.snowflake.client.core.ResultUtil;
@@ -61,15 +59,12 @@ public class IntToTimeConverter extends AbstractArrowVectorConverter {
           new Time(
               sfTime.getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS));
       if (useSessionTimezone) {
-        LocalDateTime lcd =
-            LocalDateTime.ofEpochSecond(
+        ts =
+            SnowflakeUtil.getTimeInSessionTimezone(
                 SnowflakeUtil.getSecondsFromMillis(ts.getTime()),
-                sfTime.getNanosecondsWithinSecond(),
-                ZoneOffset.UTC);
-        return Time.valueOf(lcd.toLocalTime());
-      } else {
-        return ts;
+                sfTime.getNanosecondsWithinSecond());
       }
+      return ts;
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/arrow/IntToTimeConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/IntToTimeConverter.java
@@ -6,14 +6,13 @@ package net.snowflake.client.core.arrow;
 import java.nio.ByteBuffer;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.TimeZone;
 import net.snowflake.client.core.DataConversionContext;
 import net.snowflake.client.core.ResultUtil;
 import net.snowflake.client.core.SFException;
-import net.snowflake.client.jdbc.ErrorCode;
-import net.snowflake.client.jdbc.SnowflakeTimeWithTimezone;
-import net.snowflake.client.jdbc.SnowflakeTimestampWithTimezone;
-import net.snowflake.client.jdbc.SnowflakeType;
+import net.snowflake.client.jdbc.*;
 import net.snowflake.common.core.SFTime;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.ValueVector;
@@ -58,10 +57,19 @@ public class IntToTimeConverter extends AbstractArrowVectorConverter {
       if (sfTime == null) {
         return null;
       }
-      return new SnowflakeTimeWithTimezone(
-          sfTime.getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS),
-          sfTime.getNanosecondsWithinSecond(),
-          useSessionTimezone);
+      Time ts =
+          new Time(
+              sfTime.getFractionalSeconds(ResultUtil.DEFAULT_SCALE_OF_SFTIME_FRACTION_SECONDS));
+      if (useSessionTimezone) {
+        LocalDateTime lcd =
+            LocalDateTime.ofEpochSecond(
+                SnowflakeUtil.getSecondsFromMillis(ts.getTime()),
+                sfTime.getNanosecondsWithinSecond(),
+                ZoneOffset.UTC);
+        return Time.valueOf(lcd.toLocalTime());
+      } else {
+        return ts;
+      }
     }
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -10,8 +10,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
 import java.io.*;
 import java.lang.reflect.Field;
+import java.sql.Time;
 import java.sql.Types;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -649,5 +652,24 @@ public class SnowflakeUtil {
       returnVal = millis / 1000;
     }
     return returnVal;
+  }
+
+  /**
+   * Get the time value in session timezone instead of UTC calculation done by java.sql.Time.
+   *
+   * @param time time in seconds
+   * @param nanos nanoseconds
+   * @return time in session timezone
+   */
+  public static Time getTimeInSessionTimezone(Long time, int nanos) {
+    LocalDateTime lcd = LocalDateTime.ofEpochSecond(time, nanos, ZoneOffset.UTC);
+    Time ts = Time.valueOf(lcd.toLocalTime());
+    // Time.valueOf() will create the time without the nanoseconds i.e. only hh:mm:ss
+    // Using calendar to add the nanoseconds back to time
+    Calendar c = Calendar.getInstance();
+    c.setTimeInMillis(ts.getTime());
+    c.add(Calendar.MILLISECOND, nanos / 1000000);
+    ts.setTime(c.getTimeInMillis());
+    return ts;
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -912,12 +912,40 @@ public class ResultSetLatestIT extends ResultSet0IT {
       statement.execute("insert into testGranularTime values ('10:10:10')");
       ResultSet resultSet = statement.executeQuery("select * from testGranularTime");
       resultSet.next();
-      assertEquals(resultSet.getTime(1), Time.valueOf("10:10:10"));
-      assertEquals(resultSet.getTime(1).getHours(), 10);
-      assertEquals(resultSet.getTime(1).getMinutes(), 10);
-      assertEquals(resultSet.getTime(1).getSeconds(), 10);
+      assertEquals(Time.valueOf("10:10:10"), resultSet.getTime(1));
+      assertEquals(10, resultSet.getTime(1).getHours());
+      assertEquals(10, resultSet.getTime(1).getMinutes());
+      assertEquals(10, resultSet.getTime(1).getSeconds());
       resultSet.close();
     } finally {
+      statement.execute("drop table if exists testGranularTime");
+      statement.close();
+      connection.close();
+    }
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testGranularTimeFunctionsInUTC() throws SQLException {
+    Connection connection = null;
+    Statement statement = null;
+    TimeZone origTz = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+    try {
+      connection = getConnection();
+      statement = connection.createStatement();
+      statement.execute("alter session set JDBC_USE_SESSION_TIMEZONE=false");
+      statement.execute("create or replace table testGranularTime(t time)");
+      statement.execute("insert into testGranularTime values ('10:10:10')");
+      ResultSet resultSet = statement.executeQuery("select * from testGranularTime");
+      resultSet.next();
+      assertEquals(Time.valueOf("02:10:10"), resultSet.getTime(1));
+      assertEquals(02, resultSet.getTime(1).getHours());
+      assertEquals(10, resultSet.getTime(1).getMinutes());
+      assertEquals(10, resultSet.getTime(1).getSeconds());
+      resultSet.close();
+    } finally {
+      TimeZone.setDefault(origTz);
       statement.execute("drop table if exists testGranularTime");
       statement.close();
       connection.close();

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -900,4 +900,27 @@ public class ResultSetLatestIT extends ResultSet0IT {
                   "https://community.snowflake.com/s/article/Snowflake-Client-Connectivity-Troubleshooting."));
     }
   }
+
+  @Test
+  public void testGranularTimeFunctionsInSessionTimezone() throws SQLException {
+    Connection connection = null;
+    Statement statement = null;
+    try {
+      connection = getConnection();
+      statement = connection.createStatement();
+      statement.execute("create or replace table testGranularTime(t time)");
+      statement.execute("insert into testGranularTime values ('10:10:10')");
+      ResultSet resultSet = statement.executeQuery("select * from testGranularTime");
+      resultSet.next();
+      assertEquals(resultSet.getTime(1), Time.valueOf("10:10:10"));
+      assertEquals(resultSet.getTime(1).getHours(), 10);
+      assertEquals(resultSet.getTime(1).getMinutes(), 10);
+      assertEquals(resultSet.getTime(1).getSeconds(), 10);
+      resultSet.close();
+    } finally {
+      statement.execute("drop table if exists testGranularTime");
+      statement.close();
+      connection.close();
+    }
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-807489
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/359

The java.sql.Time library uses UTC so when calling getTime().getHours() the result is skewed and not returned in the session timezone. 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Use java.time.LocalTime for the conversion, that way we can get granular functions in the same timezone as getTime()

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

