### PR TITLE
SNOW-1356389: Use junit assertions instead of jvm assert in tests

### DIFF
--- a/src/test/java/net/snowflake/client/core/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilTest.java
@@ -66,7 +66,7 @@ public class SessionUtilTest {
     parameterMap.put("other_parameter", BooleanNode.getTrue());
     SFBaseSession session = new MockConnectionTest.MockSnowflakeConnectionImpl().getSFSession();
     SessionUtil.updateSfDriverParamValues(parameterMap, session);
-    assert (((BooleanNode) session.getOtherParameter("other_parameter")).asBoolean());
+    assertTrue(((BooleanNode) session.getOtherParameter("other_parameter")).asBoolean());
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/CustomProxyLatestIT.java
@@ -741,7 +741,7 @@ public class CustomProxyLatestIT {
 
         // Make sure that the downloaded file exists, it should be gzip compressed
         File downloaded = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
-        assert (downloaded.exists());
+        assertTrue(downloaded.exists());
 
         Process p =
             Runtime.getRuntime()
@@ -750,7 +750,7 @@ public class CustomProxyLatestIT {
 
         File original = new File(sourceFilePath);
         File unzipped = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE);
-        assert (original.length() == unzipped.length());
+        assertEquals(original.length(), unzipped.length());
       } catch (Throwable t) {
         t.printStackTrace();
       } finally {

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
@@ -4,6 +4,7 @@
 package net.snowflake.client.jdbc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -114,15 +115,14 @@ public class FileUploaderExpandFileNamesTest {
     SnowflakeFileTransferConfig config = builder.build();
 
     // Assert setting fields are in config
-    assert (config.getSnowflakeFileTransferMetadata() == metadata);
-    assert (config.getUploadStream() == input);
-    assert (config.getOcspMode() == OCSPMode.FAIL_CLOSED);
-    assert (!config.getRequireCompress());
-    assert (config.getNetworkTimeoutInMilli() == 12345);
-    assert (config.getProxyProperties() == props);
-    assert (config.getPrefix().equals("dummy_prefix"));
-    assert (config.getDestFileName().equals("dummy_dest_file_name"));
-
+    assertEquals(metadata, config.getSnowflakeFileTransferMetadata());
+    assertEquals(input, config.getUploadStream());
+    assertEquals(OCSPMode.FAIL_CLOSED, config.getOcspMode());
+    assertFalse(config.getRequireCompress());
+    assertEquals(12345, config.getNetworkTimeoutInMilli());
+    assertEquals(props, config.getProxyProperties());
+    assertEquals("dummy_prefix", config.getPrefix());
+    assertEquals("dummy_dest_file_name", config.getDestFileName());
     assertEquals(expectedThrowCount, throwCount);
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverConnectionStressTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverConnectionStressTest.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.client.jdbc;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -88,7 +90,7 @@ public class SnowflakeDriverConnectionStressTest {
         try (ResultSet resultSet = statement.executeQuery(QUERY)) {
           while (resultSet.next()) {
             final String user = resultSet.getString(1);
-            assert user != null;
+            assertNotNull(user);
           }
         }
       }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -769,7 +769,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
         for (int i = 0; i < fileNames.length; i++) {
           // Make sure that the downloaded file exists, it should be gzip compressed
           downloaded = new File(destFolderCanonicalPathWithSeparator + fileNames[i] + ".gz");
-          assert (downloaded.exists());
+          assertTrue(downloaded.exists());
 
           Process p =
               Runtime.getRuntime()
@@ -780,8 +780,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
           File original = new File(individualFilePath);
           File unzipped = new File(destFolderCanonicalPathWithSeparator + fileNames[i]);
-          assert (original.length() == unzipped.length());
-          assert (FileUtils.contentEquals(original, unzipped));
+          assertEquals(original.length(), unzipped.length());
+          assertTrue(FileUtils.contentEquals(original, unzipped));
         }
       } finally {
         statement.execute("DROP STAGE IF EXISTS wildcard_stage");
@@ -862,7 +862,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
         // Make sure that the downloaded file exists; it should be gzip compressed
         File downloaded = new File(destFolderCanonicalPathWithSeparator + "bigFile.csv.gz");
-        assert (downloaded.exists());
+        assertTrue(downloaded.exists());
 
         // unzip the file
         Process p =
@@ -874,8 +874,8 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
         // back into a stage,
         // downloaded, and unzipped
         File unzipped = new File(destFolderCanonicalPathWithSeparator + "bigFile.csv");
-        assert (largeTempFile.length() == unzipped.length());
-        assert (FileUtils.contentEquals(largeTempFile, unzipped));
+        assertEquals(largeTempFile.length(), unzipped.length());
+        assertTrue(FileUtils.contentEquals(largeTempFile, unzipped));
       } finally {
         statement.execute("DROP STAGE IF EXISTS largefile_stage");
         statement.execute("DROP STAGE IF EXISTS extra_stage");
@@ -937,7 +937,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
           // Make sure that the downloaded file exists; it should be gzip compressed
           File downloaded = new File(destFolderCanonicalPathWithSeparator + "testfile.csv.gz");
-          assert (downloaded.exists());
+          assertTrue(downloaded.exists());
 
           // unzip the file
           Process p =
@@ -946,7 +946,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
           p.waitFor();
 
           File unzipped = new File(destFolderCanonicalPathWithSeparator + "testfile.csv");
-          assert (FileUtils.contentEqualsIgnoreEOL(file2, unzipped, null));
+          assertTrue(FileUtils.contentEqualsIgnoreEOL(file2, unzipped, null));
         } finally {
           statement.execute("DROP TABLE IF EXISTS testLoadToLocalFS");
         }
@@ -2695,7 +2695,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
           // Make sure that the downloaded file exists, it should be gzip compressed
           File downloaded = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
-          assert (downloaded.exists());
+          assertTrue(downloaded.exists());
 
           Process p =
               Runtime.getRuntime()
@@ -2704,7 +2704,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
           File original = new File(sourceFilePath);
           File unzipped = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE);
-          assert (original.length() == unzipped.length());
+          assertEquals(original.length(), unzipped.length());
         } finally {
           statement.execute("DROP STAGE IF EXISTS testGetPut_stage");
         }
@@ -2754,7 +2754,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
           // Make sure that the downloaded file exists, it should be gzip compressed
           File downloaded = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE + ".gz");
-          assert (downloaded.exists());
+          assertTrue(downloaded.exists());
 
           Process p =
               Runtime.getRuntime()
@@ -2763,7 +2763,7 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
           File original = new File(sourceFilePath);
           File unzipped = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE);
-          assert (original.length() == unzipped.length());
+          assertEquals(original.length(), unzipped.length());
         } finally {
           statement.execute("DROP STAGE IF EXISTS testPutGet_unencstage");
         }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -224,7 +224,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
         for (SnowflakeFileTransferMetadata oneMetadata : metadatas1) {
           InputStream inputStream = new FileInputStream(srcPath1);
 
-          assert (oneMetadata.isForOneFile());
+          assertTrue(oneMetadata.isForOneFile());
           SnowflakeFileTransferAgent.uploadWithoutConnection(
               SnowflakeFileTransferConfig.Builder.newInstance()
                   .setSnowflakeFileTransferMetadata(oneMetadata)
@@ -252,7 +252,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
           p.waitFor();
 
           InputStream gzInputStream = new FileInputStream(gzfilePath);
-          assert (oneMetadata.isForOneFile());
+          assertTrue(oneMetadata.isForOneFile());
           SnowflakeFileTransferAgent.uploadWithoutConnection(
               SnowflakeFileTransferConfig.Builder.newInstance()
                   .setSnowflakeFileTransferMetadata(oneMetadata)
@@ -271,8 +271,10 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
 
         // Make sure that the downloaded files are EQUAL,
         // they should be gzip compressed
-        assert (isFileContentEqual(srcPath1, false, destFolderCanonicalPath + "/file1.gz", true));
-        assert (isFileContentEqual(srcPath2, false, destFolderCanonicalPath + "/file2.gz", true));
+        assertTrue(
+            isFileContentEqual(srcPath1, false, destFolderCanonicalPath + "/file1.gz", true));
+        assertTrue(
+            isFileContentEqual(srcPath2, false, destFolderCanonicalPath + "/file2.gz", true));
       } finally {
         statement.execute("DROP STAGE if exists " + testStageName);
       }
@@ -360,8 +362,10 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
 
           // Make sure that the downloaded files are EQUAL,
           // they should be gzip compressed
-          assert (isFileContentEqual(srcPath1, false, destFolderCanonicalPath + "/file1.gz", true));
-          assert (isFileContentEqual(srcPath2, false, destFolderCanonicalPath + "/file2.gz", true));
+          assertTrue(
+              isFileContentEqual(srcPath1, false, destFolderCanonicalPath + "/file1.gz", true));
+          assertTrue(
+              isFileContentEqual(srcPath2, false, destFolderCanonicalPath + "/file2.gz", true));
         } finally {
           statement.execute("DROP STAGE if exists " + testStageName);
         }
@@ -1057,7 +1061,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
 
       // Make sure that the downloaded file exists, it should be gzip compressed
       File downloaded = new File(destFolderCanonicalPathWithSeparator + TEST_DATA_FILE_2 + ".gz");
-      assert (downloaded.exists());
+      assertTrue(downloaded.exists());
 
       Process p =
           Runtime.getRuntime()
@@ -1070,7 +1074,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
           "Original file: " + original.getAbsolutePath() + ", size: " + original.length());
       System.out.println(
           "Unzipped file: " + unzipped.getAbsolutePath() + ", size: " + unzipped.length());
-      assert (original.length() == unzipped.length());
+      assertEquals(original.length(), unzipped.length());
     } finally {
       statement.execute("DROP STAGE IF EXISTS testGetPut_stage");
     }
@@ -1137,7 +1141,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
 
         // Make sure that the downloaded file exists; it should be gzip compressed
         File downloaded = new File(destFolderCanonicalPathWithSeparator + "bigFile.csv.gz");
-        assert (downloaded.exists());
+        assertTrue(downloaded.exists());
 
         // unzip the file
         Process p =
@@ -1149,8 +1153,8 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
         // back into a stage,
         // downloaded, and unzipped
         File unzipped = new File(destFolderCanonicalPathWithSeparator + "bigFile.csv");
-        assert (largeTempFile.length() == unzipped.length());
-        assert (FileUtils.contentEquals(largeTempFile, unzipped));
+        assertEquals(largeTempFile.length(), unzipped.length());
+        assertTrue(FileUtils.contentEquals(largeTempFile, unzipped));
       } finally {
         statement.execute("DROP STAGE IF EXISTS largefile_stage");
         statement.execute("DROP STAGE IF EXISTS extra_stage");
@@ -1213,7 +1217,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
 
         // Make sure that the downloaded file exists; it should be gzip compressed
         File downloaded = new File(destFolderCanonicalPathWithSeparator + "bigFile.csv.gz");
-        assert (downloaded.exists());
+        assertTrue(downloaded.exists());
 
         // unzip the file
         Process p =
@@ -1225,8 +1229,8 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
         // back into a stage,
         // downloaded, and unzipped
         File unzipped = new File(destFolderCanonicalPathWithSeparator + "bigFile.csv");
-        assert (largeTempFile.length() == unzipped.length());
-        assert (FileUtils.contentEquals(largeTempFile, unzipped));
+        assertEquals(largeTempFile.length(), unzipped.length());
+        assertTrue(FileUtils.contentEquals(largeTempFile, unzipped));
       } finally {
         statement.execute("DROP STAGE IF EXISTS largefile_stage");
         statement.execute("DROP STAGE IF EXISTS extra_stage");
@@ -1349,8 +1353,10 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
 
           // Make sure that the downloaded files are EQUAL,
           // they should be gzip compressed
-          assert (isFileContentEqual(srcPath1, false, destFolderCanonicalPath + "/file1.gz", true));
-          assert (isFileContentEqual(srcPath2, false, destFolderCanonicalPath + "/file2.gz", true));
+          assertTrue(
+              isFileContentEqual(srcPath1, false, destFolderCanonicalPath + "/file1.gz", true));
+          assertTrue(
+              isFileContentEqual(srcPath2, false, destFolderCanonicalPath + "/file2.gz", true));
         } finally {
           statement.execute("DROP STAGE if exists " + testStageName);
         }
@@ -1489,7 +1495,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
         for (SnowflakeFileTransferMetadata oneMetadata : metadata) {
           InputStream inputStream = new FileInputStream(srcPath);
 
-          assert (oneMetadata.isForOneFile());
+          assertTrue(oneMetadata.isForOneFile());
           SnowflakeFileTransferAgent.uploadWithoutConnection(
               SnowflakeFileTransferConfig.Builder.newInstance()
                   .setSnowflakeFileTransferMetadata(oneMetadata)
@@ -1504,7 +1510,7 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
             "Failed to get files",
             statement.execute(
                 "GET @" + testStageName + " 'file://" + destFolderCanonicalPath + "/' parallel=8"));
-        assert (isFileContentEqual(srcPath, false, destFolderCanonicalPath + "/file1.gz", true));
+        assertTrue(isFileContentEqual(srcPath, false, destFolderCanonicalPath + "/file1.gz", true));
       } finally {
         statement.execute("DROP STAGE if exists " + testStageName);
       }

--- a/src/test/java/net/snowflake/client/jdbc/StatementLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/StatementLatestIT.java
@@ -132,7 +132,7 @@ public class StatementLatestIT extends BaseJDBCTest {
             // Make sure that the downloaded file exists, it should be gzip compressed
             File downloaded =
                 new File(tempFolder.getCanonicalPath() + File.separator + fileName + ".gz");
-            assert (downloaded.exists());
+            assertTrue(downloaded.exists());
           }
           // unzip the new file
           Process p =

--- a/src/test/java/net/snowflake/client/pooling/LogicalConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/pooling/LogicalConnectionLatestIT.java
@@ -161,7 +161,7 @@ public class LogicalConnectionLatestIT extends BaseJDBCTest {
     PooledConnection pooledConnection = poolDataSource.getPooledConnection();
     try (Connection logicalConnection = pooledConnection.getConnection()) {
       logicalConnection.setAutoCommit(false);
-      assert (!logicalConnection.getAutoCommit());
+      assertFalse(logicalConnection.getAutoCommit());
       logicalConnection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
       assertEquals(2, logicalConnection.getTransactionIsolation());
 


### PR DESCRIPTION
# Overview

SNOW-1356389

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
