### PR TITLE
SNOW-1446336: Use S3 regional url domain base on region name

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -217,9 +217,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     } else {
       if (region != null) {
         if (this.isUseS3RegionalUrl) {
+          String domainSuffixForRegionalUrl = getDomainSuffixForRegionalUrl(region.getName());
           amazonS3Builder.withEndpointConfiguration(
               new AwsClientBuilder.EndpointConfiguration(
-                  "s3." + region.getName() + ".amazonaws.com", region.getName()));
+                  "s3." + region.getName() + "." + domainSuffixForRegionalUrl, region.getName()));
         } else {
           amazonS3Builder.withRegion(region.getName());
         }
@@ -228,6 +229,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     // Explicitly force to use virtual address style
     amazonS3Builder.withPathStyleAccessEnabled(false);
     amazonClient = (AmazonS3) amazonS3Builder.build();
+  }
+
+  static String getDomainSuffixForRegionalUrl(String regionName) {
+    return regionName.startsWith("cn-") ? "amazonaws.com.cn" : "amazonaws.com";
   }
 
   // Returns the Max number of retry attempts

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeS3ClientTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+package net.snowflake.client.jdbc.cloud.storage;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SnowflakeS3ClientTest {
+
+  @Test
+  public void shouldDetermineDomainForRegion() {
+    assertEquals("amazonaws.com", SnowflakeS3Client.getDomainSuffixForRegionalUrl("us-east-1"));
+    assertEquals(
+        "amazonaws.com.cn", SnowflakeS3Client.getDomainSuffixForRegionalUrl("cn-northwest-1"));
+  }
+}


### PR DESCRIPTION
# Overview

SNOW-1446336

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
