### PR TITLE
Change the session parameter to run tests as is before with old driver

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -786,6 +786,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
     String destFolderCanonicalPathWithSeparator = destFolderCanonicalPath + File.separator;
 
     try {
+      statement.execute("alter session set ENABLE_GCP_PUT_EXCEPTION_FOR_OLD_DRIVERS=false");
       statement.execute("CREATE OR REPLACE STAGE wildcard_stage");
       assertTrue(
           "Failed to put a file",
@@ -873,6 +874,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
         copyContentFrom(largeTempFile2, largeTempFile);
       }
 
+      statement.execute("alter session set ENABLE_GCP_PUT_EXCEPTION_FOR_OLD_DRIVERS=false");
+
       // create a stage to put the file in
       statement.execute("CREATE OR REPLACE STAGE largefile_stage");
       assertTrue(
@@ -952,6 +955,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
         statement = connection.createStatement();
 
+        statement.execute("alter session set ENABLE_GCP_PUT_EXCEPTION_FOR_OLD_DRIVERS=false");
+
         // create a stage to put the file in
         statement.execute("CREATE OR REPLACE STAGE testing_stage");
         assertTrue(
@@ -1011,6 +1016,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
         // load file test
         // create a unique data file name by using current timestamp in millis
         try {
+          statement.execute("alter session set ENABLE_GCP_PUT_EXCEPTION_FOR_OLD_DRIVERS=false");
           // test external table load
           statement.execute("CREATE OR REPLACE TABLE testLoadToLocalFS(a number)");
 
@@ -2957,6 +2963,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
         String destFolderCanonicalPathWithSeparator = destFolderCanonicalPath + File.separator;
 
         try {
+          statement.execute("alter session set ENABLE_GCP_PUT_EXCEPTION_FOR_OLD_DRIVERS=false");
           statement.execute("CREATE OR REPLACE STAGE testPutGet_stage");
 
           assertTrue(
@@ -3020,6 +3027,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
         try {
           statement.execute("alter session set ENABLE_UNENCRYPTED_INTERNAL_STAGES=true");
+          statement.execute("alter session set ENABLE_GCP_PUT_EXCEPTION_FOR_OLD_DRIVERS=false");
           statement.execute(
               "CREATE OR REPLACE STAGE testPutGet_unencstage encryption=(TYPE='SNOWFLAKE_SSE')");
 


### PR DESCRIPTION
# Overview

Tests with old driver was failing with this error message: "net.snowflake.client.jdbc.SnowflakeSQLException: Your client app version, JDBC 3.9.2, is using a deprecated pre-signed URL for PUT. Please upgrade to a version that supports GCP downscoped token. See https://community.snowflake.com/s/article/faq-2023-client-driver-deprecation-for-GCP-customers." This happens because server side change. After talking to Timothy, he suggest to add session parameter to go back to previous behavior in the test: alter session set ENABLE_GCP_PUT_EXCEPTION_FOR_OLD_DRIVERS = false; 
This change is server is intended for GCP downscope token changes and early adoption of the new driver.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

