### PR TITLE
SNOW-618478: support passing private key as base64 encoded string (private_key_base64) as alternative to (private_key_file)

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -334,7 +334,7 @@ public class SFLoginInput {
     return privateKeyFile;
   }
 
-  String getPrivateKeyBase64(){
+  String getPrivateKeyBase64() {
     return privateKeyBase64;
   }
 

--- a/src/main/java/net/snowflake/client/core/SFLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFLoginInput.java
@@ -45,6 +45,7 @@ public class SFLoginInput {
   private OCSPMode ocspMode;
   private HttpClientSettingsKey httpClientKey;
   private String privateKeyFile;
+  private String privateKeyBase64;
   private String privateKeyFilePwd;
   private String inFlightCtx; // Opaque string sent for Snowsight account activation
 
@@ -314,6 +315,11 @@ public class SFLoginInput {
     return this;
   }
 
+  SFLoginInput setPrivateKeyBase64(String privateKeyBase64) {
+    this.privateKeyBase64 = privateKeyBase64;
+    return this;
+  }
+
   SFLoginInput setPrivateKeyFile(String privateKeyFile) {
     this.privateKeyFile = privateKeyFile;
     return this;
@@ -326,6 +332,10 @@ public class SFLoginInput {
 
   String getPrivateKeyFile() {
     return privateKeyFile;
+  }
+
+  String getPrivateKeyBase64(){
+    return privateKeyBase64;
   }
 
   String getPrivateKeyFilePwd() {

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -597,7 +597,8 @@ public class SFSession extends SFBaseSession {
         .setSessionParameters(sessionParametersMap)
         .setPrivateKey((PrivateKey) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY))
         .setPrivateKeyFile((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE))
-        .setPrivateKeyBase64((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_BASE64))
+        .setPrivateKeyBase64(
+            (String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_BASE64))
         .setPrivateKeyFilePwd(
             (String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
         .setApplication((String) connectionPropertiesMap.get(SFSessionProperty.APPLICATION))
@@ -615,7 +616,7 @@ public class SFSession extends SFBaseSession {
                     connectionPropertiesMap.get(SFSessionProperty.DISABLE_SAML_URL_CHECK))
                 : false);
 
-      // Enable or disable OOB telemetry based on connection parameter. Default is disabled.
+    // Enable or disable OOB telemetry based on connection parameter. Default is disabled.
     // The value may still change later when session parameters from the server are read.
     if (getBooleanValue(
         connectionPropertiesMap.get(SFSessionProperty.CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED))) {

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -597,6 +597,7 @@ public class SFSession extends SFBaseSession {
         .setSessionParameters(sessionParametersMap)
         .setPrivateKey((PrivateKey) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY))
         .setPrivateKeyFile((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE))
+        .setPrivateKeyBase64((String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_BASE64))
         .setPrivateKeyFilePwd(
             (String) connectionPropertiesMap.get(SFSessionProperty.PRIVATE_KEY_FILE_PWD))
         .setApplication((String) connectionPropertiesMap.get(SFSessionProperty.APPLICATION))
@@ -614,7 +615,7 @@ public class SFSession extends SFBaseSession {
                     connectionPropertiesMap.get(SFSessionProperty.DISABLE_SAML_URL_CHECK))
                 : false);
 
-    // Enable or disable OOB telemetry based on connection parameter. Default is disabled.
+      // Enable or disable OOB telemetry based on connection parameter. Default is disabled.
     // The value may still change later when session parameters from the server are read.
     if (getBooleanValue(
         connectionPropertiesMap.get(SFSessionProperty.CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED))) {

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -54,6 +54,7 @@ public enum SFSessionProperty {
   VALIDATE_DEFAULT_PARAMETERS("validateDefaultParameters", false, Boolean.class),
   INJECT_WAIT_IN_PUT("inject_wait_in_put", false, Integer.class),
   PRIVATE_KEY_FILE("private_key_file", false, String.class),
+  PRIVATE_KEY_BASE64("private_key_base64", false, String.class),
   PRIVATE_KEY_FILE_PWD("private_key_file_pwd", false, String.class),
   CLIENT_INFO("snowflakeClientInfo", false, String.class),
   ALLOW_UNDERSCORES_IN_HOST("allowUnderscoresInHost", false, Boolean.class),

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -241,7 +241,7 @@ public class SessionUtil {
     // authenticator is null, then jdbc will decide authenticator depends on
     // if privateKey is specified or not. If yes, authenticator type will be
     // SNOWFLAKE_JWT, otherwise it will use SNOWFLAKE.
-    return (loginInput.getPrivateKey() != null || loginInput.getPrivateKeyFile() != null)
+    return (loginInput.getPrivateKey() != null || loginInput.getPrivateKeyFile() != null || loginInput.getPrivateKeyBase64() != null)
         ? ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT
         : ClientAuthnDTO.AuthenticatorType.SNOWFLAKE;
   }
@@ -422,6 +422,7 @@ public class SessionUtil {
             new SessionUtilKeyPair(
                 loginInput.getPrivateKey(),
                 loginInput.getPrivateKeyFile(),
+                loginInput.getPrivateKeyBase64(),
                 loginInput.getPrivateKeyFilePwd(),
                 loginInput.getAccountName(),
                 loginInput.getUserName());
@@ -677,6 +678,7 @@ public class SessionUtil {
                     new SessionUtilKeyPair(
                         loginInput.getPrivateKey(),
                         loginInput.getPrivateKeyFile(),
+                        loginInput.getPrivateKeyBase64(),
                         loginInput.getPrivateKeyFilePwd(),
                         loginInput.getAccountName(),
                         loginInput.getUserName());
@@ -1730,13 +1732,14 @@ public class SessionUtil {
   public static String generateJWTToken(
       PrivateKey privateKey,
       String privateKeyFile,
+      String privateKeyBase64,
       String privateKeyFilePwd,
       String accountName,
       String userName)
       throws SFException {
     SessionUtilKeyPair s =
         new SessionUtilKeyPair(
-            privateKey, privateKeyFile, privateKeyFilePwd, accountName, userName);
+            privateKey, privateKeyFile, privateKeyBase64, privateKeyFilePwd, accountName, userName);
     return s.issueJwtToken();
   }
 

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -241,7 +241,9 @@ public class SessionUtil {
     // authenticator is null, then jdbc will decide authenticator depends on
     // if privateKey is specified or not. If yes, authenticator type will be
     // SNOWFLAKE_JWT, otherwise it will use SNOWFLAKE.
-    return (loginInput.getPrivateKey() != null || loginInput.getPrivateKeyFile() != null || loginInput.getPrivateKeyBase64() != null)
+    return (loginInput.getPrivateKey() != null
+            || loginInput.getPrivateKeyFile() != null
+            || loginInput.getPrivateKeyBase64() != null)
         ? ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT
         : ClientAuthnDTO.AuthenticatorType.SNOWFLAKE;
   }

--- a/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
@@ -16,6 +16,7 @@ import com.nimbusds.jwt.SignedJWT;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -80,6 +81,7 @@ class SessionUtilKeyPair {
   SessionUtilKeyPair(
       PrivateKey privateKey,
       String privateKeyFile,
+      String privateKeyBase64,
       String privateKeyFilePwd,
       String accountName,
       String userName)
@@ -103,14 +105,27 @@ class SessionUtilKeyPair {
     // if there is both a file and a private key, there is a problem
     if (!Strings.isNullOrEmpty(privateKeyFile) && privateKey != null) {
       throw new SFException(
-          ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
-          "Cannot have both private key value and private key file.");
+              ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
+              "Cannot have both private key object and private key file.");
+    } else if (!Strings.isNullOrEmpty(privateKeyBase64) && privateKey != null) {
+        throw new SFException(
+                ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
+                "Cannot have both private key object and private key string value.");
+    } else if (!Strings.isNullOrEmpty(privateKeyBase64) && !Strings.isNullOrEmpty(privateKeyFile)) {
+      throw new SFException(
+              ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
+              "Cannot have both private key file and private key string value.");
     } else {
-      // if privateKeyFile has a value and privateKey is null
-      this.privateKey =
-          Strings.isNullOrEmpty(privateKeyFile)
-              ? privateKey
-              : extractPrivateKeyFromFile(privateKeyFile, privateKeyFilePwd);
+      if(!Strings.isNullOrEmpty(privateKeyBase64)){
+        // privateKeyBase64 has a value and other options for passing private key are null
+        this.privateKey = extractPrivateKeyFromBase64(privateKeyBase64, privateKeyFilePwd);
+      }else{
+        // either extract from privateKeyFile or use the passed object
+        this.privateKey =
+                Strings.isNullOrEmpty(privateKeyFile)
+                        ? privateKey
+                        : extractPrivateKeyFromFile(privateKeyFile, privateKeyFilePwd);
+      }
     }
     // construct public key from raw bytes
     if (this.privateKey instanceof RSAPrivateCrtKey) {
@@ -148,31 +163,52 @@ class SessionUtilKeyPair {
 
   private PrivateKey extractPrivateKeyFromFile(String privateKeyFile, String privateKeyFilePwd)
       throws SFException {
+
+    try {
+      Path privKeyPath = Paths.get(privateKeyFile);
+      FileUtil.logFileUsage(
+              privKeyPath, "Extract private key from file", true);
+      byte[] bytes = Files.readAllBytes(privKeyPath);
+      return extractPrivateKeyFromBytes(bytes, privateKeyFilePwd);
+    } catch (IOException ie) {
+      logger.error("Could not read private key from file", ie);
+      throw new SFException(ie, ErrorCode.INVALID_PARAMETER_VALUE, ie.getCause());
+    }
+  }
+  private PrivateKey extractPrivateKeyFromBytes(byte[] privateKeyBytes, String privateKeyFilePwd)
+          throws SFException {
     if (isBouncyCastleProviderEnabled) {
       try {
-        return extractPrivateKeyWithBouncyCastle(privateKeyFile, privateKeyFilePwd);
+        return extractPrivateKeyWithBouncyCastle(privateKeyBytes, privateKeyFilePwd);
       } catch (IOException | PKCSException | OperatorCreationException e) {
         logger.error("Could not extract private key using Bouncy Castle provider", e);
         throw new SFException(e, ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY, e.getCause());
       }
     } else {
       try {
-        return extractPrivateKeyWithJdk(privateKeyFile, privateKeyFilePwd);
+        return extractPrivateKeyWithJdk(privateKeyBytes, privateKeyFilePwd);
       } catch (NoSuchAlgorithmException
-          | InvalidKeySpecException
-          | IOException
-          | IllegalArgumentException
-          | NullPointerException
-          | InvalidKeyException e) {
+               | InvalidKeySpecException
+               | IOException
+               | IllegalArgumentException
+               | NullPointerException
+               | InvalidKeyException e) {
         logger.error(
-            "Could not extract private key. Try setting the JVM argument: " + "-D{}" + "=TRUE",
-            SecurityUtil.ENABLE_BOUNCYCASTLE_PROVIDER_JVM);
+                "Could not extract private key using standard JDK. Try setting the JVM argument: " + "-D{}" + "=TRUE",
+                SecurityUtil.ENABLE_BOUNCYCASTLE_PROVIDER_JVM);
         throw new SFException(
-            e,
-            ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
-            privateKeyFile + ": " + e.getMessage());
+                e,
+                ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
+                e.getMessage());
       }
     }
+  }
+
+
+  private PrivateKey extractPrivateKeyFromBase64(String privateKeyBase64, String privateKeyFilePwd)
+          throws SFException {
+    byte[] decodedKey = java.util.Base64.getDecoder().decode(privateKeyBase64);
+    return extractPrivateKeyFromBytes(decodedKey, privateKeyFilePwd);
   }
 
   public String issueJwtToken() throws SFException {
@@ -232,13 +268,11 @@ class SessionUtilKeyPair {
   }
 
   private PrivateKey extractPrivateKeyWithBouncyCastle(
-      String privateKeyFile, String privateKeyFilePwd)
+      byte[] privateKeyBytes, String privateKeyFilePwd)
       throws IOException, PKCSException, OperatorCreationException {
-    Path privKeyPath = Paths.get(privateKeyFile);
-    FileUtil.logFileUsage(
-        privKeyPath, "Extract private key from file using Bouncy Castle provider", true);
+
     PrivateKeyInfo privateKeyInfo = null;
-    PEMParser pemParser = new PEMParser(new FileReader(privKeyPath.toFile()));
+    PEMParser pemParser = new PEMParser(new StringReader(new String(privateKeyBytes, StandardCharsets.UTF_8)));
     Object pemObject = pemParser.readObject();
     if (pemObject instanceof PKCS8EncryptedPrivateKeyInfo) {
       // Handle the case where the private key is encrypted.
@@ -264,11 +298,9 @@ class SessionUtilKeyPair {
     return converter.getPrivateKey(privateKeyInfo);
   }
 
-  private PrivateKey extractPrivateKeyWithJdk(String privateKeyFile, String privateKeyFilePwd)
+  private PrivateKey extractPrivateKeyWithJdk(byte[] privateKeyFileBytes, String privateKeyFilePwd)
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
-    Path privKeyPath = Paths.get(privateKeyFile);
-    FileUtil.logFileUsage(privKeyPath, "Extract private key from file using Jdk", true);
-    String privateKeyContent = new String(Files.readAllBytes(privKeyPath));
+    String privateKeyContent = new String(privateKeyFileBytes, StandardCharsets.UTF_8);
     if (Strings.isNullOrEmpty(privateKeyFilePwd)) {
       // unencrypted private key file
       return generatePrivateKey(false, privateKeyContent, privateKeyFilePwd);

--- a/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
@@ -13,7 +13,6 @@ import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -105,26 +104,26 @@ class SessionUtilKeyPair {
     // if there is both a file and a private key, there is a problem
     if (!Strings.isNullOrEmpty(privateKeyFile) && privateKey != null) {
       throw new SFException(
-              ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
-              "Cannot have both private key object and private key file.");
+          ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
+          "Cannot have both private key object and private key file.");
     } else if (!Strings.isNullOrEmpty(privateKeyBase64) && privateKey != null) {
-        throw new SFException(
-                ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
-                "Cannot have both private key object and private key string value.");
+      throw new SFException(
+          ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
+          "Cannot have both private key object and private key string value.");
     } else if (!Strings.isNullOrEmpty(privateKeyBase64) && !Strings.isNullOrEmpty(privateKeyFile)) {
       throw new SFException(
-              ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
-              "Cannot have both private key file and private key string value.");
+          ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
+          "Cannot have both private key file and private key string value.");
     } else {
-      if(!Strings.isNullOrEmpty(privateKeyBase64)){
+      if (!Strings.isNullOrEmpty(privateKeyBase64)) {
         // privateKeyBase64 has a value and other options for passing private key are null
         this.privateKey = extractPrivateKeyFromBase64(privateKeyBase64, privateKeyFilePwd);
-      }else{
+      } else {
         // either extract from privateKeyFile or use the passed object
         this.privateKey =
-                Strings.isNullOrEmpty(privateKeyFile)
-                        ? privateKey
-                        : extractPrivateKeyFromFile(privateKeyFile, privateKeyFilePwd);
+            Strings.isNullOrEmpty(privateKeyFile)
+                ? privateKey
+                : extractPrivateKeyFromFile(privateKeyFile, privateKeyFilePwd);
       }
     }
     // construct public key from raw bytes
@@ -166,8 +165,7 @@ class SessionUtilKeyPair {
 
     try {
       Path privKeyPath = Paths.get(privateKeyFile);
-      FileUtil.logFileUsage(
-              privKeyPath, "Extract private key from file", true);
+      FileUtil.logFileUsage(privKeyPath, "Extract private key from file", true);
       byte[] bytes = Files.readAllBytes(privKeyPath);
       return extractPrivateKeyFromBytes(bytes, privateKeyFilePwd);
     } catch (IOException ie) {
@@ -175,8 +173,9 @@ class SessionUtilKeyPair {
       throw new SFException(ie, ErrorCode.INVALID_PARAMETER_VALUE, ie.getCause());
     }
   }
+
   private PrivateKey extractPrivateKeyFromBytes(byte[] privateKeyBytes, String privateKeyFilePwd)
-          throws SFException {
+      throws SFException {
     if (isBouncyCastleProviderEnabled) {
       try {
         return extractPrivateKeyWithBouncyCastle(privateKeyBytes, privateKeyFilePwd);
@@ -188,25 +187,23 @@ class SessionUtilKeyPair {
       try {
         return extractPrivateKeyWithJdk(privateKeyBytes, privateKeyFilePwd);
       } catch (NoSuchAlgorithmException
-               | InvalidKeySpecException
-               | IOException
-               | IllegalArgumentException
-               | NullPointerException
-               | InvalidKeyException e) {
+          | InvalidKeySpecException
+          | IOException
+          | IllegalArgumentException
+          | NullPointerException
+          | InvalidKeyException e) {
         logger.error(
-                "Could not extract private key using standard JDK. Try setting the JVM argument: " + "-D{}" + "=TRUE",
-                SecurityUtil.ENABLE_BOUNCYCASTLE_PROVIDER_JVM);
-        throw new SFException(
-                e,
-                ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY,
-                e.getMessage());
+            "Could not extract private key using standard JDK. Try setting the JVM argument: "
+                + "-D{}"
+                + "=TRUE",
+            SecurityUtil.ENABLE_BOUNCYCASTLE_PROVIDER_JVM);
+        throw new SFException(e, ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY, e.getMessage());
       }
     }
   }
 
-
   private PrivateKey extractPrivateKeyFromBase64(String privateKeyBase64, String privateKeyFilePwd)
-          throws SFException {
+      throws SFException {
     byte[] decodedKey = java.util.Base64.getDecoder().decode(privateKeyBase64);
     return extractPrivateKeyFromBytes(decodedKey, privateKeyFilePwd);
   }
@@ -272,7 +269,8 @@ class SessionUtilKeyPair {
       throws IOException, PKCSException, OperatorCreationException {
 
     PrivateKeyInfo privateKeyInfo = null;
-    PEMParser pemParser = new PEMParser(new StringReader(new String(privateKeyBytes, StandardCharsets.UTF_8)));
+    PEMParser pemParser =
+        new PEMParser(new StringReader(new String(privateKeyBytes, StandardCharsets.UTF_8)));
     Object pemObject = pemParser.readObject();
     if (pemObject instanceof PKCS8EncryptedPrivateKeyInfo) {
       // Handle the case where the private key is encrypted.

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
@@ -228,6 +228,14 @@ public class SnowflakeBasicDataSource implements DataSource, Serializable {
     }
   }
 
+  public void setPrivateKeyBase64(String privateKeyBase64, String password) {
+    this.setAuthenticator(AUTHENTICATOR_SNOWFLAKE_JWT);
+    this.properties.put("private_key_base64", privateKeyBase64);
+    if (!Strings.isNullOrEmpty(password)) {
+      this.properties.put("private_key_file_pwd", password);
+    }
+  }
+
   public void setTracing(String tracing) {
     this.properties.put("tracing", tracing);
   }

--- a/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
@@ -91,11 +91,17 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
         .thenReturn(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"));
     try {
       when(loginInput.getPrivateKeyBase64())
-              .thenReturn(Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"))))));
+          .thenReturn(
+              Arrays.toString(
+                  Base64.getEncoder()
+                      .encode(
+                          Files.readAllBytes(
+                              Paths.get(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"))))));
     } catch (IOException e) {
-        throw new SFException(e,ErrorCode.INVALID_PARAMETER_VALUE, systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"));
+      throw new SFException(
+          e, ErrorCode.INVALID_PARAMETER_VALUE, systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"));
     }
-      when(loginInput.getPrivateKeyFilePwd())
+    when(loginInput.getPrivateKeyFilePwd())
         .thenReturn(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE_PWD"));
     when(loginInput.getUserName()).thenReturn(systemGetEnv("SNOWFLAKE_TEST_USER"));
     when(loginInput.getAccountName()).thenReturn("testaccount");

--- a/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilLatestIT.java
@@ -16,10 +16,10 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.category.TestCategoryCore;
 import net.snowflake.client.jdbc.BaseJDBCTest;
@@ -81,7 +81,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
    *
    * @return a mock object for SFLoginInput
    */
-  private SFLoginInput initMockLoginInput() {
+  private SFLoginInput initMockLoginInput() throws SFException {
     // mock SFLoginInput
     SFLoginInput loginInput = mock(SFLoginInput.class);
     when(loginInput.getServerUrl()).thenReturn(systemGetEnv("SNOWFLAKE_TEST_HOST"));
@@ -89,7 +89,13 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
         .thenReturn(ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT.name());
     when(loginInput.getPrivateKeyFile())
         .thenReturn(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"));
-    when(loginInput.getPrivateKeyFilePwd())
+    try {
+      when(loginInput.getPrivateKeyBase64())
+              .thenReturn(Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"))))));
+    } catch (IOException e) {
+        throw new SFException(e,ErrorCode.INVALID_PARAMETER_VALUE, systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE"));
+    }
+      when(loginInput.getPrivateKeyFilePwd())
         .thenReturn(systemGetEnv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE_PWD"));
     when(loginInput.getUserName()).thenReturn(systemGetEnv("SNOWFLAKE_TEST_USER"));
     when(loginInput.getAccountName()).thenReturn("testaccount");

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -779,40 +779,45 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     ds.setAccount(params.get("account"));
     ds.setPortNumber(Integer.parseInt(params.get("port")));
     ds.setUser(params.get("user"));
-    String privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
+    String privateKeyBase64 =
+        Arrays.toString(
+            Base64.getEncoder()
+                .encode(
+                    Files.readAllBytes(
+                        Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
     ds.setPrivateKeyBase64(privateKeyBase64, "test");
 
     // set up public key
     try (Connection con = getConnection();
-         Statement statement = con.createStatement()) {
+        Statement statement = con.createStatement()) {
       statement.execute("use role accountadmin");
       String pathfile = getFullPathFileInResource("encrypted_rsa_key.pub");
       String pubKey = new String(Files.readAllBytes(Paths.get(pathfile)));
       pubKey = pubKey.replace("-----BEGIN PUBLIC KEY-----", "");
       pubKey = pubKey.replace("-----END PUBLIC KEY-----", "");
       statement.execute(
-              String.format("alter user %s set rsa_public_key='%s'", params.get("user"), pubKey));
+          String.format("alter user %s set rsa_public_key='%s'", params.get("user"), pubKey));
     }
 
     try (Connection con = ds.getConnection();
-         Statement statement = con.createStatement();
-         ResultSet resultSet = statement.executeQuery("select 1")) {
+        Statement statement = con.createStatement();
+        ResultSet resultSet = statement.executeQuery("select 1")) {
       resultSet.next();
       assertThat("select 1", resultSet.getInt(1), equalTo(1));
     }
     File serializedFile = tmpFolder.newFile("serializedStuff.ser");
     // serialize datasource object into a file
     try (FileOutputStream outputFile = new FileOutputStream(serializedFile);
-         ObjectOutputStream out = new ObjectOutputStream(outputFile)) {
+        ObjectOutputStream out = new ObjectOutputStream(outputFile)) {
       out.writeObject(ds);
     }
     // deserialize into datasource object again
     try (FileInputStream inputFile = new FileInputStream(serializedFile);
-         ObjectInputStream in = new ObjectInputStream(inputFile)) {
+        ObjectInputStream in = new ObjectInputStream(inputFile)) {
       SnowflakeBasicDataSource ds2 = (SnowflakeBasicDataSource) in.readObject();
       // test connection a second time
       try (Connection con = ds2.getConnection();
-           Statement statement = con.createStatement()) {
+          Statement statement = con.createStatement()) {
         ResultSet resultSet = statement.executeQuery("select 1");
         resultSet.next();
         assertThat("select 1", resultSet.getInt(1), equalTo(1));
@@ -826,7 +831,6 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       }
     }
   }
-
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
@@ -955,7 +959,7 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     String pubKey = null;
     // Test with non-password-protected private key file (.pem)
     try (Connection connection = getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
       statement.execute("use role accountadmin");
       pathfile = getFullPathFileInResource("rsa_key.pub");
       pubKey = new String(Files.readAllBytes(Paths.get(pathfile)));
@@ -965,7 +969,10 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     }
 
     // PKCS #8
-    String privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("rsa_key.p8")))));
+    String privateKeyBase64 =
+        Arrays.toString(
+            Base64.getEncoder()
+                .encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("rsa_key.p8")))));
     String uri = parameters.get("uri") + "/?private_key_base64=" + privateKeyBase64;
     Properties properties = new Properties();
     properties.put("account", parameters.get("account"));
@@ -975,7 +982,10 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     try (Connection connection = DriverManager.getConnection(uri, properties)) {}
 
     // PKCS #1
-    privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("rsa_key.pem")))));
+    privateKeyBase64 =
+        Arrays.toString(
+            Base64.getEncoder()
+                .encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("rsa_key.pem")))));
     uri = parameters.get("uri") + "/?private_key_base64=" + privateKeyBase64;
     properties = new Properties();
     properties.put("account", parameters.get("account"));
@@ -987,7 +997,7 @@ public class ConnectionLatestIT extends BaseJDBCTest {
 
     // test with password-protected private key file (.p8)
     try (Connection connection = getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
       statement.execute("use role accountadmin");
       pathfile = getFullPathFileInResource("encrypted_rsa_key.pub");
       pubKey = new String(Files.readAllBytes(Paths.get(pathfile)));
@@ -996,29 +1006,34 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       statement.execute(String.format("alter user %s set rsa_public_key='%s'", testUser, pubKey));
     }
 
-    privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
+    privateKeyBase64 =
+        Arrays.toString(
+            Base64.getEncoder()
+                .encode(
+                    Files.readAllBytes(
+                        Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
     uri =
-            parameters.get("uri")
-                    + "/?private_key_file_pwd=test&private_key_base64="
-                    + privateKeyBase64;
+        parameters.get("uri")
+            + "/?private_key_file_pwd=test&private_key_base64="
+            + privateKeyBase64;
 
     try (Connection connection = DriverManager.getConnection(uri, properties)) {}
     // test with incorrect password for private key
     uri =
-            parameters.get("uri")
-                    + "/?private_key_file_pwd=wrong_password&private_key_base64="
-                    + privateKeyBase64;
+        parameters.get("uri")
+            + "/?private_key_file_pwd=wrong_password&private_key_base64="
+            + privateKeyBase64;
 
     try (Connection connection = DriverManager.getConnection(uri, properties)) {
       fail();
     } catch (SQLException e) {
       assertEquals(
-              (int) ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY.getMessageCode(), e.getErrorCode());
+          (int) ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY.getMessageCode(), e.getErrorCode());
     }
 
     // test with invalid public/private key combo (using 1st public key with 2nd private key)
     try (Connection connection = getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
       statement.execute("use role accountadmin");
       pathfile = getFullPathFileInResource("rsa_key.pub");
       pubKey = new String(Files.readAllBytes(Paths.get(pathfile)));
@@ -1027,11 +1042,16 @@ public class ConnectionLatestIT extends BaseJDBCTest {
       statement.execute(String.format("alter user %s set rsa_public_key='%s'", testUser, pubKey));
     }
 
-    privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
+    privateKeyBase64 =
+        Arrays.toString(
+            Base64.getEncoder()
+                .encode(
+                    Files.readAllBytes(
+                        Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
     uri =
-            parameters.get("uri")
-                    + "/?private_key_file_pwd=test&private_key_base64="
-                    + privateKeyBase64;
+        parameters.get("uri")
+            + "/?private_key_file_pwd=test&private_key_base64="
+            + privateKeyBase64;
     try (Connection connection = DriverManager.getConnection(uri, properties)) {
       fail();
     } catch (SQLException e) {
@@ -1039,18 +1059,23 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     }
 
     // test with invalid private key
-    privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("invalid_private_key.pem")))));
+    privateKeyBase64 =
+        Arrays.toString(
+            Base64.getEncoder()
+                .encode(
+                    Files.readAllBytes(
+                        Paths.get(getFullPathFileInResource("invalid_private_key.pem")))));
     uri = parameters.get("uri") + "/?private_key_base64=" + privateKeyBase64;
     try (Connection connection = DriverManager.getConnection(uri, properties)) {
       fail();
     } catch (SQLException e) {
       assertEquals(
-              (int) ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY.getMessageCode(), e.getErrorCode());
+          (int) ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY.getMessageCode(), e.getErrorCode());
     }
 
     // clean up
     try (Connection connection = getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
       statement.execute("use role accountadmin");
       statement.execute(String.format("alter user %s unset rsa_public_key", testUser));
     }
@@ -1059,7 +1084,8 @@ public class ConnectionLatestIT extends BaseJDBCTest {
   // This will only work with JDBC driver versions higher than 3.15.1
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
-  public void testPrivateKeyBase64InConnectionStringWithBouncyCastle() throws SQLException, IOException {
+  public void testPrivateKeyBase64InConnectionStringWithBouncyCastle()
+      throws SQLException, IOException {
     System.setProperty(SecurityUtil.ENABLE_BOUNCYCASTLE_PROVIDER_JVM, "true");
     testPrivateKeyBase64InConnectionString();
   }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -39,12 +39,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import net.snowflake.client.ConditionalIgnoreRule;
 import net.snowflake.client.RunningNotOnAWS;
@@ -771,6 +766,67 @@ public class ConnectionLatestIT extends BaseJDBCTest {
 
   @Test
   @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testKeyPairBase64DataSourceSerialization() throws Exception {
+    // test with key/pair authentication where key is passed as a Base64 string value
+    // set up DataSource object and ensure connection works
+    Map<String, String> params = getConnectionParameters();
+    SnowflakeBasicDataSource ds = new SnowflakeBasicDataSource();
+    ds.setServerName(params.get("host"));
+    ds.setSsl("on".equals(params.get("ssl")));
+    ds.setAccount(params.get("account"));
+    ds.setPortNumber(Integer.parseInt(params.get("port")));
+    ds.setUser(params.get("user"));
+    String privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
+    ds.setPrivateKeyBase64(privateKeyBase64, "test");
+
+    // set up public key
+    try (Connection con = getConnection();
+         Statement statement = con.createStatement()) {
+      statement.execute("use role accountadmin");
+      String pathfile = getFullPathFileInResource("encrypted_rsa_key.pub");
+      String pubKey = new String(Files.readAllBytes(Paths.get(pathfile)));
+      pubKey = pubKey.replace("-----BEGIN PUBLIC KEY-----", "");
+      pubKey = pubKey.replace("-----END PUBLIC KEY-----", "");
+      statement.execute(
+              String.format("alter user %s set rsa_public_key='%s'", params.get("user"), pubKey));
+    }
+
+    try (Connection con = ds.getConnection();
+         Statement statement = con.createStatement();
+         ResultSet resultSet = statement.executeQuery("select 1")) {
+      resultSet.next();
+      assertThat("select 1", resultSet.getInt(1), equalTo(1));
+    }
+    File serializedFile = tmpFolder.newFile("serializedStuff.ser");
+    // serialize datasource object into a file
+    try (FileOutputStream outputFile = new FileOutputStream(serializedFile);
+         ObjectOutputStream out = new ObjectOutputStream(outputFile)) {
+      out.writeObject(ds);
+    }
+    // deserialize into datasource object again
+    try (FileInputStream inputFile = new FileInputStream(serializedFile);
+         ObjectInputStream in = new ObjectInputStream(inputFile)) {
+      SnowflakeBasicDataSource ds2 = (SnowflakeBasicDataSource) in.readObject();
+      // test connection a second time
+      try (Connection con = ds2.getConnection();
+           Statement statement = con.createStatement()) {
+        ResultSet resultSet = statement.executeQuery("select 1");
+        resultSet.next();
+        assertThat("select 1", resultSet.getInt(1), equalTo(1));
+      }
+
+      // clean up
+      try (Connection connection = getConnection()) {
+        Statement statement = connection.createStatement();
+        statement.execute("use role accountadmin");
+        statement.execute(String.format("alter user %s unset rsa_public_key", params.get("user")));
+      }
+    }
+  }
+
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
   public void testPrivateKeyInConnectionString() throws SQLException, IOException {
     Map<String, String> parameters = getConnectionParameters();
     String testUser = parameters.get("user");
@@ -885,6 +941,124 @@ public class ConnectionLatestIT extends BaseJDBCTest {
   public void testPrivateKeyInConnectionStringWithBouncyCastle() throws SQLException, IOException {
     System.setProperty(SecurityUtil.ENABLE_BOUNCYCASTLE_PROVIDER_JVM, "true");
     testPrivateKeyInConnectionString();
+  }
+
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testPrivateKeyBase64InConnectionString() throws SQLException, IOException {
+    Map<String, String> parameters = getConnectionParameters();
+    String testUser = parameters.get("user");
+    String pathfile = null;
+    String pubKey = null;
+    // Test with non-password-protected private key file (.pem)
+    try (Connection connection = getConnection();
+         Statement statement = connection.createStatement()) {
+      statement.execute("use role accountadmin");
+      pathfile = getFullPathFileInResource("rsa_key.pub");
+      pubKey = new String(Files.readAllBytes(Paths.get(pathfile)));
+      pubKey = pubKey.replace("-----BEGIN PUBLIC KEY-----", "");
+      pubKey = pubKey.replace("-----END PUBLIC KEY-----", "");
+      statement.execute(String.format("alter user %s set rsa_public_key='%s'", testUser, pubKey));
+    }
+
+    // PKCS #8
+    String privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("rsa_key.p8")))));
+    String uri = parameters.get("uri") + "/?private_key_base64=" + privateKeyBase64;
+    Properties properties = new Properties();
+    properties.put("account", parameters.get("account"));
+    properties.put("user", testUser);
+    properties.put("ssl", parameters.get("ssl"));
+    properties.put("port", parameters.get("port"));
+    try (Connection connection = DriverManager.getConnection(uri, properties)) {}
+
+    // PKCS #1
+    privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("rsa_key.pem")))));
+    uri = parameters.get("uri") + "/?private_key_base64=" + privateKeyBase64;
+    properties = new Properties();
+    properties.put("account", parameters.get("account"));
+    properties.put("user", testUser);
+    properties.put("ssl", parameters.get("ssl"));
+    properties.put("port", parameters.get("port"));
+    properties.put("authenticator", ClientAuthnDTO.AuthenticatorType.SNOWFLAKE_JWT.toString());
+    try (Connection connection = DriverManager.getConnection(uri, properties)) {}
+
+    // test with password-protected private key file (.p8)
+    try (Connection connection = getConnection();
+         Statement statement = connection.createStatement()) {
+      statement.execute("use role accountadmin");
+      pathfile = getFullPathFileInResource("encrypted_rsa_key.pub");
+      pubKey = new String(Files.readAllBytes(Paths.get(pathfile)));
+      pubKey = pubKey.replace("-----BEGIN PUBLIC KEY-----", "");
+      pubKey = pubKey.replace("-----END PUBLIC KEY-----", "");
+      statement.execute(String.format("alter user %s set rsa_public_key='%s'", testUser, pubKey));
+    }
+
+    privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
+    uri =
+            parameters.get("uri")
+                    + "/?private_key_file_pwd=test&private_key_base64="
+                    + privateKeyBase64;
+
+    try (Connection connection = DriverManager.getConnection(uri, properties)) {}
+    // test with incorrect password for private key
+    uri =
+            parameters.get("uri")
+                    + "/?private_key_file_pwd=wrong_password&private_key_base64="
+                    + privateKeyBase64;
+
+    try (Connection connection = DriverManager.getConnection(uri, properties)) {
+      fail();
+    } catch (SQLException e) {
+      assertEquals(
+              (int) ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY.getMessageCode(), e.getErrorCode());
+    }
+
+    // test with invalid public/private key combo (using 1st public key with 2nd private key)
+    try (Connection connection = getConnection();
+         Statement statement = connection.createStatement()) {
+      statement.execute("use role accountadmin");
+      pathfile = getFullPathFileInResource("rsa_key.pub");
+      pubKey = new String(Files.readAllBytes(Paths.get(pathfile)));
+      pubKey = pubKey.replace("-----BEGIN PUBLIC KEY-----", "");
+      pubKey = pubKey.replace("-----END PUBLIC KEY-----", "");
+      statement.execute(String.format("alter user %s set rsa_public_key='%s'", testUser, pubKey));
+    }
+
+    privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("encrypted_rsa_key.p8")))));
+    uri =
+            parameters.get("uri")
+                    + "/?private_key_file_pwd=test&private_key_base64="
+                    + privateKeyBase64;
+    try (Connection connection = DriverManager.getConnection(uri, properties)) {
+      fail();
+    } catch (SQLException e) {
+      assertEquals(390144, e.getErrorCode());
+    }
+
+    // test with invalid private key
+    privateKeyBase64 = Arrays.toString(Base64.getEncoder().encode(Files.readAllBytes(Paths.get(getFullPathFileInResource("invalid_private_key.pem")))));
+    uri = parameters.get("uri") + "/?private_key_base64=" + privateKeyBase64;
+    try (Connection connection = DriverManager.getConnection(uri, properties)) {
+      fail();
+    } catch (SQLException e) {
+      assertEquals(
+              (int) ErrorCode.INVALID_OR_UNSUPPORTED_PRIVATE_KEY.getMessageCode(), e.getErrorCode());
+    }
+
+    // clean up
+    try (Connection connection = getConnection();
+         Statement statement = connection.createStatement()) {
+      statement.execute("use role accountadmin");
+      statement.execute(String.format("alter user %s unset rsa_public_key", testUser));
+    }
+  }
+
+  // This will only work with JDBC driver versions higher than 3.15.1
+  @Test
+  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
+  public void testPrivateKeyBase64InConnectionStringWithBouncyCastle() throws SQLException, IOException {
+    System.setProperty(SecurityUtil.ENABLE_BOUNCYCASTLE_PROVIDER_JVM, "true");
+    testPrivateKeyBase64InConnectionString();
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -213,7 +213,7 @@ public class TelemetryIT extends AbstractDriverIT {
     Map<String, String> parameters = getConnectionParameters();
     String jwtToken =
         SessionUtil.generateJWTToken(
-            null, privateKeyLocation, null, parameters.get("account"), parameters.get("user"));
+            null, privateKeyLocation, null,null, parameters.get("account"), parameters.get("user"));
 
     CloseableHttpClient httpClient = HttpUtil.buildHttpClient(null, null, false);
     TelemetryClient telemetry =
@@ -232,7 +232,7 @@ public class TelemetryIT extends AbstractDriverIT {
     Map<String, String> parameters = getConnectionParameters();
     String jwtToken =
         SessionUtil.generateJWTToken(
-            null, privateKeyLocation, null, parameters.get("account"), parameters.get("user"));
+            null, privateKeyLocation, null,null, parameters.get("account"), parameters.get("user"));
 
     CloseableHttpClient httpClient = HttpUtil.buildHttpClient(null, null, false);
     TelemetryClient telemetry =

--- a/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/telemetry/TelemetryIT.java
@@ -213,7 +213,12 @@ public class TelemetryIT extends AbstractDriverIT {
     Map<String, String> parameters = getConnectionParameters();
     String jwtToken =
         SessionUtil.generateJWTToken(
-            null, privateKeyLocation, null,null, parameters.get("account"), parameters.get("user"));
+            null,
+            privateKeyLocation,
+            null,
+            null,
+            parameters.get("account"),
+            parameters.get("user"));
 
     CloseableHttpClient httpClient = HttpUtil.buildHttpClient(null, null, false);
     TelemetryClient telemetry =
@@ -232,7 +237,12 @@ public class TelemetryIT extends AbstractDriverIT {
     Map<String, String> parameters = getConnectionParameters();
     String jwtToken =
         SessionUtil.generateJWTToken(
-            null, privateKeyLocation, null,null, parameters.get("account"), parameters.get("user"));
+            null,
+            privateKeyLocation,
+            null,
+            null,
+            parameters.get("account"),
+            parameters.get("user"));
 
     CloseableHttpClient httpClient = HttpUtil.buildHttpClient(null, null, false);
     TelemetryClient telemetry =


### PR DESCRIPTION
# Overview

SNOW-618478

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1053 

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [] I am adding new logging messages 
          - None were added but a few log messages were tweaked for clarity
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

There are currently only two options for passing a privateKey for authentication purposes. The key can be supplied as a fully instantiated PrivateKey object or a path to a private key file can be supplied and the PrivateKey object will be extracted. Neither option supports the usecase where the calling code needs to pass the privateKey as a String. 

As the GitHub issue documents, there are several scenarios where passing the privateKey as a String is required (Hikari pool only accepts property values of type String, Spark.read if you don't want to push the file to every executor, etc..).  This PR adds a new session property "private_key_base64" which complements the existing "private_key_file". The new logic ensures that only one of private_key_base64, private_key_file, or private_key are not null.  Then it extracts, decrypts, and instantiates the needed private_key as appropriate.  

The PR piggy-backs upon the existing tests for private_key_file and adds variants that instead leverage private_key_base64 to demonstrate expected behavior.