### PR TITLE
SNOW-1256247: Fix testPrivateKeyInConnectionString in ConnectionLatestIT Test

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -828,7 +828,7 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       connection = DriverManager.getConnection(uri, properties);
       fail();
     } catch (SQLException e) {
-      assertEquals(390144, e.getErrorCode());
+      assertEquals(394304, e.getErrorCode());
     }
     connection.close();
 


### PR DESCRIPTION
The private key mismatch error code returned changed from 390144: JWT_TOKEN_INVALID to
394304: JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH
