### PR TITLE
SNOW-828029 Force use of the Buffer API

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
+++ b/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
@@ -328,7 +328,7 @@ public class ResultJsonParserV2 {
                 // the last remaining data in the buffer),
                 // there is not enough bytes to parse the codepoint. Move the position back 1,
                 // so we can re-enter parsing at this position with the ESCAPE state.
-                in.position(in.position() - 1);
+                ((Buffer) in).position(in.position() - 1);
                 state = State.ESCAPE;
                 return;
               }

--- a/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
+++ b/src/main/java/net/snowflake/client/jdbc/ResultJsonParserV2.java
@@ -328,7 +328,7 @@ public class ResultJsonParserV2 {
                 // the last remaining data in the buffer),
                 // there is not enough bytes to parse the codepoint. Move the position back 1,
                 // so we can re-enter parsing at this position with the ESCAPE state.
-                ((Buffer) in).position(in.position() - 1);
+                ((Buffer) in).position(((Buffer) in).position() - 1);
                 state = State.ESCAPE;
                 return;
               }


### PR DESCRIPTION
when calling the int position(int) API

Without the type-cast the compiler uses a newer Java API signature that returns a ByteBuffer object instead

Fixes the Java 8 runtime error of:
java.lang.NoSuchMethodError: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer

# Overview

SNOW-XXXXX

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

