### PR TITLE
[Easy Logger Config] Rename connection property name

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,1 +1,0 @@
-{"common":{"log_level":"info","log_path":"/jdbc.log"}}

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -67,7 +67,7 @@ public enum SFSessionProperty {
   DISABLE_QUERY_CONTEXT_CACHE("disableQueryContextCache", false, Boolean.class),
   HTAP_OOB_TELEMETRY_ENABLED("htapOOBTelemetryEnabled", false, Boolean.class),
 
-  CLIENT_CONFIG_FILE("clientConfigFile", false, String.class),
+  CLIENT_CONFIG_FILE("client_config_file", false, String.class),
 
   MAX_HTTP_RETRIES("maxHttpRetries", false, Integer.class);
 

--- a/src/test/java/net/snowflake/client/log/JDK14LoggerWithClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/log/JDK14LoggerWithClientLatestIT.java
@@ -26,7 +26,7 @@ public class JDK14LoggerWithClientLatestIT extends AbstractDriverIT {
     try {
       Files.write(configFilePath, configJson.getBytes());
       Properties properties = new Properties();
-      properties.put("clientConfigFile", configFilePath.toString());
+      properties.put("client_config_file", configFilePath.toString());
       Connection connection = getConnection(properties);
       connection.createStatement().executeQuery("select 1");
 
@@ -46,7 +46,7 @@ public class JDK14LoggerWithClientLatestIT extends AbstractDriverIT {
   public void testJDK14LoggingWithClientConfigInvalidConfigFilePath() throws SQLException {
     Path configFilePath = Paths.get("invalid.json");
     Properties properties = new Properties();
-    properties.put("clientConfigFile", configFilePath.toString());
+    properties.put("client_config_file", configFilePath.toString());
     Connection connection = getConnection(properties);
     connection.createStatement().executeQuery("select 1");
   }
@@ -65,7 +65,7 @@ public class JDK14LoggerWithClientLatestIT extends AbstractDriverIT {
 
     Files.write(configFilePath, configJson.getBytes());
     Properties properties = new Properties();
-    properties.put("clientConfigFile", configFilePath.toString());
+    properties.put("client_config_file", configFilePath.toString());
     assertThrows(SQLException.class, () -> getConnection(properties));
 
     Files.delete(configFilePath);


### PR DESCRIPTION
# Overview

SNOW-XXXXX

PR to rename `clientConfigFile` connection property name to `client_config_file` to make the connection property name consistent with rest of the sdk's.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

