### PR TITLE
SNOW-965966: Remove unnecessary TODOs from DefaultResultStreamProvider

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -920,9 +920,8 @@ public class HttpUtil {
   }
 
   /**
-   * This method was moved from DefaultResultStreamProvider to take advantage of the HTTP connection
-   * pool manager initialized by HttpUtil
-   *
+   * This method was moved from DefaultResultStreamProvider to take advantage of the HTTP
+   * connection pool manager initialized by HttpUtil
    * @param oscpAndProxyKey OCSP mode and proxy settings for httpclient
    * @param httpRequest HttpRequest
    * @param networkTimeout network timeout
@@ -932,29 +931,29 @@ public class HttpUtil {
    * @throws SnowflakeSQLException
    */
   public static HttpResponse getHttpResponseForS3Request(
-      HttpClientSettingsKey oscpAndProxyKey,
-      HttpGet httpRequest,
-      int networkTimeout,
-      int authTimeout,
-      int socketTimeout)
-      throws SnowflakeSQLException {
-    CloseableHttpClient httpClient = HttpUtil.getHttpClient(oscpAndProxyKey);
+          HttpClientSettingsKey oscpAndProxyKey,
+          HttpGet httpRequest,
+          int networkTimeout,
+          int authTimeout,
+          int socketTimeout) throws SnowflakeSQLException {
+    CloseableHttpClient httpClient =
+            HttpUtil.getHttpClient(oscpAndProxyKey);
 
     // fetch the result chunk
     return RestRequest.execute(
-        httpClient,
-        httpRequest,
-        networkTimeout / 1000, // retry timeout
-        authTimeout,
-        socketTimeout,
-        0,
-        0, // no socket timeout injection
-        null, // no canceling
-        false, // no cookie
-        false, // no retry parameters in url
-        false, // no request_guid
-        true, // retry on HTTP403 for AWS S3
-        true, // no retry on http request
-        new ExecTimeTelemetryData());
+                    httpClient,
+                    httpRequest,
+                    networkTimeout / 1000, // retry timeout
+                    authTimeout,
+                    socketTimeout,
+                    0,
+                    0, // no socket timeout injection
+                    null, // no canceling
+                    false, // no cookie
+                    false, // no retry parameters in url
+                    false, // no request_guid
+                    true, // retry on HTTP403 for AWS S3
+                    true, // no retry on http request
+                    new ExecTimeTelemetryData());
   }
 }

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -38,14 +38,12 @@ import net.snowflake.client.util.SecretDetector;
 import net.snowflake.common.core.SqlState;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -917,43 +915,5 @@ public class HttpUtil {
     if (additionalHeaders != null && !additionalHeaders.isEmpty()) {
       additionalHeaders.forEach(request::addHeader);
     }
-  }
-
-  /**
-   * This method was moved from DefaultResultStreamProvider to take advantage of the HTTP
-   * connection pool manager initialized by HttpUtil
-   * @param oscpAndProxyKey OCSP mode and proxy settings for httpclient
-   * @param httpRequest HttpRequest
-   * @param networkTimeout network timeout
-   * @param authTimeout authenticator specific timeout
-   * @param socketTimeout socket timeout (in ms)
-   * @return
-   * @throws SnowflakeSQLException
-   */
-  public static HttpResponse getHttpResponseForS3Request(
-          HttpClientSettingsKey oscpAndProxyKey,
-          HttpGet httpRequest,
-          int networkTimeout,
-          int authTimeout,
-          int socketTimeout) throws SnowflakeSQLException {
-    CloseableHttpClient httpClient =
-            HttpUtil.getHttpClient(oscpAndProxyKey);
-
-    // fetch the result chunk
-    return RestRequest.execute(
-                    httpClient,
-                    httpRequest,
-                    networkTimeout / 1000, // retry timeout
-                    authTimeout,
-                    socketTimeout,
-                    0,
-                    0, // no socket timeout injection
-                    null, // no canceling
-                    false, // no cookie
-                    false, // no retry parameters in url
-                    false, // no request_guid
-                    true, // retry on HTTP403 for AWS S3
-                    true, // no retry on http request
-                    new ExecTimeTelemetryData());
   }
 }

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -920,8 +920,9 @@ public class HttpUtil {
   }
 
   /**
-   * This method was moved from DefaultResultStreamProvider to take advantage of the HTTP
-   * connection pool manager initialized by HttpUtil
+   * This method was moved from DefaultResultStreamProvider to take advantage of the HTTP connection
+   * pool manager initialized by HttpUtil
+   *
    * @param oscpAndProxyKey OCSP mode and proxy settings for httpclient
    * @param httpRequest HttpRequest
    * @param networkTimeout network timeout
@@ -931,29 +932,29 @@ public class HttpUtil {
    * @throws SnowflakeSQLException
    */
   public static HttpResponse getHttpResponseForS3Request(
-          HttpClientSettingsKey oscpAndProxyKey,
-          HttpGet httpRequest,
-          int networkTimeout,
-          int authTimeout,
-          int socketTimeout) throws SnowflakeSQLException {
-    CloseableHttpClient httpClient =
-            HttpUtil.getHttpClient(oscpAndProxyKey);
+      HttpClientSettingsKey oscpAndProxyKey,
+      HttpGet httpRequest,
+      int networkTimeout,
+      int authTimeout,
+      int socketTimeout)
+      throws SnowflakeSQLException {
+    CloseableHttpClient httpClient = HttpUtil.getHttpClient(oscpAndProxyKey);
 
     // fetch the result chunk
     return RestRequest.execute(
-                    httpClient,
-                    httpRequest,
-                    networkTimeout / 1000, // retry timeout
-                    authTimeout,
-                    socketTimeout,
-                    0,
-                    0, // no socket timeout injection
-                    null, // no canceling
-                    false, // no cookie
-                    false, // no retry parameters in url
-                    false, // no request_guid
-                    true, // retry on HTTP403 for AWS S3
-                    true, // no retry on http request
-                    new ExecTimeTelemetryData());
+        httpClient,
+        httpRequest,
+        networkTimeout / 1000, // retry timeout
+        authTimeout,
+        socketTimeout,
+        0,
+        0, // no socket timeout injection
+        null, // no canceling
+        false, // no cookie
+        false, // no retry parameters in url
+        false, // no request_guid
+        true, // retry on HTTP403 for AWS S3
+        true, // no retry on http request
+        new ExecTimeTelemetryData());
   }
 }

--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -38,12 +38,14 @@ import net.snowflake.client.util.SecretDetector;
 import net.snowflake.common.core.SqlState;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -915,5 +917,43 @@ public class HttpUtil {
     if (additionalHeaders != null && !additionalHeaders.isEmpty()) {
       additionalHeaders.forEach(request::addHeader);
     }
+  }
+
+  /**
+   * This method was moved from DefaultResultStreamProvider to take advantage of the HTTP
+   * connection pool manager initialized by HttpUtil
+   * @param oscpAndProxyKey OCSP mode and proxy settings for httpclient
+   * @param httpRequest HttpRequest
+   * @param networkTimeout network timeout
+   * @param authTimeout authenticator specific timeout
+   * @param socketTimeout socket timeout (in ms)
+   * @return
+   * @throws SnowflakeSQLException
+   */
+  public static HttpResponse getHttpResponseForS3Request(
+          HttpClientSettingsKey oscpAndProxyKey,
+          HttpGet httpRequest,
+          int networkTimeout,
+          int authTimeout,
+          int socketTimeout) throws SnowflakeSQLException {
+    CloseableHttpClient httpClient =
+            HttpUtil.getHttpClient(oscpAndProxyKey);
+
+    // fetch the result chunk
+    return RestRequest.execute(
+                    httpClient,
+                    httpRequest,
+                    networkTimeout / 1000, // retry timeout
+                    authTimeout,
+                    socketTimeout,
+                    0,
+                    0, // no socket timeout injection
+                    null, // no canceling
+                    false, // no cookie
+                    false, // no retry parameters in url
+                    false, // no request_guid
+                    true, // retry on HTTP403 for AWS S3
+                    true, // no retry on http request
+                    new ExecTimeTelemetryData());
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
@@ -112,8 +112,6 @@ public class DefaultResultStreamProvider implements ResultStreamProvider {
         context.getChunkIndex(),
         context.getResultChunk().getScrubbedUrl());
 
-    // TODO move this s3 request to HttpUtil class. In theory, upper layer
-    // TODO does not need to know about http client
     CloseableHttpClient httpClient =
         HttpUtil.getHttpClient(context.getChunkDownloader().getHttpClientSettingsKey());
 

--- a/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
@@ -8,9 +8,8 @@ import java.io.PushbackInputStream;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
-import net.snowflake.client.core.ExecTimeTelemetryData;
-import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.core.HttpClientSettingsKey;
+import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.log.ArgSupplier;
 import net.snowflake.client.util.SecretDetector;
 import net.snowflake.common.core.SqlState;
@@ -19,7 +18,6 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
 
 public class DefaultResultStreamProvider implements ResultStreamProvider {
   // SSE-C algorithm header
@@ -118,7 +116,9 @@ public class DefaultResultStreamProvider implements ResultStreamProvider {
     int authTimeout = context.getAuthTimeout();
     int socketTimeout = context.getSocketTimeout();
 
-    HttpResponse response = HttpUtil.getHttpResponseForS3Request(oscpAndProxyKey, httpRequest, networkTimeout, authTimeout, socketTimeout);
+    HttpResponse response =
+        HttpUtil.getHttpResponseForS3Request(
+            oscpAndProxyKey, httpRequest, networkTimeout, authTimeout, socketTimeout);
 
     SnowflakeResultSetSerializableV1.logger.debug(
         "Thread {} Call #chunk{} returned for URL: {}, response={}",

--- a/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import net.snowflake.client.core.ExecTimeTelemetryData;
 import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.HttpClientSettingsKey;
 import net.snowflake.client.log.ArgSupplier;
 import net.snowflake.client.util.SecretDetector;
 import net.snowflake.common.core.SqlState;
@@ -112,28 +113,12 @@ public class DefaultResultStreamProvider implements ResultStreamProvider {
         context.getChunkIndex(),
         context.getResultChunk().getScrubbedUrl());
 
-    // TODO move this s3 request to HttpUtil class. In theory, upper layer
-    // TODO does not need to know about http client
-    CloseableHttpClient httpClient =
-        HttpUtil.getHttpClient(context.getChunkDownloader().getHttpClientSettingsKey());
+    HttpClientSettingsKey oscpAndProxyKey = context.getChunkDownloader().getHttpClientSettingsKey();
+    int networkTimeout = context.getNetworkTimeoutInMilli();
+    int authTimeout = context.getAuthTimeout();
+    int socketTimeout = context.getSocketTimeout();
 
-    // fetch the result chunk
-    HttpResponse response =
-        RestRequest.execute(
-            httpClient,
-            httpRequest,
-            context.getNetworkTimeoutInMilli() / 1000, // retry timeout
-            context.getAuthTimeout(),
-            context.getSocketTimeout(),
-            0,
-            0, // no socket timeout injection
-            null, // no canceling
-            false, // no cookie
-            false, // no retry parameters in url
-            false, // no request_guid
-            true, // retry on HTTP403 for AWS S3
-            true, // no retry on http request
-            new ExecTimeTelemetryData());
+    HttpResponse response = HttpUtil.getHttpResponseForS3Request(oscpAndProxyKey, httpRequest, networkTimeout, authTimeout, socketTimeout);
 
     SnowflakeResultSetSerializableV1.logger.debug(
         "Thread {} Call #chunk{} returned for URL: {}, response={}",

--- a/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
+++ b/src/main/java/net/snowflake/client/jdbc/DefaultResultStreamProvider.java
@@ -8,8 +8,9 @@ import java.io.PushbackInputStream;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
-import net.snowflake.client.core.HttpClientSettingsKey;
+import net.snowflake.client.core.ExecTimeTelemetryData;
 import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.HttpClientSettingsKey;
 import net.snowflake.client.log.ArgSupplier;
 import net.snowflake.client.util.SecretDetector;
 import net.snowflake.common.core.SqlState;
@@ -18,6 +19,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 public class DefaultResultStreamProvider implements ResultStreamProvider {
   // SSE-C algorithm header
@@ -116,9 +118,7 @@ public class DefaultResultStreamProvider implements ResultStreamProvider {
     int authTimeout = context.getAuthTimeout();
     int socketTimeout = context.getSocketTimeout();
 
-    HttpResponse response =
-        HttpUtil.getHttpResponseForS3Request(
-            oscpAndProxyKey, httpRequest, networkTimeout, authTimeout, socketTimeout);
+    HttpResponse response = HttpUtil.getHttpResponseForS3Request(oscpAndProxyKey, httpRequest, networkTimeout, authTimeout, socketTimeout);
 
     SnowflakeResultSetSerializableV1.logger.debug(
         "Thread {} Call #chunk{} returned for URL: {}, response={}",


### PR DESCRIPTION
# Overview

[SNOW-965966] Move http client creation to HttpUtil class from DefaultResultStreamProvider

## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [Fixes ](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/750)


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Moved the http client creation out of DefaultResultStreamProvider

## Pre-review checklist
- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/project/branches?id=snowflake-jdbc))



[SNOW-965966]: https://snowflakecomputing.atlassian.net/browse/SNOW-965966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ