### PR TITLE
SNOW-913746 Honor useS3RegionalUrl from JsonNode in getStageInfo

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -1033,6 +1033,18 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
       }
     }
 
+    boolean useS3RegionalUrl;
+    if (stageInfo.getStageType() == StageInfo.StageType.S3) {
+      // This node's value is set if PUT is used without Session. (For Snowpipe Streaming, we rely
+      // on a response from a server to have this field set to use S3RegionalURL)
+      JsonNode useS3RegionalURLNode =
+          jsonNode.path("data").path("stageInfo").path("useS3RegionalUrl");
+      if (!useS3RegionalURLNode.isMissingNode()) {
+        useS3RegionalUrl = useS3RegionalURLNode.asBoolean(false);
+        stageInfo.setUseS3RegionalUrl(useS3RegionalUrl);
+      }
+    }
+
     return stageInfo;
   }
   /**

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderPrepIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderPrepIT.java
@@ -120,6 +120,7 @@ abstract class FileUploaderPrepIT extends BaseJDBCTest {
           + "      \"region\": \"us-west-2\",\n"
           + "      \"storageAccount\": null,\n"
           + "      \"isClientSideEncrypted\": true,\n"
+          + "      \"useS3RegionalUrl\": true,\n"
           + "      \"creds\": {\n"
           + "        \"AWS_KEY_ID\": \"EXAMPLE_AWS_KEY_ID\",\n"
           + "        \"AWS_SECRET_KEY\": \"EXAMPLE_AWS_SECRET_KEY\",\n"

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
@@ -71,6 +71,7 @@ public class FileUploaderSessionlessTest extends FileUploaderPrepIT {
     Assert.assertEquals("null", stageInfo.getEndPoint());
     Assert.assertEquals(null, stageInfo.getStorageAccount());
     Assert.assertEquals(true, stageInfo.getIsClientSideEncrypted());
+    Assert.assertEquals(true, stageInfo.getUseS3RegionalUrl());
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderSessionlessTest.java
@@ -56,7 +56,7 @@ public class FileUploaderSessionlessTest extends FileUploaderPrepIT {
 
   @Test
   public void testGetS3StageData() throws Exception {
-    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleS3JsonNode);
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleS3JsonNode, null);
     Map<String, String> expectedCreds = new HashMap<>();
     expectedCreds.put("AWS_ID", "EXAMPLE_AWS_ID");
     expectedCreds.put("AWS_KEY", "EXAMPLE_AWS_KEY");
@@ -76,7 +76,8 @@ public class FileUploaderSessionlessTest extends FileUploaderPrepIT {
 
   @Test
   public void testGetS3StageDataWithStageEndpoint() throws Exception {
-    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleS3StageEndpointJsonNode);
+    StageInfo stageInfo =
+        SnowflakeFileTransferAgent.getStageInfo(exampleS3StageEndpointJsonNode, null);
     Map<String, String> expectedCreds = new HashMap<>();
     expectedCreds.put("AWS_ID", "EXAMPLE_AWS_ID");
     expectedCreds.put("AWS_KEY", "EXAMPLE_AWS_KEY");
@@ -95,7 +96,7 @@ public class FileUploaderSessionlessTest extends FileUploaderPrepIT {
 
   @Test
   public void testGetAzureStageData() throws Exception {
-    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleAzureJsonNode);
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleAzureJsonNode, null);
     Map<String, String> expectedCreds = new HashMap<>();
     expectedCreds.put("AZURE_SAS_TOKEN", "EXAMPLE_AZURE_SAS_TOKEN");
 
@@ -110,7 +111,7 @@ public class FileUploaderSessionlessTest extends FileUploaderPrepIT {
 
   @Test
   public void testGetGCSStageData() throws Exception {
-    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleGCSJsonNode);
+    StageInfo stageInfo = SnowflakeFileTransferAgent.getStageInfo(exampleGCSJsonNode, null);
     Map<String, String> expectedCreds = new HashMap<>();
 
     Assert.assertEquals(StageInfo.StageType.GCS, stageInfo.getStageType());


### PR DESCRIPTION
# Overview

SNOW-913746


2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Currently, uploadWithoutConnection creates a Storage Client and uses StageInfo object. For Snowpipe Streaming, we need to enable useS3RegionalURL which doesn't use session instance. `getStageInfo` is the used by uploadWithoutConnection from JsonNode and doesn't check for useS3RegionalURL which will be passed from Server Side in client/configure API. Please keep an eye on Server side PR where I make changes in the response from `ConfigureClientResponse`

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

