### PR TITLE
SNOW-854356: Renew S3 token on 400 Bad Request and add putGetMaxRetries property

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -69,7 +69,9 @@ public enum SFSessionProperty {
 
   CLIENT_CONFIG_FILE("client_config_file", false, String.class),
 
-  MAX_HTTP_RETRIES("maxHttpRetries", false, Integer.class);
+  MAX_HTTP_RETRIES("maxHttpRetries", false, Integer.class),
+
+  PUT_GET_MAX_RETRIES("putGetMaxRetries", false, Integer.class);
 
   // property key in string
   private String propertyKey;

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -20,10 +20,7 @@ import java.security.InvalidKeyException;
 import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Base64;
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.core.ObjectMapperFactory;
-import net.snowflake.client.core.SFBaseSession;
-import net.snowflake.client.core.SFSession;
+import net.snowflake.client.core.*;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
@@ -133,6 +130,9 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
   // Returns the Max number of retry attempts
   @Override
   public int getMaxRetries() {
+    if (session.getConnectionPropertiesMap().containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
+      return (int) session.getConnectionPropertiesMap().get(SFSessionProperty.PUT_GET_MAX_RETRIES);
+    }
     return 25;
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -130,7 +130,10 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
   // Returns the Max number of retry attempts
   @Override
   public int getMaxRetries() {
-    if (session.getConnectionPropertiesMap().containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
+    if (session != null
+        && session
+            .getConnectionPropertiesMap()
+            .containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
       return (int) session.getConnectionPropertiesMap().get(SFSessionProperty.PUT_GET_MAX_RETRIES);
     }
     return 25;

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -81,6 +81,9 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
   // Returns the Max number of retry attempts
   @Override
   public int getMaxRetries() {
+    if (session.getConnectionPropertiesMap().containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
+      return (int) session.getConnectionPropertiesMap().get(SFSessionProperty.PUT_GET_MAX_RETRIES);
+    }
     return 25;
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -81,7 +81,10 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
   // Returns the Max number of retry attempts
   @Override
   public int getMaxRetries() {
-    if (session.getConnectionPropertiesMap().containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
+    if (session != null
+        && session
+            .getConnectionPropertiesMap()
+            .containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
       return (int) session.getConnectionPropertiesMap().get(SFSessionProperty.PUT_GET_MAX_RETRIES);
     }
     return 25;

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -40,10 +40,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.core.SFBaseSession;
-import net.snowflake.client.core.SFSSLConnectionSocketFactory;
-import net.snowflake.client.core.SFSession;
+import net.snowflake.client.core.*;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.client.log.SFLogger;
 import net.snowflake.client.log.SFLoggerFactory;
@@ -213,6 +210,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
   // Returns the Max number of retry attempts
   @Override
   public int getMaxRetries() {
+    if (session.getConnectionPropertiesMap().containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
+      return (int) session.getConnectionPropertiesMap().get(SFSessionProperty.PUT_GET_MAX_RETRIES);
+    }
     return 25;
   }
 
@@ -330,9 +330,21 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
                     })
                 .build();
 
+        logger.debug(
+            "downloading from S3. Remote location: "
+                + remoteStorageLocation
+                + ", stage file path: "
+                + stageFilePath
+                + ", local file: "
+                + localFile);
         Download myDownload = tx.download(remoteStorageLocation, stageFilePath, localFile);
 
         // Pull object metadata from S3
+        logger.debug(
+            "get object metadata from remote location: "
+                + remoteStorageLocation
+                + ", and path: "
+                + stageFilePath);
         ObjectMetadata meta = amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
 
         Map<String, String> metaMap = meta.getUserMetadata();
@@ -694,16 +706,20 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       SnowflakeFileTransferAgent.throwNoSpaceLeftError(session, operation, ex);
     }
 
+    // Don't retry if max retries has been reached or the error code is 404/400
     if (ex instanceof AmazonClientException) {
-      if (retryCount > s3Client.getMaxRetries() || s3Client.isClientException404(ex)) {
+      logger.debug("AmazonClientException: " + ex.getMessage());
+      if (retryCount > s3Client.getMaxRetries() || s3Client.isClientException400Or404(ex)) {
         String extendedRequestId = "none";
 
         if (ex instanceof AmazonS3Exception) {
           AmazonS3Exception ex1 = (AmazonS3Exception) ex;
+          logger.debug("AmazonS3Exception: " + ex1.getAdditionalDetails());
           extendedRequestId = ex1.getExtendedRequestId();
         }
 
         if (ex instanceof AmazonServiceException) {
+          logger.debug("AmazonServiceException");
           AmazonServiceException ex1 = (AmazonServiceException) ex;
           throw new SnowflakeSQLLoggedException(
               session,
@@ -793,13 +809,12 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     }
   }
 
-  /** Checks the status code of the exception to see if it's a 404 */
-  public boolean isClientException404(Exception ex) {
+  /** Checks the status code of the exception to see if it's a 400 or 404 */
+  public boolean isClientException400Or404(Exception ex) {
     if (ex instanceof AmazonServiceException) {
       AmazonServiceException asEx = (AmazonServiceException) (ex);
-      if (asEx.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-        return true;
-      }
+      return asEx.getStatusCode() == HttpStatus.SC_NOT_FOUND
+          || asEx.getStatusCode() == HttpStatus.SC_BAD_REQUEST;
     }
     return false;
   }

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -210,7 +210,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
   // Returns the Max number of retry attempts
   @Override
   public int getMaxRetries() {
-    if (session.getConnectionPropertiesMap().containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
+    if (session != null
+        && session
+            .getConnectionPropertiesMap()
+            .containsKey(SFSessionProperty.PUT_GET_MAX_RETRIES)) {
       return (int) session.getConnectionPropertiesMap().get(SFSessionProperty.PUT_GET_MAX_RETRIES);
     }
     return 25;
@@ -330,21 +333,9 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
                     })
                 .build();
 
-        logger.debug(
-            "downloading from S3. Remote location: "
-                + remoteStorageLocation
-                + ", stage file path: "
-                + stageFilePath
-                + ", local file: "
-                + localFile);
         Download myDownload = tx.download(remoteStorageLocation, stageFilePath, localFile);
 
         // Pull object metadata from S3
-        logger.debug(
-            "get object metadata from remote location: "
-                + remoteStorageLocation
-                + ", and path: "
-                + stageFilePath);
         ObjectMetadata meta = amazonClient.getObjectMetadata(remoteStorageLocation, stageFilePath);
 
         Map<String, String> metaMap = meta.getUserMetadata();
@@ -714,24 +705,31 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
         if (ex instanceof AmazonS3Exception) {
           AmazonS3Exception ex1 = (AmazonS3Exception) ex;
-          logger.debug("AmazonS3Exception: " + ex1.getAdditionalDetails());
           extendedRequestId = ex1.getExtendedRequestId();
         }
 
         if (ex instanceof AmazonServiceException) {
-          logger.debug("AmazonServiceException");
           AmazonServiceException ex1 = (AmazonServiceException) ex;
-          throw new SnowflakeSQLLoggedException(
-              session,
-              SqlState.SYSTEM_ERROR,
-              ErrorCode.S3_OPERATION_ERROR.getMessageCode(),
-              ex1,
-              operation,
-              ex1.getErrorType().toString(),
-              ex1.getErrorCode(),
-              ex1.getMessage(),
-              ex1.getRequestId(),
-              extendedRequestId);
+
+          // The AWS credentials might have expired when server returns error 400 and
+          // does not return the ExpiredToken error code.
+          // If session is null we cannot renew the token so throw the exception
+          if (ex1.getStatusCode() == HttpStatus.SC_BAD_REQUEST && session != null) {
+            SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);
+          } else {
+            throw new SnowflakeSQLLoggedException(
+                session,
+                SqlState.SYSTEM_ERROR,
+                ErrorCode.S3_OPERATION_ERROR.getMessageCode(),
+                ex1,
+                operation,
+                ex1.getErrorType().toString(),
+                ex1.getErrorCode(),
+                ex1.getMessage(),
+                ex1.getRequestId(),
+                extendedRequestId);
+          }
+
         } else {
           throw new SnowflakeSQLLoggedException(
               session,

--- a/src/test/java/net/snowflake/client/core/SFSessionPropertyTest.java
+++ b/src/test/java/net/snowflake/client/core/SFSessionPropertyTest.java
@@ -62,4 +62,23 @@ public class SFSessionPropertyTest {
 
     assertThat("Integer value should match", (int) value == expectedVal);
   }
+
+  @Test
+  public void testInvalidPutGetMaxRetries() {
+    try {
+      SFSessionProperty.checkPropertyValue(SFSessionProperty.PUT_GET_MAX_RETRIES, "invalidValue");
+      Assert.fail("testInvalidMaxRetries");
+    } catch (SFException e) {
+      assertThat(e.getVendorCode(), is(ErrorCode.INVALID_PARAMETER_VALUE.getMessageCode()));
+    }
+  }
+
+  @Test
+  public void testvalidPutGetMaxRetries() throws SFException {
+    int expectedVal = 10;
+    Object value =
+        SFSessionProperty.checkPropertyValue(SFSessionProperty.PUT_GET_MAX_RETRIES, expectedVal);
+
+    assertThat("Integer value should match", (int) value == expectedVal);
+  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeS3ClientHandleExceptionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeS3ClientHandleExceptionLatestIT.java
@@ -4,6 +4,7 @@
 package net.snowflake.client.jdbc;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.google.cloud.storage.StorageException;
@@ -103,6 +104,20 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
   public void errorNotFound() throws SQLException {
     spyingClient.handleStorageException(
         new AmazonS3Exception("Not found"), overMaxRetry, "upload", sfSession, command);
+  }
+
+  @Test(expected = SnowflakeSQLException.class)
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void errorBadRequest() throws SQLException {
+    AmazonServiceException ex = new AmazonServiceException("Bad Request");
+    ex.setServiceName("Amazon S3");
+    ex.setStatusCode(400);
+    ex.setErrorCode("400 Bad Request");
+    ex.setErrorType(AmazonServiceException.ErrorType.Client);
+    Mockito.doReturn(true).when(spyingClient).isClientException400Or404(ex);
+    spyingClient.handleStorageException(ex, 0, "download", sfSession, command);
+    // no retry
+    Mockito.verify(spyingClient, Mockito.times(1)).isClientException400Or404(ex);
   }
 
   @Test(expected = SnowflakeSQLException.class)

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeS3ClientHandleExceptionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeS3ClientHandleExceptionLatestIT.java
@@ -106,9 +106,9 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
         new AmazonS3Exception("Not found"), overMaxRetry, "upload", sfSession, command);
   }
 
-  @Test(expected = SnowflakeSQLException.class)
+  @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
-  public void errorBadRequest() throws SQLException {
+  public void errorBadRequestTokenExpired() throws SQLException {
     AmazonServiceException ex = new AmazonServiceException("Bad Request");
     ex.setServiceName("Amazon S3");
     ex.setStatusCode(400);
@@ -116,8 +116,9 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
     ex.setErrorType(AmazonServiceException.ErrorType.Client);
     Mockito.doReturn(true).when(spyingClient).isClientException400Or404(ex);
     spyingClient.handleStorageException(ex, 0, "download", sfSession, command);
-    // no retry
+    // renew token
     Mockito.verify(spyingClient, Mockito.times(1)).isClientException400Or404(ex);
+    Mockito.verify(spyingClient, Mockito.times(1)).renew(Mockito.anyMap());
   }
 
   @Test(expected = SnowflakeSQLException.class)

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
@@ -18,8 +18,8 @@ import net.snowflake.client.core.SFSession;
 import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
-import org.junit.Ignore;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -78,10 +78,10 @@ public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
       assertTrue(resultSet.next());
       statement.execute("create or replace stage " + testStageName);
       resultSet =
-              connection
-                      .createStatement()
-                      .executeQuery(
-                              "PUT file://" + getFullPathFileInResource(TEST_DATA_FILE) + " @" + testStageName);
+          connection
+              .createStatement()
+              .executeQuery(
+                  "PUT file://" + getFullPathFileInResource(TEST_DATA_FILE) + " @" + testStageName);
       while (resultSet.next()) {
         assertEquals("UPLOADED", resultSet.getString("status"));
       }

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
@@ -5,11 +5,13 @@ package net.snowflake.client.jdbc.cloud.storage;
 
 import static org.junit.Assert.*;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.core.SFSession;
@@ -17,7 +19,9 @@ import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 import org.junit.Ignore;
+import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
 
@@ -74,10 +78,10 @@ public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
       assertTrue(resultSet.next());
       statement.execute("create or replace stage " + testStageName);
       resultSet =
-          connection
-              .createStatement()
-              .executeQuery(
-                  "PUT file://" + getFullPathFileInResource(TEST_DATA_FILE) + " @" + testStageName);
+              connection
+                      .createStatement()
+                      .executeQuery(
+                              "PUT file://" + getFullPathFileInResource(TEST_DATA_FILE) + " @" + testStageName);
       while (resultSet.next()) {
         assertEquals("UPLOADED", resultSet.getString("status"));
       }
@@ -86,6 +90,80 @@ public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
         connection.createStatement().execute("DROP STAGE if exists " + testStageName);
         connection.close();
       }
+    }
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testIsClientException400Or404() throws SQLException {
+    AmazonServiceException servEx = new AmazonServiceException("S3 operation failed");
+    servEx.setServiceName("Amazon S3");
+    servEx.setErrorMessage("Bad Request");
+    servEx.setStatusCode(400);
+    servEx.setErrorCode("400 Bad Request");
+    servEx.setErrorType(AmazonServiceException.ErrorType.Client);
+
+    try (Connection connection = getConnection("s3testaccount")) {
+      SFSession sfSession = connection.unwrap(SnowflakeConnectionV1.class).getSfSession();
+      String getCommand = "GET '@~/testStage' 'file://C:/temp' PARALLEL=8";
+      SnowflakeFileTransferAgent agent =
+          new SnowflakeFileTransferAgent(getCommand, sfSession, new SFStatement(sfSession));
+      RemoteStoreFileEncryptionMaterial content =
+          new RemoteStoreFileEncryptionMaterial(
+              "LHMTKHLETLKHPSTADDGAESLFKREYGHFHGHGSDHJKLMH", "123456", 123L);
+      StageInfo info = agent.getStageInfo();
+      ClientConfiguration clientConfig = new ClientConfiguration();
+      SnowflakeS3Client client =
+          new SnowflakeS3Client(
+              info.getCredentials(),
+              clientConfig,
+              content,
+              info.getProxyProperties(),
+              info.getRegion(),
+              info.getEndPoint(),
+              info.getIsClientSideEncrypted(),
+              sfSession,
+              info.getUseS3RegionalUrl());
+      assertTrue(client.isClientException400Or404(servEx));
+    }
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testPutGetMaxRetries() throws SQLException {
+    Properties props = new Properties();
+    props.put("putGetMaxRetries", 1);
+    try (Connection connection = getConnection("s3testaccount", props)) {
+      SFSession sfSession = connection.unwrap(SnowflakeConnectionV1.class).getSfSession();
+      String command = "GET '@~/testStage' 'file://C:/temp' PARALLEL=8";
+      SnowflakeFileTransferAgent agent =
+          new SnowflakeFileTransferAgent(command, sfSession, new SFStatement(sfSession));
+      StageInfo info = agent.getStageInfo();
+      ClientConfiguration clientConfig = new ClientConfiguration();
+      RemoteStoreFileEncryptionMaterial content =
+          new RemoteStoreFileEncryptionMaterial(
+              "LHMTKHLETLKHPSTADDGAESLFKREYGHFHGHGSDHJKLMH", "123456", 123L);
+      SnowflakeS3Client client =
+          new SnowflakeS3Client(
+              info.getCredentials(),
+              clientConfig,
+              content,
+              info.getProxyProperties(),
+              info.getRegion(),
+              info.getEndPoint(),
+              info.getIsClientSideEncrypted(),
+              sfSession,
+              info.getUseS3RegionalUrl());
+      SnowflakeS3Client spy = Mockito.spy(client);
+
+      // Should retry one time, then throw error
+      try {
+        spy.handleStorageException(new InterruptedException(), 0, "download", sfSession, command);
+      } catch (Exception e) {
+        Assert.fail("Should not have exception here");
+      }
+      Mockito.verify(spy, Mockito.never()).renew(Mockito.anyMap());
+      spy.handleStorageException(new InterruptedException(), 1, "download", sfSession, command);
     }
   }
 }


### PR DESCRIPTION
# Overview

SNOW-854356
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/512

The driver retries on 400 Bad Request error codes. The S3 client can return this error response if the token is expired and the driver will retry using the same request with sleep and backoff. This will continuously fail until the max retry of 25 is reached. 

1. Check the error response and renew the token on 400 Bad Request. 
2. Add a connection property to configure the max retries for PUT/GET exceptions for storage clients.

Reproduced the exception using a sleep of 1.5 hours in the code to test the fix.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 
   https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/512

4. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

5. Please describe how your code solves the related issue.

   Instead of retrying the same request on 400 Bad Request response when the token could be expired, renew the token first and then retry.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

