### PR TITLE
[SNOW-811880] Prevent Infinite retries!

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -656,7 +656,7 @@ public class HttpUtil {
    * @param retryTimeout retry timeout
    * @param authTimeout authenticator timeout
    * @param socketTimeout socket timeout (in ms)
-   * @param retryCount retry count for the request
+   * @param maxRetries retry count for the request
    * @param injectSocketTimeout injecting socket timeout
    * @param canceling canceling?
    * @param includeRetryParameters whether to include retry parameters in retried requests
@@ -671,7 +671,7 @@ public class HttpUtil {
       int retryTimeout,
       int authTimeout,
       int socketTimeout,
-      int retryCount,
+      int maxRetries,
       int injectSocketTimeout,
       AtomicBoolean canceling,
       boolean includeRetryParameters,
@@ -686,7 +686,7 @@ public class HttpUtil {
         retryTimeout,
         authTimeout,
         socketTimeout,
-        retryCount,
+        maxRetries,
         injectSocketTimeout,
         canceling,
         false, // with cookie (do we need cookie?)
@@ -708,7 +708,7 @@ public class HttpUtil {
    * @param retryTimeout retry timeout (in seconds)
    * @param authTimeout authenticator specific timeout (in seconds)
    * @param socketTimeout socket timeout (in ms)
-   * @param retryCount retry count for the request
+   * @param maxRetries retry count for the request
    * @param injectSocketTimeout simulate socket timeout
    * @param canceling canceling flag
    * @param withoutCookies whether this request should ignore cookies
@@ -725,7 +725,7 @@ public class HttpUtil {
       int retryTimeout,
       int authTimeout,
       int socketTimeout,
-      int retryCount,
+      int maxRetries,
       int injectSocketTimeout,
       AtomicBoolean canceling,
       boolean withoutCookies,
@@ -754,7 +754,7 @@ public class HttpUtil {
               retryTimeout,
               authTimeout,
               socketTimeout,
-              retryCount,
+              maxRetries,
               injectSocketTimeout,
               canceling,
               withoutCookies,

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -105,6 +105,9 @@ public class SFSession extends SFBaseSession {
   // The cache of query context sent from Cloud Service.
   private QueryContextCache qcc;
 
+  // Max retries for outgoing http requests.
+  private int maxHttpRetries = 7;
+
   // This constructor is used only by tests with no real connection.
   // For real connections, the other constructor is always used.
   @VisibleForTesting
@@ -350,6 +353,12 @@ public class SFSession extends SFBaseSession {
         case PRIVATE_KEY_FILE_PWD:
           if (propertyValue != null) {
             privateKeyPassword = (String) propertyValue;
+          }
+          break;
+
+        case MAX_HTTP_RETRIES:
+          if (propertyValue != null) {
+            maxHttpRetries = (Integer) propertyValue;
           }
           break;
 
@@ -895,6 +904,10 @@ public class SFSession extends SFBaseSession {
 
   public int getInjectClientPause() {
     return injectClientPause;
+  }
+
+  public int getMaxHttpRetries() {
+    return maxHttpRetries;
   }
 
   public void setInjectClientPause(int injectClientPause) {

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -67,7 +67,9 @@ public enum SFSessionProperty {
   DISABLE_QUERY_CONTEXT_CACHE("disableQueryContextCache", false, Boolean.class),
   HTAP_OOB_TELEMETRY_ENABLED("htapOOBTelemetryEnabled", false, Boolean.class),
 
-  CLIENT_CONFIG_FILE("clientConfigFile", false, String.class);
+  CLIENT_CONFIG_FILE("clientConfigFile", false, String.class),
+
+  MAX_HTTP_RETRIES("maxHttpRetries", false, Integer.class);
 
   // property key in string
   private String propertyKey;
@@ -147,7 +149,14 @@ public enum SFSessionProperty {
       if (property.getValueType() == Boolean.class && propertyValue instanceof String) {
         return SFLoginInput.getBooleanValue(propertyValue);
       } else if (property.getValueType() == Integer.class && propertyValue instanceof String) {
-        return Integer.valueOf((String) propertyValue);
+        try{
+          return Integer.valueOf((String) propertyValue);
+        }catch (NumberFormatException e){
+          throw new SFException(
+                  ErrorCode.INVALID_PARAMETER_VALUE,
+                  propertyValue.getClass().getName(),
+                  property.getValueType().getName());
+        }
       }
     }
 

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -149,13 +149,13 @@ public enum SFSessionProperty {
       if (property.getValueType() == Boolean.class && propertyValue instanceof String) {
         return SFLoginInput.getBooleanValue(propertyValue);
       } else if (property.getValueType() == Integer.class && propertyValue instanceof String) {
-        try{
+        try {
           return Integer.valueOf((String) propertyValue);
-        }catch (NumberFormatException e){
+        } catch (NumberFormatException e) {
           throw new SFException(
-                  ErrorCode.INVALID_PARAMETER_VALUE,
-                  propertyValue.getClass().getName(),
-                  property.getValueType().getName());
+              ErrorCode.INVALID_PARAMETER_VALUE,
+              propertyValue.getClass().getName(),
+              property.getValueType().getName());
         }
       }
     }

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -406,7 +406,6 @@ public class SFStatement extends SFBaseStatement {
           .setOCSPMode(session.getOCSPMode())
           .setHttpClientSettingsKey(session.getHttpClientKey())
           .setQueryContextDTO(session.isAsyncSession() ? null : session.getQueryContextDTO());
-
       if (bindStagePath != null) {
         stmtInput.setBindValues(null).setBindStage(bindStagePath);
         // use the new SQL format for this query so dates/timestamps are parsed correctly

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -405,8 +405,8 @@ public class SFStatement extends SFBaseStatement {
           .setServiceName(session.getServiceName())
           .setOCSPMode(session.getOCSPMode())
           .setHttpClientSettingsKey(session.getHttpClientKey())
-          .setQueryContextDTO(session.isAsyncSession() ? null : session.getQueryContextDTO())
-              .setRetryCount(7);
+          .setQueryContextDTO(session.isAsyncSession() ? null : session.getQueryContextDTO());
+
       if (bindStagePath != null) {
         stmtInput.setBindValues(null).setBindStage(bindStagePath);
         // use the new SQL format for this query so dates/timestamps are parsed correctly

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -405,6 +405,7 @@ public class SFStatement extends SFBaseStatement {
           .setServiceName(session.getServiceName())
           .setOCSPMode(session.getOCSPMode())
           .setHttpClientSettingsKey(session.getHttpClientKey())
+          .setMaxRetries(session.getMaxHttpRetries())
           .setQueryContextDTO(session.isAsyncSession() ? null : session.getQueryContextDTO());
       if (bindStagePath != null) {
         stmtInput.setBindValues(null).setBindStage(bindStagePath);
@@ -710,6 +711,7 @@ public class SFStatement extends SFBaseStatement {
         .setSessionToken(session.getSessionToken())
         .setServiceName(session.getServiceName())
         .setOCSPMode(session.getOCSPMode())
+        .setMaxRetries(session.getMaxHttpRetries())
         .setHttpClientSettingsKey(session.getHttpClientKey());
 
     StmtUtil.cancel(stmtInput);

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -405,7 +405,8 @@ public class SFStatement extends SFBaseStatement {
           .setServiceName(session.getServiceName())
           .setOCSPMode(session.getOCSPMode())
           .setHttpClientSettingsKey(session.getHttpClientKey())
-          .setQueryContextDTO(session.isAsyncSession() ? null : session.getQueryContextDTO());
+          .setQueryContextDTO(session.isAsyncSession() ? null : session.getQueryContextDTO())
+              .setRetryCount(7);
       if (bindStagePath != null) {
         stmtInput.setBindValues(null).setBindStage(bindStagePath);
         // use the new SQL format for this query so dates/timestamps are parsed correctly

--- a/src/main/java/net/snowflake/client/core/StmtUtil.java
+++ b/src/main/java/net/snowflake/client/core/StmtUtil.java
@@ -85,6 +85,8 @@ public class StmtUtil {
     int injectSocketTimeout; // seconds
     int injectClientPause; // seconds
 
+    int retryCount;
+
     AtomicBoolean canceling = null; // canceling flag
     boolean retry;
     String prevGetResultURL = null; // previous get result URL from ping pong
@@ -229,6 +231,14 @@ public class StmtUtil {
       this.queryContextDTO = queryContext;
       return this;
     }
+
+    public int getRetryCount() {
+      return retryCount;
+    }
+
+    public void setRetryCount(int retryCount) {
+      this.retryCount = retryCount;
+    }
   }
 
   /** Output for running a statement on server */
@@ -362,7 +372,7 @@ public class StmtUtil {
                 stmtInput.networkTimeoutInMillis / 1000,
                 stmtInput.socketTimeout,
                 0,
-                0,
+                stmtInput.retryCount,
                 stmtInput.injectSocketTimeout,
                 stmtInput.canceling,
                 true, // include retry parameters

--- a/src/main/java/net/snowflake/client/core/StmtUtil.java
+++ b/src/main/java/net/snowflake/client/core/StmtUtil.java
@@ -61,8 +61,6 @@ public class StmtUtil {
   // twice as much as our default socket timeout
   static final int SF_CANCELING_RETRY_TIMEOUT_IN_MILLIS = 600000; // 10 min
 
-  static final int MAX_RETRIES = 7; // Default max retries for transient http requests!
-
   static final SFLogger logger = SFLoggerFactory.getLogger(StmtUtil.class);
 
   /** Input for executing a statement on server */
@@ -87,7 +85,7 @@ public class StmtUtil {
     int injectSocketTimeout; // seconds
     int injectClientPause; // seconds
 
-    int maxRetries = MAX_RETRIES;
+    int maxRetries;
 
     AtomicBoolean canceling = null; // canceling flag
     boolean retry;
@@ -234,12 +232,9 @@ public class StmtUtil {
       return this;
     }
 
-    public int getMaxRetries() {
-      return maxRetries;
-    }
-
-    public void setMaxRetries(int maxRetries) {
+    public StmtInput setMaxRetries(int maxRetries) {
       this.maxRetries = maxRetries;
+      return this;
     }
   }
 
@@ -652,7 +647,8 @@ public class StmtUtil {
             .setMediaType(SF_MEDIA_TYPE)
             .setServiceName(session.getServiceName())
             .setOCSPMode(session.getOCSPMode())
-            .setHttpClientSettingsKey(session.getHttpClientKey());
+            .setHttpClientSettingsKey(session.getHttpClientKey())
+            .setMaxRetries(session.getMaxHttpRetries());
 
     String resultAsString = getQueryResult(getResultPath, stmtInput);
 

--- a/src/main/java/net/snowflake/client/core/StmtUtil.java
+++ b/src/main/java/net/snowflake/client/core/StmtUtil.java
@@ -61,6 +61,8 @@ public class StmtUtil {
   // twice as much as our default socket timeout
   static final int SF_CANCELING_RETRY_TIMEOUT_IN_MILLIS = 600000; // 10 min
 
+  static final int MAX_RETRIES = 7; // Default max retries for transient http requests!
+
   static final SFLogger logger = SFLoggerFactory.getLogger(StmtUtil.class);
 
   /** Input for executing a statement on server */
@@ -85,7 +87,7 @@ public class StmtUtil {
     int injectSocketTimeout; // seconds
     int injectClientPause; // seconds
 
-    int retryCount;
+    int maxRetries = MAX_RETRIES;
 
     AtomicBoolean canceling = null; // canceling flag
     boolean retry;
@@ -232,12 +234,12 @@ public class StmtUtil {
       return this;
     }
 
-    public int getRetryCount() {
-      return retryCount;
+    public int getMaxRetries() {
+      return maxRetries;
     }
 
-    public void setRetryCount(int retryCount) {
-      this.retryCount = retryCount;
+    public void setMaxRetries(int maxRetries) {
+      this.maxRetries = maxRetries;
     }
   }
 
@@ -372,7 +374,7 @@ public class StmtUtil {
                 stmtInput.networkTimeoutInMillis / 1000,
                 stmtInput.socketTimeout,
                 0,
-                stmtInput.retryCount,
+                stmtInput.maxRetries,
                 stmtInput.injectSocketTimeout,
                 stmtInput.canceling,
                 true, // include retry parameters
@@ -612,7 +614,7 @@ public class StmtUtil {
           stmtInput.networkTimeoutInMillis / 1000,
           stmtInput.socketTimeout,
           0,
-          0,
+          stmtInput.maxRetries,
           0,
           stmtInput.canceling,
           false, // no retry parameter

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -337,6 +337,7 @@ public class RestRequest {
         String breakRetryEventName = "";
 
         if (retryTimeoutInMilliseconds > 0) {
+          // Check for retry time-out.
           // increment total elapsed due to transient issues
           elapsedMilliForTransientIssues += elapsedMilliForLastCall;
 
@@ -355,7 +356,9 @@ public class RestRequest {
             breakRetryReason = "retry timeout";
             breakRetryEventName = "HttpRequestRetryTimeout";
           }
-        } else if (maxRetries > 0 && retryCount > maxRetries) {
+        }
+        if (maxRetries > 0 && retryCount > maxRetries) {
+          // check for max retries.
           logger.error(
               "Stop retrying as max retries have been reached! max retry count: {}", maxRetries);
           breakRetryReason = "max retries reached";
@@ -363,6 +366,8 @@ public class RestRequest {
         }
 
         if (breakRetryEventName != "" && !breakRetryEventName.isEmpty()) {
+          // If either of network timeout is exhausted or max retries have been reached, stop
+          // retrying!
           TelemetryService.getInstance()
               .logHttpRequestTelemetryEvent(
                   breakRetryEventName,

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -229,7 +229,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
                   session.getNetworkTimeoutInMilli() / 1000, // retry timeout
                   session.getAuthTimeout(),
                   session.getHttpClientSocketTimeout(),
-                  0,
+                  getMaxRetries(),
                   0, // no socket timeout injection
                   null, // no canceling
                   false, // no cookie
@@ -395,7 +395,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
                   session.getNetworkTimeoutInMilli() / 1000, // retry timeout
                   session.getAuthTimeout(),
                   session.getHttpClientSocketTimeout(),
-                  0,
+                  getMaxRetries(),
                   0, // no socket timeout injection
                   null, // no canceling
                   false, // no cookie
@@ -774,7 +774,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
               networkTimeoutInMilli / 1000, // retry timeout
               authTimeout, // auth timeout
               httpClientSocketTimeout, // socket timeout in ms
-              0,
+              getMaxRetries(),
               0, // no socket timeout injection
               null, // no canceling
               false, // no cookie

--- a/src/test/java/net/snowflake/client/core/SFSessionPropertyTest.java
+++ b/src/test/java/net/snowflake/client/core/SFSessionPropertyTest.java
@@ -44,13 +44,12 @@ public class SFSessionPropertyTest {
         "user-agent header should contain the suffix ", userAgentHeader, endsWith(customSuffix));
   }
 
-
   @Test
   public void testInvalidMaxRetries() {
-    try{
+    try {
       SFSessionProperty.checkPropertyValue(SFSessionProperty.MAX_HTTP_RETRIES, "invalidValue");
       Assert.fail("testInvalidMaxRetries");
-    }catch (SFException e){
+    } catch (SFException e) {
       assertThat(e.getVendorCode(), is(ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode()));
     }
   }
@@ -58,8 +57,9 @@ public class SFSessionPropertyTest {
   @Test
   public void testvalidMaxRetries() throws SFException {
     int expectedVal = 10;
-    Object value = SFSessionProperty.checkPropertyValue(SFSessionProperty.MAX_HTTP_RETRIES, expectedVal);
+    Object value =
+        SFSessionProperty.checkPropertyValue(SFSessionProperty.MAX_HTTP_RETRIES, expectedVal);
 
-    assertThat("Integer value should match", (int)value == expectedVal);
+    assertThat("Integer value should match", (int) value == expectedVal);
   }
 }

--- a/src/test/java/net/snowflake/client/core/SFSessionPropertyTest.java
+++ b/src/test/java/net/snowflake/client/core/SFSessionPropertyTest.java
@@ -43,4 +43,23 @@ public class SFSessionPropertyTest {
     assertThat(
         "user-agent header should contain the suffix ", userAgentHeader, endsWith(customSuffix));
   }
+
+
+  @Test
+  public void testInvalidMaxRetries() {
+    try{
+      SFSessionProperty.checkPropertyValue(SFSessionProperty.MAX_HTTP_RETRIES, "invalidValue");
+      Assert.fail("testInvalidMaxRetries");
+    }catch (SFException e){
+      assertThat(e.getVendorCode(), is(ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode()));
+    }
+  }
+
+  @Test
+  public void testvalidMaxRetries() throws SFException {
+    int expectedVal = 10;
+    Object value = SFSessionProperty.checkPropertyValue(SFSessionProperty.MAX_HTTP_RETRIES, expectedVal);
+
+    assertThat("Integer value should match", (int)value == expectedVal);
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-811880 - Limits the retries to 7 when network timeout isn't defined for `/queries/v1/query-request `and `/queries/%s/result` endpoints.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

