### PR TITLE
SNOW-845270: DownloadStream() does not allow filenames that contains Japanese

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,1 @@
+{"common":{"log_level":"info","log_path":"/jdbc.log"}}

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -960,6 +960,13 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
     getCommand.append(sourceFileName);
 
+    // special characters and spaces require single quotes around stage name.
+    boolean isSpecialChar = !sourceFileName.matches("^[a-zA-Z0-9_/.]*$");
+    if (isSpecialChar) {
+      getCommand.insert(getCommand.indexOf("@"), "'");
+      getCommand.append("'");
+    }
+
     // this is a fake path, used to form Get query and retrieve stage info,
     // no file will be downloaded to this location
     getCommand.append(" file:///tmp/ /*jdbc download stream*/");


### PR DESCRIPTION
# Overview

SNOW-845270
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/479

When a user tries to download a file whose filename contains Japanese or special characters or whitespace, a SQL Compilation Error will occur.

```
   InputStream out = connection.unwrap(SnowflakeConnection.class).downloadStream(
      "@TEST_STAGE",
      "テストファイル.txt",
      true);
```

This is because Snowflake requires such filename to be single-quoted.

`If the stage name or path includes spaces or special characters, it must be enclosed in single quotes (e.g. '@"my stage"' for a stage named "my stage").`

However, as the [current implementation](https://github.com/snowflakedb/snowflake-jdbc/blob/75f5e31a42ed3956fea373cd23cf8b621d27e1cd/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java#LL945C1-L965C65) will forcibly add @ in the beginning, users have no way to add the single quotes in the correct position.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add a check for special characters or whitespace in the filename for downloadStream(). If they exist, surround the stage name and path with single quotes.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

