### PR TITLE
SNOW-1063992: Exclude JDBC perf test schemas from DatabaseMetaDataIT.testGetSchemas

### DIFF
--- a/src/test/java/net/snowflake/client/TestUtil.java
+++ b/src/test/java/net/snowflake/client/TestUtil.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.jdbc.SnowflakeUtil;
@@ -25,15 +27,18 @@ public class TestUtil {
   public static final String GENERATED_SCHEMA_PREFIX = "GENERATED_";
   public static final String ESCAPED_GENERATED_SCHEMA_PREFIX =
       GENERATED_SCHEMA_PREFIX.replaceAll("_", "\\\\_");
-  private static final String GITHUB_SCHEMA_PREFIX =
-      "GITHUB_"; // created by JDBC CI jobs before tests
-  private static final String GITHUB_JOB_SCHEMA_PREFIX =
-      "GH_JOB_"; // created by other drivers e.g. Python driver
+
+  private static final List<String> schemaGeneratedInTestsPrefixes =
+      Arrays.asList(
+          GENERATED_SCHEMA_PREFIX,
+          "GITHUB_", // created by JDBC CI jobs before tests
+          "GH_JOB_", // created by other drivers tests e.g. Python
+          "JDBCPERF", // created in JDBC perf tests
+          "SCHEMA_" // created by other drivers tests e.g. Scala
+          );
 
   public static boolean isSchemaGeneratedInTests(String schema) {
-    return schema.startsWith(TestUtil.GITHUB_SCHEMA_PREFIX)
-        || schema.startsWith(TestUtil.GITHUB_JOB_SCHEMA_PREFIX)
-        || schema.startsWith(TestUtil.GENERATED_SCHEMA_PREFIX);
+    return schemaGeneratedInTestsPrefixes.stream().anyMatch(prefix -> schema.startsWith(prefix));
   }
 
   /**


### PR DESCRIPTION
# Overview

SNOW-1063992

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
