### PR TITLE
SNOW-971408 Fix NPE if GZIP_DISABLED is not passed in by client

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -611,10 +611,11 @@ public class SnowflakeUtil {
         String nonProxyHosts = info.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey());
         String proxyProtocol = info.getProperty(SFSessionProperty.PROXY_PROTOCOL.getPropertyKey());
         Boolean gzipDisabled =
-            (info.getProperty(SFSessionProperty.GZIP_DISABLED.getPropertyKey()).isEmpty()
+            (!info.containsKey(SFSessionProperty.GZIP_DISABLED.getPropertyKey())
+                    || info.getProperty(SFSessionProperty.GZIP_DISABLED.getPropertyKey()).isEmpty())
                 ? false
                 : Boolean.valueOf(
-                    info.getProperty(SFSessionProperty.GZIP_DISABLED.getPropertyKey())));
+                    info.getProperty(SFSessionProperty.GZIP_DISABLED.getPropertyKey()));
         // Check for any user agent suffix
         String userAgentSuffix = "";
         if (info.containsKey(SFSessionProperty.USER_AGENT_SUFFIX)) {


### PR DESCRIPTION
# Overview

SNOW-971408

Coming from version 3.13.30 to 3.14.3 for proxy configuration, seems like there was a breaking change which caused NPE. This was the PR: https://github.com/snowflakedb/snowflake-jdbc/commit/0f53c507bf90f2a83e398ab95a41485dc9744eb9



## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

