### PR TITLE
SNOW-848997 - Fix CLA Assistant 

### DIFF
--- a/.github/workflows/cla_bot.yml
+++ b/.github/workflows/cla_bot.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
@@ -17,8 +22,8 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOT_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1.json'
-          path-to-document: 'https://github.com/Snowflake-Labs/CLA/blob/main/README.md'
+          path-to-document: 'https://github.com/snowflakedb/CLA/blob/main/README.md'
           branch: 'main'
-          allowlist: 'dependabot[bot],github-actions'
+          allowlist: 'dependabot[bot],github-actions,Jenkins User,_jenkins'
           remote-organization-name: 'snowflakedb'
           remote-repository-name: 'cla-db'


### PR DESCRIPTION
# Overview

SNOW-848997
CLA assistant check has been failing with the next error:
`Error: graphql call to get the committers details failed: GraphqlError: Resource not accessible by integration
`
Attempting to fix it by doing the next:

- Add write permissions
- Add Jenkins user to the allow list
- Update the link to the document.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

