### PR TITLE
SNOW-848855: Change SLF4J scope to compile

### DIFF
--- a/ci/scripts/check_content.sh
+++ b/ci/scripts/check_content.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-if jar tvf $DIR/../../target/snowflake-jdbc.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v -E "^com/sun/jna" | grep -v com/sun/ | grep -v mime.types; then
+if jar tvf $DIR/../../target/snowflake-jdbc.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v -E "^com/sun/jna" | grep -v -E "^org/slf4j" | grep -v -E "^org" | grep -v com/sun/ | grep -v mime.types; then
   echo "[ERROR] JDBC jar includes class not under the snowflake namespace"
   exit 1
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,12 @@
         <version>9.3</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.6</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
         <groupId>org.threeten</groupId>
         <artifactId>threetenbp</artifactId>
         <version>1.6.0</version>
@@ -212,12 +218,6 @@
         <groupId>org.tukaani</groupId>
         <artifactId>xz</artifactId>
         <version>1.9</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>2.0.6</version>
-        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Overview

SNOW-848855
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/497

Arrow library has SLF4J implemented in its projects. Previously we used custom arrow jars where we replaced the SLF4J dependence with a NOOP logger implementation. Since #1382, we are no longer using the custom arrow jars and the scope was changed to provided which causes a ClassNotFoundException for SLF4J when trying to fetch with arrow format. 

We will need to add a notes to the docs that this change will try to configure SLF4J logger by default when using arrow and if users don't include a logging implementation it will print on the console:

```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
```

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    Change the scope to compile so that the user is not required to have it on the classpath. 

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

