### PR TITLE
SNOW-1460355: Fix getHostFromServerUrl

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -426,7 +426,11 @@ public class SFLoginInput {
   String getHostFromServerUrl() throws SFException {
     URL url;
     try {
-      url = new URL(serverUrl);
+      if (!serverUrl.startsWith("http")) {
+        url = new URL("https://" + serverUrl);
+      } else {
+        url = new URL(serverUrl);
+      }
     } catch (MalformedURLException e) {
       throw new SFException(
           e, ErrorCode.INTERNAL_ERROR, "Invalid serverUrl for retrieving host name");

--- a/src/test/java/net/snowflake/client/core/SFLoginInputTest.java
+++ b/src/test/java/net/snowflake/client/core/SFLoginInputTest.java
@@ -1,0 +1,22 @@
+package net.snowflake.client.core;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SFLoginInputTest {
+
+  @Test
+  public void testGetHostFromServerUrlWithoutProtocolShouldNotThrow() throws SFException {
+    SFLoginInput sfLoginInput = new SFLoginInput();
+    sfLoginInput.setServerUrl("host.com:443");
+    assertEquals("host.com", sfLoginInput.getHostFromServerUrl());
+  }
+
+  @Test
+  public void testGetHostFromServerUrlWithProtocolShouldNotThrow() throws SFException {
+    SFLoginInput sfLoginInput = new SFLoginInput();
+    sfLoginInput.setServerUrl("https://host.com");
+    assertEquals("host.com", sfLoginInput.getHostFromServerUrl());
+  }
+}


### PR DESCRIPTION
# Overview

SNOW-1460355

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
