### PR TITLE
Add new connection property enablePatternSearch to flag if pattern searches for some DatabaseMetaData methods are allowed

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -132,6 +132,11 @@ public abstract class SFBaseSession {
   // Connection string setting
   private boolean enablePutGet = true;
 
+  // Enables the use of pattern searches for certain DatabaseMetaData methods
+  // which do not by definition allow the use of patterns, but
+  // we need to allow for it to maintain backwards compatibility.
+  private boolean enablePatternSearch = true;
+
   private Map<String, Object> commonParameters;
 
   protected SFBaseSession(SFConnectionHandler sfConnectionHandler) {
@@ -711,6 +716,14 @@ public abstract class SFBaseSession {
 
   public boolean setEnablePutGet(boolean enablePutGet) {
     return this.enablePutGet = enablePutGet;
+  }
+
+  public boolean getEnablePatternSearch() {
+    return enablePatternSearch;
+  }
+
+  public void setEnablePatternSearch(boolean enablePatternSearch) {
+    this.enablePatternSearch = enablePatternSearch;
   }
 
   public int getClientResultChunkSize() {

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -464,6 +464,13 @@ public class SFSession extends SFBaseSession {
           }
           break;
 
+        case ENABLE_PATTERN_SEARCH:
+          if (propertyValue != null) {
+            setEnablePatternSearch(getBooleanValue(propertyValue));
+          }
+          break;
+
+
         default:
           break;
       }

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -76,7 +76,9 @@ public enum SFSessionProperty {
 
   PUT_GET_MAX_RETRIES("putGetMaxRetries", false, Integer.class),
 
-  RETRY_TIMEOUT("retryTimeout", false, Integer.class);
+  RETRY_TIMEOUT("retryTimeout", false, Integer.class),
+
+  ENABLE_PATTERN_SEARCH("enablePatternSearch", false, Boolean.class);
 
   // property key in string
   private String propertyKey;

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -1694,4 +1694,9 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
       assertFalse(metaData.locatorsUpdateCopy());
     }
   }
+
+  @Test
+  public void testGetPrimaryKeysNoPatternSearchAllowed() throws SQLException {
+
+  }
 }


### PR DESCRIPTION
# Overview

SNOW-974129

## Pre-review self checklist
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] I don't expose unnecessary new public API (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] Pull request name is prefixed with `SNOW-XXXX: `

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [Fixes #NNNN ](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/758)


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   I added a new connection property called enblePatterSearch to allow a user to decide if they want to allow pattern searches to be used in certain metadata methods (getPrimaryKeys, getImportedKeys, getExportedKeys, getCrossReference). The default is true meaning by default we allow pattern searches on these methods. This is the current behavior of the driver so we won't be breaking anything for users who may currently be using patterns. 
