### PR TITLE
SNOW-928973: Date field is returning one day less when getting through getString method

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
@@ -238,7 +238,11 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
   }
 
   public Date getDate(int columnIndex) throws SFException {
-    return getDate(columnIndex, this.getSession().getUseSessionTimezone() ? this.getSessionTimeZone() : TimeZone.getDefault());
+    return getDate(
+        columnIndex,
+        this.getSession().getUseSessionTimezone()
+            ? this.getSessionTimeZone()
+            : TimeZone.getDefault());
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
@@ -233,7 +233,7 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
   }
 
   public Date getDate(int columnIndex) throws SFException {
-    return getDate(columnIndex, TimeZone.getTimeZone("UTC"));
+    return getDate(columnIndex, this.getSession().getUseSessionTimezone() ? this.getSessionTimeZone() : TimeZone.getDefault());
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
@@ -233,7 +233,7 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
   }
 
   public Date getDate(int columnIndex) throws SFException {
-    return getDate(columnIndex, TimeZone.getDefault());
+    return getDate(columnIndex, TimeZone.getTimeZone("UTC"));
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/arrow/DateConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/DateConverter.java
@@ -21,9 +21,14 @@ import org.apache.arrow.vector.ValueVector;
 public class DateConverter extends AbstractArrowVectorConverter {
   private DateDayVector dateVector;
   private static TimeZone timeZoneUTC = TimeZone.getTimeZone("UTC");
-
   private boolean useDateFormat;
 
+  public DateConverter(ValueVector fieldVector, int columnIndex, DataConversionContext context) {
+    super(SnowflakeType.DATE.name(), fieldVector, columnIndex, context);
+    this.dateVector = (DateDayVector) fieldVector;
+    this.useDateFormat = false;
+  }
+  
   public DateConverter(
       ValueVector fieldVector,
       int columnIndex,

--- a/src/main/java/net/snowflake/client/core/arrow/DateConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/DateConverter.java
@@ -24,7 +24,11 @@ public class DateConverter extends AbstractArrowVectorConverter {
 
   private boolean useDateFormat;
 
-  public DateConverter(ValueVector fieldVector, int columnIndex, DataConversionContext context, boolean useDateFormat) {
+  public DateConverter(
+      ValueVector fieldVector,
+      int columnIndex,
+      DataConversionContext context,
+      boolean useDateFormat) {
     super(SnowflakeType.DATE.name(), fieldVector, columnIndex, context);
     this.dateVector = (DateDayVector) fieldVector;
     this.useDateFormat = useDateFormat;
@@ -102,16 +106,20 @@ public class DateConverter extends AbstractArrowVectorConverter {
     if (context.getDateFormatter() == null) {
       throw new SFException(ErrorCode.INTERNAL_ERROR, "missing date formatter");
     }
-    Date date = getDate(
-      index,
-      this.useSessionTimezone ? this.sessionTimeZone : TimeZone.getDefault(),
-      this.useDateFormat);
+    Date date =
+        getDate(
+            index,
+            this.useSessionTimezone ? this.sessionTimeZone : TimeZone.getDefault(),
+            this.useDateFormat);
     return date == null ? null : ResultUtil.getDateAsString(date, context.getDateFormatter());
   }
 
   @Override
   public Object toObject(int index) throws SFException {
-    return toDate(index, this.useSessionTimezone ? this.sessionTimeZone : TimeZone.getDefault(), this.useDateFormat);
+    return toDate(
+        index,
+        this.useSessionTimezone ? this.sessionTimeZone : TimeZone.getDefault(),
+        this.useDateFormat);
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/arrow/DateConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/DateConverter.java
@@ -28,7 +28,7 @@ public class DateConverter extends AbstractArrowVectorConverter {
     this.dateVector = (DateDayVector) fieldVector;
     this.useDateFormat = false;
   }
-  
+
   public DateConverter(
       ValueVector fieldVector,
       int columnIndex,

--- a/src/main/java/net/snowflake/client/core/json/StringConverter.java
+++ b/src/main/java/net/snowflake/client/core/json/StringConverter.java
@@ -108,7 +108,7 @@ public class StringConverter {
     Date date =
         converters
             .getDateTimeConverter()
-            .getDate(obj, columnType, columnSubType, TimeZone.getDefault(), scale);
+            .getDate(obj, columnType, columnSubType, TimeZone.getTimeZone("UTC"), scale);
 
     if (dateFormatter == null) {
       throw new SFException(ErrorCode.INTERNAL_ERROR, "missing date formatter");

--- a/src/main/java/net/snowflake/client/core/json/StringConverter.java
+++ b/src/main/java/net/snowflake/client/core/json/StringConverter.java
@@ -108,7 +108,11 @@ public class StringConverter {
     Date date =
         converters
             .getDateTimeConverter()
-            .getDate(obj, columnType, columnSubType, TimeZone.getTimeZone("UTC"), scale);
+            .getDate(obj,
+              columnType,
+              columnSubType,
+              this.session.getUseSessionTimezone() ? sessionTimeZone : TimeZone.getDefault(),
+              scale);
 
     if (dateFormatter == null) {
       throw new SFException(ErrorCode.INTERNAL_ERROR, "missing date formatter");

--- a/src/main/java/net/snowflake/client/core/json/StringConverter.java
+++ b/src/main/java/net/snowflake/client/core/json/StringConverter.java
@@ -108,11 +108,12 @@ public class StringConverter {
     Date date =
         converters
             .getDateTimeConverter()
-            .getDate(obj,
-              columnType,
-              columnSubType,
-              this.session.getUseSessionTimezone() ? sessionTimeZone : TimeZone.getDefault(),
-              scale);
+            .getDate(
+                obj,
+                columnType,
+                columnSubType,
+                this.session.getUseSessionTimezone() ? sessionTimeZone : TimeZone.getDefault(),
+                scale);
 
     if (dateFormatter == null) {
       throw new SFException(ErrorCode.INTERNAL_ERROR, "missing date formatter");

--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -238,7 +238,7 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
             break;
 
           case DATE:
-            converters.add(new DateConverter(vector, i, context));
+            converters.add(new DateConverter(vector, i, context, context.getSession().getFormatDateWithTimezone()));
             break;
 
           case FIXED:

--- a/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
+++ b/src/main/java/net/snowflake/client/jdbc/ArrowResultChunk.java
@@ -238,7 +238,9 @@ public class ArrowResultChunk extends SnowflakeResultChunk {
             break;
 
           case DATE:
-            converters.add(new DateConverter(vector, i, context, context.getSession().getFormatDateWithTimezone()));
+            converters.add(
+                new DateConverter(
+                    vector, i, context, context.getSession().getFormatDateWithTimezone()));
             break;
 
           case FIXED:

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -136,8 +136,10 @@ public abstract class SnowflakeBaseResultSet implements ResultSet {
   public Date getDate(int columnIndex) throws SQLException {
     raiseSQLExceptionIfResultSetIsClosed();
     return getDate(
-      columnIndex,
-      this.session.getUseSessionTimezone() ? sfBaseResultSet.getSessionTimeZone() : TimeZone.getDefault());
+        columnIndex,
+        this.session.getUseSessionTimezone()
+            ? sfBaseResultSet.getSessionTimeZone()
+            : TimeZone.getDefault());
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
@@ -30,13 +30,13 @@ public class DateConverterTest extends BaseConverterTest {
   @Parameterized.Parameters
   public static Object[][] data() {
     return new Object[][] {
-            {"UTC"},
-            {"America/Los_Angeles"},
-            {"America/New_York"},
-            {"Pacific/Honolulu"},
-            {"Asia/Singapore"},
-            {"MEZ"},
-            {"MESZ"}
+      {"UTC"},
+      {"America/Los_Angeles"},
+      {"America/New_York"},
+      {"Pacific/Honolulu"},
+      {"Asia/Singapore"},
+      {"MEZ"},
+      {"MESZ"}
     };
   }
 
@@ -53,15 +53,15 @@ public class DateConverterTest extends BaseConverterTest {
   int[] testDates = {-8865, -719162, -354285, -244712, -208156, -171664, -135107, 0, 16911};
 
   String[] expectedDates = {
-          "1945-09-24",
-          "0001-01-01",
-          "1000-01-01",
-          "1300-01-01",
-          "1400-02-02",
-          "1500-01-01",
-          "1600-02-03",
-          "1970-01-01",
-          "2016-04-20"
+    "1945-09-24",
+    "0001-01-01",
+    "1000-01-01",
+    "1300-01-01",
+    "1400-02-02",
+    "1500-01-01",
+    "1600-02-03",
+    "1970-01-01",
+    "2016-04-20"
   };
 
   public static final int MILLIS_IN_ONE_HOUR = 3600000;
@@ -73,7 +73,7 @@ public class DateConverterTest extends BaseConverterTest {
     Set<Integer> nullValIndex = new HashSet<>();
     // test normal date
     FieldType fieldType =
-            new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
+        new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
 
     DateDayVector vector = new DateDayVector("date", fieldType, allocator);
     int i = 0, j = 0;
@@ -102,7 +102,7 @@ public class DateConverterTest extends BaseConverterTest {
         assertTrue(converter.isNull(j));
       }
       Object oldObj =
-              ArrowResultUtil.getDate(intVal, TimeZone.getTimeZone("UTC"), TimeZone.getDefault());
+          ArrowResultUtil.getDate(intVal, TimeZone.getTimeZone("UTC"), TimeZone.getDefault());
       if (nullValIndex.contains(j)) {
         assertThat(intVal, is(0));
         assertThat(obj, is(nullValue()));
@@ -132,7 +132,7 @@ public class DateConverterTest extends BaseConverterTest {
     Set<Integer> nullValIndex = new HashSet<>();
     // test normal date
     FieldType fieldType =
-            new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
+        new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
 
     DateDayVector vector = new DateDayVector("date", fieldType, allocator);
     int[] rawDates = new int[rowCount];
@@ -173,7 +173,7 @@ public class DateConverterTest extends BaseConverterTest {
     customFieldMeta.put("logicalType", "DATE");
     // test normal date
     FieldType fieldType =
-            new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
+        new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
 
     DateDayVector vector = new DateDayVector("date", fieldType, allocator);
 
@@ -186,10 +186,10 @@ public class DateConverterTest extends BaseConverterTest {
     converter.setSessionTimeZone(TimeZone.getTimeZone(System.getProperty("user.timezone")));
     Object obj = converter.toObject(0);
     Object utcObj =
-            ArrowResultUtil.getDate(
-                    testDay,
-                    TimeZone.getTimeZone("UTC"),
-                    TimeZone.getTimeZone(System.getProperty("user.timezone")));
+        ArrowResultUtil.getDate(
+            testDay,
+            TimeZone.getTimeZone("UTC"),
+            TimeZone.getTimeZone(System.getProperty("user.timezone")));
 
     String tz = System.getProperty("user.timezone");
     switch (System.getProperty("user.timezone")) {
@@ -202,25 +202,25 @@ public class DateConverterTest extends BaseConverterTest {
         assertThat(obj.toString(), is("2016-04-20"));
         assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(
-                ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (7 * MILLIS_IN_ONE_HOUR)));
+            ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (7 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("America/New_York"):
         assertThat(obj.toString(), is("2016-04-20"));
         assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(
-                ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (4 * MILLIS_IN_ONE_HOUR)));
+            ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (4 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("Pacific/Honolulu"):
         assertThat(obj.toString(), is("2016-04-20"));
         assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(
-                ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (10 * MILLIS_IN_ONE_HOUR)));
+            ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (10 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("Asia/Singapore"):
         assertThat(obj.toString(), is("2016-04-20"));
         assertThat(utcObj.toString(), is("2016-04-19"));
         assertThat(
-                ((Date) obj).getTime(), is(((Date) utcObj).getTime() + (8 * MILLIS_IN_ONE_HOUR)));
+            ((Date) obj).getTime(), is(((Date) utcObj).getTime() + (8 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("MEZ"):
         assertThat(obj.toString(), is("2016-04-20"));

--- a/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
@@ -30,13 +30,13 @@ public class DateConverterTest extends BaseConverterTest {
   @Parameterized.Parameters
   public static Object[][] data() {
     return new Object[][] {
-      {"UTC"},
-      {"America/Los_Angeles"},
-      {"America/New_York"},
-      {"Pacific/Honolulu"},
-      {"Asia/Singapore"},
-      {"MEZ"},
-      {"MESZ"}
+            {"UTC"},
+            {"America/Los_Angeles"},
+            {"America/New_York"},
+            {"Pacific/Honolulu"},
+            {"Asia/Singapore"},
+            {"MEZ"},
+            {"MESZ"}
     };
   }
 
@@ -53,15 +53,15 @@ public class DateConverterTest extends BaseConverterTest {
   int[] testDates = {-8865, -719162, -354285, -244712, -208156, -171664, -135107, 0, 16911};
 
   String[] expectedDates = {
-    "1945-09-24",
-    "0001-01-01",
-    "1000-01-01",
-    "1300-01-01",
-    "1400-02-02",
-    "1500-01-01",
-    "1600-02-03",
-    "1970-01-01",
-    "2016-04-20"
+          "1945-09-24",
+          "0001-01-01",
+          "1000-01-01",
+          "1300-01-01",
+          "1400-02-02",
+          "1500-01-01",
+          "1600-02-03",
+          "1970-01-01",
+          "2016-04-20"
   };
 
   public static final int MILLIS_IN_ONE_HOUR = 3600000;
@@ -73,7 +73,7 @@ public class DateConverterTest extends BaseConverterTest {
     Set<Integer> nullValIndex = new HashSet<>();
     // test normal date
     FieldType fieldType =
-        new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
+            new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
 
     DateDayVector vector = new DateDayVector("date", fieldType, allocator);
     int i = 0, j = 0;
@@ -102,7 +102,7 @@ public class DateConverterTest extends BaseConverterTest {
         assertTrue(converter.isNull(j));
       }
       Object oldObj =
-          ArrowResultUtil.getDate(intVal, TimeZone.getTimeZone("UTC"), TimeZone.getDefault());
+              ArrowResultUtil.getDate(intVal, TimeZone.getTimeZone("UTC"), TimeZone.getDefault());
       if (nullValIndex.contains(j)) {
         assertThat(intVal, is(0));
         assertThat(obj, is(nullValue()));
@@ -132,7 +132,7 @@ public class DateConverterTest extends BaseConverterTest {
     Set<Integer> nullValIndex = new HashSet<>();
     // test normal date
     FieldType fieldType =
-        new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
+            new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
 
     DateDayVector vector = new DateDayVector("date", fieldType, allocator);
     int[] rawDates = new int[rowCount];
@@ -173,7 +173,7 @@ public class DateConverterTest extends BaseConverterTest {
     customFieldMeta.put("logicalType", "DATE");
     // test normal date
     FieldType fieldType =
-        new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
+            new FieldType(true, Types.MinorType.DATEDAY.getType(), null, customFieldMeta);
 
     DateDayVector vector = new DateDayVector("date", fieldType, allocator);
 
@@ -185,49 +185,42 @@ public class DateConverterTest extends BaseConverterTest {
     converter.setSessionTimeZone(TimeZone.getTimeZone(System.getProperty("user.timezone")));
     Object obj = converter.toObject(0);
     Object utcObj =
-        ArrowResultUtil.getDate(
-            testDay,
-            TimeZone.getTimeZone("UTC"),
-            TimeZone.getTimeZone(System.getProperty("user.timezone")));
+            ArrowResultUtil.getDate(
+                    testDay,
+                    TimeZone.getTimeZone("UTC"),
+                    TimeZone.getTimeZone(System.getProperty("user.timezone")));
 
     String tz = System.getProperty("user.timezone");
     switch (System.getProperty("user.timezone")) {
       case ("UTC"):
-        assertThat(obj.toString(), is("2016-04-19"));
         assertThat(utcObj.toString(), is("2016-04-19"));
         assertThat(((Date) obj).getTime(), is(((Date) utcObj).getTime()));
         break;
       case ("America/Los_Angeles"):
-        assertThat(obj.toString(), is("2016-04-19"));
         assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(
-            ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (7 * MILLIS_IN_ONE_HOUR)));
+                ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (7 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("America/New_York"):
-        assertThat(obj.toString(), is("2016-04-19"));
         assertThat(utcObj.toString(), is("2016-04-19"));
         assertThat(
-            ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (4 * MILLIS_IN_ONE_HOUR)));
+                ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (4 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("Pacific/Honolulu"):
-        assertThat(obj.toString(), is("2016-04-19"));
         assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(
-            ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (10 * MILLIS_IN_ONE_HOUR)));
+                ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (10 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("Asia/Singapore"):
-        assertThat(obj.toString(), is("2016-04-19"));
         assertThat(utcObj.toString(), is("2016-04-19"));
         assertThat(
-            ((Date) obj).getTime(), is(((Date) utcObj).getTime() + (8 * MILLIS_IN_ONE_HOUR)));
+                ((Date) obj).getTime(), is(((Date) utcObj).getTime() + (8 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("MEZ"):
-        assertThat(obj.toString(), is("2016-04-19"));
         assertThat(utcObj.toString(), is("2016-04-19"));
         assertThat(((Date) obj).getTime(), is(((Date) utcObj).getTime()));
         break;
       case ("MESZ"):
-        assertThat(obj.toString(), is("2016-04-19"));
         assertThat(utcObj.toString(), is("2016-04-19"));
         assertThat(((Date) obj).getTime(), is(((Date) utcObj).getTime()));
         break;

--- a/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
@@ -3,7 +3,9 @@ package net.snowflake.client.core.arrow;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.sql.Date;
 import java.util.HashMap;
@@ -28,7 +30,7 @@ public class DateConverterTest extends BaseConverterTest {
   @Parameterized.Parameters
   public static Object[][] data() {
     return new Object[][] {
-      // {"UTC"},
+      {"UTC"},
       {"America/Los_Angeles"},
       {"America/New_York"},
       {"Pacific/Honolulu"},

--- a/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/DateConverterTest.java
@@ -180,6 +180,7 @@ public class DateConverterTest extends BaseConverterTest {
     vector.setSafe(0, testDay);
 
     // Test JDBC_FORMAT_DATE_WITH_TIMEZONE=TRUE with different session timezones
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     ArrowVectorConverter converter = new DateConverter(vector, 0, this, true);
     converter.setUseSessionTimezone(true);
     converter.setSessionTimeZone(TimeZone.getTimeZone(System.getProperty("user.timezone")));
@@ -193,35 +194,42 @@ public class DateConverterTest extends BaseConverterTest {
     String tz = System.getProperty("user.timezone");
     switch (System.getProperty("user.timezone")) {
       case ("UTC"):
-        assertThat(utcObj.toString(), is("2016-04-19"));
+        assertThat(obj.toString(), is("2016-04-20"));
+        assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(((Date) obj).getTime(), is(((Date) utcObj).getTime()));
         break;
       case ("America/Los_Angeles"):
+        assertThat(obj.toString(), is("2016-04-20"));
         assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(
                 ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (7 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("America/New_York"):
-        assertThat(utcObj.toString(), is("2016-04-19"));
+        assertThat(obj.toString(), is("2016-04-20"));
+        assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(
                 ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (4 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("Pacific/Honolulu"):
+        assertThat(obj.toString(), is("2016-04-20"));
         assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(
                 ((Date) obj).getTime(), is(((Date) utcObj).getTime() - (10 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("Asia/Singapore"):
+        assertThat(obj.toString(), is("2016-04-20"));
         assertThat(utcObj.toString(), is("2016-04-19"));
         assertThat(
                 ((Date) obj).getTime(), is(((Date) utcObj).getTime() + (8 * MILLIS_IN_ONE_HOUR)));
         break;
       case ("MEZ"):
-        assertThat(utcObj.toString(), is("2016-04-19"));
+        assertThat(obj.toString(), is("2016-04-20"));
+        assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(((Date) obj).getTime(), is(((Date) utcObj).getTime()));
         break;
       case ("MESZ"):
-        assertThat(utcObj.toString(), is("2016-04-19"));
+        assertThat(obj.toString(), is("2016-04-20"));
+        assertThat(utcObj.toString(), is("2016-04-20"));
         assertThat(((Date) obj).getTime(), is(((Date) utcObj).getTime()));
         break;
       default:


### PR DESCRIPTION
SNOW-928973: Date field is returning one day less when getting through getString method

Fixes date field issue by setting timezone to UTC when converting from date to string and objects. For [761](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/761)