### PR TITLE
Revert "SNOW-848855: Change SLF4J scope to compile"

### DIFF
--- a/ci/scripts/check_content.sh
+++ b/ci/scripts/check_content.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-if jar tvf $DIR/../../target/snowflake-jdbc.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v -E "^com/sun/jna" | grep -v -E "^org/slf4j" | grep -v -E "^org" | grep -v com/sun/ | grep -v mime.types; then
+if jar tvf $DIR/../../target/snowflake-jdbc.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v -E "^com/sun/jna" | grep -v com/sun/ | grep -v mime.types; then
   echo "[ERROR] JDBC jar includes class not under the snowflake namespace"
   exit 1
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -204,12 +204,6 @@
         <version>9.3</version>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>2.0.6</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
         <groupId>org.threeten</groupId>
         <artifactId>threetenbp</artifactId>
         <version>1.6.0</version>
@@ -218,6 +212,12 @@
         <groupId>org.tukaani</groupId>
         <artifactId>xz</artifactId>
         <version>1.9</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.6</version>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Reverts snowflakedb/snowflake-jdbc#1462

We need to make this change without including the following lines:

> SLF4J: No SLF4J providers were found.
! SLF4J: Defaulting to no-operation (NOP) logger implementation
! SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
! SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
! SLF4J: Ignoring binding found at [jar:file:/mnt/jenkinsSF_REGRESS_ROOT/Client/henplus/lib/slf4j-jdk14-1.7.26.jar!/org/slf4j/impl/StaticLoggerBinder.class]
! SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.