### PR TITLE
 SNOW-933005 Fix Wrong Error Code Issues in testProdConnectivity and testInsecureMode

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -135,7 +135,7 @@ public class ConnectionIT extends BaseJDBCTest {
         DriverManager.getConnection(url, properties);
         fail();
       } catch (SQLException e) {
-        assertThat(e.getErrorCode(), is(INVALID_CONNECTION_INFO_CODE));
+        assertThat(e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
       }
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -135,7 +135,8 @@ public class ConnectionIT extends BaseJDBCTest {
         DriverManager.getConnection(url, properties);
         fail();
       } catch (SQLException e) {
-        assertThat(e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
+        assertThat(
+            e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
       }
     }
   }
@@ -544,7 +545,8 @@ public class ConnectionIT extends BaseJDBCTest {
       DriverManager.getConnection(deploymentUrl, properties);
       fail();
     } catch (SQLException e) {
-      assertThat(e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
+      assertThat(
+          e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
     }
 
     deploymentUrl = "jdbc:snowflake://sfcsupport.snowflakecomputing.com?insecureMode=true";
@@ -558,7 +560,8 @@ public class ConnectionIT extends BaseJDBCTest {
       DriverManager.getConnection(deploymentUrl, properties);
       fail();
     } catch (SQLException e) {
-      assertThat(e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
+      assertThat(
+          e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -4,8 +4,7 @@
 package net.snowflake.client.jdbc;
 
 import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
@@ -545,7 +544,7 @@ public class ConnectionIT extends BaseJDBCTest {
       DriverManager.getConnection(deploymentUrl, properties);
       fail();
     } catch (SQLException e) {
-      assertThat(e.getErrorCode(), is(INVALID_CONNECTION_INFO_CODE));
+      assertThat(e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
     }
 
     deploymentUrl = "jdbc:snowflake://sfcsupport.snowflakecomputing.com?insecureMode=true";
@@ -559,7 +558,7 @@ public class ConnectionIT extends BaseJDBCTest {
       DriverManager.getConnection(deploymentUrl, properties);
       fail();
     } catch (SQLException e) {
-      assertThat(e.getErrorCode(), is(INVALID_CONNECTION_INFO_CODE));
+      assertThat(e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
     }
   }
 


### PR DESCRIPTION
# Overview

SNOW-933005 Fix Wrong Error Code Issues in testProdConnectivity and testInsecureMode

The error code of wrong account name was changed from 390100 (incorrect username and password) to 390400 (bad request). This PR fixes all related tests.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

