### PR TITLE
SNOW-844477: Allow connection property CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED to disable OOB telemetry

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -484,6 +484,15 @@ public class SFSession extends SFBaseSession {
         .setOCSPMode(getOCSPMode())
         .setHttpClientSettingsKey(httpClientSettingsKey);
 
+    // Enable or disable OOB telemetry based on connection parameter. Default is disabled.
+    // The value may still change later when session parameters from the server are read.
+    if (getBooleanValue(
+        connectionPropertiesMap.get(SFSessionProperty.CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED))) {
+      TelemetryService.enable();
+    } else {
+      TelemetryService.disable();
+    }
+
     // propagate OCSP mode to SFTrustManager. Note OCSP setting is global on JVM.
     HttpUtil.initHttpClient(httpClientSettingsKey, null);
     SFLoginOutput loginOutput =

--- a/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryServiceIT.java
@@ -2,7 +2,7 @@ package net.snowflake.client.jdbc.telemetryOOB;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -305,6 +305,58 @@ public class TelemetryServiceIT extends BaseJDBCTest {
       TelemetryService.disableHTAP();
       // Ensure that no telemetry is collected for below select 3 statement
       statement.execute("select 3");
+    }
+  }
+
+  /**
+   * Requires part 2 of SNOW-844477. Make sure CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED is true at
+   * account level. Tests connection property CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED=true
+   */
+  @Ignore
+  @Test
+  public void testOOBTelemetryEnabled() throws SQLException {
+    Properties properties = new Properties();
+    properties.put("CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED", "true");
+    try (Connection con = getConnection(properties)) {
+      Statement statement = con.createStatement();
+      statement.execute("select 1");
+      // Make sure OOB telemetry is enabled
+      assertTrue(TelemetryService.getInstance().isEnabled());
+    }
+  }
+
+  /**
+   * Requires part 2 of SNOW-844477. Make sure CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED is false at
+   * account level. Tests connection property CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED=false
+   */
+  @Ignore
+  @Test
+  public void testOOBTelemetryDisabled() throws SQLException {
+    Properties properties = new Properties();
+    properties.put("CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED", "false");
+    try (Connection con = getConnection(properties)) {
+      Statement statement = con.createStatement();
+      statement.execute("select 1");
+      // Make sure OOB telemetry is disabled
+      assertFalse(TelemetryService.getInstance().isEnabled());
+    }
+  }
+
+  /**
+   * Requires part 2 of SNOW-844477. Make sure CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED is true at
+   * account level. Tests connection property CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED=false but
+   * CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED is enabled on account level
+   */
+  @Ignore
+  @Test
+  public void testOOBTelemetryEnabledOnServerDisabledOnClient() throws SQLException {
+    Properties properties = new Properties();
+    properties.put("CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED", "false");
+    try (Connection con = getConnection(properties)) {
+      Statement statement = con.createStatement();
+      statement.execute("select 1");
+      // Make sure OOB telemetry is enabled
+      assertTrue(TelemetryService.getInstance().isEnabled());
     }
   }
 


### PR DESCRIPTION
# Overview

SNOW-844477

Out-of-band telemetry is enabled by default in the driver until a session is opened and the session properties are read. If CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED is disabled on the account level and returned in the session properties, the telemetry will then be disabled. But since it is enabled before connection, if there are OCSP exceptions they will send telemetry requests. 

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/478

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   To allow CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED connection property to control if OOB telemetry is enabled or not. This can still be overridden by session properties later in the login flow. Part 2 will be on the server side to allow telemetry session properties to be configured by the user on the account level.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

