### PR TITLE
SNOW-872558: add path to private link OCSP retry url

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFTrustManager.java
+++ b/src/main/java/net/snowflake/client/core/SFTrustManager.java
@@ -1128,7 +1128,7 @@ public class SFTrustManager extends X509ExtendedTrustManager {
                 new URL(
                     String.format(
                         SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN,
-                        ocspUrl.getHost() + ":" + ocspUrl.getPort() + ocspUrl.getPath(),
+                        ocspUrl.getHost() + ":" + ocspUrl.getPort() + path,
                         urlEncodedOCSPReq));
           } else {
             url =

--- a/src/main/java/net/snowflake/client/core/SFTrustManager.java
+++ b/src/main/java/net/snowflake/client/core/SFTrustManager.java
@@ -1115,16 +1115,30 @@ public class SFTrustManager extends X509ExtendedTrustManager {
       telemetryData.setOcspReq(ocspReqDerBase64);
 
       URL url;
+      String path = "";
       if (!ocspCacheServer.new_endpoint_enabled) {
         String urlEncodedOCSPReq = URLUtil.urlEncode(ocspReqDerBase64);
         if (SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN != null) {
           URL ocspUrl = new URL(ocspUrlStr);
-          url =
-              new URL(
-                  String.format(
-                      SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN,
-                      ocspUrl.getHost(),
-                      urlEncodedOCSPReq));
+          if (!Strings.isNullOrEmpty(ocspUrl.getPath())) {
+            path = ocspUrl.getPath();
+          }
+          if (ocspUrl.getPort() > 0) {
+            url =
+                new URL(
+                    String.format(
+                        SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN,
+                        ocspUrl.getHost() + ":" + ocspUrl.getPort() + ocspUrl.getPath(),
+                        urlEncodedOCSPReq));
+          } else {
+            url =
+                new URL(
+                    String.format(
+                        SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN,
+                        ocspUrl.getHost() + path,
+                        urlEncodedOCSPReq));
+          }
+
         } else {
           url = new URL(String.format("%s/%s", ocspUrlStr, urlEncodedOCSPReq));
         }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -1665,7 +1665,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
     resultSet.next();
     // Verify it matches the new statement parameter specified output format
     assertEquals("08/17/2023", resultSet.getString(3));
-    statement.execute("drop table timetable if exists");
+    statement.execute("drop table if exists timetable");
     statement.close();
     con.close();
     // cleanup


### PR DESCRIPTION
# Overview

SNOW-872558

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [#559](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/559)


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Add the path and port, if exist, to the OCSP retry URL instead of taking just the host.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

