### PR TITLE
SNOW-1003959: Implement toString() in SnowflakePreparedStatementV1

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakePreparedStatementV1.java
@@ -966,4 +966,8 @@ class SnowflakePreparedStatementV1 extends SnowflakeStatementV1
       alreadyDescribed = true;
     }
   }
+
+  public String toString() {
+    return (this.sql != null) ? this.sql + " - Query ID: " + this.getQueryID() : super.toString();
+  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
@@ -354,4 +354,24 @@ public class PreparedStatement2LatestIT extends PreparedStatement0IT {
       assertTrue(prepStatement.unwrap(SnowflakePreparedStatementV1.class).isArrayBindSupported());
     }
   }
+
+  @Test
+  public void testToString() throws SQLException {
+    try (Connection connection = init()) {
+      PreparedStatement prepStatement =
+          connection.prepareStatement("select current_version() --testing toString()");
+
+      // Query ID is going to be null since we didn't execute the statement yet
+      assertEquals(
+          "select current_version() --testing toString() - Query ID: null",
+          prepStatement.toString());
+
+      prepStatement.executeQuery();
+      assertTrue(
+          prepStatement
+              .toString()
+              .matches(
+                  "select current_version\\(\\) --testing toString\\(\\) - Query ID: (\\d|\\w)+(-(\\d|\\w)+)+$"));
+    }
+  }
 }


### PR DESCRIPTION
Invoking the PreparedStatement's toString() method will now return the actual SQL query and
query ID if available rahter than the object's hashCode. This is helpful when using features
in frameworks like Spring Boot to monitor and log information about slow running queries.

# Overview

SNOW-1003959

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1601 


2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))

