### PR TITLE
SNOW-852665: Allow ~ in PUT/GET file path

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -864,8 +864,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         localLocation = systemGetProperty("user.home") + localLocation.substring(1);
       }
 
-      // it should not contain any ~ after the above replacement
-      if (localLocation.contains("~")) {
+      // it should not start with any ~ after the above replacement
+      if (localLocation.startsWith("~")) {
         throw new SnowflakeSQLLoggedException(
             session,
             ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(),
@@ -1690,7 +1690,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
     for (String path : filePathList) {
       // replace ~ with user home
-      path = path.replace("~", systemGetProperty("user.home"));
+      if (path.startsWith("~")) {
+        path = systemGetProperty("user.home") + path.substring(1);
+      }
 
       // user may also specify files relative to current directory
       // add the current path if that is the case

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
@@ -29,7 +29,11 @@ public class FileUploaderExpandFileNamesTest {
     System.setProperty("user.home", folderName);
 
     String[] locations = {
-      folderName + "/Tes*Fil*A", folderName + "/TestFil?B", "~/TestFileC", "TestFileD"
+      folderName + "/Tes*Fil*A",
+      folderName + "/TestFil?B",
+      "~/TestFileC",
+      "TestFileD",
+      folderName + "/TestFileE~"
     };
 
     Set<String> files = SnowflakeFileTransferAgent.expandFileNames(locations);
@@ -38,6 +42,7 @@ public class FileUploaderExpandFileNamesTest {
     assertTrue(files.contains(folderName + "/TestFileB"));
     assertTrue(files.contains(folderName + "/TestFileC"));
     assertTrue(files.contains(folderName + "/TestFileD"));
+    assertTrue(files.contains(folderName + "/TestFileE~"));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderLatestIT.java
@@ -3,17 +3,16 @@
  */
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.sql.*;
@@ -28,6 +27,7 @@ import net.snowflake.client.core.SFSession;
 import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.cloud.storage.*;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -809,5 +809,98 @@ public class FileUploaderLatestIT extends FileUploaderPrepIT {
     sfAgent.setDestFileNameForStreamSource("test_file");
 
     sfAgent.execute();
+  }
+
+  @Test
+  public void testUploadFileWithTildeInFolderName() throws SQLException, IOException {
+    Connection connection = null;
+    Statement statement = null;
+    ResultSet resultSet = null;
+    Writer writer = null;
+    Path topDataDir = null;
+
+    try {
+      topDataDir = Files.createTempDirectory("testPutFileTilde");
+      topDataDir.toFile().deleteOnExit();
+
+      // create sub directory where the name includes ~
+      Path subDir = Files.createDirectories(Paths.get(topDataDir.toString(), "snowflake~"));
+
+      // create a test data
+      File dataFile = new File(subDir.toFile(), "test.txt");
+      writer =
+          new BufferedWriter(
+              new OutputStreamWriter(
+                  Files.newOutputStream(Paths.get(dataFile.getCanonicalPath())),
+                  StandardCharsets.UTF_8));
+      writer.write("1,test1");
+      writer.close();
+
+      connection = getConnection();
+      statement = connection.createStatement();
+      statement.execute("create or replace stage testStage");
+      String sql = String.format("PUT 'file://%s' @testStage", dataFile.getCanonicalPath());
+
+      // Escape backslashes. This must be done by the application.
+      sql = sql.replaceAll("\\\\", "\\\\\\\\");
+      resultSet = statement.executeQuery(sql);
+      while (resultSet.next()) {
+        assertEquals("UPLOADED", resultSet.getString("status"));
+      }
+    } finally {
+      if (connection != null) {
+        connection.createStatement().execute("drop stage if exists testStage");
+      }
+      closeSQLObjects(resultSet, statement, connection);
+      if (writer != null) {
+        writer.close();
+      }
+      FileUtils.deleteDirectory(topDataDir.toFile());
+    }
+  }
+
+  @Test
+  public void testUploadWithTildeInPath() throws SQLException, IOException {
+    Connection connection = null;
+    Statement statement = null;
+    ResultSet resultSet = null;
+    Writer writer = null;
+    Path subDir = null;
+
+    try {
+
+      String homeDir = systemGetProperty("user.home");
+
+      // create sub directory where the name includes ~
+      subDir = Files.createDirectories(Paths.get(homeDir, "snowflake"));
+
+      // create a test data
+      File dataFile = new File(subDir.toFile(), "test.txt");
+      writer =
+          new BufferedWriter(
+              new OutputStreamWriter(
+                  Files.newOutputStream(Paths.get(dataFile.getCanonicalPath())),
+                  StandardCharsets.UTF_8));
+      writer.write("1,test1");
+      writer.close();
+
+      connection = getConnection();
+      statement = connection.createStatement();
+      statement.execute("create or replace stage testStage");
+
+      resultSet = statement.executeQuery("PUT 'file://~/snowflake/test.txt' @testStage");
+      while (resultSet.next()) {
+        assertEquals("UPLOADED", resultSet.getString("status"));
+      }
+    } finally {
+      if (connection != null) {
+        connection.createStatement().execute("drop stage if exists testStage");
+      }
+      closeSQLObjects(resultSet, statement, connection);
+      if (writer != null) {
+        writer.close();
+      }
+      FileUtils.deleteDirectory(subDir.toFile());
+    }
   }
 }


### PR DESCRIPTION
# Overview

SNOW-852665

PUT commands will fail if the source file path contains ~ even though this is accepted in folder names. This is because during parsing of the command, the driver filters out any ~ with the user home directory.

```
for (String path : filePathList) {
      // replace ~ with user home
      path = path.replace("~", systemGetProperty("user.home"));
```

So file path in the command `"PUT 'file:///C:/snowflake~/test.txt' '@~' AUTO_COMPRESS=FALSE"` would be parsed to "`/C:/snowflakeC:\Users\user/test.txt`"

GET commands will also fail if trying to download to a directory with ~ in the path name. This is because the driver checks if ~ is at the start of the command, then replaces with the user home directory. Afterwards it checks to see if the command still contains an ~ and will throw a PATH_NOT_DIRECTORY error.

```
      if (localLocation.startsWith("~")) {
        // replace ~ with user home
        localLocation = systemGetProperty("user.home") + localLocation.substring(1);
      }

      // it should not contain any ~ after the above replacement
      if (localLocation.contains("~")) {
        throw new SnowflakeSQLLoggedException(
            session,
            ErrorCode.PATH_NOT_DIRECTORY.getMessageCode(),
            SqlState.IO_ERROR,
            localLocation);
      }
```

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1458 
   https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/508

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Ensure that ~ is only replaced for PUT/GET if it's at the start of the command. Otherwise, allow ~ in folder directories.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

