### PR TITLE
SNOW-969200: Default logpath to home directory instead of temp directory

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/DefaultSFConnectionHandler.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultSFConnectionHandler.java
@@ -150,7 +150,7 @@ public class DefaultSFConnectionHandler implements SFConnectionHandler {
           (String) connectionPropertiesMap.getOrDefault(SFSessionProperty.TRACING, null);
 
       Level logLevel = null;
-      String logPattern = "%t/snowflake_jdbc%u.log"; // default pattern.
+      String logPattern = "%h/snowflake_jdbc%u.log"; // default pattern.
       SFClientConfig sfClientConfig = sfSession.getSfClientConfig();
 
       if (sfClientConfig != null) {


### PR DESCRIPTION
# Overview

SNOW-969200
Change the default LogPath to home directory if not specified in the config file. Previously it was default to temp directory.

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

