### PR TITLE
SNOW-1437655 Fix for getQueryMetadata retry

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -211,7 +211,7 @@ public class SFSession extends SFBaseSession {
             HttpUtil.executeGeneralRequest(
                 get,
                 loginTimeout,
-                authTimeout,
+                0,
                 (int) httpClientSocketTimeout.toMillis(),
                 maxHttpRetries,
                 getHttpClientKey());

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -211,7 +211,7 @@ public class SFSession extends SFBaseSession {
             HttpUtil.executeGeneralRequest(
                 get,
                 loginTimeout,
-                0,
+                0, // no authentication timeout for the request
                 (int) httpClientSocketTimeout.toMillis(),
                 maxHttpRetries,
                 getHttpClientKey());

--- a/src/main/java/net/snowflake/client/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/jdbc/RestRequest.java
@@ -388,6 +388,7 @@ public class RestRequest {
                   ErrorCode.NETWORK_ERROR.getMessageCode());
           // rethrow the timeout exception
           if (response == null && savedEx != null) {
+            logger.debug("Rethrow the timeout exception for: {}", savedEx.getMessage());
             throw new SnowflakeSQLException(
                 savedEx,
                 ErrorCode.NETWORK_ERROR,
@@ -402,6 +403,7 @@ public class RestRequest {
         // If this was a request for an Okta one-time token that failed with a retry-able error,
         // throw exception to renew the token before trying again.
         if (String.valueOf(httpRequest.getURI()).contains("okta.com/api/v1/authn")) {
+          logger.debug("Exception to renew the Okta one-time token before trying again");
           throw new SnowflakeSQLException(
               ErrorCode.AUTHENTICATOR_REQUEST_TIMEOUT,
               retryCount,
@@ -422,6 +424,7 @@ public class RestRequest {
           /* connect timeout not reached */
           // check if this is a login-request
           if (String.valueOf(httpRequest.getURI()).contains("login-request")) {
+            logger.debug("Authentication timeout for login request");
             throw new SnowflakeSQLException(
                 ErrorCode.AUTHENTICATOR_REQUEST_TIMEOUT,
                 retryCount,
@@ -466,6 +469,7 @@ public class RestRequest {
         // increase the retry count and throw special exception to renew the token before retrying.
         if (authTimeout > 0) {
           if (elapsedMilliForTransientIssues >= authTimeoutInMilli) {
+            logger.debug("Authentication request timeout for: {}", requestInfoScrubbed);
             throw new SnowflakeSQLException(
                 ErrorCode.AUTHENTICATOR_REQUEST_TIMEOUT,
                 retryCount,
@@ -547,6 +551,7 @@ public class RestRequest {
 
       // rethrow the timeout exception
       if (response == null && savedEx != null) {
+        logger.debug("Rethrow (2) the timeout exception for: {}", savedEx.getMessage());
         throw new SnowflakeSQLException(
             savedEx,
             ErrorCode.NETWORK_ERROR,


### PR DESCRIPTION
# Overview

SNOW-1437655 Fix for getQueryMetadata retry

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
