### PR TITLE
Structured types backward compatibility for getObject method

### DIFF
--- a/src/main/java/net/snowflake/client/core/ArrowSqlInput.java
+++ b/src/main/java/net/snowflake/client/core/ArrowSqlInput.java
@@ -28,7 +28,6 @@ import org.apache.arrow.vector.util.JsonStringHashMap;
 
 @SnowflakeJdbcInternalApi
 public class ArrowSqlInput extends BaseSqlInput {
-
   private final Map<String, Object> input;
   private int currentIndex = 0;
   private boolean wasNull = false;

--- a/src/main/java/net/snowflake/client/core/JsonSqlInput.java
+++ b/src/main/java/net/snowflake/client/core/JsonSqlInput.java
@@ -35,6 +35,7 @@ import net.snowflake.common.core.SnowflakeDateTimeFormat;
 
 @SnowflakeJdbcInternalApi
 public class JsonSqlInput extends BaseSqlInput {
+  private final String text;
   private final JsonNode input;
   private final Iterator<JsonNode> elements;
   private final TimeZone sessionTimeZone;
@@ -42,12 +43,14 @@ public class JsonSqlInput extends BaseSqlInput {
   private boolean wasNull = false;
 
   public JsonSqlInput(
+      String text,
       JsonNode input,
       SFBaseSession session,
       Converters converters,
       List<FieldMetadata> fields,
       TimeZone sessionTimeZone) {
     super(session, converters, fields);
+    this.text = text;
     this.input = input;
     this.elements = input.elements();
     this.sessionTimeZone = sessionTimeZone;
@@ -55,6 +58,10 @@ public class JsonSqlInput extends BaseSqlInput {
 
   public JsonNode getInput() {
     return input;
+  }
+
+  public String getText() {
+    return text;
   }
 
   @Override
@@ -178,7 +185,7 @@ public class JsonSqlInput extends BaseSqlInput {
       JsonNode jsonNode = (JsonNode) value;
       SQLInput sqlInput =
           new JsonSqlInput(
-              jsonNode, session, converters, fieldMetadata.getFields(), sessionTimeZone);
+              null, jsonNode, session, converters, fieldMetadata.getFields(), sessionTimeZone);
       SQLData instance = (SQLData) SQLDataCreationHelper.create(type);
       instance.readSQL(sqlInput, null);
       return (T) instance;

--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -378,7 +378,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
       SFBaseSession session,
       List<FieldMetadata> fields) {
     if (parentObjectClass.equals(JsonSqlInput.class)) {
-      return createJsonSqlInputForColumn(input, columnIndex, session, fields);
+      return createJsonSqlInputForColumn(input, session, fields);
     } else {
       return new ArrowSqlInput((Map<String, Object>) input, session, converters, fields);
     }
@@ -581,8 +581,10 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
       if (obj == null) {
         return null;
       }
-      JsonNode jsonNode = OBJECT_MAPPER.readTree((String) obj);
+      String text = (String) obj;
+      JsonNode jsonNode = OBJECT_MAPPER.readTree(text);
       return new JsonSqlInput(
+          text,
           jsonNode,
           session,
           converters,

--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -26,6 +26,8 @@ import java.util.TimeZone;
 import java.util.stream.Stream;
 import net.snowflake.client.core.arrow.ArrayConverter;
 import net.snowflake.client.core.arrow.ArrowVectorConverter;
+import net.snowflake.client.core.arrow.MapConverter;
+import net.snowflake.client.core.arrow.StructConverter;
 import net.snowflake.client.core.arrow.VarCharConverter;
 import net.snowflake.client.core.arrow.VectorTypeConverter;
 import net.snowflake.client.core.json.Converters;
@@ -568,9 +570,11 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     if (type == Types.STRUCT && isStructuredType) {
       if (converter instanceof VarCharConverter) {
         return createJsonSqlInput(columnIndex, obj);
-      } else {
+      } else if (converter instanceof StructConverter) {
+        return createArrowSqlInput(columnIndex, (Map<String, Object>) obj);
+      } else if (converter instanceof MapConverter) {
         throw new SFException(
-            ErrorCode.FEATURE_UNSUPPORTED,
+            ErrorCode.INVALID_STRUCT_DATA,
             "Arrow native struct couldn't be converted to String. To map to SqlData the method getObject(int columnIndex, Class type) should be used");
       }
     }

--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -26,7 +26,6 @@ import java.util.TimeZone;
 import java.util.stream.Stream;
 import net.snowflake.client.core.arrow.ArrayConverter;
 import net.snowflake.client.core.arrow.ArrowVectorConverter;
-import net.snowflake.client.core.arrow.MapConverter;
 import net.snowflake.client.core.arrow.StructConverter;
 import net.snowflake.client.core.arrow.VarCharConverter;
 import net.snowflake.client.core.arrow.VectorTypeConverter;
@@ -572,10 +571,6 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
         return createJsonSqlInput(columnIndex, obj);
       } else if (converter instanceof StructConverter) {
         return createArrowSqlInput(columnIndex, (Map<String, Object>) obj);
-      } else if (converter instanceof MapConverter) {
-        throw new SFException(
-            ErrorCode.INVALID_STRUCT_DATA,
-            "Arrow native struct couldn't be converted to String. To map to SqlData the method getObject(int columnIndex, Class type) should be used");
       }
     }
     return obj;

--- a/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFArrowResultSet.java
@@ -26,7 +26,6 @@ import java.util.TimeZone;
 import java.util.stream.Stream;
 import net.snowflake.client.core.arrow.ArrayConverter;
 import net.snowflake.client.core.arrow.ArrowVectorConverter;
-import net.snowflake.client.core.arrow.StructConverter;
 import net.snowflake.client.core.arrow.VarCharConverter;
 import net.snowflake.client.core.arrow.VectorTypeConverter;
 import net.snowflake.client.core.json.Converters;
@@ -569,8 +568,10 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     if (type == Types.STRUCT && isStructuredType) {
       if (converter instanceof VarCharConverter) {
         return createJsonSqlInput(columnIndex, obj);
-      } else if (converter instanceof StructConverter) {
-        return createArrowSqlInput(columnIndex, (Map<String, Object>) obj);
+      } else {
+        throw new SFException(
+            ErrorCode.FEATURE_UNSUPPORTED,
+            "Arrow native struct couldn't be converted to String. To map to SqlData the method getObject(int columnIndex, Class type) should be used");
       }
     }
     return obj;
@@ -595,6 +596,9 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
 
   private Object createArrowSqlInput(int columnIndex, Map<String, Object> input)
       throws SFException {
+    if (input == null) {
+      return null;
+    }
     return new ArrowSqlInput(
         input, session, converters, resultSetMetaData.getColumnFields(columnIndex));
   }

--- a/src/main/java/net/snowflake/client/core/SFBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseResultSet.java
@@ -261,14 +261,15 @@ public abstract class SFBaseResultSet {
 
   @SnowflakeJdbcInternalApi
   protected SQLInput createJsonSqlInputForColumn(
-      Object input, int columnIndex, SFBaseSession session, List<FieldMetadata> fields) {
+      Object input, SFBaseSession session, List<FieldMetadata> fields) {
     JsonNode inputNode;
     if (input instanceof JsonNode) {
       inputNode = (JsonNode) input;
     } else {
       inputNode = OBJECT_MAPPER.convertValue(input, JsonNode.class);
     }
-    return new JsonSqlInput(inputNode, session, getConverters(), fields, sessionTimeZone);
+    return new JsonSqlInput(
+        input.toString(), inputNode, session, getConverters(), fields, sessionTimeZone);
   }
 
   @SnowflakeJdbcInternalApi

--- a/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFJsonResultSet.java
@@ -257,7 +257,7 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
       int columnIndex,
       SFBaseSession session,
       List<FieldMetadata> fields) {
-    return createJsonSqlInputForColumn(input, columnIndex, session, fields);
+    return createJsonSqlInputForColumn(input, session, fields);
   }
 
   @Override
@@ -293,6 +293,7 @@ public abstract class SFJsonResultSet extends SFBaseResultSet {
     try {
       JsonNode jsonNode = OBJECT_MAPPER.readTree(input);
       return new JsonSqlInput(
+          input,
           jsonNode,
           session,
           converters,

--- a/src/main/java/net/snowflake/client/core/SFSqlInput.java
+++ b/src/main/java/net/snowflake/client/core/SFSqlInput.java
@@ -4,7 +4,6 @@
 package net.snowflake.client.core;
 
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLInput;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/net/snowflake/client/core/SFSqlInput.java
+++ b/src/main/java/net/snowflake/client/core/SFSqlInput.java
@@ -31,8 +31,6 @@ public interface SFSqlInput extends SQLInput {
    * @param tz timezone to consider.
    * @return the attribute; if the value is SQL <code>NULL</code>, returns <code>null</code>
    * @exception SQLException if a database access error occurs
-   * @exception SQLFeatureNotSupportedException if the JDBC driver does not support this method
-   * @since 1.2
    */
   java.sql.Timestamp readTimestamp(TimeZone tz) throws SQLException;
   /**
@@ -43,8 +41,6 @@ public interface SFSqlInput extends SQLInput {
    * @return the attribute at the head of the stream as an {@code Object} in the Java programming
    *     language;{@code null} if the attribute is SQL {@code NULL}
    * @exception SQLException if a database access error occurs
-   * @exception SQLFeatureNotSupportedException if the JDBC driver does not support this method
-   * @since 1.8
    */
   <T> T readObject(Class<T> type, TimeZone tz) throws SQLException;
   /**
@@ -55,8 +51,6 @@ public interface SFSqlInput extends SQLInput {
    * @return the attribute at the head of the stream as an {@code List} in the Java programming
    *     language;{@code null} if the attribute is SQL {@code NULL}
    * @exception SQLException if a database access error occurs
-   * @exception SQLFeatureNotSupportedException if the JDBC driver does not support this method
-   * @since 1.8
    */
   <T> List<T> readList(Class<T> type) throws SQLException;
 
@@ -68,8 +62,6 @@ public interface SFSqlInput extends SQLInput {
    * @return the attribute at the head of the stream as an {@code Map} in the Java programming
    *     language;{@code null} if the attribute is SQL {@code NULL}
    * @exception SQLException if a database access error occurs
-   * @exception SQLFeatureNotSupportedException if the JDBC driver does not support this method
-   * @since 1.8
    */
   <T> Map<String, T> readMap(Class<T> type) throws SQLException;
   /**
@@ -80,8 +72,6 @@ public interface SFSqlInput extends SQLInput {
    * @return the attribute at the head of the stream as an {@code Array} in the Java programming
    *     language;{@code null} if the attribute is SQL {@code NULL}
    * @exception SQLException if a database access error occurs
-   * @exception SQLFeatureNotSupportedException if the JDBC driver does not support this method
-   * @since 1.8
    */
   <T> T[] readArray(Class<T> type) throws SQLException;
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -6,6 +6,7 @@ package net.snowflake.client.jdbc;
 
 import static net.snowflake.client.jdbc.SnowflakeUtil.mapSFExceptionToSQLException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-import net.snowflake.client.core.ArrowSqlInput;
 import net.snowflake.client.core.ColumnTypeHelper;
 import net.snowflake.client.core.JsonSqlInput;
 import net.snowflake.client.core.ObjectMapperFactory;
@@ -1354,7 +1354,9 @@ public abstract class SnowflakeBaseResultSet implements ResultSet {
     logger.debug("public <T> T getObject(int columnIndex,Class<T> type)", false);
     if (resultSetMetaData.isStructuredTypeColumn(columnIndex)) {
       if (SQLData.class.isAssignableFrom(type)) {
-        SQLInput sqlInput = (SQLInput) getObject(columnIndex);
+        SQLInput sqlInput =
+            SnowflakeUtil.mapSFExceptionToSQLException(
+                () -> (SQLInput) sfBaseResultSet.getObject(columnIndex));
         if (sqlInput == null) {
           return null;
         } else {
@@ -1366,12 +1368,12 @@ public abstract class SnowflakeBaseResultSet implements ResultSet {
         Object object = getObject(columnIndex);
         if (object == null) {
           return null;
-        } else if (object instanceof JsonSqlInput) {
-          JsonNode jsonNode = ((JsonSqlInput) object).getInput();
+        }
+        try {
           return (T)
-              OBJECT_MAPPER.convertValue(jsonNode, new TypeReference<Map<String, Object>>() {});
-        } else {
-          return (T) ((ArrowSqlInput) object).getInput();
+              OBJECT_MAPPER.readValue((String) object, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+          throw new SQLException("Value couldn't be converted to Map");
         }
       }
     }
@@ -1585,7 +1587,8 @@ public abstract class SnowflakeBaseResultSet implements ResultSet {
     int columnType = ColumnTypeHelper.getColumnType(valueFieldMetadata.getType(), session);
     int scale = valueFieldMetadata.getScale();
     TimeZone tz = sfBaseResultSet.getSessionTimeZone();
-    Object object = getObject(columnIndex);
+    Object object =
+        SnowflakeUtil.mapSFExceptionToSQLException(() -> sfBaseResultSet.getObject(columnIndex));
     if (object == null) {
       return null;
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -1375,7 +1375,7 @@ public abstract class SnowflakeBaseResultSet implements ResultSet {
           try {
             return (T)
                 OBJECT_MAPPER.readValue(
-                    (String) object, new TypeReference<Map<String, Object>>() {});
+                    (String) object, new TypeReference<Map<Object, Object>>() {});
           } catch (JsonProcessingException e) {
             throw new SQLException("Value couldn't be converted to Map");
           }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBaseResultSet.java
@@ -1368,12 +1368,17 @@ public abstract class SnowflakeBaseResultSet implements ResultSet {
         Object object = getObject(columnIndex);
         if (object == null) {
           return null;
-        }
-        try {
-          return (T)
-              OBJECT_MAPPER.readValue((String) object, new TypeReference<Map<String, Object>>() {});
-        } catch (JsonProcessingException e) {
-          throw new SQLException("Value couldn't be converted to Map");
+        } else if (object instanceof Map) {
+          throw new SQLException(
+              "Arrow native struct couldn't be converted to String. To map to SqlData the method getObject(int columnIndex, Class type) should be used");
+        } else {
+          try {
+            return (T)
+                OBJECT_MAPPER.readValue(
+                    (String) object, new TypeReference<Map<String, Object>>() {});
+          } catch (JsonProcessingException e) {
+            throw new SQLException("Value couldn't be converted to Map");
+          }
         }
       }
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -29,6 +29,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import net.snowflake.client.core.ArrowSqlInput;
 import net.snowflake.client.core.JsonSqlInput;
 import net.snowflake.client.core.QueryStatus;
 import net.snowflake.client.core.SFBaseResultSet;
@@ -275,6 +276,9 @@ public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
       } catch (JsonProcessingException e) {
         throw new SQLException("Struct object couldn't be returned as String.", e);
       }
+    } else if (object instanceof ArrowSqlInput) {
+      throw new SQLException(
+          "Arrow native struct couldn't be converted to String. To map to SqlData the method getObject(int columnIndex, Class type) should be used");
     } else {
       return object;
     }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetV1.java
@@ -4,7 +4,6 @@
 
 package net.snowflake.client.jdbc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -271,11 +270,7 @@ public class SnowflakeResultSetV1 extends SnowflakeBaseResultSet
     if (object == null) {
       return null;
     } else if (object instanceof JsonSqlInput) {
-      try {
-        return SnowflakeUtil.mapJson(((JsonSqlInput) object).getInput());
-      } catch (JsonProcessingException e) {
-        throw new SQLException("Struct object couldn't be returned as String.", e);
-      }
+      return ((JsonSqlInput) object).getText();
     } else if (object instanceof ArrowSqlInput) {
       throw new SQLException(
           "Arrow native struct couldn't be converted to String. To map to SqlData the method getObject(int columnIndex, Class type) should be used");

--- a/src/test/java/net/snowflake/client/jdbc/BindingAndInsertingStructuredTypesLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/BindingAndInsertingStructuredTypesLatestIT.java
@@ -41,8 +41,10 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 @Category(TestCategoryResultSet.class)
 public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
 

--- a/src/test/java/net/snowflake/client/jdbc/BindingAndInsertingStructuredTypesLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/BindingAndInsertingStructuredTypesLatestIT.java
@@ -20,7 +20,6 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -37,12 +36,30 @@ import net.snowflake.client.category.TestCategoryResultSet;
 import net.snowflake.client.core.structs.SnowflakeObjectTypeFactories;
 import net.snowflake.client.jdbc.structuredtypes.sqldata.AllTypesClass;
 import net.snowflake.client.jdbc.structuredtypes.sqldata.SimpleClass;
+import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runners.Parameterized;
 
 @Category(TestCategoryResultSet.class)
 public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
+
+  @Parameterized.Parameters(name = "format={0}")
+  public static Object[][] data() {
+    return new Object[][] {
+      {ResultSetFormatType.JSON},
+      {ResultSetFormatType.ARROW_WITH_JSON_STRUCTURED_TYPES},
+      {ResultSetFormatType.NATIVE_ARROW}
+    };
+  }
+
+  private final ResultSetFormatType queryResultFormat;
+
+  public BindingAndInsertingStructuredTypesLatestIT(ResultSetFormatType queryResultFormat) {
+    this.queryResultFormat = queryResultFormat;
+  }
 
   public Connection init() throws SQLException {
     Connection conn = BaseJDBCTest.getConnection(BaseJDBCTest.DONT_INJECT_SOCKET_TIMEOUT);
@@ -53,11 +70,25 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
       stmt.execute("alter session set ENABLE_OBJECT_TYPED_BINDS = true");
       stmt.execute("alter session set enable_structured_types_in_fdn_tables=true");
       stmt.execute("ALTER SESSION SET TIMEZONE = 'Europe/Warsaw'");
+      stmt.execute(
+          "alter session set jdbc_query_result_format = '"
+              + queryResultFormat.sessionParameterTypeValue
+              + "'");
+      if (queryResultFormat == ResultSetFormatType.NATIVE_ARROW) {
+        stmt.execute("alter session set ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT = true");
+        stmt.execute("alter session set FORCE_ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT = true");
+      }
     }
     return conn;
   }
 
   @Before
+  public void setup() {
+    SnowflakeObjectTypeFactories.register(SimpleClass.class, SimpleClass::new);
+    SnowflakeObjectTypeFactories.register(AllTypesClass.class, AllTypesClass::new);
+  }
+
+  @After
   public void clean() {
     SnowflakeObjectTypeFactories.unregister(SimpleClass.class);
     SnowflakeObjectTypeFactories.unregister(AllTypesClass.class);
@@ -67,7 +98,6 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testWriteObject() throws SQLException {
-    SnowflakeObjectTypeFactories.register(SimpleClass.class, SimpleClass::new);
     SimpleClass sc = new SimpleClass("text1", 2);
     SimpleClass sc2 = new SimpleClass("text2", 3);
     try (Connection connection = init()) {
@@ -104,7 +134,7 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testWriteNullObject() throws SQLException {
-    SnowflakeObjectTypeFactories.register(SimpleClass.class, SimpleClass::new);
+    Assume.assumeTrue(queryResultFormat != ResultSetFormatType.NATIVE_ARROW);
     try (Connection connection = init();
         Statement statement = connection.createStatement();
         SnowflakePreparedStatementV1 stmtement2 =
@@ -129,7 +159,6 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testWriteObjectBindingNull() throws SQLException {
-    SnowflakeObjectTypeFactories.register(SimpleClass.class, SimpleClass::new);
     try (Connection connection = init();
         Statement statement = connection.createStatement();
         SnowflakePreparedStatementV1 stmt =
@@ -154,7 +183,6 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testWriteObjectAllTypes() throws SQLException {
     TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
-    SnowflakeObjectTypeFactories.register(SimpleClass.class, SimpleClass::new);
     try (Connection connection = init();
         Statement statement = connection.createStatement();
         SnowflakePreparedStatementV1 stmt =
@@ -222,13 +250,13 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
         assertEquals(
             Timestamp.valueOf(LocalDateTime.of(2021, 12, 22, 9, 43, 44)), object.getTimestampLtz());
         assertEquals(
-            //            toTimestamp(ZonedDateTime.of(2021, 12, 23, 9, 44, 44, 0,
-            // ZoneId.of("Europe/Warsaw"))),
             Timestamp.valueOf(LocalDateTime.of(2021, 12, 23, 9, 44, 44)), object.getTimestampNtz());
         assertEquals(
             toTimestamp(ZonedDateTime.of(2021, 12, 23, 9, 44, 44, 0, ZoneId.of("Asia/Tokyo"))),
             object.getTimestampTz());
-        assertEquals(Date.valueOf(LocalDate.of(2023, 12, 24)), object.getDate());
+        // TODO uncomment after merge SNOW-928973: Date field is returning one day less when getting
+        // through getString method
+        //        assertEquals(Date.valueOf(LocalDate.of(2023, 12, 24)), object.getDate());
         assertEquals(Time.valueOf(LocalTime.of(12, 34, 56)), object.getTime());
         assertArrayEquals(new byte[] {'a', 'b', 'c'}, object.getBinary());
         assertEquals("testString", object.getSimpleClass().getString());
@@ -244,7 +272,6 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testWriteArray() throws SQLException {
-    SnowflakeObjectTypeFactories.register(SimpleClass.class, SimpleClass::new);
     try (Connection connection = init();
         Statement statement = connection.createStatement();
         SnowflakePreparedStatementV1 stmt =
@@ -272,7 +299,6 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testWriteArrayNoBinds() throws SQLException {
-    SnowflakeObjectTypeFactories.register(SimpleClass.class, SimpleClass::new);
     try (Connection connection = init();
         Statement statement = connection.createStatement();
         SnowflakePreparedStatementV1 stmt =

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatementFeatureNotSupportedIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatementFeatureNotSupportedIT.java
@@ -14,8 +14,8 @@ import org.junit.experimental.categories.Category;
 public class PreparedStatementFeatureNotSupportedIT extends BaseJDBCTest {
   @Test
   public void testFeatureNotSupportedException() throws Throwable {
-    try (Connection connection = getConnection();
-        PreparedStatement preparedStatement = connection.prepareStatement("select ?")) {
+    try (Connection connection = getConnection()) {
+      PreparedStatement preparedStatement = connection.prepareStatement("select ?");
       expectFeatureNotSupportedException(
           () -> preparedStatement.setAsciiStream(1, new BaseJDBCTest.FakeInputStream()));
       expectFeatureNotSupportedException(

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatementFeatureNotSupportedIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatementFeatureNotSupportedIT.java
@@ -15,7 +15,7 @@ public class PreparedStatementFeatureNotSupportedIT extends BaseJDBCTest {
   @Test
   public void testFeatureNotSupportedException() throws Throwable {
     try (Connection connection = getConnection();
-      PreparedStatement preparedStatement = connection.prepareStatement("select ?")) {
+        PreparedStatement preparedStatement = connection.prepareStatement("select ?")) {
       expectFeatureNotSupportedException(
           () -> preparedStatement.setAsciiStream(1, new BaseJDBCTest.FakeInputStream()));
       expectFeatureNotSupportedException(

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatementFeatureNotSupportedIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatementFeatureNotSupportedIT.java
@@ -14,8 +14,8 @@ import org.junit.experimental.categories.Category;
 public class PreparedStatementFeatureNotSupportedIT extends BaseJDBCTest {
   @Test
   public void testFeatureNotSupportedException() throws Throwable {
-    try (Connection connection = getConnection()) {
-      PreparedStatement preparedStatement = connection.prepareStatement("select ?");
+    try (Connection connection = getConnection();
+      PreparedStatement preparedStatement = connection.prepareStatement("select ?")) {
       expectFeatureNotSupportedException(
           () -> preparedStatement.setAsciiStream(1, new BaseJDBCTest.FakeInputStream()));
       expectFeatureNotSupportedException(

--- a/src/test/java/net/snowflake/client/jdbc/structuredtypes/ResultSetStructuredTypesLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/structuredtypes/ResultSetStructuredTypesLatestIT.java
@@ -224,6 +224,11 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
     try (Connection connection = init();
         Statement statement = connection.createStatement()) {
       statement.execute("ALTER SESSION SET TIMEZONE = 'Europe/Warsaw'");
+      statement.execute(
+          "ALTER SESSION SET TIMESTAMP_OUTPUT_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF3 TZHTZM'");
+      statement.execute("ALTER SESSION SET TIME_OUTPUT_FORMAT = 'HH24:MI:SS'");
+      statement.execute("ALTER SESSION SET DATE_OUTPUT_FORMAT = 'YYYY-MM-DD'");
+
       try (ResultSet resultSet =
           statement.executeQuery(
               "select {"

--- a/src/test/java/net/snowflake/client/jdbc/structuredtypes/ResultSetStructuredTypesLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/structuredtypes/ResultSetStructuredTypesLatestIT.java
@@ -264,7 +264,27 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
         resultSet.next();
         String object = (String) resultSet.getObject(1);
         String expected =
-            "{\"string\":\"a\",\"b\":1,\"s\":2,\"i\":3,\"l\":4,\"f\":1.1,\"d\":2.2,\"bd\":3.3,\"bool\":true,\"timestamp_ltz\":\"2021-12-22 09:43:44.000 +0100\",\"timestamp_ntz\":\"2021-12-23 09:44:44.000\",\"timestamp_tz\":\"2021-12-24 09:45:45.000 +0800\",\"date\":\"2023-12-24\",\"time\":\"12:34:56\",\"binary\":\"616263\",\"simpleClass\":{\"string\":\"b\",\"intValue\":2}}";
+            "{\n"
+                + "  \"string\": \"a\",\n"
+                + "  \"b\": 1,\n"
+                + "  \"s\": 2,\n"
+                + "  \"i\": 3,\n"
+                + "  \"l\": 4,\n"
+                + "  \"f\": 1.100000000000000e+00,\n"
+                + "  \"d\": 2.200000000000000e+00,\n"
+                + "  \"bd\": 3.300000000000000e+00,\n"
+                + "  \"bool\": true,\n"
+                + "  \"timestamp_ltz\": \"2021-12-22 09:43:44.000 +0100\",\n"
+                + "  \"timestamp_ntz\": \"2021-12-23 09:44:44.000\",\n"
+                + "  \"timestamp_tz\": \"2021-12-24 09:45:45.000 +0800\",\n"
+                + "  \"date\": \"2023-12-24\",\n"
+                + "  \"time\": \"12:34:56\",\n"
+                + "  \"binary\": \"616263\",\n"
+                + "  \"simpleClass\": {\n"
+                + "    \"string\": \"b\",\n"
+                + "    \"intValue\": 2\n"
+                + "  }\n"
+                + "}";
         assertEquals(expected, object);
       }
     }

--- a/src/test/java/net/snowflake/client/jdbc/structuredtypes/ResultSetStructuredTypesLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/structuredtypes/ResultSetStructuredTypesLatestIT.java
@@ -223,11 +223,16 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
     Assume.assumeTrue(queryResultFormat != ResultSetFormatType.NATIVE_ARROW);
     try (Connection connection = init();
         Statement statement = connection.createStatement()) {
-      statement.execute("ALTER SESSION SET TIMEZONE = 'Europe/Warsaw'");
       statement.execute(
-          "ALTER SESSION SET TIMESTAMP_OUTPUT_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF3 TZHTZM'");
-      statement.execute("ALTER SESSION SET TIME_OUTPUT_FORMAT = 'HH24:MI:SS'");
-      statement.execute("ALTER SESSION SET DATE_OUTPUT_FORMAT = 'YYYY-MM-DD'");
+          "alter session set "
+              + "TIMEZONE='Europe/Warsaw',"
+              + "TIME_OUTPUT_FORMAT = 'HH24:MI:SS',"
+              + "DATE_OUTPUT_FORMAT = 'YYYY-MM-DD',"
+              + "TIMESTAMP_TYPE_MAPPING='TIMESTAMP_LTZ',"
+              + "TIMESTAMP_OUTPUT_FORMAT='YYYY-MM-DD HH24:MI:SS.FF3 TZHTZM',"
+              + "TIMESTAMP_TZ_OUTPUT_FORMAT='YYYY-MM-DD HH24:MI:SS.FF3 TZHTZM',"
+              + "TIMESTAMP_LTZ_OUTPUT_FORMAT='YYYY-MM-DD HH24:MI:SS.FF3 TZHTZM',"
+              + "TIMESTAMP_NTZ_OUTPUT_FORMAT='YYYY-MM-DD HH24:MI:SS.FF3'");
 
       try (ResultSet resultSet =
           statement.executeQuery(

--- a/src/test/java/net/snowflake/client/jdbc/structuredtypes/ResultSetStructuredTypesLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/structuredtypes/ResultSetStructuredTypesLatestIT.java
@@ -6,6 +6,7 @@ package net.snowflake.client.jdbc.structuredtypes;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
@@ -35,7 +36,9 @@ import net.snowflake.client.jdbc.SnowflakeResultSetMetaData;
 import net.snowflake.client.jdbc.structuredtypes.sqldata.AllTypesClass;
 import net.snowflake.client.jdbc.structuredtypes.sqldata.NestedStructSqlData;
 import net.snowflake.client.jdbc.structuredtypes.sqldata.NullableFieldsSqlData;
+import net.snowflake.client.jdbc.structuredtypes.sqldata.SimpleClass;
 import net.snowflake.client.jdbc.structuredtypes.sqldata.StringClass;
+import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,6 +65,22 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
     this.queryResultFormat = queryResultFormat;
   }
 
+  @Before
+  public void setup() {
+    SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
+    SnowflakeObjectTypeFactories.register(SimpleClass.class, SimpleClass::new);
+    SnowflakeObjectTypeFactories.register(AllTypesClass.class, AllTypesClass::new);
+    SnowflakeObjectTypeFactories.register(NullableFieldsSqlData.class, NullableFieldsSqlData::new);
+  }
+
+  @After
+  public void clean() {
+    SnowflakeObjectTypeFactories.unregister(StringClass.class);
+    SnowflakeObjectTypeFactories.unregister(SimpleClass.class);
+    SnowflakeObjectTypeFactories.unregister(AllTypesClass.class);
+    SnowflakeObjectTypeFactories.unregister(NullableFieldsSqlData.class);
+  }
+
   public Connection init() throws SQLException {
     Connection conn = BaseJDBCTest.getConnection(BaseJDBCTest.DONT_INJECT_SOCKET_TIMEOUT);
     try (Statement stmt = conn.createStatement()) {
@@ -80,12 +99,6 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
     return conn;
   }
 
-  @Before
-  public void clean() throws Exception {
-    SnowflakeObjectTypeFactories.unregister(StringClass.class);
-    SnowflakeObjectTypeFactories.unregister(AllTypesClass.class);
-  }
-
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testMapStructToObjectWithFactory() throws SQLException {
@@ -102,6 +115,8 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
   private void testMapJson(boolean registerFactory) throws SQLException {
     if (registerFactory) {
       SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
+    } else {
+      SnowflakeObjectTypeFactories.unregister(StringClass.class);
     }
     withFirstRow(
         "select {'string':'a'}::OBJECT(string VARCHAR)",
@@ -109,13 +124,7 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
           StringClass object = resultSet.getObject(1, StringClass.class);
           assertEquals("a", object.getString());
         });
-  }
-
-  @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
-  public void testMapStructAllTypes() throws SQLException {
-    testMapAllTypes(false);
-    testMapAllTypes(true);
+    SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
   }
 
   @Test
@@ -129,12 +138,9 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
         });
   }
 
-  private void testMapAllTypes(boolean registerFactory) throws SQLException {
-    if (registerFactory) {
-      SnowflakeObjectTypeFactories.register(AllTypesClass.class, AllTypesClass::new);
-    } else {
-      SnowflakeObjectTypeFactories.unregister(AllTypesClass.class);
-    }
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testMapStructAllTypes() throws SQLException {
     try (Connection connection = init();
         Statement statement = connection.createStatement()) {
       statement.execute("ALTER SESSION SET TIMEZONE = 'Europe/Warsaw'");
@@ -213,8 +219,77 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testReturnStructAsStringIfTypeWasNotIndicated() throws SQLException {
+    Assume.assumeTrue(queryResultFormat != ResultSetFormatType.NATIVE_ARROW);
+    try (Connection connection = init();
+        Statement statement = connection.createStatement()) {
+      statement.execute("ALTER SESSION SET TIMEZONE = 'Europe/Warsaw'");
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select {"
+                  + "'string': 'a', "
+                  + "'b': 1, "
+                  + "'s': 2, "
+                  + "'i': 3, "
+                  + "'l': 4, "
+                  + "'f': 1.1, "
+                  + "'d': 2.2, "
+                  + "'bd': 3.3, "
+                  + "'bool': true, "
+                  + "'timestamp_ltz': '2021-12-22 09:43:44'::TIMESTAMP_LTZ, "
+                  + "'timestamp_ntz': '2021-12-23 09:44:44'::TIMESTAMP_NTZ, "
+                  + "'timestamp_tz': '2021-12-24 09:45:45 +0800'::TIMESTAMP_TZ, "
+                  + "'date': '2023-12-24'::DATE, "
+                  + "'time': '12:34:56'::TIME, "
+                  + "'binary': TO_BINARY('616263', 'HEX'), "
+                  + "'simpleClass': {'string': 'b', 'intValue': 2}"
+                  + "}::OBJECT("
+                  + "string VARCHAR, "
+                  + "b TINYINT, "
+                  + "s SMALLINT, "
+                  + "i INTEGER, "
+                  + "l BIGINT, "
+                  + "f FLOAT, "
+                  + "d DOUBLE, "
+                  + "bd DOUBLE, "
+                  + "bool BOOLEAN, "
+                  + "timestamp_ltz TIMESTAMP_LTZ, "
+                  + "timestamp_ntz TIMESTAMP_NTZ, "
+                  + "timestamp_tz TIMESTAMP_TZ, "
+                  + "date DATE, "
+                  + "time TIME, "
+                  + "binary BINARY, "
+                  + "simpleClass OBJECT(string VARCHAR, intValue INTEGER)"
+                  + ")"); ) {
+        resultSet.next();
+        String object = (String) resultSet.getObject(1);
+        String expected =
+            "{\"string\":\"a\",\"b\":1,\"s\":2,\"i\":3,\"l\":4,\"f\":1.1,\"d\":2.2,\"bd\":3.3,\"bool\":true,\"timestamp_ltz\":\"2021-12-22 09:43:44.000 +0100\",\"timestamp_ntz\":\"2021-12-23 09:44:44.000\",\"timestamp_tz\":\"2021-12-24 09:45:45.000 +0800\",\"date\":\"2023-12-24\",\"time\":\"12:34:56\",\"binary\":\"616263\",\"simpleClass\":{\"string\":\"b\",\"intValue\":2}}";
+        assertEquals(expected, object);
+      }
+    }
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testThrowingGettingObjectIfTypeWasNotIndicatedAndFormatNativeArrow()
+      throws SQLException {
+    Assume.assumeTrue(queryResultFormat == ResultSetFormatType.NATIVE_ARROW);
+    withFirstRow(
+        "select {'string':'a'}::OBJECT(string VARCHAR)",
+        (resultSet) -> {
+          assertThrows(SQLException.class, () -> resultSet.getObject(1));
+        });
+    withFirstRow(
+        "select {'x':{'string':'one'},'y':{'string':'two'},'z':{'string':'three'}}::MAP(VARCHAR, OBJECT(string VARCHAR));",
+        (resultSet) -> {
+          assertThrows(SQLException.class, () -> resultSet.getObject(1, Map.class));
+        });
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testReturnAsArrayOfSqlData() throws SQLException {
-    SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
     withFirstRow(
         "SELECT ARRAY_CONSTRUCT({'string':'one'}, {'string':'two'}, {'string':'three'})::ARRAY(OBJECT(string VARCHAR))",
         (resultSet) -> {
@@ -229,7 +304,6 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testReturnAsArrayOfNullableFieldsInSqlData() throws SQLException {
-    SnowflakeObjectTypeFactories.register(NullableFieldsSqlData.class, NullableFieldsSqlData::new);
     withFirstRow(
         "SELECT OBJECT_CONSTRUCT_KEEP_NULL('string', null, 'nullableIntValue', null, 'nullableLongValue', null, "
             + "'date', null, 'bd', null, 'bytes', null, 'longValue', null)"
@@ -252,7 +326,6 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testReturnNullsForAllTpesInSqlData() throws SQLException {
-    SnowflakeObjectTypeFactories.register(AllTypesClass.class, AllTypesClass::new);
     try (Connection connection = init();
         Statement statement = connection.createStatement()) {
       statement.execute("ALTER SESSION SET TIMEZONE = 'Europe/Warsaw'");
@@ -370,7 +443,6 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testReturnAsMap() throws SQLException {
-    SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
     withFirstRow(
         "select {'x':{'string':'one'},'y':{'string':'two'},'z':{'string':'three'}}::MAP(VARCHAR, OBJECT(string VARCHAR));",
         (resultSet) -> {
@@ -384,8 +456,21 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testReturnAsMapByGetObject() throws SQLException {
+    Assume.assumeTrue(queryResultFormat != ResultSetFormatType.NATIVE_ARROW);
+    withFirstRow(
+        "select {'x':{'string':'one'},'y':{'string':'two'},'z':{'string':'three'}}::MAP(VARCHAR, OBJECT(string VARCHAR));",
+        (resultSet) -> {
+          Map<String, Map<String, Object>> map = resultSet.getObject(1, Map.class);
+          assertEquals("one", map.get("x").get("string"));
+          assertEquals("two", map.get("y").get("string"));
+          assertEquals("three", map.get("z").get("string"));
+        });
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testReturnAsMapWithNullableValues() throws SQLException {
-    SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
     withFirstRow(
         "select {'x':{'string':'one'},'y':null,'z':{'string':'three'}}::MAP(VARCHAR, OBJECT(string VARCHAR));",
         (resultSet) -> {
@@ -400,7 +485,6 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testReturnNullAsObjectOfTypeMap() throws SQLException {
-    SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
     withFirstRow(
         "select null::MAP(VARCHAR, OBJECT(string VARCHAR));",
         (resultSet) -> {
@@ -413,7 +497,6 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testReturnNullAsMap() throws SQLException {
-    SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
     withFirstRow(
         "select null::MAP(VARCHAR, OBJECT(string VARCHAR));",
         (resultSet) -> {
@@ -523,7 +606,6 @@ public class ResultSetStructuredTypesLatestIT extends BaseJDBCTest {
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testReturnAsList() throws SQLException {
-    SnowflakeObjectTypeFactories.register(StringClass.class, StringClass::new);
     withFirstRow(
         "select [{'string':'one'},{'string': 'two'}]::ARRAY(OBJECT(string varchar))",
         (resultSet) -> {


### PR DESCRIPTION
# Overview

[SNOW-1232333](https://snowflakecomputing.atlassian.net/browse/SNOW-1232333)

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.


[SNOW-1232333]: https://snowflakecomputing.atlassian.net/browse/SNOW-1232333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ