### PR TITLE
SNOW-997216 Init serverDeployment to default value

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetryOOB/TelemetryService.java
@@ -90,7 +90,7 @@ public class TelemetryService {
     numOfRetryToTriggerTelemetry = num;
   }
 
-  private TELEMETRY_SERVER_DEPLOYMENT serverDeployment;
+  private TELEMETRY_SERVER_DEPLOYMENT serverDeployment = TELEMETRY_SERVER_DEPLOYMENT.PROD;
 
   /**
    * control enable/disable the whole service: disabled service will skip added events and uploading


### PR DESCRIPTION
# Overview

SNOW-997216 When using upload without connection the OOB telemetry is not initialized properly - server deployment is not set. Now we set it to PROD by default.

