### PR TITLE
SNOW-823977: Fix NPE when calling driver.getPropertyInfo()

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectString.java
@@ -135,6 +135,12 @@ public class SnowflakeConnectString implements Serializable {
         // if it's a global url
         parameters.put("ACCOUNT", account);
       }
+
+      if (Strings.isNullOrEmpty(account)) {
+        logger.debug("Connect strings must contain account identifier");
+        return INVALID_CONNECT_STRING;
+      }
+
       // By default, don't allow underscores in host name unless the property is set to true via
       // connection properties.
       boolean allowUnderscoresInHost = false;

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
@@ -432,4 +432,16 @@ public class SnowflakeDriverTest {
     String jdbcConnectString = "jdbc:mysql://host:port/database";
     assertNull(snowflakeDriver.connect(jdbcConnectString, info));
   }
+
+  @Test
+  public void testConnectWithMissingAccountIdentifier() throws SQLException {
+    SnowflakeDriver snowflakeDriver = SnowflakeDriver.INSTANCE;
+    try {
+      snowflakeDriver.getPropertyInfo("jdbc:snowflake://localhost:443/?&ssl=on", new Properties());
+      fail();
+    } catch (SnowflakeSQLException ex) {
+      assertEquals(
+          "Invalid Connect String: jdbc:snowflake://localhost:443/?&ssl=on.", ex.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-823977
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/381

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1388 

A NullPointerException is thrown from account.contains("_") if the account is nul:
` if (account.contains("_") && !allowUnderscoresInHost && host.startsWith(account)) {...}`

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Check if account is still null after parsing connection string and parameters.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

