### PR TITLE
[SNOW-849814] Remove un-neccassary SFPreparedStatementMetaData object creation in SnowflakeStatement.java

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -952,7 +952,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   }
 
   @Override
-  public void resultSetHandler(SFBaseResultSet resultSet) throws SQLException {
+  public void resultSetMetadataHandler(SFBaseResultSet resultSet) throws SQLException {
     if (!this.preparedStatementMetaData.isValidMetaData()) {
       this.preparedStatementMetaData =
           new SFPreparedStatementMetaData(

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -41,6 +41,9 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
 
   private final String sql;
 
+  private SFPreparedStatementMetaData preparedStatementMetaData;
+
+  /** statement and result metadata from describe phase */
   private boolean showStatementParameters;
 
   /**
@@ -117,9 +120,6 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       logger.debug("executeQuery()", false);
     }
     ResultSet rs = executeQueryInternal(sql, false, parameterBindings, execTimeData);
-    if (preparedStatementMetaData.isValidMetaData()) {
-      alreadyDescribed = true;
-    }
     execTimeData.setQueryEnd();
     execTimeData.generateTelemetry();
     return rs;
@@ -152,9 +152,6 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
         new ExecTimeTelemetryData("long PreparedStatement.executeLargeUpdate()", this.batchID);
     logger.debug("executeLargeUpdate()", false);
     long updates = executeUpdateInternal(sql, parameterBindings, true, execTimeTelemetryData);
-    if (preparedStatementMetaData.isValidMetaData()) {
-      alreadyDescribed = true;
-    }
     return updates;
   }
 
@@ -468,9 +465,7 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
         new ExecTimeTelemetryData("boolean PreparedStatement.execute(String)", this.batchID);
     logger.debug("execute: {}", sql);
     boolean success = executeInternal(sql, parameterBindings, execTimeData);
-    if (preparedStatementMetaData.isValidMetaData()) {
-      alreadyDescribed = true;
-    }
+
     execTimeData.setQueryEnd();
     execTimeData.generateTelemetry();
     return success;
@@ -954,5 +949,21 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
   // For testing use only
   public boolean isArrayBindSupported() {
     return this.preparedStatementMetaData.isArrayBindSupported();
+  }
+
+  @Override
+  public void resultSetHandler(SFBaseResultSet resultSet) throws SQLException {
+    if (!this.preparedStatementMetaData.isValidMetaData()) {
+      this.preparedStatementMetaData =
+          new SFPreparedStatementMetaData(
+              resultSet.getMetaData(),
+              resultSet.getStatementType(),
+              resultSet.getNumberOfBinds(),
+              resultSet.isArrayBindSupported(),
+              resultSet.getMetaDataOfBinds(),
+              true);
+
+      alreadyDescribed = true;
+    }
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatement.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatement.java
@@ -48,5 +48,5 @@ public interface SnowflakeStatement {
    * @param resultSet
    * @throws SQLException
    */
-  void resultSetHandler(SFBaseResultSet resultSet) throws SQLException;
+  void resultSetMetadataHandler(SFBaseResultSet resultSet) throws SQLException;
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatement.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatement.java
@@ -7,6 +7,7 @@ package net.snowflake.client.jdbc;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import net.snowflake.client.core.SFBaseResultSet;
 
 /** This interface defines Snowflake specific APIs for Statement */
 public interface SnowflakeStatement {
@@ -38,4 +39,14 @@ public interface SnowflakeStatement {
    * @throws SQLException if @link{#executeQueryInternal(String, Map)} throws an exception
    */
   ResultSet executeAsyncQuery(String sql) throws SQLException;
+
+  /**
+   * This method exposes SFBaseResultSet to the sub-classes of SnowflakeStatementV1.java. This is
+   * required as SnowflakeStatementV1 doesn't directly expose ResultSet to the sub-classes making it
+   * challenging to get additional information from the previously executed query.
+   *
+   * @param resultSet
+   * @throws SQLException
+   */
+  void resultSetHandler(SFBaseResultSet resultSet) throws SQLException;
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -60,10 +60,6 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   /** Snowflake query ID from the latest executed query */
   private String queryID;
 
-  /** statement and result metadata from describe phase */
-  protected SFPreparedStatementMetaData preparedStatementMetaData =
-      SFPreparedStatementMetaData.emptyMetaData();
-
   /** Snowflake query IDs from the latest executed batch */
   private List<String> batchQueryIDs = new LinkedList<>();
 
@@ -161,6 +157,11 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
     return rs;
   }
 
+  @Override
+  public void resultSetHandler(SFBaseResultSet resultSet) throws SQLException {
+    // No-Op.
+  }
+
   /**
    * Execute an update statement
    *
@@ -215,18 +216,8 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       sfResultSet.setSession(this.connection.getSFBaseSession());
       updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       queryID = sfResultSet.getQueryId();
-      if (!preparedStatementMetaData.isValidMetaData()) {
-        preparedStatementMetaData =
-            new SFPreparedStatementMetaData(
-                sfResultSet.getMetaData(),
-                sfResultSet.getStatementType(),
-                sfResultSet.getNumberOfBinds(),
-                sfResultSet.isArrayBindSupported(),
-                sfResultSet.getMetaDataOfBinds(),
-                true); // valid metadata
-      }
+      resultSetHandler(sfResultSet);
     } catch (SFException ex) {
-      preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     } finally {
@@ -271,27 +262,16 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
         sfResultSet =
             sfBaseStatement.asyncExecute(
                 sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_QUERY, execTimeData);
-        preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
       } else {
         sfResultSet =
             sfBaseStatement.execute(
                 sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_QUERY, execTimeData);
-        if (!preparedStatementMetaData.isValidMetaData()) {
-          preparedStatementMetaData =
-              new SFPreparedStatementMetaData(
-                  sfResultSet.getMetaData(),
-                  sfResultSet.getStatementType(),
-                  sfResultSet.getNumberOfBinds(),
-                  sfResultSet.isArrayBindSupported(),
-                  sfResultSet.getMetaDataOfBinds(),
-                  true); // valid metadata
-        }
+        resultSetHandler(sfResultSet);
       }
       sfResultSet.setSession(this.connection.getSFBaseSession());
       queryID = sfResultSet.getQueryId();
 
     } catch (SFException ex) {
-      preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }
@@ -340,16 +320,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
           sfBaseStatement.execute(
               sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE, execTimeData);
       sfResultSet.setSession(this.connection.getSFBaseSession());
-      if (!preparedStatementMetaData.isValidMetaData()) {
-        preparedStatementMetaData =
-            new SFPreparedStatementMetaData(
-                sfResultSet.getMetaData(),
-                sfResultSet.getStatementType(),
-                sfResultSet.getNumberOfBinds(),
-                sfResultSet.isArrayBindSupported(),
-                sfResultSet.getMetaDataOfBinds(),
-                true); // valid metadata
-      }
+      resultSetHandler(sfResultSet);
       if (resultSet != null && !resultSet.isClosed()) {
         openResultSets.add(resultSet);
       }
@@ -373,7 +344,6 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       updateCount = NO_UPDATES;
       return true;
     } catch (SFException ex) {
-      preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeStatementV1.java
@@ -158,7 +158,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
   }
 
   @Override
-  public void resultSetHandler(SFBaseResultSet resultSet) throws SQLException {
+  public void resultSetMetadataHandler(SFBaseResultSet resultSet) throws SQLException {
     // No-Op.
   }
 
@@ -216,7 +216,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
       sfResultSet.setSession(this.connection.getSFBaseSession());
       updateCount = ResultUtil.calculateUpdateCount(sfResultSet);
       queryID = sfResultSet.getQueryId();
-      resultSetHandler(sfResultSet);
+      resultSetMetadataHandler(sfResultSet);
     } catch (SFException ex) {
       throw new SnowflakeSQLException(
           ex.getCause(), ex.getSqlState(), ex.getVendorCode(), ex.getParams());
@@ -266,7 +266,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
         sfResultSet =
             sfBaseStatement.execute(
                 sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE_QUERY, execTimeData);
-        resultSetHandler(sfResultSet);
+        resultSetMetadataHandler(sfResultSet);
       }
       sfResultSet.setSession(this.connection.getSFBaseSession());
       queryID = sfResultSet.getQueryId();
@@ -320,7 +320,7 @@ class SnowflakeStatementV1 implements Statement, SnowflakeStatement {
           sfBaseStatement.execute(
               sql, parameterBindings, SFBaseStatement.CallingMethod.EXECUTE, execTimeData);
       sfResultSet.setSession(this.connection.getSFBaseSession());
-      resultSetHandler(sfResultSet);
+      resultSetMetadataHandler(sfResultSet);
       if (resultSet != null && !resultSet.isClosed()) {
         openResultSets.add(resultSet);
       }


### PR DESCRIPTION
# Overview

SNOW-849814

Follow up PR for https://github.com/snowflakedb/snowflake-jdbc/pull/1439 where we are unnecessarily creating `SFPreparedStatementMetaData` for simple Snowflake statement types. This PR introduces a new method in snowflakestatement.java which enables the sub-classes of SnowflakeStatementV1 to access the resultset constructed in execute* methods. 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

