### PR TITLE
SNOW-1446174: Allow 513 in SFTrustManager tests

### DIFF
--- a/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
+++ b/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
@@ -182,7 +182,7 @@ public class SFTrustManagerIT extends BaseJDBCTest {
     assertThat(
         String.format("response code for %s", host),
         statusCode,
-        anyOf(equalTo(200), equalTo(403), equalTo(400)));
+        anyOf(equalTo(200), equalTo(403), equalTo(400), equalTo(513)));
   }
 
   /**

--- a/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
+++ b/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
@@ -182,7 +182,7 @@ public class SFTrustManagerIT extends BaseJDBCTest {
     assertThat(
         String.format("response code for %s", host),
         statusCode,
-        anyOf(equalTo(200), equalTo(403), equalTo(400), equalTo(513)));
+        anyOf(equalTo(200), equalTo(400), equalTo(403), equalTo(404), equalTo(513)));
   }
 
   /**

--- a/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
@@ -272,6 +272,7 @@ public class RestRequestTest {
     testCases.add(new TestCase(509, false, false));
     testCases.add(new TestCase(510, false, false));
     testCases.add(new TestCase(511, false, false));
+    testCases.add(new TestCase(513, false, false));
     // do retry on HTTP 403 option
     testCases.add(new TestCase(100, true, true));
     testCases.add(new TestCase(101, true, true));
@@ -325,6 +326,7 @@ public class RestRequestTest {
     testCases.add(new TestCase(509, true, false));
     testCases.add(new TestCase(510, true, false));
     testCases.add(new TestCase(511, true, false));
+    testCases.add(new TestCase(513, true, false));
 
     for (TestCase t : testCases) {
       if (t.result) {


### PR DESCRIPTION
# Overview

SNOW-1446174

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
