### PR TITLE
SNOW-1226600: Add parameter to disable SAML URL check

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -49,7 +49,7 @@ public class SFLoginInput {
   private String inFlightCtx; // Opaque string sent for Snowsight account activation
 
   private boolean disableConsoleLogin = true;
-  private boolean disableSamlUrlCheck = false;
+  private boolean disableSamlURLCheck = false;
 
   // Additional headers to add for Snowsight.
   Map<String, String> additionalHttpHeadersForSnowsight;
@@ -379,12 +379,12 @@ public class SFLoginInput {
     return this;
   }
 
-  boolean getDisableSamlUrlCheck() {
-    return disableSamlUrlCheck;
+  boolean getDisableSamlURLCheck() {
+    return disableSamlURLCheck;
   }
 
-  SFLoginInput setDisableSamlUrlCheck(boolean disableSamlUrlCheck) {
-    this.disableSamlUrlCheck = disableSamlUrlCheck;
+  SFLoginInput setDisableSamlURLCheck(boolean disableSamlURLCheck) {
+    this.disableSamlURLCheck = disableSamlURLCheck;
     return this;
   }
 

--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -49,6 +49,7 @@ public class SFLoginInput {
   private String inFlightCtx; // Opaque string sent for Snowsight account activation
 
   private boolean disableConsoleLogin = true;
+  private boolean disableSamlUrlCheck = false;
 
   // Additional headers to add for Snowsight.
   Map<String, String> additionalHttpHeadersForSnowsight;
@@ -375,6 +376,15 @@ public class SFLoginInput {
   // Opaque string sent for Snowsight account activation
   SFLoginInput setInFlightCtx(String inFlightCtx) {
     this.inFlightCtx = inFlightCtx;
+    return this;
+  }
+
+  boolean getDisableSamlUrlCheck() {
+    return disableSamlUrlCheck;
+  }
+
+  SFLoginInput setDisableSamlUrlCheck(boolean disableSamlUrlCheck) {
+    this.disableSamlUrlCheck = disableSamlUrlCheck;
     return this;
   }
 

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -608,7 +608,12 @@ public class SFSession extends SFBaseSession {
             connectionPropertiesMap.get(SFSessionProperty.DISABLE_CONSOLE_LOGIN) != null
                 ? getBooleanValue(
                     connectionPropertiesMap.get(SFSessionProperty.DISABLE_CONSOLE_LOGIN))
-                : true);
+                : true)
+        .setDisableSamlUrlCheck(
+            connectionPropertiesMap.get(SFSessionProperty.DISABLE_SAML_URL_CHECK) != null
+                ? getBooleanValue(
+                    connectionPropertiesMap.get(SFSessionProperty.DISABLE_SAML_URL_CHECK))
+                : false);
 
     // Enable or disable OOB telemetry based on connection parameter. Default is disabled.
     // The value may still change later when session parameters from the server are read.

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -609,7 +609,7 @@ public class SFSession extends SFBaseSession {
                 ? getBooleanValue(
                     connectionPropertiesMap.get(SFSessionProperty.DISABLE_CONSOLE_LOGIN))
                 : true)
-        .setDisableSamlUrlCheck(
+        .setDisableSamlURLCheck(
             connectionPropertiesMap.get(SFSessionProperty.DISABLE_SAML_URL_CHECK) != null
                 ? getBooleanValue(
                     connectionPropertiesMap.get(SFSessionProperty.DISABLE_SAML_URL_CHECK))

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -82,7 +82,9 @@ public enum SFSessionProperty {
 
   DISABLE_GCS_DEFAULT_CREDENTIALS("disableGcsDefaultCredentials", false, Boolean.class),
 
-  JDBC_ARROW_TREAT_DECIMAL_AS_INT("JDBC_ARROW_TREAT_DECIMAL_AS_INT", false, Boolean.class);
+  JDBC_ARROW_TREAT_DECIMAL_AS_INT("JDBC_ARROW_TREAT_DECIMAL_AS_INT", false, Boolean.class),
+
+  DISABLE_SAML_URL_CHECK("disableSamlUrlCheck", false, Boolean.class);
 
   // property key in string
   private String propertyKey;

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -84,7 +84,7 @@ public enum SFSessionProperty {
 
   JDBC_ARROW_TREAT_DECIMAL_AS_INT("JDBC_ARROW_TREAT_DECIMAL_AS_INT", false, Boolean.class),
 
-  DISABLE_SAML_URL_CHECK("disableSamlUrlCheck", false, Boolean.class);
+  DISABLE_SAML_URL_CHECK("disableSamlURLCheck", false, Boolean.class);
 
   // property key in string
   private String propertyKey;

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -1154,26 +1154,29 @@ public class SessionUtil {
               loginInput.getHttpClientSettingsKey());
 
       // step 5
-      String postBackUrl = getPostBackUrlFromHTML(responseHtml);
-      if (!isPrefixEqual(postBackUrl, loginInput.getServerUrl())) {
-        URL idpDestinationUrl = new URL(postBackUrl);
-        URL clientDestinationUrl = new URL(loginInput.getServerUrl());
-        String idpDestinationHostName = idpDestinationUrl.getHost();
-        String clientDestinationHostName = clientDestinationUrl.getHost();
+      if (!loginInput.getDisableSamlUrlCheck()) {
+        String postBackUrl = getPostBackUrlFromHTML(responseHtml);
+        if (!isPrefixEqual(postBackUrl, loginInput.getServerUrl())) {
+          URL idpDestinationUrl = new URL(postBackUrl);
+          URL clientDestinationUrl = new URL(loginInput.getServerUrl());
+          String idpDestinationHostName = idpDestinationUrl.getHost();
+          String clientDestinationHostName = clientDestinationUrl.getHost();
 
-        logger.error(
-            "The Snowflake hostname specified in the client connection {} does not match "
-                + "the destination hostname in the SAML response returned by the IdP: {}",
-            clientDestinationHostName,
-            idpDestinationHostName);
+          logger.error(
+              "The Snowflake hostname specified in the client connection {} does not match "
+                  + "the destination hostname in the SAML response returned by the IdP: {}",
+              clientDestinationHostName,
+              idpDestinationHostName);
 
-        // Session is in process of getting created, so exception constructor takes in null session
-        // value
-        throw new SnowflakeSQLLoggedException(
-            null,
-            ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(),
-            SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION
-            /* session = */ );
+          // Session is in process of getting created, so exception constructor takes in null
+          // session
+          // value
+          throw new SnowflakeSQLLoggedException(
+              null,
+              ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(),
+              SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION
+              /* session = */ );
+        }
       }
     } catch (IOException | URISyntaxException ex) {
       handleFederatedFlowError(loginInput, ex);

--- a/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
@@ -403,6 +403,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
     input.setLoginTimeout(1000);
     input.setSessionParameters(new HashMap<>());
     input.setAuthenticator("https://testauth.okta.com");
+    input.setDisableSamlUrlCheck(false);
     return input;
   }
 

--- a/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
@@ -403,7 +403,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
     input.setLoginTimeout(1000);
     input.setSessionParameters(new HashMap<>());
     input.setAuthenticator("https://testauth.okta.com");
-    input.setDisableSamlUrlCheck(false);
+    input.setDisableSamlUrlCheck(true);
     return input;
   }
 

--- a/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
@@ -466,10 +466,17 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
     }
   }
 
+  /**
+   * Tests the disableSamlURLCheck. If the disableSamlUrl is provided to the login input with true,
+   * the driver will skip checking the format of the saml URL response. This latest test will work
+   * with jdbc > 3.16.0
+   *
+   * @throws Throwable
+   */
   @Test
   public void testOktaDisableSamlUrlCheck() throws Throwable {
     SFLoginInput loginInput = createOktaLoginInput();
-    loginInput.setDisableSamlUrlCheck(true);
+    loginInput.setDisableSamlURLCheck(true);
     Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
     try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
       mockedHttpUtil
@@ -515,6 +522,119 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
           .thenReturn("<body><form action=\"invalidformError\"></form></body>");
 
       SessionUtil.openSession(loginInput, connectionPropertiesMap, "ALL");
+    }
+  }
+
+  /**
+   * Tests when the response from the server is invalid.
+   *
+   * @throws Throwable
+   */
+  @Test
+  public void testInvalidOktaSamlForm() throws Throwable {
+    SFLoginInput loginInput = createOktaLoginInput();
+    Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
+    try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequest(
+                      Mockito.any(HttpPost.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(HttpClientSettingsKey.class)))
+          .thenReturn(
+              "{\"data\":{\"tokenUrl\":\"https://testauth.okta.com/api/v1/authn\","
+                  + "\"ssoUrl\":\"https://testauth.okta.com/app/snowflake/abcdefghijklmnopqrstuvwxyz/sso/saml\","
+                  + "\"proofKey\":null},\"code\":null,\"message\":null,\"success\":true}");
+
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeRequestWithoutCookies(
+                      Mockito.any(HttpRequestBase.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(AtomicBoolean.class),
+                      Mockito.nullable(HttpClientSettingsKey.class)))
+          .thenReturn(
+              "{\"expiresAt\":\"2023-10-13T19:18:09.000Z\",\"status\":\"SUCCESS\",\"sessionToken\":\"testsessiontoken\"}");
+
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequest(
+                      Mockito.any(HttpGet.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(HttpClientSettingsKey.class)))
+          .thenReturn("<body><form action=\"invalidformError\"></form></body>");
+
+      SessionUtil.openSession(loginInput, connectionPropertiesMap, "ALL");
+      fail("Should be failed because of the invalid form");
+    } catch (SnowflakeSQLException ex) {
+      assertEquals((int) ErrorCode.NETWORK_ERROR.getMessageCode(), ex.getErrorCode());
+    }
+  }
+
+  @Test
+  public void testInvalidOktaSaml() throws Throwable {
+    SFLoginInput loginInput = createOktaLoginInput();
+    Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
+    try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequest(
+                      Mockito.any(HttpPost.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(HttpClientSettingsKey.class)))
+          .thenReturn(
+              "{\"data\":{\"tokenUrl\":\"https://testauth.okta.com/api/v1/authn\","
+                  + "\"ssoUrl\":\"https://testauth.okta.com/app/snowflake/abcdefghijklmnopqrstuvwxyz/sso/saml\","
+                  + "\"proofKey\":null},\"code\":null,\"message\":null,\"success\":true}");
+
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeRequestWithoutCookies(
+                      Mockito.any(HttpRequestBase.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(AtomicBoolean.class),
+                      Mockito.nullable(HttpClientSettingsKey.class)))
+          .thenReturn(
+              "{\"expiresAt\":\"2023-10-13T19:18:09.000Z\",\"status\":\"SUCCESS\",\"sessionToken\":\"testsessiontoken\"}");
+
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequest(
+                      Mockito.any(HttpGet.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(HttpClientSettingsKey.class)))
+          .thenReturn("<body><form action=\"https://helloworld.okta.com\"></form></body>");
+
+      SessionUtil.openSession(loginInput, connectionPropertiesMap, "ALL");
+      fail("Should be failed because of the invalid form");
+    } catch (SnowflakeSQLException ex) {
+      assertEquals((int) ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(), ex.getErrorCode());
     }
   }
 }

--- a/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
@@ -525,11 +525,6 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
     }
   }
 
-  /**
-   * Tests when the response from the server is invalid.
-   *
-   * @throws Throwable
-   */
   @Test
   public void testInvalidOktaSamlFormat() throws Throwable {
     SFLoginInput loginInput = createOktaLoginInput();
@@ -585,7 +580,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
   }
 
   @Test
-  public void testOktaWithWrongHostName() throws Throwable {
+  public void testOktaWithInvalidHostName() throws Throwable {
     SFLoginInput loginInput = createOktaLoginInput();
     Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
     try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {

--- a/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
@@ -531,7 +531,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
    * @throws Throwable
    */
   @Test
-  public void testInvalidOktaSamlForm() throws Throwable {
+  public void testInvalidOktaSamlFormat() throws Throwable {
     SFLoginInput loginInput = createOktaLoginInput();
     Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
     try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
@@ -585,7 +585,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
   }
 
   @Test
-  public void testInvalidOktaSaml() throws Throwable {
+  public void testOktaWithWrongHostName() throws Throwable {
     SFLoginInput loginInput = createOktaLoginInput();
     Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
     try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {


### PR DESCRIPTION
# Overview

SNOW-1226600

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
- [x] added a new option to disable the saml URL check for the Okta authenticator.


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
