### PR TITLE
SNOW-836396: InvalidPathException loading client config file on Windows

### DIFF
--- a/src/main/java/net/snowflake/client/config/SFClientConfigParser.java
+++ b/src/main/java/net/snowflake/client/config/SFClientConfigParser.java
@@ -79,26 +79,33 @@ public class SFClientConfigParser {
   }
 
   public static String getConfigFilePathFromJDBCJarLocation() {
-    if (SnowflakeDriver.class.getProtectionDomain() != null
-        && SnowflakeDriver.class.getProtectionDomain().getCodeSource() != null
-        && SnowflakeDriver.class.getProtectionDomain().getCodeSource().getLocation() != null) {
+    try {
+      if (SnowflakeDriver.class.getProtectionDomain() != null
+          && SnowflakeDriver.class.getProtectionDomain().getCodeSource() != null
+          && SnowflakeDriver.class.getProtectionDomain().getCodeSource().getLocation() != null) {
 
-      String jarPath =
-          SnowflakeDriver.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        String jarPath =
+            SnowflakeDriver.class.getProtectionDomain().getCodeSource().getLocation().getPath();
 
-      // remove /snowflake-jdbc-3.13.29.jar from the path.
-      String updatedPath = jarPath.substring(0, jarPath.lastIndexOf("/"));
+        // remove /snowflake-jdbc-3.13.29.jar and anything that follows it from the path.
+        String updatedPath = new File(jarPath).getParentFile().getPath();
 
-      if (systemGetProperty("os.name") != null
-          && systemGetProperty("os.name").toLowerCase().startsWith("windows")) {
-        // Path translation for windows
-        if (updatedPath.startsWith("/")) {
-          updatedPath = updatedPath.substring(1);
+        if (systemGetProperty("os.name") != null
+            && systemGetProperty("os.name").toLowerCase().startsWith("windows")) {
+          // Path translation for windows
+          if (updatedPath.startsWith("/")) {
+            updatedPath = updatedPath.substring(1);
+          } else if (updatedPath.startsWith("file:\\")) {
+            updatedPath = updatedPath.substring(6);
+          }
+          updatedPath = updatedPath.replace("/", "\\");
         }
-        updatedPath = updatedPath.replace("/", "\\");
+        return updatedPath;
       }
-      return updatedPath;
+      return "";
+    } catch (Exception ex) {
+      // return empty path and move to step 4 of loadSFClientConfig()
+      return "";
     }
-    return "";
   }
 }


### PR DESCRIPTION
# Overview

SNOW-836396

When the driver tries to load the path of the jar directory as part of the easy logging configuration process, sometimes the path can have a prefix on Windows. This was partially fixed in #1390 but a customer faced another issue where the path had file:\ prefix:
 
```
Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 4: file:\C:\dev\<snip>\build\libs\<snip>-application.jar!\BOOT-INF\lib\snowflake-jdbc-3.13.31.jar!\sf_client_config.json
        at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182) ~[?:?]
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153) ~[?:?]
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77) ~[?:?]
        at sun.nio.fs.WindowsPath.parse(WindowsPath.java:92) ~[?:?]
        at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:232) ~[?:?]
        at java.nio.file.Path.of(Path.java:147) ~[?:?]
        at java.nio.file.Paths.get(Paths.java:69) ~[?:?]
        at net.snowflake.client.config.SFClientConfigParser.loadSFClientConfig(SFClientConfigParser.java:44) ~[snowflake-jdbc-3.13.31.jar!/:3.13.31]
        at net.snowflake.client.jdbc.DefaultSFConnectionHandler.setClientConfig(DefaultSFConnectionHandler.java:128) ~[snowflake-jdbc-3.13.31.jar!/:3.13.31]
        at net.snowflake.client.jdbc.DefaultSFConnectionHandler.initialize(DefaultSFConnectionHandler.java:109) ~[snowflake-jdbc-3.13.31.jar!/:3.13.31]
        at net.snowflake.client.jdbc.DefaultSFConnectionHandler.initializeConnection(DefaultSFConnectionHandler.java:85) ~[snowflake-jdbc-3.13.31.jar!/:3.13.31]
        at net.snowflake.client.jdbc.SnowflakeConnectionV1.initConnectionWithImpl(SnowflakeConnectionV1.java:116) ~[snowflake-jdbc-3.13.31.jar!/:3.13.31]
        at net.snowflake.client.jdbc.SnowflakeConnectionV1.<init>(SnowflakeConnectionV1.java:96) ~[snowflake-jdbc-3.13.31.jar!/:3.13.31]
        at net.snowflake.client.jdbc.SnowflakeDriver.connect(SnowflakeDriver.java:180) ~[snowflake-jdbc-3.13.31.jar!/:3.13.31]
```

Once the driver finds the path of the driver jar file, it attempts to remove snowflake-jdbc-<version>.jar from the path. Depending on how the path is loaded by the application, it could be returned like:

`file:\C:\dev\<snip>\build\libs\<snip>-application.jar!\BOOT-INF\lib\snowflake-jdbc-3.13.31.jar!`

Then the driver won't be able to remove the jar or the exclamation point from the path.

This is only reproducible for me if I build an executable jar on Spring boot that connects to the driver so there are no tests for these edge cases.

The fix:

Parse 'file://' out of file path when trying to retrieve jar location
Use File to get the parent directory where the driver jar is located so that we remove the driver jar and anything following it e.g. `snowflake-jdbc-3.13.31.jar! `
   
## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1405 
   https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/458

4. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

5. Please describe how your code solves the related issue.



## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

