### PR TITLE
[SNOW-835640] Gracefully handle MessageFormat.format exceptions

### DIFF
--- a/src/main/java/net/snowflake/client/log/JDK14Logger.java
+++ b/src/main/java/net/snowflake/client/log/JDK14Logger.java
@@ -134,7 +134,12 @@ public class JDK14Logger implements SFLogger {
   private void logInternal(Level level, String msg, Object... arguments) {
     if (jdkLogger.isLoggable(level)) {
       String[] source = findSourceInStack();
-      String message = MessageFormat.format(refactorString(msg), evaluateLambdaArgs(arguments));
+      String message = "";
+      try {
+        message = MessageFormat.format(refactorString(msg), evaluateLambdaArgs(arguments));
+      } catch (IllegalArgumentException e) {
+        message = "Unable to format msg: " + msg;
+      }
       jdkLogger.logp(level, source[0], source[1], SecretDetector.maskSecrets(message));
     }
   }

--- a/src/test/java/net/snowflake/client/log/JDK14LoggerWithClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/log/JDK14LoggerWithClientLatestIT.java
@@ -74,8 +74,6 @@ public class JDK14LoggerWithClientLatestIT extends AbstractDriverIT {
 
   @Test
   public void testJDK14LoggerWithBracesInMessage() {
-    String tmpDir = System.getProperty("java.io.tmpdir");
-    System.out.println(tmpDir);
     JDK14Logger logger = new JDK14Logger(JDK14LoggerWithClientLatestIT.class.getName());
     JDK14Logger.setLevel(Level.FINE);
     logger.debug("Returning column: 12: a: Group b) Hi {Hello World War} cant wait");
@@ -84,8 +82,6 @@ public class JDK14LoggerWithClientLatestIT extends AbstractDriverIT {
 
   @Test
   public void testJDK14LoggerWithQuotesInMessage() {
-    String tmpDir = System.getProperty("java.io.tmpdir");
-    System.out.println(tmpDir);
     JDK14Logger logger = new JDK14Logger(JDK14LoggerWithClientLatestIT.class.getName());
     JDK14Logger.setLevel(Level.FINE);
     logger.debug("Returning column: 12: a: Group b) Hi {Hello 'World' War} cant wait");

--- a/src/test/java/net/snowflake/client/log/JDK14LoggerWithClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/log/JDK14LoggerWithClientLatestIT.java
@@ -12,6 +12,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Properties;
+import java.util.logging.Level;
 import net.snowflake.client.AbstractDriverIT;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
@@ -69,5 +70,25 @@ public class JDK14LoggerWithClientLatestIT extends AbstractDriverIT {
 
     Files.delete(configFilePath);
     directory.delete();
+  }
+
+  @Test
+  public void testJDK14LoggerWithBracesInMessage() {
+    String tmpDir = System.getProperty("java.io.tmpdir");
+    System.out.println(tmpDir);
+    JDK14Logger logger = new JDK14Logger(JDK14LoggerWithClientLatestIT.class.getName());
+    JDK14Logger.setLevel(Level.FINE);
+    logger.debug("Returning column: 12: a: Group b) Hi {Hello World War} cant wait");
+    JDK14Logger.setLevel(Level.OFF);
+  }
+
+  @Test
+  public void testJDK14LoggerWithQuotesInMessage() {
+    String tmpDir = System.getProperty("java.io.tmpdir");
+    System.out.println(tmpDir);
+    JDK14Logger logger = new JDK14Logger(JDK14LoggerWithClientLatestIT.class.getName());
+    JDK14Logger.setLevel(Level.FINE);
+    logger.debug("Returning column: 12: a: Group b) Hi {Hello 'World' War} cant wait");
+    JDK14Logger.setLevel(Level.OFF);
   }
 }


### PR DESCRIPTION
# Overview

SNOW-835640: `MessageFormat.format` throws `IllegalArgumentException` if the message contains either `{` or `'`. This change will gracefully handle the `IllegalArgumentException`

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
   Fixes #NNNN 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

