### PR TITLE
Revert "[SNOW-747966] Fetch metadata.getTableTypes() from the backend service"

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/DBMetadataResultSetMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/DBMetadataResultSetMetadata.java
@@ -324,10 +324,6 @@ public enum DBMetadataResultSetMetadata {
           Types.VARCHAR,
           Types.VARCHAR,
           Types.VARCHAR)),
-  GET_TABLE_TYPES(
-      Collections.singletonList("TABLE_TYPE"),
-      Collections.singletonList("TEXT"),
-      Collections.singletonList(Types.VARCHAR)),
   ;
 
   private List<String> columnNames;

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -1601,15 +1601,13 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
     raiseSQLExceptionIfConnectionIsClosed();
     Statement statement = connection.createStatement();
 
-    String tableTypeCommand =
-        "SELECT DISTINCT\n"
-            + "  CASE TABLE_TYPE\n"
-            + "    WHEN 'BASE TABLE' THEN 'TABLE' // For backward compatibility. \n"
-            + "    ELSE TABLE_TYPE\n"
-            + "  END AS TABLE_TYPE\n"
-            + "FROM INFORMATION_SCHEMA.TABLES;";
-
-    return executeAndReturnEmptyResultIfNotFound(statement, tableTypeCommand, GET_TABLE_TYPES);
+    // TODO: We should really get the list of table types from GS
+    return new SnowflakeDatabaseMetaDataResultSet(
+        Collections.singletonList("TABLE_TYPE"),
+        Collections.singletonList("TEXT"),
+        Collections.singletonList(Types.VARCHAR),
+        new Object[][] {{"TABLE"}, {"VIEW"}},
+        statement);
   }
 
   @Override


### PR DESCRIPTION
Reverts snowflakedb/snowflake-jdbc#1337 

Introduces regression as `SELECT DISTINCT` query always assumes that current db is set. 