### PR TITLE
SNOW-844431: Return false for unsupported  locatorsUpdateCopy() function in SnowflakeDatabaseMetadata.java

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java
@@ -3023,10 +3023,10 @@ public class SnowflakeDatabaseMetaData implements DatabaseMetaData {
   }
 
   @Override
-  public boolean locatorsUpdateCopy() throws SQLException {
+  public boolean locatorsUpdateCopy() {
     logger.debug("public boolean locatorsUpdateCopy()", false);
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(session);
+    return false;
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
@@ -798,7 +798,6 @@ public class DatabaseMetaDataIT extends BaseJDBCTest {
       expectFeatureNotSupportedException(() -> metaData.getSuperTypes(null, null, null));
       expectFeatureNotSupportedException(() -> metaData.getSuperTables(null, null, null));
       expectFeatureNotSupportedException(() -> metaData.getAttributes(null, null, null, null));
-      expectFeatureNotSupportedException(metaData::locatorsUpdateCopy);
       expectFeatureNotSupportedException(metaData::getRowIdLifetime);
       expectFeatureNotSupportedException(metaData::autoCommitFailureClosesAllResultSets);
       expectFeatureNotSupportedException(metaData::getClientInfoProperties);

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -1639,4 +1639,12 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
       assertEquals(0, res.getInt("ORDINAL_POSITION"));
     }
   }
+
+  @Test
+  public void testUpdateLocatorsCopyUnsupported() throws SQLException {
+    try (Connection con = getConnection()) {
+      DatabaseMetaData metaData = con.getMetaData();
+      assertFalse(metaData.locatorsUpdateCopy());
+    }
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-844431

## External contributors - please answer these questions before submitting a pull request. Thanks!

If an application makes a call to DatabaseMetadata describe function locatorsUpdateCopy(), a SnowflakeLoggedFeatureNotSupportedException is thrown and causes cascading failures.

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1416 
   https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/475

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Return false for this function instead of exception.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

