### PR TITLE
SNOW-352846 OAuth authentication for sessionless telemetry client

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -97,13 +97,15 @@ public class TelemetryClient implements Telemetry {
    * @param authType authorization type, should be either KEYPAIR_JWY or OAUTH
    * @param flushSize maximum size of telemetry batch before flush
    */
-  private TelemetryClient(CloseableHttpClient httpClient, String serverUrl, String authType, int flushSize) {
+  private TelemetryClient(
+      CloseableHttpClient httpClient, String serverUrl, String authType, int flushSize) {
     this.session = null;
     this.serverUrl = serverUrl;
     this.httpClient = httpClient;
 
     if (!Objects.equals(authType, "KEYPAIR_JWT") && !Objects.equals(authType, "OAUTH")) {
-      throw new IllegalArgumentException("Invalid authType, should be \"KEYPAIR_JWT\" or \"OAUTH\"");
+      throw new IllegalArgumentException(
+          "Invalid authType, should be \"KEYPAIR_JWT\" or \"OAUTH\"");
     }
     this.authType = authType;
 
@@ -341,19 +343,19 @@ public class TelemetryClient implements Telemetry {
         response =
             this.session == null
                 ? HttpUtil.executeGeneralRequest(
-                post,
-                TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC,
-                0,
-                DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT,
-                0,
-                this.httpClient)
+                    post,
+                    TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC,
+                    0,
+                    DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT,
+                    0,
+                    this.httpClient)
                 : HttpUtil.executeGeneralRequest(
-                post,
-                TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC,
-                this.session.getAuthTimeout(),
-                this.session.getHttpClientSocketTimeout(),
-                0,
-                this.session.getHttpClientKey());
+                    post,
+                    TELEMETRY_HTTP_RETRY_TIMEOUT_IN_SEC,
+                    this.session.getAuthTimeout(),
+                    this.session.getHttpClientSocketTimeout(),
+                    0,
+                    this.session.getHttpClientKey());
       } catch (SnowflakeSQLException e) {
         disableTelemetry(); // when got error like 404 or bad request, disable telemetry in this
         // telemetry instance

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -212,7 +212,9 @@ public class TelemetryIT extends AbstractDriverIT {
     TelemetryClient telemetry =
         (TelemetryClient)
             TelemetryClient.createSessionlessTelemetry(
-                httpClient, String.format("%s:%s", parameters.get("host"), parameters.get("port")), "KEYPAIR_JWT");
+                httpClient,
+                String.format("%s:%s", parameters.get("host"), parameters.get("port")),
+                "KEYPAIR_JWT");
     telemetry.refreshToken(jwtToken);
     return telemetry;
   }
@@ -241,9 +243,11 @@ public class TelemetryIT extends AbstractDriverIT {
     TelemetryClient telemetry =
         (TelemetryClient)
             TelemetryClient.createSessionlessTelemetry(
-                httpClient, String.format("%s:%s", parameters.get("host"), parameters.get("port")), "OAUTH");
+                httpClient,
+                String.format("%s:%s", parameters.get("host"), parameters.get("port")),
+                "OAUTH");
     telemetry.refreshToken(oAuthToken);
-    return telemetry;
+    return telemetry;g
   }
 
   // Helper function to set up and get OAuth token

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -17,7 +17,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
-import java.util.Properties;
 
 import net.snowflake.client.AbstractDriverIT;
 import net.snowflake.client.ConditionalIgnoreRule;
@@ -26,7 +25,6 @@ import net.snowflake.client.category.TestCategoryCore;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.core.SessionUtil;
-import net.snowflake.common.core.ClientAuthnDTO;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -247,7 +247,7 @@ public class TelemetryIT extends AbstractDriverIT {
                 String.format("%s:%s", parameters.get("host"), parameters.get("port")),
                 "OAUTH");
     telemetry.refreshToken(oAuthToken);
-    return telemetry;g
+    return telemetry;
   }
 
   // Helper function to set up and get OAuth token

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -17,7 +17,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
-
 import net.snowflake.client.AbstractDriverIT;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;


### PR DESCRIPTION
# Overview

SNOW-352846 requires a stateless telemetry service client with OAuth authentication.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   This is a precedence task of SNOW-352846. 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    Add an additional param in telemetry client to switch between key-pair JWT or OAuth.

## Pre-review checklist
- [x] This change has passed precommit
- [x] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

