### PR TITLE
Fix META-INF/versions relocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -640,7 +640,6 @@
           <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
           <sortExecutions>true</sortExecutions>
           <sortModules>true</sortModules>
-          <sortPlugins>groupId,artifactId</sortPlugins>
           <sortProperties>true</sortProperties>
           <verifyFail>stop</verifyFail>
           <verifyFailOn>strict</verifyFailOn>
@@ -1067,33 +1066,6 @@
       <build>
         <plugins>
           <plugin>
-            <!-- relocate the META-INF/versions files manually due to the maven bug -->
-            <!-- https://issues.apache.org/jira/browse/MSHADE-406 -->
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>repack</id>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <phase>package</phase>
-                <configuration>
-                  <target>
-                    <unzip dest="${project.build.directory}/relocate" src="${project.build.directory}/${project.build.finalName}.jar"/>
-                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}"/>
-                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}"/>
-                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/15/${relocationBase}"/>
-                    <zip basedir="${project.build.directory}/relocate" destfile="${project.build.directory}/${project.build.finalName}.jar"/>
-                    <delete dir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}"/>
-                    <delete dir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}"/>
-                    <delete dir="${project.build.directory}/relocate/META-INF/versions/15/${relocationBase}"/>
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <!-- google linkage checker doesn't work well with shaded jar, disable the check in this case for now -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
@@ -1340,6 +1312,36 @@
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
                   </transformers>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <!-- relocate the META-INF/versions files manually due to the maven bug -->
+            <!-- https://issues.apache.org/jira/browse/MSHADE-406 -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>repack</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <target>
+                    <unzip dest="${project.build.directory}/relocate" src="${project.build.directory}/${project.build.finalName}.jar"/>
+                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}"/>
+                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}"/>
+                    <mkdir dir="${project.build.directory}/relocate/META-INF/versions/15/${relocationBase}"/>
+                    <move file="${project.build.directory}/relocate/META-INF/versions/9/org" todir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}"/>
+                    <move file="${project.build.directory}/relocate/META-INF/versions/11/org" todir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}"/>
+                    <move file="${project.build.directory}/relocate/META-INF/versions/15/org" todir="${project.build.directory}/relocate/META-INF/versions/15/${relocationBase}"/>
+                    <zip basedir="${project.build.directory}/relocate" destfile="${project.build.directory}/${project.build.finalName}.jar"/>
+                    <delete dir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}"/>
+                    <delete dir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}"/>
+                    <delete dir="${project.build.directory}/relocate/META-INF/versions/15/${relocationBase}"/>
+                  </target>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
# Overview

Fixes https://github.com/snowflakedb/snowflake-jdbc/issues/1503

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowflake-jdbc/issues/1503

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   - Removes the `sortPlugins` from the `sortpom-maven-plugin` configuration.
   - Reorders the plugins so `maven-antrun-plugin` is applied after `maven-shade-plugin`.
   - Brings back the `move` elements in the `maven-antrun-plugin` configuration.

    Here's a screenshot comparing the JAR produced on `master` to the one produced on this branch. Notice that the `META-INF/versions` classes are once again correctly relocated.

    
![Screenshot 2023-08-31 at 12 48 30 PM](https://github.com/snowflakedb/snowflake-jdbc/assets/5273164/6e9fbcb8-f4d2-4c45-95f8-8a9394518542)


## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

