### PR TITLE
Log exception instead of message

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -2088,7 +2088,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           break;
       }
     } catch (Exception ex) {
-      logger.error("Exception encountered during file upload: ", ex.getMessage());
+      logger.error("Exception encountered during file upload: ", ex);
       throw ex;
     } finally {
       if (fileBackedOutputStream != null) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -2088,7 +2088,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           break;
       }
     } catch (Exception ex) {
-      logger.error("Exception encountered during file upload: ", ex);
+      logger.error("Exception encountered during file upload.", ex);
       throw ex;
     } finally {
       if (fileBackedOutputStream != null) {


### PR DESCRIPTION
Currently when an error is encountered its entirely possible for an exception to have been thrown with no message. This means we end up with logs that look like:

`Exception encountered during file upload: `

This makes the log line largely useless for debugging purposes.

Fixes #1530
