### PR TITLE
SNOW-1369651 Add exception handling for UncheckedIOException when trying to list

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -1956,7 +1956,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           result.add(((File) file).getCanonicalPath());
         }
       } catch (Exception ex) {
-        if (ex instanceof UncheckedIOException && !dir.exists()) {
+        if (ex instanceof UncheckedIOException && dir != null && !dir.exists()) {
           logger.warn(
               "The directory: {} has been deleted. Ignoring files under this directory.",
               entry.getKey());

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -1935,9 +1935,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
     // For each location, list files and match against the patterns
     for (Map.Entry<String, List<String>> entry : locationToFilePatterns.entrySet()) {
-      java.io.File dir = null;
+      File dir = null;
       try {
-        dir = new java.io.File(entry.getKey());
+        dir = new File(entry.getKey());
 
         logger.debug(
             "Listing files under: {} with patterns: {}",
@@ -1953,28 +1953,13 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         // The following currently ignore sub directories
         for (Object file :
             FileUtils.listFiles(dir, new WildcardFileFilter(entry.getValue()), null)) {
-          result.add(((java.io.File) file).getCanonicalPath());
+          result.add(((File) file).getCanonicalPath());
         }
       } catch (Exception ex) {
-        if (ex instanceof UncheckedIOException) {
-          if (!dir.exists()) {
-            logger.debug(
-                "The directory: "
-                    + entry.getKey()
-                    + " has been deleted. Ignoring files under this directory.");
-          } else {
-            throw new SnowflakeSQLException(
-                queryId,
-                ex,
-                SqlState.DATA_EXCEPTION,
-                ErrorCode.FAIL_LIST_FILES.getMessageCode(),
-                "Exception: "
-                    + ex.getMessage()
-                    + ", Dir="
-                    + entry.getKey()
-                    + ", Patterns="
-                    + entry.getValue().toString());
-          }
+        if (ex instanceof UncheckedIOException && !dir.exists()) {
+          logger.warn(
+              "The directory: {} has been deleted. Ignoring files under this directory.",
+              entry.getKey());
         } else {
           throw new SnowflakeSQLException(
               queryId,

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
@@ -4,7 +4,9 @@
 package net.snowflake.client.jdbc;
 
 import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderLatestIT.java
@@ -32,7 +32,6 @@ import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningOnGithubAction;
 import net.snowflake.client.category.TestCategoryOthers;
@@ -49,10 +48,8 @@ import net.snowflake.client.jdbc.cloud.storage.StorageProviderException;
 import net.snowflake.common.core.RemoteStoreFileEncryptionMaterial;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 
 /** Tests for SnowflakeFileTransferAgent that require an active connection */
 @Category(TestCategoryOthers.class)
@@ -60,8 +57,6 @@ public class FileUploaderLatestIT extends FileUploaderPrepIT {
   private static final String OBJ_META_STAGE = "testObjMeta";
   private ObjectMapper mapper = new ObjectMapper();
   private static final String PUT_COMMAND = "put file:///dummy/path/file2.gz @testStage";
-  @Rule public TemporaryFolder secondFolder = new TemporaryFolder();
-  private String localFSFileSep = systemGetProperty("file.separator");
 
   /**
    * This tests that getStageInfo(JsonNode, session) reflects the boolean value of UseS3RegionalUrl
@@ -870,47 +865,6 @@ public class FileUploaderLatestIT extends FileUploaderPrepIT {
       }
     } finally {
       FileUtils.deleteDirectory(subDir.toFile());
-    }
-  }
-
-  /**
-   * Test fix for if a folder has been deleted before calling FileUtils.listFiles we ignore that
-   * directory. Fix available after version 3.16.0.
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testDeleteDirectoryBeforeListFilesWithWildCard() throws Exception {
-    folder.newFile("TestFileA");
-    folder.newFile("TestFileB");
-
-    secondFolder.newFile("TestFileC");
-    secondFolder.newFile("TestFileD");
-
-    String folderName = folder.getRoot().getCanonicalPath();
-    String secondFolderName = secondFolder.getRoot().getCanonicalPath();
-    System.setProperty("user.dir", folderName);
-    System.setProperty("user.home", folderName);
-
-    folder.delete();
-
-    String[] locations = {
-      folderName + localFSFileSep + "TestFil*A",
-      folderName + localFSFileSep + "TestFil*B",
-      secondFolderName + localFSFileSep + "TestFil*C",
-      secondFolderName + localFSFileSep + "TestFil*D",
-    };
-
-    try {
-
-      Set<String> files = SnowflakeFileTransferAgent.expandFileNames(locations, null);
-      assertFalse(files.contains(folderName + localFSFileSep + "TestFileA"));
-      assertFalse(files.contains(folderName + localFSFileSep + "TestFileB"));
-      assertTrue(files.contains(secondFolderName + localFSFileSep + "TestFileC"));
-      assertTrue(files.contains(secondFolderName + localFSFileSep + "TestFileD"));
-      assertEquals(2, files.size());
-    } catch (SnowflakeSQLException e) {
-      fail("Should not throw exception.");
     }
   }
 }


### PR DESCRIPTION
files from deleted directory.

# Overview

SNOW-1369651

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [#NNNN ]


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
