### PR TITLE
SNOW-909180: Pass query id in exceptions from file agent

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -51,18 +51,24 @@ public class SnowflakeSQLException extends SQLException {
         queryId);
   }
 
-  public SnowflakeSQLException(String reason, String SQLState) {
-    super(reason, SQLState);
+  public SnowflakeSQLException(String reason, String sqlState) {
+    super(reason, sqlState);
     // log user error from GS at fine level
-    logger.debug("Snowflake exception: {}, sqlState:{}", reason, SQLState);
+    logger.debug("Snowflake exception: {}, sqlState:{}", reason, sqlState);
   }
 
+  /** use {@link SnowflakeSQLException#SnowflakeSQLException(String, String, int)} */
+  @Deprecated
   public SnowflakeSQLException(String sqlState, int vendorCode) {
+    this((String) null, sqlState, vendorCode);
+  }
+
+  public SnowflakeSQLException(String queryId, String sqlState, int vendorCode) {
     super(
         errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
         sqlState,
         vendorCode);
-
+    this.queryId = queryId;
     logger.debug(
         "Snowflake exception: {}, sqlState:{}, vendorCode:{}",
         errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode)),
@@ -70,12 +76,18 @@ public class SnowflakeSQLException extends SQLException {
         vendorCode);
   }
 
+  /** use {@link SnowflakeSQLException#SnowflakeSQLException(String, String, int, Object...)} */
+  @Deprecated
   public SnowflakeSQLException(String sqlState, int vendorCode, Object... params) {
+    this((String) null, sqlState, vendorCode, params);
+  }
+
+  public SnowflakeSQLException(String queryId, String sqlState, int vendorCode, Object... params) {
     super(
         errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params),
         sqlState,
         vendorCode);
-
+    this.queryId = queryId;
     logger.debug(
         "Snowflake exception: {}, sqlState:{}, vendorCode:{}",
         errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params),
@@ -100,12 +112,23 @@ public class SnowflakeSQLException extends SQLException {
     this(ex, errorCode.getSqlState(), errorCode.getMessageCode(), params);
   }
 
+  /**
+   * @deprecated use {@link SnowflakeSQLException#SnowflakeSQLException(String, Throwable, String,
+   *     int, Object...)}
+   */
+  @Deprecated
   public SnowflakeSQLException(Throwable ex, String sqlState, int vendorCode, Object... params) {
+    this(null, ex, sqlState, vendorCode, params);
+  }
+
+  public SnowflakeSQLException(
+      String queryId, Throwable ex, String sqlState, int vendorCode, Object... params) {
     super(
         errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params),
         sqlState,
         vendorCode,
         ex);
+    this.queryId = queryId;
 
     logger.debug(
         "Snowflake exception: "
@@ -119,6 +142,15 @@ public class SnowflakeSQLException extends SQLException {
             String.valueOf(errorCode.getMessageCode()), params),
         errorCode.getSqlState(),
         errorCode.getMessageCode());
+  }
+
+  public SnowflakeSQLException(String queryId, ErrorCode errorCode, Object... params) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(
+            String.valueOf(errorCode.getMessageCode()), params),
+        errorCode.getSqlState(),
+        errorCode.getMessageCode());
+    this.queryId = queryId;
   }
 
   public SnowflakeSQLException(

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -232,6 +232,12 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     sendTelemetryData(null, SQLState, vendorCode, session, this);
   }
 
+  public SnowflakeSQLLoggedException(
+      String queryId, SFBaseSession session, int vendorCode, String SQLState) {
+    super(queryId, SQLState, vendorCode);
+    sendTelemetryData(queryId, SQLState, vendorCode, session, this);
+  }
+
   public SnowflakeSQLLoggedException(SFBaseSession session, String SQLState, String reason) {
     super(reason, SQLState);
     sendTelemetryData(null, SQLState, -1, session, this);
@@ -239,40 +245,45 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
 
   public SnowflakeSQLLoggedException(
       SFBaseSession session, int vendorCode, String SQLState, Object... params) {
-    super(SQLState, vendorCode, params);
-    String reason =
-        errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
-    sendTelemetryData(null, SQLState, vendorCode, session, this);
+    this(null, session, vendorCode, SQLState, params);
+  }
+
+  public SnowflakeSQLLoggedException(
+      String queryId, SFBaseSession session, int vendorCode, String SQLState, Object... params) {
+    super(queryId, SQLState, vendorCode, params);
+    sendTelemetryData(queryId, SQLState, vendorCode, session, this);
   }
 
   public SnowflakeSQLLoggedException(
       SFBaseSession session, ErrorCode errorCode, Throwable ex, Object... params) {
     super(ex, errorCode, params);
-    // add telemetry
     sendTelemetryData(null, errorCode.getSqlState(), errorCode.getMessageCode(), session, this);
   }
 
   public SnowflakeSQLLoggedException(
       SFBaseSession session, String SQLState, int vendorCode, Throwable ex, Object... params) {
     super(ex, SQLState, vendorCode, params);
-    // add telemetry
-    String reason =
-        errorResourceBundleManager.getLocalizedMessage(String.valueOf(vendorCode), params);
     sendTelemetryData(null, SQLState, vendorCode, session, this);
+  }
+
+  public SnowflakeSQLLoggedException(
+      String queryId,
+      SFBaseSession session,
+      String SQLState,
+      int vendorCode,
+      Throwable ex,
+      Object... params) {
+    super(queryId, ex, SQLState, vendorCode, params);
+    sendTelemetryData(queryId, SQLState, vendorCode, session, this);
   }
 
   public SnowflakeSQLLoggedException(SFBaseSession session, ErrorCode errorCode, Object... params) {
     super(errorCode, params);
-    // add telemetry
-    String reason =
-        errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(errorCode.getMessageCode()), params);
     sendTelemetryData(null, null, -1, session, this);
   }
 
   public SnowflakeSQLLoggedException(SFBaseSession session, SFException e) {
     super(e);
-    // add telemetry
     sendTelemetryData(null, null, -1, session, this);
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/QueryIdHelper.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/QueryIdHelper.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ */
+package net.snowflake.client.jdbc.cloud.storage;
+
+import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
+
+class QueryIdHelper {
+  static String queryIdFromEncMatOr(RemoteStoreFileEncryptionMaterial encMat, String queryId) {
+    return encMat != null && encMat.getQueryId() != null ? encMat.getQueryId() : queryId;
+  }
+}

--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeStorageClient.java
@@ -90,6 +90,8 @@ public interface SnowflakeStorageClient {
   /**
    * Download a file from remote storage.
    *
+   * @deprecated use {@link #download(SFSession, String, String, String, int, String, String,
+   *     String, String, String)}
    * @param connection connection object
    * @param command command to download file
    * @param localLocation local file path
@@ -101,7 +103,8 @@ public interface SnowflakeStorageClient {
    * @param presignedUrl presigned URL for download. Used by GCP.
    * @throws SnowflakeSQLException download failure
    */
-  void download(
+  @Deprecated
+  default void download(
       SFSession connection,
       String command,
       String localLocation,
@@ -111,7 +114,83 @@ public interface SnowflakeStorageClient {
       String stageFilePath,
       String stageRegion,
       String presignedUrl)
+      throws SnowflakeSQLException {
+    download(
+        connection,
+        command,
+        localLocation,
+        destFileName,
+        parallelism,
+        remoteStorageLocation,
+        stageFilePath,
+        stageRegion,
+        presignedUrl,
+        null);
+  }
+
+  /**
+   * Download a file from remote storage.
+   *
+   * @param connection connection object
+   * @param command command to download file
+   * @param localLocation local file path
+   * @param destFileName destination file name
+   * @param parallelism number of threads for parallel downloading
+   * @param remoteStorageLocation remote storage location, i.e. bucket for S3
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl presigned URL for download. Used by GCP.
+   * @param queryId last query id
+   * @throws SnowflakeSQLException download failure
+   */
+  void download(
+      SFSession connection,
+      String command,
+      String localLocation,
+      String destFileName,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion,
+      String presignedUrl,
+      String queryId)
       throws SnowflakeSQLException;
+
+  /**
+   * Download a file from remote storage
+   *
+   * @deprecated use {@link #download(SFSession, String, String, String, int, String, String,
+   *     String, String, String)}
+   * @param connection connection object
+   * @param command command to download file
+   * @param parallelism number of threads for parallel downloading
+   * @param remoteStorageLocation remote storage location, i.e. bucket for s3
+   * @param stageFilePath stage file path
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl presigned URL for download. Used by GCP.
+   * @return input file stream
+   * @throws SnowflakeSQLException when download failure
+   */
+  @Deprecated
+  default InputStream downloadToStream(
+      SFSession connection,
+      String command,
+      int parallelism,
+      String remoteStorageLocation,
+      String stageFilePath,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
+    return downloadToStream(
+        connection,
+        command,
+        parallelism,
+        remoteStorageLocation,
+        stageFilePath,
+        stageRegion,
+        presignedUrl,
+        null);
+  }
 
   /**
    * Download a file from remote storage
@@ -123,6 +202,7 @@ public interface SnowflakeStorageClient {
    * @param stageFilePath stage file path
    * @param stageRegion region name where the stage persists
    * @param presignedUrl presigned URL for download. Used by GCP.
+   * @param queryId last query id
    * @return input file stream
    * @throws SnowflakeSQLException when download failure
    */
@@ -133,8 +213,59 @@ public interface SnowflakeStorageClient {
       String remoteStorageLocation,
       String stageFilePath,
       String stageRegion,
-      String presignedUrl)
+      String presignedUrl,
+      String queryId)
       throws SnowflakeSQLException;
+
+  /**
+   * Upload a file (-stream) to remote storage
+   *
+   * @deprecated user {@link #upload(SFSession, String, int, boolean, String, File, String,
+   *     InputStream, FileBackedOutputStream, StorageObjectMetadata, String, String, String)}
+   * @param connection connection object
+   * @param command upload command
+   * @param parallelism number of threads do parallel uploading
+   * @param uploadFromStream true if upload source is stream
+   * @param remoteStorageLocation s3 bucket name
+   * @param srcFile source file if not uploading from a stream
+   * @param destFileName file name on remote storage after upload
+   * @param inputStream stream used for uploading if fileBackedOutputStream is null
+   * @param fileBackedOutputStream stream used for uploading if not null
+   * @param meta object meta data
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl presigned URL for upload. Used by GCP.
+   * @throws SnowflakeSQLException if upload failed even after retry
+   */
+  @Deprecated
+  default void upload(
+      SFSession connection,
+      String command,
+      int parallelism,
+      boolean uploadFromStream,
+      String remoteStorageLocation,
+      File srcFile,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      StorageObjectMetadata meta,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
+    upload(
+        connection,
+        command,
+        parallelism,
+        uploadFromStream,
+        remoteStorageLocation,
+        srcFile,
+        destFileName,
+        inputStream,
+        fileBackedOutputStream,
+        meta,
+        stageRegion,
+        presignedUrl,
+        null);
+  }
 
   /**
    * Upload a file (-stream) to remote storage
@@ -151,6 +282,7 @@ public interface SnowflakeStorageClient {
    * @param meta object meta data
    * @param stageRegion region name where the stage persists
    * @param presignedUrl presigned URL for upload. Used by GCP.
+   * @param queryId last query id
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   void upload(
@@ -165,8 +297,63 @@ public interface SnowflakeStorageClient {
       FileBackedOutputStream fileBackedOutputStream,
       StorageObjectMetadata meta,
       String stageRegion,
-      String presignedUrl)
+      String presignedUrl,
+      String queryId)
       throws SnowflakeSQLException;
+
+  /**
+   * Upload a file (-stream) to remote storage with Pre-signed URL without JDBC connection.
+   *
+   * <p>NOTE: This function is only supported when pre-signed URL is used.
+   *
+   * @deprecated use {@link #uploadWithPresignedUrlWithoutConnection(int, HttpClientSettingsKey,
+   *     int, boolean, String, File, String, InputStream, FileBackedOutputStream,
+   *     StorageObjectMetadata, String, String, String)} This method was left to keep backward
+   *     compatibility
+   * @param networkTimeoutInMilli Network timeout for the upload
+   * @param ocspModeAndProxyKey OCSP mode and proxy settings for the upload.
+   * @param parallelism number of threads do parallel uploading
+   * @param uploadFromStream true if upload source is stream
+   * @param remoteStorageLocation s3 bucket name
+   * @param srcFile source file if not uploading from a stream
+   * @param destFileName file name on remote storage after upload
+   * @param inputStream stream used for uploading if fileBackedOutputStream is null
+   * @param fileBackedOutputStream stream used for uploading if not null
+   * @param meta object meta data
+   * @param stageRegion region name where the stage persists
+   * @param presignedUrl presigned URL for upload. Used by GCP.
+   * @throws SnowflakeSQLException if upload failed even after retry
+   */
+  @Deprecated
+  default void uploadWithPresignedUrlWithoutConnection(
+      int networkTimeoutInMilli,
+      HttpClientSettingsKey ocspModeAndProxyKey,
+      int parallelism,
+      boolean uploadFromStream,
+      String remoteStorageLocation,
+      File srcFile,
+      String destFileName,
+      InputStream inputStream,
+      FileBackedOutputStream fileBackedOutputStream,
+      StorageObjectMetadata meta,
+      String stageRegion,
+      String presignedUrl)
+      throws SnowflakeSQLException {
+    uploadWithPresignedUrlWithoutConnection(
+        networkTimeoutInMilli,
+        ocspModeAndProxyKey,
+        parallelism,
+        uploadFromStream,
+        remoteStorageLocation,
+        srcFile,
+        destFileName,
+        inputStream,
+        fileBackedOutputStream,
+        meta,
+        stageRegion,
+        presignedUrl,
+        null);
+  }
 
   /**
    * Upload a file (-stream) to remote storage with Pre-signed URL without JDBC connection.
@@ -185,6 +372,7 @@ public interface SnowflakeStorageClient {
    * @param meta object meta data
    * @param stageRegion region name where the stage persists
    * @param presignedUrl presigned URL for upload. Used by GCP.
+   * @param queryId last query id
    * @throws SnowflakeSQLException if upload failed even after retry
    */
   default void uploadWithPresignedUrlWithoutConnection(
@@ -199,10 +387,12 @@ public interface SnowflakeStorageClient {
       FileBackedOutputStream fileBackedOutputStream,
       StorageObjectMetadata meta,
       String stageRegion,
-      String presignedUrl)
+      String presignedUrl,
+      String queryId)
       throws SnowflakeSQLException {
     if (!requirePresignedUrl()) {
       throw new SnowflakeSQLLoggedException(
+          queryId,
           null,
           ErrorCode.INTERNAL_ERROR.getMessageCode(),
           SqlState.INTERNAL_ERROR,
@@ -214,6 +404,8 @@ public interface SnowflakeStorageClient {
   /**
    * Handles exceptions thrown by the remote storage provider
    *
+   * @deprecated use {@link #handleStorageException(Exception, int, String, SFSession, String,
+   *     String)}
    * @param ex the exception to handle
    * @param retryCount current number of retries, incremented by the caller before each call
    * @param operation string that indicates the function/operation that was taking place, when the
@@ -223,8 +415,33 @@ public interface SnowflakeStorageClient {
    * @throws SnowflakeSQLException exceptions that were not handled, or retried past what the retry
    *     policy allows, are propagated
    */
-  void handleStorageException(
+  @Deprecated
+  default void handleStorageException(
       Exception ex, int retryCount, String operation, SFSession connection, String command)
+      throws SnowflakeSQLException {
+    handleStorageException(ex, retryCount, operation, connection, command, null);
+  }
+
+  /**
+   * Handles exceptions thrown by the remote storage provider
+   *
+   * @param ex the exception to handle
+   * @param retryCount current number of retries, incremented by the caller before each call
+   * @param operation string that indicates the function/operation that was taking place, when the
+   *     exception was raised, for example "upload"
+   * @param connection the current SFSession object used by the client
+   * @param command the command attempted at the time of the exception
+   * @param queryId last query id
+   * @throws SnowflakeSQLException exceptions that were not handled, or retried past what the retry
+   *     policy allows, are propagated
+   */
+  void handleStorageException(
+      Exception ex,
+      int retryCount,
+      String operation,
+      SFSession connection,
+      String command,
+      String queryId)
       throws SnowflakeSQLException;
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -194,16 +194,18 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       try {
         statement.executeQuery("PUT file://" + sourceFilePath + " @not_existing_state");
         fail("PUT statement should fail");
-      } catch (Exception __) {
+      } catch (SnowflakeSQLException e) {
         TestUtil.assertValidQueryId(snowflakeStatement.getQueryID());
+        assertEquals(snowflakeStatement.getQueryID(), e.getQueryId());
       }
       String putQueryId = snowflakeStatement.getQueryID();
       try {
         statement.executeQuery(
             "GET @not_existing_state 'file://" + destFolderCanonicalPath + "' parallel=8");
         fail("GET statement should fail");
-      } catch (Exception __) {
+      } catch (SnowflakeSQLException e) {
         TestUtil.assertValidQueryId(snowflakeStatement.getQueryID());
+        assertEquals(snowflakeStatement.getQueryID(), e.getQueryId());
       }
       String getQueryId = snowflakeStatement.getQueryID();
       assertNotEquals("put and get query id should be different", putQueryId, getQueryId);
@@ -213,8 +215,9 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       try {
         statement.executeQuery("PUT file://not_existing_file @" + stageName);
         fail("PUT statement should fail");
-      } catch (Exception __) {
-        assertNull(snowflakeStatement.getQueryID());
+      } catch (SnowflakeSQLException e) {
+        TestUtil.assertValidQueryId(snowflakeStatement.getQueryID());
+        assertEquals(snowflakeStatement.getQueryID(), e.getQueryId());
       }
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
@@ -36,7 +36,7 @@ public class FileUploaderExpandFileNamesTest {
       folderName + "/TestFileE~"
     };
 
-    Set<String> files = SnowflakeFileTransferAgent.expandFileNames(locations);
+    Set<String> files = SnowflakeFileTransferAgent.expandFileNames(locations, null);
 
     assertTrue(files.contains(folderName + "/TestFileA"));
     assertTrue(files.contains(folderName + "/TestFileB"));
@@ -52,7 +52,7 @@ public class FileUploaderExpandFileNamesTest {
     String[] locations = {"/Tes*Fil*A", "/TestFil?B", "~/TestFileC", "TestFileD"};
 
     try {
-      SnowflakeFileTransferAgent.expandFileNames(locations);
+      SnowflakeFileTransferAgent.expandFileNames(locations, null);
     } catch (SnowflakeSQLException err) {
       Assert.assertEquals(200007, err.getErrorCode());
       Assert.assertEquals("22000", err.getSQLState());

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeAzureClientHandleExceptionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeAzureClientHandleExceptionLatestIT.java
@@ -65,7 +65,8 @@ public class SnowflakeAzureClientHandleExceptionLatestIT extends AbstractDriverI
         0,
         "upload",
         sfSession,
-        command);
+        command,
+        null);
     Mockito.verify(spyingClient, Mockito.times(2)).renew(Mockito.anyMap());
 
     // Unauthenticated, backoff with interrupt, renew is called
@@ -86,7 +87,8 @@ public class SnowflakeAzureClientHandleExceptionLatestIT extends AbstractDriverI
                       maxRetry,
                       "upload",
                       sfSession,
-                      command);
+                      command,
+                      null);
                 } catch (SnowflakeSQLException e) {
                   exceptionContainer[0] = e;
                 }
@@ -108,7 +110,8 @@ public class SnowflakeAzureClientHandleExceptionLatestIT extends AbstractDriverI
         overMaxRetry,
         "upload",
         sfSession,
-        command);
+        command,
+        null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -120,14 +123,15 @@ public class SnowflakeAzureClientHandleExceptionLatestIT extends AbstractDriverI
         0,
         "upload",
         null,
-        command);
+        command,
+        null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void errorInvalidKey() throws SQLException {
     spyingClient.handleStorageException(
-        new Exception(new InvalidKeyException()), 0, "upload", sfSession, command);
+        new Exception(new InvalidKeyException()), 0, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -136,13 +140,13 @@ public class SnowflakeAzureClientHandleExceptionLatestIT extends AbstractDriverI
     // Can still retry, no error thrown
     try {
       spyingClient.handleStorageException(
-          new InterruptedException(), 0, "upload", sfSession, command);
+          new InterruptedException(), 0, "upload", sfSession, command, null);
     } catch (Exception e) {
       Assert.fail("Should not have exception here");
     }
     Mockito.verify(spyingClient, Mockito.never()).renew(Mockito.anyMap());
     spyingClient.handleStorageException(
-        new InterruptedException(), 26, "upload", sfSession, command);
+        new InterruptedException(), 26, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -151,19 +155,19 @@ public class SnowflakeAzureClientHandleExceptionLatestIT extends AbstractDriverI
     // Can still retry, no error thrown
     try {
       spyingClient.handleStorageException(
-          new SocketTimeoutException(), 0, "upload", sfSession, command);
+          new SocketTimeoutException(), 0, "upload", sfSession, command, null);
     } catch (Exception e) {
       Assert.fail("Should not have exception here");
     }
     Mockito.verify(spyingClient, Mockito.never()).renew(Mockito.anyMap());
     spyingClient.handleStorageException(
-        new SocketTimeoutException(), 26, "upload", sfSession, command);
+        new SocketTimeoutException(), 26, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void errorUnknownException() throws SQLException {
-    spyingClient.handleStorageException(new Exception(), 0, "upload", sfSession, command);
+    spyingClient.handleStorageException(new Exception(), 0, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -181,7 +185,8 @@ public class SnowflakeAzureClientHandleExceptionLatestIT extends AbstractDriverI
         0,
         "download",
         null,
-        getCommand);
+        getCommand,
+        null);
   }
 
   @After

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -1529,7 +1529,8 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
             client.getMaxRetries(),
             "download",
             null,
-            command);
+            command,
+            null);
       } finally {
         if (connection != null) {
           connection.createStatement().execute("DROP STAGE if exists testPutGet_stage");

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeGcsClientHandleExceptionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeGcsClientHandleExceptionLatestIT.java
@@ -59,12 +59,12 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
   public void error401RenewExpired() throws SQLException, InterruptedException {
     // Unauthenticated, renew is called.
     spyingClient.handleStorageException(
-        new StorageException(401, "Unauthenticated"), 0, "upload", sfSession, command);
+        new StorageException(401, "Unauthenticated"), 0, "upload", sfSession, command, null);
     Mockito.verify(spyingClient, Mockito.times(1)).renew(Mockito.anyMap());
 
     // Unauthenticated, command null, not renew, renew called remaining 1
     spyingClient.handleStorageException(
-        new StorageException(401, "Unauthenticated"), 0, "upload", sfSession, null);
+        new StorageException(401, "Unauthenticated"), 0, "upload", sfSession, null, null);
     Mockito.verify(spyingClient, Mockito.times(1)).renew(Mockito.anyMap());
 
     // Unauthenticated, backoff with interrupt, renew is called
@@ -80,7 +80,8 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
                       maxRetry,
                       "upload",
                       sfSession,
-                      command);
+                      command,
+                      null);
                 } catch (SnowflakeSQLException e) {
                   exceptionContainer[0] = e;
                 }
@@ -97,7 +98,12 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void error401OverMaxRetryThrow() throws SQLException {
     spyingClient.handleStorageException(
-        new StorageException(401, "Unauthenticated"), overMaxRetry, "upload", sfSession, command);
+        new StorageException(401, "Unauthenticated"),
+        overMaxRetry,
+        "upload",
+        sfSession,
+        command,
+        null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -105,7 +111,7 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
   public void errorInvalidKey() throws SQLException {
     // Unauthenticated, renew is called.
     spyingClient.handleStorageException(
-        new Exception(new InvalidKeyException()), 0, "upload", sfSession, command);
+        new Exception(new InvalidKeyException()), 0, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -114,13 +120,13 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
     // Can still retry, no error thrown
     try {
       spyingClient.handleStorageException(
-          new InterruptedException(), 0, "upload", sfSession, command);
+          new InterruptedException(), 0, "upload", sfSession, command, null);
     } catch (Exception e) {
       Assert.fail("Should not have exception here");
     }
     Mockito.verify(spyingClient, Mockito.never()).renew(Mockito.anyMap());
     spyingClient.handleStorageException(
-        new InterruptedException(), 26, "upload", sfSession, command);
+        new InterruptedException(), 26, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -129,27 +135,27 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
     // Can still retry, no error thrown
     try {
       spyingClient.handleStorageException(
-          new SocketTimeoutException(), 0, "upload", sfSession, command);
+          new SocketTimeoutException(), 0, "upload", sfSession, command, null);
     } catch (Exception e) {
       Assert.fail("Should not have exception here");
     }
     Mockito.verify(spyingClient, Mockito.never()).renew(Mockito.anyMap());
     spyingClient.handleStorageException(
-        new SocketTimeoutException(), 26, "upload", sfSession, command);
+        new SocketTimeoutException(), 26, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void errorUnknownException() throws SQLException {
     // Unauthenticated, renew is called.
-    spyingClient.handleStorageException(new Exception(), 0, "upload", sfSession, command);
+    spyingClient.handleStorageException(new Exception(), 0, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void errorWithNullSession() throws SQLException {
     spyingClient.handleStorageException(
-        new StorageException(401, "Unauthenticated"), 0, "upload", null, command);
+        new StorageException(401, "Unauthenticated"), 0, "upload", null, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -167,7 +173,8 @@ public class SnowflakeGcsClientHandleExceptionLatestIT extends AbstractDriverIT 
         0,
         "download",
         null,
-        getCommand);
+        getCommand,
+        null);
   }
 
   @After

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeS3ClientHandleExceptionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeS3ClientHandleExceptionLatestIT.java
@@ -75,7 +75,7 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
   public void errorRenewExpired() throws SQLException, InterruptedException {
     AmazonS3Exception ex = new AmazonS3Exception("unauthenticated");
     ex.setErrorCode(EXPIRED_AWS_TOKEN_ERROR_CODE);
-    spyingClient.handleStorageException(ex, 0, "upload", sfSession, command);
+    spyingClient.handleStorageException(ex, 0, "upload", sfSession, command, null);
     Mockito.verify(spyingClient, Mockito.times(1)).renew(Mockito.anyMap());
 
     // Unauthenticated, backoff with interrupt, renew is called
@@ -86,7 +86,8 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
               @Override
               public void run() {
                 try {
-                  spyingClient.handleStorageException(ex, maxRetry, "upload", sfSession, command);
+                  spyingClient.handleStorageException(
+                      ex, maxRetry, "upload", sfSession, command, null);
                 } catch (SnowflakeSQLException e) {
                   exceptionContainer[0] = e;
                 }
@@ -103,7 +104,7 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void errorNotFound() throws SQLException {
     spyingClient.handleStorageException(
-        new AmazonS3Exception("Not found"), overMaxRetry, "upload", sfSession, command);
+        new AmazonS3Exception("Not found"), overMaxRetry, "upload", sfSession, command, null);
   }
 
   @Test
@@ -115,7 +116,7 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
     ex.setErrorCode("400 Bad Request");
     ex.setErrorType(AmazonServiceException.ErrorType.Client);
     Mockito.doReturn(true).when(spyingClient).isClientException400Or404(ex);
-    spyingClient.handleStorageException(ex, 0, "download", sfSession, command);
+    spyingClient.handleStorageException(ex, 0, "download", sfSession, command, null);
     // renew token
     Mockito.verify(spyingClient, Mockito.times(1)).isClientException400Or404(ex);
     Mockito.verify(spyingClient, Mockito.times(1)).renew(Mockito.anyMap());
@@ -129,7 +130,8 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
         overMaxRetry,
         "upload",
         sfSession,
-        command);
+        command,
+        null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -137,7 +139,7 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
   public void errorInvalidKey() throws SQLException {
     // Unauthenticated, renew is called.
     spyingClient.handleStorageException(
-        new Exception(new InvalidKeyException()), 0, "upload", sfSession, command);
+        new Exception(new InvalidKeyException()), 0, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -146,13 +148,13 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
     // Can still retry, no error thrown
     try {
       spyingClient.handleStorageException(
-          new InterruptedException(), 0, "upload", sfSession, command);
+          new InterruptedException(), 0, "upload", sfSession, command, null);
     } catch (Exception e) {
       Assert.fail("Should not have exception here");
     }
     Mockito.verify(spyingClient, Mockito.never()).renew(Mockito.anyMap());
     spyingClient.handleStorageException(
-        new InterruptedException(), 26, "upload", sfSession, command);
+        new InterruptedException(), 26, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -161,19 +163,19 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
     // Can still retry, no error thrown
     try {
       spyingClient.handleStorageException(
-          new SocketTimeoutException(), 0, "upload", sfSession, command);
+          new SocketTimeoutException(), 0, "upload", sfSession, command, null);
     } catch (Exception e) {
       Assert.fail("Should not have exception here");
     }
     Mockito.verify(spyingClient, Mockito.never()).renew(Mockito.anyMap());
     spyingClient.handleStorageException(
-        new SocketTimeoutException(), 26, "upload", sfSession, command);
+        new SocketTimeoutException(), 26, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void errorUnknownException() throws SQLException {
-    spyingClient.handleStorageException(new Exception(), 0, "upload", sfSession, command);
+    spyingClient.handleStorageException(new Exception(), 0, "upload", sfSession, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -182,7 +184,7 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
     // Unauthenticated, renew is called.
     AmazonS3Exception ex = new AmazonS3Exception("unauthenticated");
     ex.setErrorCode(EXPIRED_AWS_TOKEN_ERROR_CODE);
-    spyingClient.handleStorageException(ex, 0, "upload", null, command);
+    spyingClient.handleStorageException(ex, 0, "upload", null, command, null);
   }
 
   @Test(expected = SnowflakeSQLException.class)
@@ -200,7 +202,8 @@ public class SnowflakeS3ClientHandleExceptionLatestIT extends AbstractDriverIT {
         0,
         "download",
         null,
-        getCommand);
+        getCommand,
+        null);
   }
 
   @After

--- a/src/test/java/net/snowflake/client/jdbc/StatementLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/StatementLatestIT.java
@@ -248,9 +248,10 @@ public class StatementLatestIT extends BaseJDBCTest {
         try {
           stmt.execute("use database not_existing_database");
           fail("Statement should fail with exception");
-        } catch (Exception __) {
+        } catch (SnowflakeSQLException e) {
           String queryID = stmt.unwrap(SnowflakeStatement.class).getQueryID();
           TestUtil.assertValidQueryId(queryID);
+          assertEquals(queryID, e.getQueryId());
         }
       }
     }
@@ -265,9 +266,10 @@ public class StatementLatestIT extends BaseJDBCTest {
         try {
           stmt.executeUpdate("update not_existing_table set a = 1 where id = 42");
           fail("Statement should fail with exception");
-        } catch (Exception __) {
+        } catch (SnowflakeSQLException e) {
           String queryID = stmt.unwrap(SnowflakeStatement.class).getQueryID();
           TestUtil.assertValidQueryId(queryID);
+          assertEquals(queryID, e.getQueryId());
         }
       }
     }
@@ -282,9 +284,10 @@ public class StatementLatestIT extends BaseJDBCTest {
         try {
           stmt.executeQuery("select * from not_existing_table");
           fail("Statement should fail with exception");
-        } catch (Exception __) {
+        } catch (SnowflakeSQLException e) {
           String queryID = stmt.unwrap(SnowflakeStatement.class).getQueryID();
           TestUtil.assertValidQueryId(queryID);
+          assertEquals(queryID, e.getQueryId());
         }
       }
     }

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientLatestIT.java
@@ -158,12 +158,14 @@ public class SnowflakeS3ClientLatestIT extends BaseJDBCTest {
 
       // Should retry one time, then throw error
       try {
-        spy.handleStorageException(new InterruptedException(), 0, "download", sfSession, command);
+        spy.handleStorageException(
+            new InterruptedException(), 0, "download", sfSession, command, null);
       } catch (Exception e) {
         Assert.fail("Should not have exception here");
       }
       Mockito.verify(spy, Mockito.never()).renew(Mockito.anyMap());
-      spy.handleStorageException(new InterruptedException(), 1, "download", sfSession, command);
+      spy.handleStorageException(
+          new InterruptedException(), 1, "download", sfSession, command, null);
     }
   }
 }


### PR DESCRIPTION
SNOW-909180: Pass query id in exceptions from file agent

- Added new methods with query id passed as parameters
- Deprecating methods without query id paramter