### PR TITLE
SNOW-830719 Fix issue with consecutive batch array binding not working

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseStatement.java
@@ -59,7 +59,7 @@ public abstract class SFBaseStatement {
    * @throws SQLException if connection is already closed
    * @throws SFException if result set is null
    */
-  public abstract SFStatementMetaData describe(String sql) throws SFException, SQLException;
+  public abstract SFPreparedStatementMetaData describe(String sql) throws SFException, SQLException;
 
   /**
    * Executes the given SQL string.

--- a/src/main/java/net/snowflake/client/core/SFPreparedStatementMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFPreparedStatementMetaData.java
@@ -18,7 +18,7 @@ import net.snowflake.common.core.SqlState;
  * @author jhuang
  *     <p>Created on 1/21/16
  */
-public class SFStatementMetaData {
+public class SFPreparedStatementMetaData {
   // result metadata
   private SFResultSetMetaData resultSetMetaData;
 
@@ -33,7 +33,7 @@ public class SFStatementMetaData {
 
   private final boolean isValidMetaData;
 
-  public SFStatementMetaData(
+  public SFPreparedStatementMetaData(
       SFResultSetMetaData resultSetMetaData,
       SFStatementType statementType,
       int numberOfBinds,
@@ -110,8 +110,8 @@ public class SFStatementMetaData {
    *
    * @return statement metadata
    */
-  public static SFStatementMetaData emptyMetaData() {
-    return new SFStatementMetaData(
+  public static SFPreparedStatementMetaData emptyMetaData() {
+    return new SFPreparedStatementMetaData(
         new SFResultSetMetaData(
             0,
             Collections.<String>emptyList(),

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -149,13 +149,13 @@ public class SFStatement extends SFBaseStatement {
    * @throws SFException if result set is null
    */
   @Override
-  public SFStatementMetaData describe(String sql) throws SFException, SQLException {
+  public SFPreparedStatementMetaData describe(String sql) throws SFException, SQLException {
     SFBaseResultSet baseResultSet =
         executeQuery(sql, null, true, false, null, new ExecTimeTelemetryData());
 
     describeJobUUID = baseResultSet.getQueryId();
 
-    return new SFStatementMetaData(
+    return new SFPreparedStatementMetaData(
         baseResultSet.getMetaData(),
         baseResultSet.getStatementType(),
         baseResultSet.getNumberOfBinds(),

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeParameterMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeParameterMetadata.java
@@ -15,23 +15,23 @@ import net.snowflake.client.core.SFPreparedStatementMetaData;
  * describe sql response.
  */
 class SnowflakeParameterMetadata implements ParameterMetaData {
-  private SFPreparedStatementMetaData statementMetaData;
+  private SFPreparedStatementMetaData sfPreparedStatementMetaData;
   private SFBaseSession session;
 
   SnowflakeParameterMetadata(
       SFPreparedStatementMetaData sfStatementMetaData, SFBaseSession session) {
-    this.statementMetaData = sfStatementMetaData;
+    this.sfPreparedStatementMetaData = sfStatementMetaData;
     this.session = session;
   }
 
   @Override
   public int getParameterCount() throws SQLException {
-    return statementMetaData.getNumberOfBinds();
+    return sfPreparedStatementMetaData.getNumberOfBinds();
   }
 
   @Override
   public int isNullable(int param) throws SQLException {
-    MetaDataOfBinds paramInfo = statementMetaData.getMetaDataForBindParam(param);
+    MetaDataOfBinds paramInfo = sfPreparedStatementMetaData.getMetaDataForBindParam(param);
     if (paramInfo.isNullable()) {
       return ParameterMetaData.parameterNullable;
     }
@@ -45,25 +45,25 @@ class SnowflakeParameterMetadata implements ParameterMetaData {
 
   @Override
   public int getPrecision(int param) throws SQLException {
-    MetaDataOfBinds paramInfo = statementMetaData.getMetaDataForBindParam(param);
+    MetaDataOfBinds paramInfo = sfPreparedStatementMetaData.getMetaDataForBindParam(param);
     return paramInfo.getPrecision();
   }
 
   @Override
   public int getScale(int param) throws SQLException {
-    MetaDataOfBinds paramInfo = statementMetaData.getMetaDataForBindParam(param);
+    MetaDataOfBinds paramInfo = sfPreparedStatementMetaData.getMetaDataForBindParam(param);
     return paramInfo.getScale();
   }
 
   @Override
   public int getParameterType(int param) throws SQLException {
-    MetaDataOfBinds paramInfo = statementMetaData.getMetaDataForBindParam(param);
+    MetaDataOfBinds paramInfo = sfPreparedStatementMetaData.getMetaDataForBindParam(param);
     return convertStringToType(paramInfo.getTypeName());
   }
 
   @Override
   public String getParameterTypeName(int param) throws SQLException {
-    MetaDataOfBinds paramInfo = statementMetaData.getMetaDataForBindParam(param);
+    MetaDataOfBinds paramInfo = sfPreparedStatementMetaData.getMetaDataForBindParam(param);
     return paramInfo.getTypeName();
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeParameterMetadata.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeParameterMetadata.java
@@ -6,7 +6,7 @@ import java.sql.ParameterMetaData;
 import java.sql.SQLException;
 import net.snowflake.client.core.MetaDataOfBinds;
 import net.snowflake.client.core.SFBaseSession;
-import net.snowflake.client.core.SFStatementMetaData;
+import net.snowflake.client.core.SFPreparedStatementMetaData;
 
 /**
  * Naive implementation of ParameterMetadata class.
@@ -15,10 +15,11 @@ import net.snowflake.client.core.SFStatementMetaData;
  * describe sql response.
  */
 class SnowflakeParameterMetadata implements ParameterMetaData {
-  private SFStatementMetaData statementMetaData;
+  private SFPreparedStatementMetaData statementMetaData;
   private SFBaseSession session;
 
-  SnowflakeParameterMetadata(SFStatementMetaData sfStatementMetaData, SFBaseSession session) {
+  SnowflakeParameterMetadata(
+      SFPreparedStatementMetaData sfStatementMetaData, SFBaseSession session) {
     this.statementMetaData = sfStatementMetaData;
     this.session = session;
   }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -950,4 +950,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   public boolean isAlreadyDescribed() {
     return this.alreadyDescribed;
   }
+
+  // For testing use only
+  public boolean isArrayBindSupported() {
+    return this.statementMetaData.isArrayBindSupported();
+  }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -61,7 +61,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   private String queryID;
 
   /** statement and result metadata from describe phase */
-  protected SFStatementMetaData statementMetaData = SFStatementMetaData.emptyMetaData();
+  protected SFPreparedStatementMetaData preparedStatementMetaData =
+      SFPreparedStatementMetaData.emptyMetaData();
 
   /** Snowflake query IDs from the latest executed batch */
   private List<String> batchQueryIDs = new LinkedList<>();
@@ -214,9 +215,9 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       sfResultSet.setSession(this.connection.getSFBaseSession());
       updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       queryID = sfResultSet.getQueryId();
-      if (!statementMetaData.isValidMetaData()) {
-        statementMetaData =
-            new SFStatementMetaData(
+      if (!preparedStatementMetaData.isValidMetaData()) {
+        preparedStatementMetaData =
+            new SFPreparedStatementMetaData(
                 sfResultSet.getMetaData(),
                 sfResultSet.getStatementType(),
                 sfResultSet.getNumberOfBinds(),
@@ -225,7 +226,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
                 true); // valid metadata
       }
     } catch (SFException ex) {
-      statementMetaData = SFStatementMetaData.emptyMetaData();
+      preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     } finally {
@@ -270,14 +271,14 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
         sfResultSet =
             sfBaseStatement.asyncExecute(
                 sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_QUERY, execTimeData);
-        statementMetaData = SFStatementMetaData.emptyMetaData();
+        preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
       } else {
         sfResultSet =
             sfBaseStatement.execute(
                 sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_QUERY, execTimeData);
-        if (!statementMetaData.isValidMetaData()) {
-          statementMetaData =
-              new SFStatementMetaData(
+        if (!preparedStatementMetaData.isValidMetaData()) {
+          preparedStatementMetaData =
+              new SFPreparedStatementMetaData(
                   sfResultSet.getMetaData(),
                   sfResultSet.getStatementType(),
                   sfResultSet.getNumberOfBinds(),
@@ -290,7 +291,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       queryID = sfResultSet.getQueryId();
 
     } catch (SFException ex) {
-      statementMetaData = SFStatementMetaData.emptyMetaData();
+      preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
@@ -339,9 +340,9 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
           sfBaseStatement.execute(
               sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE, execTimeData);
       sfResultSet.setSession(this.connection.getSFBaseSession());
-      if (!statementMetaData.isValidMetaData()) {
-        statementMetaData =
-            new SFStatementMetaData(
+      if (!preparedStatementMetaData.isValidMetaData()) {
+        preparedStatementMetaData =
+            new SFPreparedStatementMetaData(
                 sfResultSet.getMetaData(),
                 sfResultSet.getStatementType(),
                 sfResultSet.getNumberOfBinds(),
@@ -372,7 +373,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       updateCount = NO_UPDATES;
       return true;
     } catch (SFException ex) {
-      statementMetaData = SFStatementMetaData.emptyMetaData();
+      preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -214,14 +214,16 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       sfResultSet.setSession(this.connection.getSFBaseSession());
       updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       queryID = sfResultSet.getQueryId();
-      statementMetaData =
-          new SFStatementMetaData(
-              sfResultSet.getMetaData(),
-              sfResultSet.getStatementType(),
-              sfResultSet.getNumberOfBinds(),
-              sfResultSet.isArrayBindSupported(),
-              sfResultSet.getMetaDataOfBinds(),
-              true); // valid metadata
+      if (!statementMetaData.isValidMetaData()) {
+        statementMetaData =
+            new SFStatementMetaData(
+                sfResultSet.getMetaData(),
+                sfResultSet.getStatementType(),
+                sfResultSet.getNumberOfBinds(),
+                sfResultSet.isArrayBindSupported(),
+                sfResultSet.getMetaDataOfBinds(),
+                true); // valid metadata
+      }
     } catch (SFException ex) {
       statementMetaData = SFStatementMetaData.emptyMetaData();
       throw new SnowflakeSQLException(
@@ -273,14 +275,16 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
         sfResultSet =
             sfBaseStatement.execute(
                 sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_QUERY, execTimeData);
-        statementMetaData =
-            new SFStatementMetaData(
-                sfResultSet.getMetaData(),
-                sfResultSet.getStatementType(),
-                sfResultSet.getNumberOfBinds(),
-                sfResultSet.isArrayBindSupported(),
-                sfResultSet.getMetaDataOfBinds(),
-                true); // valid metadata
+        if (!statementMetaData.isValidMetaData()) {
+          statementMetaData =
+              new SFStatementMetaData(
+                  sfResultSet.getMetaData(),
+                  sfResultSet.getStatementType(),
+                  sfResultSet.getNumberOfBinds(),
+                  sfResultSet.isArrayBindSupported(),
+                  sfResultSet.getMetaDataOfBinds(),
+                  true); // valid metadata
+        }
       }
       sfResultSet.setSession(this.connection.getSFBaseSession());
       queryID = sfResultSet.getQueryId();
@@ -335,14 +339,16 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
           sfBaseStatement.execute(
               sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE, execTimeData);
       sfResultSet.setSession(this.connection.getSFBaseSession());
-      statementMetaData =
-          new SFStatementMetaData(
-              sfResultSet.getMetaData(),
-              sfResultSet.getStatementType(),
-              sfResultSet.getNumberOfBinds(),
-              sfResultSet.isArrayBindSupported(),
-              sfResultSet.getMetaDataOfBinds(),
-              true); // valid metadata
+      if (!statementMetaData.isValidMetaData()) {
+        statementMetaData =
+            new SFStatementMetaData(
+                sfResultSet.getMetaData(),
+                sfResultSet.getStatementType(),
+                sfResultSet.getNumberOfBinds(),
+                sfResultSet.isArrayBindSupported(),
+                sfResultSet.getMetaDataOfBinds(),
+                true); // valid metadata
+      }
       if (resultSet != null && !resultSet.isClosed()) {
         openResultSets.add(resultSet);
       }

--- a/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/MockConnectionTest.java
@@ -531,7 +531,7 @@ public class MockConnectionTest extends BaseJDBCTest {
     public void addProperty(String propertyName, Object propertyValue) {}
 
     @Override
-    public SFStatementMetaData describe(String sql) {
+    public SFPreparedStatementMetaData describe(String sql) {
       return null;
     }
 

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
@@ -329,29 +329,29 @@ public class PreparedStatement2LatestIT extends PreparedStatement0IT {
     try (Connection connection = init()) {
       connection
           .createStatement()
-          .execute("create or replace table testStageArrayBind(c1 integer)");
-      try (PreparedStatement prepStatement =
-          connection.prepareStatement("insert into testStageArrayBind values (?)")) {
-        // Assert to begin with that before the describe call, array binding is not supported
-        assertFalse(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isAlreadyDescribed());
-        assertFalse(
-            prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
-        // Insert enough rows to hit the default binding array threshold
-        for (int i = 0; i < 70000; i++) {
-          prepStatement.setInt(1, i);
-          prepStatement.addBatch();
-        }
-        prepStatement.executeBatch();
-        // After executing the first batch, verify that array bind support is still true
-        assertTrue(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
-        for (int i = 0; i < 70000; i++) {
-          prepStatement.setInt(1, i);
-          prepStatement.addBatch();
-        }
-        prepStatement.executeBatch();
-        // After executing the second batch, verify that array bind support is still true
-        assertTrue(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
+          .execute("create or replace table testStageArrayBind(c1 integer, c2 string)");
+      PreparedStatement prepStatement =
+          connection.prepareStatement("insert into testStageArrayBind values (?, ?)");
+      // Assert to begin with that before the describe call, array binding is not supported
+      assertFalse(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isAlreadyDescribed());
+      assertFalse(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
+      // Insert enough rows to hit the default binding array threshold
+      for (int i = 0; i < 35000; i++) {
+        prepStatement.setInt(1, i);
+        prepStatement.setString(2, "test" + i);
+        prepStatement.addBatch();
       }
+      prepStatement.executeBatch();
+      // After executing the first batch, verify that array bind support is still true
+      assertTrue(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
+      for (int i = 0; i < 35000; i++) {
+        prepStatement.setInt(1, i);
+        prepStatement.setString(2, "test" + i);
+        prepStatement.addBatch();
+      }
+      prepStatement.executeBatch();
+      // After executing the second batch, verify that array bind support is still true
+      assertTrue(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
     }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
@@ -286,9 +286,9 @@ public class PreparedStatement2LatestIT extends PreparedStatement0IT {
     // metadata form the executeUpdate
     String queryId4 =
         preparedStatement.getMetaData().unwrap(SnowflakeResultSetMetaData.class).getQueryID();
-    // Assert the query IDs are the same. This will be the case if there is no additional describe
-    // call for getMetadata().
-    assertEquals(queryId3, queryId4);
+    // Assert the query IDs for the 2 identical getMetadata() calls are the same. They should match
+    // since metadata no longer gets overwritten after successive query calls.
+    assertEquals(queryId2, queryId4);
 
     connection.createStatement().execute("drop table if exists test_uuid_with_bind");
     preparedStatement.close();
@@ -316,5 +316,42 @@ public class PreparedStatement2LatestIT extends PreparedStatement0IT {
     rs = prepStatement.executeQuery();
     assertTrue(rs.next());
     assertTrue(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isAlreadyDescribed());
+  }
+
+  /**
+   * Test that consecutive batch inserts can occur. See SNOW-830719. Fixes regression caused by
+   * SNOW-762522.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testConsecutiveBatchInsertError() throws SQLException {
+    try (Connection connection = init()) {
+      connection
+          .createStatement()
+          .execute("create or replace table testStageArrayBind(c1 integer)");
+      try (PreparedStatement prepStatement =
+          connection.prepareStatement("insert into testStageArrayBind values (?)")) {
+        // Assert to begin with that before the describe call, array binding is not supported
+        assertFalse(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isAlreadyDescribed());
+        assertFalse(
+            prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
+        // Insert enough rows to hit the default binding array threshold
+        for (int i = 0; i < 70000; i++) {
+          prepStatement.setInt(1, i);
+          prepStatement.addBatch();
+        }
+        prepStatement.executeBatch();
+        // After executing the first batch, verify that array bind support is still true
+        assertTrue(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
+        for (int i = 0; i < 70000; i++) {
+          prepStatement.setInt(1, i);
+          prepStatement.addBatch();
+        }
+        prepStatement.executeBatch();
+        // After executing the second batch, verify that array bind support is still true
+        assertTrue(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
+      }
+    }
   }
 }


### PR DESCRIPTION
# Overview

SNOW-830719

After trying to fix metadata issue (https://github.com/snowflakedb/snowflake-jdbc/pull/1301/files), this led to a regression where using the same PreparedStatement object to call executeBatch() several times was no longer using array binding even when the threshold was met; instead, it was inserting the bind values in the payload.

The reason for this is that inside the execute() call when using array bind, there is an embedded call to the server to create a stage if needed. The resultset returned from creating the stage is what was being used to re-populate the metadata, and array binding is not supported for stage creation.

We do not need to continuously re-write over the metadata after every query execution anyway; in the original before the metadata fix, we were only grabbing the metadata from the describe call and then never re-populating. 

So the solution is to populate the metadata whenever it's available but never re-populate it after that.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

