### PR TITLE
Fix JDBC compliance for java.sql.Driver#connect behavior

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -30,6 +30,10 @@ public class SnowflakeConnectString implements Serializable {
 
   private static final String PREFIX = "jdbc:snowflake://";
 
+  public static boolean hasSupportedPrefix(String url) {
+    return url.startsWith(PREFIX);
+  }
+
   public static SnowflakeConnectString parse(String url, Properties info) {
     if (url == null) {
       logger.debug("Connect strings must be non-null");

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -173,6 +173,13 @@ public class SnowflakeDriver implements Driver {
    */
   @Override
   public Connection connect(String url, Properties info) throws SQLException {
+    if (url == null) {
+      // expected return format per the JDBC spec for java.sql.Driver#connect()
+      throw new SnowflakeSQLException("Unable to connect to url of 'null'.");
+    }
+    if (!SnowflakeConnectString.hasSupportedPrefix(url)) {
+      return null; // expected return format per the JDBC spec for java.sql.Driver#connect()
+    }
     SnowflakeConnectString conStr = SnowflakeConnectString.parse(url, info);
     if (!conStr.isValid()) {
       throw new SnowflakeSQLException("Connection string is invalid. Unable to parse.");

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
@@ -358,14 +358,19 @@ public class SnowflakeDriverTest {
     assertFalse(snowflakeDriver.acceptsURL("jdbc:snowflake://localhost:8080/a=b"));
     assertFalse(snowflakeDriver.acceptsURL("jdbc:snowflake://testaccount.com?proxyHost=%%"));
     assertFalse(
-        snowflakeDriver.acceptsURL("jdbc:snowflake://testaccount.com?proxyHost=%b&proxyPort="));
+            snowflakeDriver.acceptsURL("jdbc:snowflake://testaccount.com?proxyHost=%b&proxyPort="));
     assertFalse(snowflakeDriver.acceptsURL("jdbc:mysql://localhost:3306/dbname"));
   }
 
-  @Test(expected = SQLException.class)
-  public void testInvalidNullConnect() throws SQLException {
+  @Test
+  public void testInvalidNullConnect() {
     SnowflakeDriver snowflakeDriver = SnowflakeDriver.INSTANCE;
-    snowflakeDriver.connect(null, null);
+    try {
+      snowflakeDriver.connect(/* url= */ null, null);
+      fail();
+    } catch (SQLException ex) {
+      assertEquals("Unable to connect to url of 'null'.", ex.getMessage());
+    }
   }
 
   @Test
@@ -418,5 +423,13 @@ public class SnowflakeDriverTest {
     } catch (Exception ex) {
       assertEquals("Connection string is invalid. Unable to parse.", ex.getMessage());
     }
+  }
+
+  @Test
+  public void testReturnsNullForOtherJdbcConnectString() throws SQLException {
+    SnowflakeDriver snowflakeDriver = SnowflakeDriver.INSTANCE;
+    Properties info = new Properties();
+    String jdbcConnectString = "jdbc:mysql://host:port/database";
+    assertNull(snowflakeDriver.connect(jdbcConnectString, info));
   }
 }


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowflake-jdbc/issues/1385


2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

With the change at https://github.com/snowflakedb/snowflake-jdbc/commit/002bc9bb528a71b0233742240d02ce4677fb75d6#diff-4f3178596882a13c6056798452dcfe204fb223a11840cc8de8677ba4acc4fec2R178 the snowflake-jdbc driver is now out of compliance with the JDBC spec.  Drivers are supposed to return null if they don't support a connection string, but with that change the snowflake-jdbc driver is now throwing an exception.  This makes the driver unable to be used in the same JVM as other JDBC connections.

This PR fixes the problem by returning null in the right scenario, instead of throwing.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

