### PR TITLE
SNOW-1045548: Set the http request socket timeout

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -205,6 +205,11 @@ public class RestRequest {
           builder.setParameter("clientStartTime", String.valueOf(startTime));
         }
 
+        // Set the socket timeout
+        if (socketTimeout > 0) {
+          httpRequest.setConfig(
+              HttpUtil.getDefaultRequestConfigWithSocketTimeout(socketTimeout, withoutCookies));
+        }
         // When the auth timeout is set, set the socket timeout as the authTimeout
         // so that it can be renewed in time and pass it to the http request configuration.
         if (authTimeout > 0) {


### PR DESCRIPTION
# Overview

SNOW-1045548

## Pre-review self checklist
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] I don't expose unnecessary new public API (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] Pull request name is prefixed with `SNOW-XXXX: `

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1045548 - RT flaky test.


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   The rest request was stuck on execution thus adding the socket timeout should fix the issue.
