### PR TITLE
SNOW-1270256 - Concurrency bug around ResultSet and Session parameters

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -599,7 +599,7 @@ public class SnowflakeResultSetSerializableV1
     resultSetSerializable.parameters =
         SessionUtil.getCommonParams(rootNode.path("data").path("parameters"));
     if (resultSetSerializable.parameters.isEmpty()) {
-      resultSetSerializable.parameters = sfSession.getCommonParameters();
+      resultSetSerializable.parameters = new HashMap<>(sfSession.getCommonParameters());
       resultSetSerializable.setStatemementLevelParameters(sfStatement.getStatementParameters());
     }
 


### PR DESCRIPTION
# Overview

SNOW-1270256

## Pre-review self checklist
- [X] PR branch is updated with all the changes from `master` branch
- [X] The code is correctly formatted (run `mvn -P check-style validate`)
- [X] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [X] The pull request name is prefixed with `SNOW-XXXX: `

This change fixes ConcurrentModificationException when one thread updates parameters (line 603, right below the changed line) and another iterates over the session parameters. The code itself is not supposed to update the session parameters in the first place, so it must make a copy (the fix) instead of referencing the session's parameters map directly.