### PR TITLE
SNOW-1170182: Return decimal as int in ARROW results configured by flag

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -142,6 +142,8 @@ public abstract class SFBaseSession {
 
   private Map<String, Object> commonParameters;
 
+  private boolean isJdbcArrowTreatDecimalAsInt = true;
+
   protected SFBaseSession(SFConnectionHandler sfConnectionHandler) {
     this.sfConnectionHandler = sfConnectionHandler;
   }
@@ -269,6 +271,15 @@ public abstract class SFBaseSession {
   public void setJdbcTreatDecimalAsInt(boolean jdbcTreatDecimalAsInt) {
     isJdbcTreatDecimalAsInt = jdbcTreatDecimalAsInt;
   }
+
+  public boolean isJdbcArrowTreatDecimalAsInt() {
+    return isJdbcArrowTreatDecimalAsInt;
+  }
+
+  public void setJdbcArrowTreatDecimalAsInt(boolean jdbcArrowTreatDecimalAsInt) {
+    isJdbcArrowTreatDecimalAsInt = jdbcArrowTreatDecimalAsInt;
+  }
+
 
   public String getServerUrl() {
     if (connectionPropertiesMap.containsKey(SFSessionProperty.SERVER_URL)) {

--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -280,7 +280,6 @@ public abstract class SFBaseSession {
     isJdbcArrowTreatDecimalAsInt = jdbcArrowTreatDecimalAsInt;
   }
 
-
   public String getServerUrl() {
     if (connectionPropertiesMap.containsKey(SFSessionProperty.SERVER_URL)) {
       return (String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL);

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -475,6 +475,12 @@ public class SFSession extends SFBaseSession {
           }
           break;
 
+        case JDBC_ARROW_TREAT_DECIMAL_AS_INT:
+          if (propertyValue != null) {
+            setJdbcArrowTreatDecimalAsInt(getBooleanValue(propertyValue));
+          }
+          break;
+
         default:
           break;
       }

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -80,7 +80,10 @@ public enum SFSessionProperty {
 
   ENABLE_PATTERN_SEARCH("enablePatternSearch", false, Boolean.class),
 
-  DISABLE_GCS_DEFAULT_CREDENTIALS("disableGcsDefaultCredentials", false, Boolean.class);
+  DISABLE_GCS_DEFAULT_CREDENTIALS("disableGcsDefaultCredentials", false, Boolean.class),
+
+  JDBC_ARROW_TREAT_DECIMAL_AS_INT("jdbc_arrow_treat_decimal_as_int", false, Boolean.class);
+
 
   // property key in string
   private String propertyKey;

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -82,7 +82,7 @@ public enum SFSessionProperty {
 
   DISABLE_GCS_DEFAULT_CREDENTIALS("disableGcsDefaultCredentials", false, Boolean.class),
 
-  JDBC_ARROW_TREAT_DECIMAL_AS_INT("jdbc_arrow_treat_decimal_as_int", false, Boolean.class);
+  JDBC_ARROW_TREAT_DECIMAL_AS_INT("JDBC_ARROW_TREAT_DECIMAL_AS_INT", false, Boolean.class);
 
   // property key in string
   private String propertyKey;

--- a/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
@@ -146,7 +146,7 @@ abstract class AbstractArrowVectorConverter implements ArrowVectorConverter {
         ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BIG_DECIMAL_STR, "");
   }
 
-  public boolean shouldTreatDecimalAsInt() {
+  public boolean shouldTreatDecimalAsInt(DataConversionContext context) {
     if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
         && !context.getSession().isJdbcTreatDecimalAsInt()) {
       return false;

--- a/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
@@ -148,8 +148,10 @@ abstract class AbstractArrowVectorConverter implements ArrowVectorConverter {
   }
 
   public boolean shouldTreatDecimalAsInt(SFBaseSession session) {
-    if (!session.isJdbcArrowTreatDecimalAsInt() && !session.isJdbcTreatDecimalAsInt()) {
-      return false;
+    if (session != null) {
+      if (!session.isJdbcArrowTreatDecimalAsInt() && !session.isJdbcTreatDecimalAsInt()) {
+        return false;
+      }
     }
     return true;
   }

--- a/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
@@ -146,9 +146,9 @@ abstract class AbstractArrowVectorConverter implements ArrowVectorConverter {
         ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BIG_DECIMAL_STR, "");
   }
 
-  public boolean shouldTreatDecimalAsInt(){
+  public boolean shouldTreatDecimalAsInt() {
     if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
-            && !context.getSession().isJdbcTreatDecimalAsInt()) {
+        && !context.getSession().isJdbcTreatDecimalAsInt()) {
       return false;
     }
     return true;

--- a/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
@@ -146,6 +146,14 @@ abstract class AbstractArrowVectorConverter implements ArrowVectorConverter {
         ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BIG_DECIMAL_STR, "");
   }
 
+  public boolean shouldTreatDecimalAsInt(){
+    if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
+            && !context.getSession().isJdbcTreatDecimalAsInt()) {
+      return false;
+    }
+    return true;
+  }
+
   @Override
   public void setTreatNTZAsUTC(boolean isUTC) {
     this.treatNTZasUTC = isUTC;

--- a/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/AbstractArrowVectorConverter.java
@@ -9,6 +9,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.TimeZone;
 import net.snowflake.client.core.DataConversionContext;
+import net.snowflake.client.core.SFBaseSession;
 import net.snowflake.client.core.SFException;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeUtil;
@@ -146,9 +147,8 @@ abstract class AbstractArrowVectorConverter implements ArrowVectorConverter {
         ErrorCode.INVALID_VALUE_CONVERT, logicalTypeStr, SnowflakeUtil.BIG_DECIMAL_STR, "");
   }
 
-  public boolean shouldTreatDecimalAsInt(DataConversionContext context) {
-    if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
-        && !context.getSession().isJdbcTreatDecimalAsInt()) {
+  public boolean shouldTreatDecimalAsInt(SFBaseSession session) {
+    if (!session.isJdbcArrowTreatDecimalAsInt() && !session.isJdbcTreatDecimalAsInt()) {
       return false;
     }
     return true;

--- a/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
@@ -137,7 +137,7 @@ public class BigIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (bigIntVector.isNull(index)) {
       return null;
-    } else if (!shouldTreatDecimalAsInt(context)) {
+    } else if (!shouldTreatDecimalAsInt(context.getSession())) {
       return BigDecimal.valueOf(getLong(index), sfScale);
     }
     return getLong(index);

--- a/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
@@ -137,8 +137,7 @@ public class BigIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (bigIntVector.isNull(index)) {
       return null;
-    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
-        && !context.getSession().isJdbcTreatDecimalAsInt()) {
+    } else if (!shouldTreatDecimalAsInt()) {
       return BigDecimal.valueOf(getLong(index), sfScale);
     }
     return getLong(index);

--- a/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
@@ -137,7 +137,7 @@ public class BigIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (bigIntVector.isNull(index)) {
       return null;
-    } else if (!shouldTreatDecimalAsInt()) {
+    } else if (!shouldTreatDecimalAsInt(context)) {
       return BigDecimal.valueOf(getLong(index), sfScale);
     }
     return getLong(index);

--- a/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
@@ -137,7 +137,8 @@ public class BigIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (bigIntVector.isNull(index)) {
       return null;
-    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt() && !context.getSession().isJdbcTreatDecimalAsInt()) {
+    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
+        && !context.getSession().isJdbcTreatDecimalAsInt()) {
       return BigDecimal.valueOf(getLong(index), sfScale);
     }
     return getLong(index);

--- a/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BigIntToFixedConverter.java
@@ -137,9 +137,10 @@ public class BigIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (bigIntVector.isNull(index)) {
       return null;
-    } else {
-      return getLong(index);
+    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt() && !context.getSession().isJdbcTreatDecimalAsInt()) {
+      return BigDecimal.valueOf(getLong(index), sfScale);
     }
+    return getLong(index);
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
@@ -105,7 +105,12 @@ public class IntToFixedConverter extends AbstractArrowVectorConverter {
 
   @Override
   public Object toObject(int index) throws SFException {
-    return isNull(index) ? null : (long) getInt(index);
+    if (isNull(index)){
+      return null;
+    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt() && !context.getSession().isJdbcTreatDecimalAsInt()) {
+      return BigDecimal.valueOf((long) getInt(index), sfScale);
+    }
+    return (long) getInt(index);
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
@@ -107,8 +107,7 @@ public class IntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
-        && !context.getSession().isJdbcTreatDecimalAsInt()) {
+    } else if (!shouldTreatDecimalAsInt()) {
       return BigDecimal.valueOf((long) getInt(index), sfScale);
     }
     return (long) getInt(index);

--- a/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
@@ -107,7 +107,7 @@ public class IntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!shouldTreatDecimalAsInt()) {
+    } else if (!shouldTreatDecimalAsInt(context)) {
       return BigDecimal.valueOf((long) getInt(index), sfScale);
     }
     return (long) getInt(index);

--- a/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
@@ -105,9 +105,10 @@ public class IntToFixedConverter extends AbstractArrowVectorConverter {
 
   @Override
   public Object toObject(int index) throws SFException {
-    if (isNull(index)){
+    if (isNull(index)) {
       return null;
-    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt() && !context.getSession().isJdbcTreatDecimalAsInt()) {
+    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
+        && !context.getSession().isJdbcTreatDecimalAsInt()) {
       return BigDecimal.valueOf((long) getInt(index), sfScale);
     }
     return (long) getInt(index);

--- a/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/IntToFixedConverter.java
@@ -107,7 +107,7 @@ public class IntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!shouldTreatDecimalAsInt(context)) {
+    } else if (!shouldTreatDecimalAsInt(context.getSession())) {
       return BigDecimal.valueOf((long) getInt(index), sfScale);
     }
     return (long) getInt(index);

--- a/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
@@ -99,6 +99,8 @@ public class SmallIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
+    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt() && !context.getSession().isJdbcTreatDecimalAsInt()) {
+      return BigDecimal.valueOf((long) getShort(index), sfScale);
     }
     return (long) getShort(index);
   }

--- a/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
@@ -99,7 +99,7 @@ public class SmallIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!shouldTreatDecimalAsInt(context)) {
+    } else if (!shouldTreatDecimalAsInt(context.getSession())) {
       return BigDecimal.valueOf((long) getShort(index), sfScale);
     }
     return (long) getShort(index);

--- a/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
@@ -99,7 +99,8 @@ public class SmallIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt() && !context.getSession().isJdbcTreatDecimalAsInt()) {
+    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
+        && !context.getSession().isJdbcTreatDecimalAsInt()) {
       return BigDecimal.valueOf((long) getShort(index), sfScale);
     }
     return (long) getShort(index);

--- a/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
@@ -99,8 +99,7 @@ public class SmallIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
-        && !context.getSession().isJdbcTreatDecimalAsInt()) {
+    } else if (!shouldTreatDecimalAsInt()) {
       return BigDecimal.valueOf((long) getShort(index), sfScale);
     }
     return (long) getShort(index);

--- a/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/SmallIntToFixedConverter.java
@@ -99,7 +99,7 @@ public class SmallIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!shouldTreatDecimalAsInt()) {
+    } else if (!shouldTreatDecimalAsInt(context)) {
       return BigDecimal.valueOf((long) getShort(index), sfScale);
     }
     return (long) getShort(index);

--- a/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
@@ -90,7 +90,12 @@ public class TinyIntToFixedConverter extends AbstractArrowVectorConverter {
 
   @Override
   public Object toObject(int index) throws SFException {
-    return isNull(index) ? null : (long) toByte(index);
+    if (isNull(index)) {
+      return null;
+    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt() && !context.getSession().isJdbcTreatDecimalAsInt()) {
+      return BigDecimal.valueOf((long) getByte(index), sfScale);
+    }
+    return (long) toByte(index);
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
@@ -92,7 +92,7 @@ public class TinyIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!shouldTreatDecimalAsInt(context)) {
+    } else if (!shouldTreatDecimalAsInt(context.getSession())) {
       return BigDecimal.valueOf((long) getByte(index), sfScale);
     }
     return (long) toByte(index);

--- a/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
@@ -92,7 +92,8 @@ public class TinyIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt() && !context.getSession().isJdbcTreatDecimalAsInt()) {
+    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
+        && !context.getSession().isJdbcTreatDecimalAsInt()) {
       return BigDecimal.valueOf((long) getByte(index), sfScale);
     }
     return (long) toByte(index);

--- a/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
@@ -92,7 +92,7 @@ public class TinyIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!shouldTreatDecimalAsInt()) {
+    } else if (!shouldTreatDecimalAsInt(context)) {
       return BigDecimal.valueOf((long) getByte(index), sfScale);
     }
     return (long) toByte(index);

--- a/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/TinyIntToFixedConverter.java
@@ -92,8 +92,7 @@ public class TinyIntToFixedConverter extends AbstractArrowVectorConverter {
   public Object toObject(int index) throws SFException {
     if (isNull(index)) {
       return null;
-    } else if (!context.getSession().isJdbcArrowTreatDecimalAsInt()
-        && !context.getSession().isJdbcTreatDecimalAsInt()) {
+    } else if (!shouldTreatDecimalAsInt()) {
       return BigDecimal.valueOf((long) getByte(index), sfScale);
     }
     return (long) toByte(index);

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetArrowLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetArrowLatestIT.java
@@ -3,16 +3,17 @@
  */
 package net.snowflake.client.jdbc;
 
-import static org.junit.Assert.assertEquals;
+import net.snowflake.client.category.TestCategoryArrow;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-import net.snowflake.client.category.TestCategoryArrow;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -22,71 +23,5 @@ import org.junit.experimental.categories.Category;
 public class ResultSetArrowLatestIT extends ResultSetLatestIT {
   public ResultSetArrowLatestIT() {
     super("arrow");
-  }
-
-  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property
-  // introduced after version 3.15.0.
-  @Test
-  public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntFalse() throws SQLException {
-    Properties properties = new Properties();
-    properties.put("jdbc_arrow_treat_decimal_as_int", false);
-    try (Connection con = init(properties);
-        Statement stmt = con.createStatement()) {
-      stmt.execute(createTableSql);
-      stmt.execute(insertStmt);
-
-      // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=true
-      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
-          assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
-          assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");
-          assertEquals(rs.getObject(4).getClass().toString(), "class java.lang.Long");
-        }
-      }
-
-      // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=false
-      stmt.execute(setJdbcTreatDecimalAsIntFalse);
-      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals(rs.getObject(1).getClass().toString(), "class java.math.BigDecimal");
-          assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
-          assertEquals(rs.getObject(3).getClass().toString(), "class java.math.BigDecimal");
-          assertEquals(rs.getObject(4).getClass().toString(), "class java.math.BigDecimal");
-        }
-      }
-    }
-  }
-
-  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true.
-  // Connection property introduced after version 3.15.0.
-  @Test
-  public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntTrue() throws SQLException {
-    try (Connection con = init();
-        Statement stmt = con.createStatement()) {
-      stmt.execute(createTableSql);
-      stmt.execute(insertStmt);
-
-      // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=true
-      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
-          assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
-          assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");
-          assertEquals(rs.getObject(4).getClass().toString(), "class java.lang.Long");
-        }
-      }
-
-      // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=false
-      stmt.execute(setJdbcTreatDecimalAsIntFalse);
-      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
-          assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
-          assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");
-          assertEquals(rs.getObject(4).getClass().toString(), "class java.lang.Long");
-        }
-      }
-    }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetArrowLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetArrowLatestIT.java
@@ -4,16 +4,7 @@
 package net.snowflake.client.jdbc;
 
 import net.snowflake.client.category.TestCategoryArrow;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetArrowLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetArrowLatestIT.java
@@ -3,17 +3,16 @@
  */
 package net.snowflake.client.jdbc;
 
-import net.snowflake.client.category.TestCategoryArrow;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import static org.junit.Assert.assertEquals;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
+import net.snowflake.client.category.TestCategoryArrow;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -25,19 +24,20 @@ public class ResultSetArrowLatestIT extends ResultSetLatestIT {
     super("arrow");
   }
 
-  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property introduced after version 3.15.0.
+  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property
+  // introduced after version 3.15.0.
   @Test
   public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntFalse() throws SQLException {
     Properties properties = new Properties();
     properties.put("jdbc_arrow_treat_decimal_as_int", false);
     try (Connection con = init(properties);
-         Statement stmt = con.createStatement()) {
+        Statement stmt = con.createStatement()) {
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
 
       // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=true
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while(rs.next()) {
+        while (rs.next()) {
           assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
           assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
           assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");
@@ -58,17 +58,18 @@ public class ResultSetArrowLatestIT extends ResultSetLatestIT {
     }
   }
 
-  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true. Connection property introduced after version 3.15.0.
+  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true.
+  // Connection property introduced after version 3.15.0.
   @Test
   public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntTrue() throws SQLException {
     try (Connection con = init();
-         Statement stmt = con.createStatement()) {
+        Statement stmt = con.createStatement()) {
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
 
       // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=true
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while(rs.next()) {
+        while (rs.next()) {
           assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
           assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
           assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetArrowLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetArrowLatestIT.java
@@ -4,7 +4,16 @@
 package net.snowflake.client.jdbc;
 
 import net.snowflake.client.category.TestCategoryArrow;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * ResultSet integration tests for the latest JDBC driver. This doesn't work for the oldest
@@ -14,5 +23,69 @@ import org.junit.experimental.categories.Category;
 public class ResultSetArrowLatestIT extends ResultSetLatestIT {
   public ResultSetArrowLatestIT() {
     super("arrow");
+  }
+
+  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property introduced after version 3.15.0.
+  @Test
+  public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntFalse() throws SQLException {
+    Properties properties = new Properties();
+    properties.put("jdbc_arrow_treat_decimal_as_int", false);
+    try (Connection con = init(properties);
+         Statement stmt = con.createStatement()) {
+      stmt.execute(createTableSql);
+      stmt.execute(insertStmt);
+
+      // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=true
+      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
+        while(rs.next()) {
+          assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
+          assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
+          assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");
+          assertEquals(rs.getObject(4).getClass().toString(), "class java.lang.Long");
+        }
+      }
+
+      // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=false
+      stmt.execute(setJdbcTreatDecimalAsIntFalse);
+      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
+        while (rs.next()) {
+          assertEquals(rs.getObject(1).getClass().toString(), "class java.math.BigDecimal");
+          assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
+          assertEquals(rs.getObject(3).getClass().toString(), "class java.math.BigDecimal");
+          assertEquals(rs.getObject(4).getClass().toString(), "class java.math.BigDecimal");
+        }
+      }
+    }
+  }
+
+  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true. Connection property introduced after version 3.15.0.
+  @Test
+  public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntTrue() throws SQLException {
+    try (Connection con = init();
+         Statement stmt = con.createStatement()) {
+      stmt.execute(createTableSql);
+      stmt.execute(insertStmt);
+
+      // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=true
+      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
+        while(rs.next()) {
+          assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
+          assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
+          assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");
+          assertEquals(rs.getObject(4).getClass().toString(), "class java.lang.Long");
+        }
+      }
+
+      // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=false
+      stmt.execute(setJdbcTreatDecimalAsIntFalse);
+      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
+        while (rs.next()) {
+          assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
+          assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
+          assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");
+          assertEquals(rs.getObject(4).getClass().toString(), "class java.lang.Long");
+        }
+      }
+    }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -1055,7 +1055,7 @@ public class ResultSetLatestIT extends ResultSet0IT {
   // Test getObject for numeric types when JDBC_TREAT_DECIMAL_AS_INT is set and using JSON result
   // format.
   @Test
-  public void testGetObjectForJSONResultFormatJDBCDecimalAsIntFalse() throws SQLException {
+  public void testGetObjectForJSONResultFormatUsingJDBCDecimalAsInt() throws SQLException {
     try (Connection con = BaseJDBCTest.getConnection();
         Statement stmt = con.createStatement()) {
       stmt.execute("alter session set jdbc_query_result_format = 'JSON'");

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -980,6 +980,24 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
+  private static void assertAllColumnsAreLongButBigIntIsBigDecimal(ResultSet rs) throws SQLException {
+    while(rs.next()) {
+      assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
+      assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
+      assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
+      assertEquals("class java.lang.Long", rs.getObject(4).getClass().toString());
+    }
+  }
+
+  private static void assertAllColumnsAreBigDecimal(ResultSet rs) throws SQLException {
+    while (rs.next()) {
+      assertEquals("class java.math.BigDecimal", rs.getObject(1).getClass().toString());
+      assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
+      assertEquals("class java.math.BigDecimal", rs.getObject(3).getClass().toString());
+      assertEquals("class java.math.BigDecimal", rs.getObject(4).getClass().toString());
+    }
+  }
+
   // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property introduced after version 3.15.0.
   @Test
   public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntFalse() throws SQLException {
@@ -993,23 +1011,13 @@ public class ResultSetLatestIT extends ResultSet0IT {
 
       // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=true
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while(rs.next()) {
-          assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(4).getClass().toString());
-        }
+        assertAllColumnsAreLongButBigIntIsBigDecimal(rs);
       }
 
       // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=false
       stmt.execute(setJdbcTreatDecimalAsIntFalse);
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals("class java.math.BigDecimal", rs.getObject(1).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(3).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(4).getClass().toString());
-        }
+        assertAllColumnsAreBigDecimal(rs);
       }
     }
   }
@@ -1036,80 +1044,29 @@ public class ResultSetLatestIT extends ResultSet0IT {
       // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=false
       stmt.execute(setJdbcTreatDecimalAsIntFalse);
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(4).getClass().toString());
-        }
+        assertAllColumnsAreLongButBigIntIsBigDecimal(rs);
       }
     }
   }
 
-  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property
-  // introduced after version 3.15.0.
+  // Test getObject for numeric types when JDBC_TREAT_DECIMAL_AS_INT is set and using JSON result format.
   @Test
-  public void testGetObjectForJSONResultFormatJDBCArrowDecimalAsIntFalse() throws SQLException {
-    Properties properties = new Properties();
-    properties.put("jdbc_arrow_treat_decimal_as_int", false);
-    try (Connection con = getConnection(properties);
-        Statement stmt = con.createStatement()) {
-      stmt.execute("alter session set jdbc_query_result_format = 'JSON'");
-      stmt.execute(createTableSql);
-      stmt.execute(insertStmt);
-
-      // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=true
-      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(4).getClass().toString());
-        }
-      }
-
-      // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=false
-      stmt.execute(setJdbcTreatDecimalAsIntFalse);
-      try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals("class java.math.BigDecimal", rs.getObject(1).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(3).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(4).getClass().toString());
-        }
-      }
-    }
-  }
-
-  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true.
-  // Connection property introduced after version 3.15.0.
-  @Test
-  public void testGetObjectForJSONResultFormatJDBCArrowDecimalAsIntTrue() throws SQLException {
+  public void testGetObjectForJSONResultFormatJDBCDecimalAsIntFalse() throws SQLException {
     try (Connection con = BaseJDBCTest.getConnection();
         Statement stmt = con.createStatement()) {
       stmt.execute("alter session set jdbc_query_result_format = 'JSON'");
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
 
-      // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=true
+      // Test with JDBC_TREAT_DECIMAL_AS_INT=true (default value)
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(4).getClass().toString());
-        }
+        assertAllColumnsAreLongButBigIntIsBigDecimal(rs);
       }
 
-      // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=false
+      // Test with JDBC_TREAT_DECIMAL_AS_INT=false
       stmt.execute(setJdbcTreatDecimalAsIntFalse);
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals("class java.math.BigDecimal", rs.getObject(1).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(3).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(4).getClass().toString());
-        }
+        assertAllColumnsAreBigDecimal(rs);
       }
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -999,24 +999,24 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
-  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property
+  // Test setting new connection property JDBC_ARROW_TREAT_DECIMAL_AS_INT=false. Connection property
   // introduced after version 3.15.0.
   @Test
   public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntFalse() throws SQLException {
     Properties properties = new Properties();
-    properties.put("jdbc_arrow_treat_decimal_as_int", false);
+    properties.put("JDBC_ARROW_TREAT_DECIMAL_AS_INT", false);
     try (Connection con = getConnection(properties);
         Statement stmt = con.createStatement()) {
       stmt.execute("alter session set jdbc_query_result_format = 'ARROW'");
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
 
-      // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=true
+      // Test with JDBC_ARROW_TREAT_DECIMAL_AS_INT=false and JDBC_TREAT_DECIMAL_AS_INT=true
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
         assertAllColumnsAreLongButBigIntIsBigDecimal(rs);
       }
 
-      // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=false
+      // Test with JDBC_ARROW_TREAT_DECIMAL_AS_INT=false and JDBC_TREAT_DECIMAL_AS_INT=false
       stmt.execute(setJdbcTreatDecimalAsIntFalse);
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
         assertAllColumnsAreBigDecimal(rs);
@@ -1024,7 +1024,7 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
-  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true.
+  // Test default setting of new connection property JDBC_ARROW_TREAT_DECIMAL_AS_INT=true.
   // Connection property introduced after version 3.15.0.
   @Test
   public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntTrue() throws SQLException {
@@ -1034,17 +1034,12 @@ public class ResultSetLatestIT extends ResultSet0IT {
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
 
-      // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=true
+      // Test with JDBC_ARROW_TREAT_DECIMAL_AS_INT=true and JDBC_TREAT_DECIMAL_AS_INT=true
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while (rs.next()) {
-          assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
-          assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
-          assertEquals("class java.lang.Long", rs.getObject(4).getClass().toString());
-        }
+        assertAllColumnsAreLongButBigIntIsBigDecimal(rs);
       }
 
-      // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=false
+      // Test with JDBC_ARROW_TREAT_DECIMAL_AS_INT=true and JDBC_TREAT_DECIMAL_AS_INT=false
       stmt.execute(setJdbcTreatDecimalAsIntFalse);
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
         assertAllColumnsAreLongButBigIntIsBigDecimal(rs);

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -983,19 +983,19 @@ public class ResultSetLatestIT extends ResultSet0IT {
   private static void assertAllColumnsAreLongButBigIntIsBigDecimal(ResultSet rs)
       throws SQLException {
     while (rs.next()) {
-      assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
-      assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-      assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
-      assertEquals("class java.lang.Long", rs.getObject(4).getClass().toString());
+      assertEquals(java.lang.Long.class, rs.getObject(1).getClass());
+      assertEquals(java.math.BigDecimal.class, rs.getObject(2).getClass());
+      assertEquals(java.lang.Long.class, rs.getObject(3).getClass());
+      assertEquals(java.lang.Long.class, rs.getObject(4).getClass());
     }
   }
 
   private static void assertAllColumnsAreBigDecimal(ResultSet rs) throws SQLException {
     while (rs.next()) {
-      assertEquals("class java.math.BigDecimal", rs.getObject(1).getClass().toString());
-      assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
-      assertEquals("class java.math.BigDecimal", rs.getObject(3).getClass().toString());
-      assertEquals("class java.math.BigDecimal", rs.getObject(4).getClass().toString());
+      assertEquals(java.math.BigDecimal.class, rs.getObject(1).getClass());
+      assertEquals(java.math.BigDecimal.class, rs.getObject(2).getClass());
+      assertEquals(java.math.BigDecimal.class, rs.getObject(3).getClass());
+      assertEquals(java.math.BigDecimal.class, rs.getObject(4).getClass());
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -73,10 +73,13 @@ public class ResultSetLatestIT extends ResultSet0IT {
     super(queryResultFormat);
   }
 
-  public String createTableSql = "Create or replace table get_object_for_numeric_types (c1 INT, c2 BIGINT, c3 SMALLINT, c4 TINYINT) ";
-  public String insertStmt = "Insert into get_object_for_numeric_types (c1, c2, c3, c4) values (1000000000, 2000000000000000000000000, 3, 4)";
+  public String createTableSql =
+      "Create or replace table get_object_for_numeric_types (c1 INT, c2 BIGINT, c3 SMALLINT, c4 TINYINT) ";
+  public String insertStmt =
+      "Insert into get_object_for_numeric_types (c1, c2, c3, c4) values (1000000000, 2000000000000000000000000, 3, 4)";
   public String selectQuery = "Select * from get_object_for_numeric_types";
-  public String setJdbcTreatDecimalAsIntFalse = "alter session set JDBC_TREAT_DECIMAL_AS_INT = false";
+  public String setJdbcTreatDecimalAsIntFalse =
+      "alter session set JDBC_TREAT_DECIMAL_AS_INT = false";
 
   /**
    * Test that when closing of results is interrupted by Thread.Interrupt(), the memory is released
@@ -977,19 +980,20 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
-  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property introduced after version 3.15.0.
+  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property
+  // introduced after version 3.15.0.
   @Test
   public void testGetObjectForJSONResultFormatJDBCArrowDecimalAsIntFalse() throws SQLException {
     Properties properties = new Properties();
     properties.put("jdbc_arrow_treat_decimal_as_int", false);
     try (Connection con = init(properties);
-         Statement stmt = con.createStatement()) {
+        Statement stmt = con.createStatement()) {
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
 
       // Test with jdbc_arrow_treat_decimal_as_int=false and JDBC_TREAT_DECIMAL_AS_INT=true
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while(rs.next()) {
+        while (rs.next()) {
           assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
           assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
           assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");
@@ -1010,17 +1014,18 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
-  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true. Connection property introduced after version 3.15.0.
+  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true.
+  // Connection property introduced after version 3.15.0.
   @Test
   public void testGetObjectForJSONResultFormatJDBCArrowDecimalAsIntTrue() throws SQLException {
     try (Connection con = init();
-         Statement stmt = con.createStatement()) {
+        Statement stmt = con.createStatement()) {
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
 
       // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=true
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while(rs.next()) {
+        while (rs.next()) {
           assertEquals(rs.getObject(1).getClass().toString(), "class java.lang.Long");
           assertEquals(rs.getObject(2).getClass().toString(), "class java.math.BigDecimal");
           assertEquals(rs.getObject(3).getClass().toString(), "class java.lang.Long");

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -980,8 +980,9 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
-  private static void assertAllColumnsAreLongButBigIntIsBigDecimal(ResultSet rs) throws SQLException {
-    while(rs.next()) {
+  private static void assertAllColumnsAreLongButBigIntIsBigDecimal(ResultSet rs)
+      throws SQLException {
+    while (rs.next()) {
       assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
       assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
       assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
@@ -998,13 +999,14 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
-  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property introduced after version 3.15.0.
+  // Test setting new connection property jdbc_arrow_treat_decimal_as_int=false. Connection property
+  // introduced after version 3.15.0.
   @Test
   public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntFalse() throws SQLException {
     Properties properties = new Properties();
     properties.put("jdbc_arrow_treat_decimal_as_int", false);
     try (Connection con = getConnection(properties);
-         Statement stmt = con.createStatement()) {
+        Statement stmt = con.createStatement()) {
       stmt.execute("alter session set jdbc_query_result_format = 'ARROW'");
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
@@ -1022,18 +1024,19 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
-  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true. Connection property introduced after version 3.15.0.
+  // Test default setting of new connection property jdbc_arrow_treat_decimal_as_int=true.
+  // Connection property introduced after version 3.15.0.
   @Test
   public void testGetObjectForArrowResultFormatJDBCArrowDecimalAsIntTrue() throws SQLException {
     try (Connection con = BaseJDBCTest.getConnection();
-         Statement stmt = con.createStatement()) {
+        Statement stmt = con.createStatement()) {
       stmt.execute("alter session set jdbc_query_result_format = 'ARROW'");
       stmt.execute(createTableSql);
       stmt.execute(insertStmt);
 
       // Test with jdbc_arrow_treat_decimal_as_int=true and JDBC_TREAT_DECIMAL_AS_INT=true
       try (ResultSet rs = stmt.executeQuery(selectQuery)) {
-        while(rs.next()) {
+        while (rs.next()) {
           assertEquals("class java.lang.Long", rs.getObject(1).getClass().toString());
           assertEquals("class java.math.BigDecimal", rs.getObject(2).getClass().toString());
           assertEquals("class java.lang.Long", rs.getObject(3).getClass().toString());
@@ -1049,7 +1052,8 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
-  // Test getObject for numeric types when JDBC_TREAT_DECIMAL_AS_INT is set and using JSON result format.
+  // Test getObject for numeric types when JDBC_TREAT_DECIMAL_AS_INT is set and using JSON result
+  // format.
   @Test
   public void testGetObjectForJSONResultFormatJDBCDecimalAsIntFalse() throws SQLException {
     try (Connection con = BaseJDBCTest.getConnection();


### PR DESCRIPTION
# Overview

SNOW-1170182

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

[   Fixes #NNNN ](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/889)


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Added new connection property jdbc_arrow_treat_decimal_as_int to allow for resultSet.getObject for certain numeric types to report the object class more consistently. 
