### PR TITLE
SNOW-835387 alter parameter to upload using presigned url

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -1459,6 +1459,9 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
       connection = getConnection("gcpaccount");
       Statement statement = connection.createStatement();
 
+      // set parameter for presignedUrl upload instead of downscoped token
+      statement.execute("alter session set GCS_USE_DOWNSCOPED_CREDENTIAL = false");
+
       // create a stage to put the file in
       statement.execute("CREATE OR REPLACE STAGE " + testStageName);
 

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -1456,11 +1456,11 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
     File destFolder = tmpFolder.newFolder();
     String destFolderCanonicalPath = destFolder.getCanonicalPath();
     try {
-      connection = getConnection("gcpaccount");
-      Statement statement = connection.createStatement();
-
       // set parameter for presignedUrl upload instead of downscoped token
-      statement.execute("alter session set GCS_USE_DOWNSCOPED_CREDENTIAL = false");
+      Properties paramProperties = new Properties();
+      paramProperties.put("GCS_USE_DOWNSCOPED_CREDENTIAL", false);
+      connection = getConnection("gcpaccount", paramProperties);
+      Statement statement = connection.createStatement();
 
       // create a stage to put the file in
       statement.execute("CREATE OR REPLACE STAGE " + testStageName);


### PR DESCRIPTION
# Overview

SNOW-835387
A change was made in GS code to use downscoped token for [get and put by default](https://github.com/snowflakedb/snowflake/pull/102264). This parameter needs to be set to false to use presigned URL. Note: for future reference, a get or put in JDBC should be expected to return a downscope token. Pre-signed URLS are only for large results.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

