### PR TITLE
SNOW-968787: Fix NullPointerException when property key "gzipDisabled" is not specified

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -610,16 +610,15 @@ public class SnowflakeUtil {
         String proxyPassword = info.getProperty(SFSessionProperty.PROXY_PASSWORD.getPropertyKey());
         String nonProxyHosts = info.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey());
         String proxyProtocol = info.getProperty(SFSessionProperty.PROXY_PROTOCOL.getPropertyKey());
+        String userAgentSuffix =
+            info.getProperty(SFSessionProperty.USER_AGENT_SUFFIX.getPropertyKey());
         Boolean gzipDisabled =
-            (info.getProperty(SFSessionProperty.GZIP_DISABLED.getPropertyKey()).isEmpty()
+            Strings.isNullOrEmpty(
+                    info.getProperty(SFSessionProperty.GZIP_DISABLED.getPropertyKey()))
                 ? false
                 : Boolean.valueOf(
-                    info.getProperty(SFSessionProperty.GZIP_DISABLED.getPropertyKey())));
-        // Check for any user agent suffix
-        String userAgentSuffix = "";
-        if (info.containsKey(SFSessionProperty.USER_AGENT_SUFFIX)) {
-          userAgentSuffix = (String) info.get(SFSessionProperty.USER_AGENT_SUFFIX);
-        }
+                    info.getProperty(SFSessionProperty.GZIP_DISABLED.getPropertyKey()));
+
         // create key for proxy properties
         return new HttpClientSettingsKey(
             mode,


### PR DESCRIPTION
# Overview

SNOW-968787
[#752](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/752)

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [#752](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/752)


2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Null check was missing in convertProxyPropertiesToHttpClientKey() when the property key "gzipDisabled" is not specified, resulting in NullPointerException.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

