### PR TITLE
SNOW-931105: Add createSessionlessTelemetry(CloseableHttpClient, String) method

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -193,8 +193,9 @@ public class TelemetryClient implements Telemetry {
    */
   public static Telemetry createSessionlessTelemetry(
       CloseableHttpClient httpClient, String serverUrl) {
-	// By default, use KEYPAIR_JWT as the auth type
-    return createSessionlessTelemetry(httpClient, serverUrl, "KEYPAIR_JWT", DEFAULT_FORCE_FLUSH_SIZE);
+    // By default, use KEYPAIR_JWT as the auth type
+    return createSessionlessTelemetry(
+        httpClient, serverUrl, "KEYPAIR_JWT", DEFAULT_FORCE_FLUSH_SIZE);
   }
 
   /**

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -192,6 +192,20 @@ public class TelemetryClient implements Telemetry {
    * @return a telemetry connector
    */
   public static Telemetry createSessionlessTelemetry(
+      CloseableHttpClient httpClient, String serverUrl) {
+	// By default, use KEYPAIR_JWT as the auth type
+    return createSessionlessTelemetry(httpClient, serverUrl, "KEYPAIR_JWT", DEFAULT_FORCE_FLUSH_SIZE);
+  }
+
+  /**
+   * Initialize the sessionless telemetry connector
+   *
+   * @param httpClient client object used to communicate with other machine
+   * @param serverUrl server url
+   * @param authType authorization type for sessionless telemetry
+   * @return a telemetry connector
+   */
+  public static Telemetry createSessionlessTelemetry(
       CloseableHttpClient httpClient, String serverUrl, String authType) {
     return createSessionlessTelemetry(httpClient, serverUrl, authType, DEFAULT_FORCE_FLUSH_SIZE);
   }

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -185,7 +185,7 @@ public class TelemetryClient implements Telemetry {
   }
 
   /**
-   * Initialize the sessionless telemetry connector
+   * Initialize the sessionless telemetry connector using KEYPAIR_JWT as the default auth type
    *
    * @param httpClient client object used to communicate with other machine
    * @param serverUrl server url

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -50,6 +50,13 @@ public class TelemetryIT extends AbstractDriverIT {
   @Ignore
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testSessionlessTelemetry() throws Exception, SFException {
+    testTelemetryInternal(createSessionlessTelemetry());
+  }
+
+  @Ignore
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testJWTSessionlessTelemetry() throws Exception, SFException {
     testTelemetryInternal(createJWTSessionlessTelemetry());
   }
@@ -195,6 +202,27 @@ public class TelemetryIT extends AbstractDriverIT {
     node.put("query_id", "sdasdasdasdasds");
     telemetry.addLogToBatch(node, 1234567);
     Assert.assertFalse(telemetry.sendBatchAsync().get());
+  }
+
+  // Helper function to create a sessionless telemetry
+  // using createSessionlessTelemetry(CloseableHttpClient httpClient, String serverUrl)
+  private TelemetryClient createSessionlessTelemetry()
+      throws SFException, SQLException, IOException {
+    setUpPublicKey();
+    String privateKeyLocation = getFullPathFileInResource("rsa_key.p8");
+    Map<String, String> parameters = getConnectionParameters();
+    String jwtToken =
+        SessionUtil.generateJWTToken(
+            null, privateKeyLocation, null, parameters.get("account"), parameters.get("user"));
+
+    CloseableHttpClient httpClient = HttpUtil.buildHttpClient(null, null, false);
+    TelemetryClient telemetry =
+        (TelemetryClient)
+            TelemetryClient.createSessionlessTelemetry(
+                httpClient,
+                String.format("%s:%s", parameters.get("host"), parameters.get("port")));
+    telemetry.refreshToken(jwtToken);
+    return telemetry;
   }
 
   // Helper function to create a sessionless telemetry using keypair JWT

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -219,8 +219,7 @@ public class TelemetryIT extends AbstractDriverIT {
     TelemetryClient telemetry =
         (TelemetryClient)
             TelemetryClient.createSessionlessTelemetry(
-                httpClient,
-                String.format("%s:%s", parameters.get("host"), parameters.get("port")));
+                httpClient, String.format("%s:%s", parameters.get("host"), parameters.get("port")));
     telemetry.refreshToken(jwtToken);
     return telemetry;
   }


### PR DESCRIPTION
# Overview

SNOW-931105
Issue 698: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/698

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1524


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add an additional overload of the createSessionlessTelemetry method with 2 parameters and by default, it uses "KEYPAIR_JWT" as the auth type. This fix helps the snowflake-ingest-sdk to work correctly with the latest version of the driver.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

