### PR TITLE
SNOW-1050447: Cleanup schemas in testGetProcedureColumnsWildcards

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -389,7 +389,7 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
    * @throws SQLException
    */
   @Test
-  public void testGetProcedureColumnsWildcards() throws SQLException {
+  public void testGetProcedureColumnsWildcards() throws Exception {
     try (Connection con = getConnection();
         Statement statement = con.createStatement()) {
       String database = con.getCatalog();
@@ -397,19 +397,28 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCTest {
           TestUtil.GENERATED_SCHEMA_PREFIX + SnowflakeUtil.randomAlphaNumeric(5).toUpperCase();
       String schema1 = schemaPrefix + "SCH1";
       String schema2 = schemaPrefix + "SCH2";
-      // Create 2 schemas, each with the same stored procedure declared in them
-      statement.execute("create or replace schema " + schema1);
-      statement.execute(TEST_PROC);
-      statement.execute("create or replace schema " + schema2);
-      statement.execute(TEST_PROC);
-      DatabaseMetaData metaData = con.getMetaData();
-      try (ResultSet rs =
-          metaData.getProcedureColumns(database, schemaPrefix + "SCH_", "TESTPROC", "PARAM1")) {
-        // Assert 4 rows returned for the param PARAM1 that's present in each of the 2 identical
-        // stored procs in different schemas. A result row is returned for each procedure, making
-        // the total rowcount 4
-        assertEquals(4, getSizeOfResultSet(rs));
-      }
+      TestUtil.withSchema(
+          statement,
+          schema1,
+          () -> {
+            statement.execute(TEST_PROC);
+            TestUtil.withSchema(
+                statement,
+                schema2,
+                () -> {
+                  statement.execute(TEST_PROC);
+                  // Create 2 schemas, each with the same stored procedure declared in them
+                  DatabaseMetaData metaData = con.getMetaData();
+                  try (ResultSet rs =
+                      metaData.getProcedureColumns(
+                          database, schemaPrefix + "SCH_", "TESTPROC", "PARAM1")) {
+                    // Assert 4 rows returned for the param PARAM1 that's present in each of the 2
+                    // identical stored procs in different schemas. A result row is returned for
+                    // each procedure, making the total rowcount 4
+                    assertEquals(4, getSizeOfResultSet(rs));
+                  }
+                });
+          });
     }
   }
 


### PR DESCRIPTION
# Overview

SNOW-1050447

## Pre-review self checklist
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] I don't expose unnecessary new public API (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] Pull request name is prefixed with `SNOW-XXXX: `
