### PR TITLE
SNOW-848763 upgrade awssdk to 1.12.501

### DIFF
--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -46,7 +46,7 @@
     <httpclient.version>4.5.11</httpclient.version>
     <jacoco.version>0.8.4</jacoco.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
-    <awssdk.version>1.11.394</awssdk.version>
+    <awssdk.version>1.12.501</awssdk.version>
     <google.api.client.version>1.33.2</google.api.client.version>
     <google.http.client.version>1.43.2</google.http.client.version>
     <jna.version>5.13.0</jna.version>


### PR DESCRIPTION
# Overview

SNOW-848763

aws-java-sdk-s3 in FIPS/pom.xml uses a vulnerable version of jackson-dataformat-cbor.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1434 
   https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/494

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

-    Upgrade awssdk to 1.12.501 in FIPS/pom.xml which uses jackson-dataformat-cbor 2.12.6.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

