### PR TITLE
SNOW-844604 Fix Failing TelemetryIT for JDBC in JDBC-3 and the Code Coverage

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -252,9 +252,9 @@ public class TelemetryIT extends AbstractDriverIT {
   // Helper function to set up and get OAuth token
   private String getOAuthToken() throws SQLException {
     Map<String, String> parameters = getConnectionParameters();
-    String testUser = parameters.get("user");
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
+    statement.execute("use role accountadmin");
     statement.execute(
         "create or replace security integration telemetry_oauth_integration\n"
             + "  type=oauth\n"


### PR DESCRIPTION
# Overview

SNOW-844604 Fix Failing Tests for JDBC in JDBC Connector and the Code Coverage. TelemetryIT test failed due to invalid privilege when setting up OAuth integration, switch session roles to fix it.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes failing TelemetryIT


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    Upgrade the privilege to accountadmin before setting up oauth integration for telemetry test. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

