### PR TITLE
HTTP calls should give up eventually

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -48,6 +48,8 @@ public class RestRequest {
 
   // retry at least once even if timeout limit has been reached
   private static final int MIN_RETRY_COUNT = 1;
+  // assume that if we reach this point, then something catastrophic has happened
+  private static final int MAX_RETRY_COUNT = 100;
 
   public static CloseableHttpResponse execute(
       CloseableHttpClient httpClient,
@@ -157,7 +159,7 @@ public class RestRequest {
     String lastStatusCodeForRetry = "";
 
     // try request till we get a good response or retry timeout
-    while (true) {
+    while (retryCount < MAX_RETRY_COUNT) {
       logger.debug("Retry count: {}", retryCount);
       logger.debug("Attempting request: {}", requestInfoScrubbed);
 


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowflake-jdbc/issues/204 (was closed as stale, but is still a problem).

   This issue was causing problems in `PUT` calls into GCP snowflake instances, because GCS uploads sometimes throw a plain `IOException`. The `PUT` call then spins in the RestRequest loop forever, and repeatedly calls `response = httpClient.execute(httpRequest);`, resulting in these two log lines being printed forever:
   ```
   2023-02-09 21:35:07 �[43mdestination�[0m > INFO: I/O exception (java.io.IOException) caught when processing request to {s}->https://gcpuscentral1-a4twomm-stage.storage.googleapis.com:443: Stream Closed
   2023-02-09 21:35:09 �[43mdestination�[0m > Feb 09, 2023 9:35:09 PM net.snowflake.client.jdbc.internal.apache.http.impl.execchain.RetryExec execute
   ```

   With this new behavior, after exhausting all 100 attempts, the caller will receive an exception. Example logs:
   ```
   SEVERE: Returning null response for request: PUT https://gcpuscentral1-z5072lr-stage.storage.googleapis.com/stages/8e247a4c-bfca-4e21-a661-f6bc466b65d9/foo/test.csv.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=gcpuscentral1-z5072lr-stage%40us-central1-stage1-6e1d.iam.gserviceaccount.com%2F20230519%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230519T232829Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&X-Goog-Signature=**** HTTP/1.1
   May 19, 2023 4:28:46 PM net.snowflake.client.jdbc.SnowflakeFileTransferAgent$1 call
   SEVERE: Exception encountered during file upload
   net.snowflake.client.jdbc.SnowflakeSQLLoggedException: JDBC driver internal error: Unexpected: upload with presigned url failed.
   	at net.snowflake.client.jdbc.cloud.storage.SnowflakeGCSClient.uploadWithPresignedUrl(SnowflakeGCSClient.java:777)
   	at net.snowflake.client.jdbc.cloud.storage.SnowflakeGCSClient.upload(SnowflakeGCSClient.java:624)
   	at net.snowflake.client.jdbc.SnowflakeFileTransferAgent.pushFileToRemoteStore(SnowflakeFileTransferAgent.java:1850)
   	at net.snowflake.client.jdbc.SnowflakeFileTransferAgent.access$400(SnowflakeFileTransferAgent.java:51)
   	at net.snowflake.client.jdbc.SnowflakeFileTransferAgent$1.call(SnowflakeFileTransferAgent.java:556)
   	at net.snowflake.client.jdbc.SnowflakeFileTransferAgent$1.call(SnowflakeFileTransferAgent.java:437)
   	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
   	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
   	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
   	at java.base/java.lang.Thread.run(Thread.java:833)
   ```


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Adds a backstop condition to RestRequest's retry loop. This is nonconfigurable, but IMO if we hit 100 attempts, then there's no point in continuing. (the exact threshold is debatable, ofc)

   I can't get the tests to run locally, so would appreciate some pointers with adding a testcase to RestRequestTest. Specifically, Mockito is throwing errors about being unable to mock httpClient:
<details>
<summary>maven output</summary>

```
org.mockito.exceptions.base.MockitoException:

Mockito cannot mock this class: class org.apache.http.impl.client.CloseableHttpClient.

If you're not sure why you're getting this error, please report to the mailing list.


Java               : 17
JVM vendor name    : Oracle Corporation
JVM vendor version : 17+35-2724
JVM name           : OpenJDK 64-Bit Server VM
JVM version        : 17+35-2724
JVM info           : mixed mode, sharing
OS name            : Mac OS X
OS version         : 12.2.1


You are seeing this disclaimer because Mockito is configured to create inlined mocks.
You can learn about inline mocks and their limitations under item #39 of the Mockito class javadoc.

Underlying exception : org.mockito.exceptions.base.MockitoException: Could not modify all classes [interface java.io.Closeable, class java.lang.Object, interface java.lang.AutoCloseable, class org.apache.http.impl.client.CloseableHttpClient, interface org.apache.http.client.HttpClient]
	at net.snowflake.client.jdbc.RestRequestTest.testNoRetry(RestRequestTest.java:338)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
Caused by: org.mockito.exceptions.base.MockitoException: Could not modify all classes [interface java.io.Closeable, class java.lang.Object, interface java.lang.AutoCloseable, class org.apache.http.impl.client.CloseableHttpClient, interface org.apache.http.client.HttpClient]
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:152)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:365)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:174)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:376)
	... 29 more
Caused by: java.lang.IllegalStateException:
Byte Buddy could not instrument all classes within the mock's type hierarchy

This problem should never occur for javac-compiled classes. This problem has been observed for classes that are:
 - Compiled by older versions of scalac
 - Classes that are part of the Android distribution
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.triggerRetransformation(InlineBytecodeGenerator.java:254)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.mockClass(InlineBytecodeGenerator.java:210)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator$1.call(TypeCachingBytecodeGenerator.java:46)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator$1.call(TypeCachingBytecodeGenerator.java:43)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:152)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:365)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:174)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:376)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator.mockClass(TypeCachingBytecodeGenerator.java:36)
	at org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker.createMockType(InlineByteBuddyMockMaker.java:379)
	at org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker.doCreateMock(InlineByteBuddyMockMaker.java:339)
	at org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker.createMock(InlineByteBuddyMockMaker.java:318)
	at org.mockito.internal.util.MockUtil.createMock(MockUtil.java:52)
	at org.mockito.internal.MockitoCore.mock(MockitoCore.java:61)
	at org.mockito.Mockito.mock(Mockito.java:1949)
	at org.mockito.Mockito.mock(Mockito.java:1860)
	... 29 more
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 61
	at net.bytebuddy.jar.asm.ClassReader.<init>(ClassReader.java:196)
	at net.bytebuddy.jar.asm.ClassReader.<init>(ClassReader.java:177)
	at net.bytebuddy.jar.asm.ClassReader.<init>(ClassReader.java:163)
	at net.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:86)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForInlining.create(TypeWriter.java:3824)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2166)
	at net.bytebuddy.dynamic.scaffold.inline.RedefinitionDynamicTypeBuilder.make(RedefinitionDynamicTypeBuilder.java:224)
	at net.bytebuddy.dynamic.scaffold.inline.AbstractInliningDynamicTypeBuilder.make(AbstractInliningDynamicTypeBuilder.java:123)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3595)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.transform(InlineBytecodeGenerator.java:365)
	at java.instrument/java.lang.instrument.ClassFileTransformer.transform(ClassFileTransformer.java:244)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:541)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:169)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.triggerRetransformation(InlineBytecodeGenerator.java:250)
	... 44 more
```
</details>

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

