### PR TITLE
SNOW-837400: Fix S3 client builder reading proxy environment variables

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/StorageClientFactory.java
@@ -122,6 +122,13 @@ public class StorageClientFactory {
     clientConfig.setMaxErrorRetry(S3_TRANSFER_MAX_RETRIES);
     clientConfig.setDisableSocketProxy(HttpUtil.isSocksProxyDisabled());
 
+    // If proxy is set via connection properties or JVM settings these will be overridden later.
+    // This is to prevent the aws client builder from reading proxy environment variables.
+    clientConfig.setProxyHost("");
+    clientConfig.setProxyPort(0);
+    clientConfig.setProxyUsername("");
+    clientConfig.setProxyPassword("");
+
     logger.debug(
         "s3 client configuration: maxConnection={}, connectionTimeout={}, "
             + "socketTimeout={}, maxErrorRetry={}",

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
@@ -7,7 +7,9 @@ import static org.junit.Assert.*;
 
 import com.amazonaws.ClientConfiguration;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.core.SFSession;
@@ -46,5 +48,35 @@ public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
               info.getUseS3RegionalUrl());
       assertEquals(256, client.getEncryptionKeySize());
     }
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testS3ConnectionWithProxyEnvVariablesSet() throws SQLException {
+    Connection connection = null;
+    SnowflakeUtil.systemSetEnv("HTTPS_PROXY", "myproxy:8080");
+    String testStageName = "s3TestStage";
+    try {
+      connection = getConnection("s3testaccount");
+      Statement statement = connection.createStatement();
+      ResultSet resultSet = statement.executeQuery("select 1");
+      assertTrue(resultSet.next());
+
+      statement.execute("create or replace stage " + testStageName);
+      resultSet =
+          connection
+              .createStatement()
+              .executeQuery(
+                  "PUT file://" + getFullPathFileInResource(TEST_DATA_FILE) + " @" + testStageName);
+      while (resultSet.next()) {
+        assertEquals("UPLOADED", resultSet.getString("status"));
+      }
+    } finally {
+      if (connection != null) {
+        connection.createStatement().execute("DROP STAGE if exists " + testStageName);
+        connection.close();
+      }
+    }
+    SnowflakeUtil.systemUnsetEnv("HTTPS_PROXY");
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
@@ -16,6 +16,7 @@ import net.snowflake.client.core.SFSession;
 import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.*;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
@@ -50,18 +51,27 @@ public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
     }
   }
 
+  /**
+   * This is a manual test to confirm that the s3 client builder doesn't read from
+   * https_proxy/http_proxy environment variable.
+   *
+   * <p>Prerequisite: 1. Set HTTPS_PROXY/HTTP_PROXY to a proxy that won't connect i.e.
+   * HTTPS_PROXY=https://myproxy:8080
+   *
+   * <p>2. Connect to S3 host.
+   *
+   * @throws SQLException
+   */
   @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  @Ignore
   public void testS3ConnectionWithProxyEnvVariablesSet() throws SQLException {
     Connection connection = null;
-    SnowflakeUtil.systemSetEnv("HTTPS_PROXY", "myproxy:8080");
     String testStageName = "s3TestStage";
     try {
-      connection = getConnection("s3testaccount");
+      connection = getConnection();
       Statement statement = connection.createStatement();
       ResultSet resultSet = statement.executeQuery("select 1");
       assertTrue(resultSet.next());
-
       statement.execute("create or replace stage " + testStageName);
       resultSet =
           connection
@@ -77,6 +87,5 @@ public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
         connection.close();
       }
     }
-    SnowflakeUtil.systemUnsetEnv("HTTPS_PROXY");
   }
 }


### PR DESCRIPTION
# Overview

SNOW-837400

The jdbc driver should only use proxy settings that are specified in connection properties or JVM properties. 
During the setup of the S3 client in SnowflakeS3Client.java, the aws-java-sdk-core library will try to resolve the client configuration including the proxy host, port, user and password settings. It will try to read proxy settings in the following order:

1. If provided, returns the value set on the ClientConfiguration object i.e clientConfig.setProxyHost("value")
2. If not provided, checks the java system properties i.e http.proxyHost
3. If neither above two are provided, checks the environment variables HTTP_PROXY/HTTPS_PROXY

The value will be used in all requests to the external stage. There is no option to disable the proxy in the aws library.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

  https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/462


5. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

6. Please describe how your code solves the related issue.

   Before we build the client, set the proxy values to empty string. If proxy properties are set correctly for the driver via the JVM or connection properties, then the empty string will be overridden in HttpUtil.setProxyForS3(). By passing empty string to the client builder instead of null, it won't look for JVM or env variable settings.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

