### PR TITLE
SNOW-1503887: Limit retry backoff to always be in range

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
@@ -5,6 +5,7 @@ package net.snowflake.client.jdbc;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -23,6 +24,7 @@ import net.snowflake.client.RunningNotOnLinuxMac;
 import net.snowflake.client.core.ExecTimeTelemetryData;
 import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.jdbc.telemetryOOB.TelemetryService;
+import net.snowflake.client.util.DecorrelatedJitterBackoff;
 import org.apache.http.StatusLine;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -594,6 +596,43 @@ public class RestRequestTest {
       } else {
         TelemetryService.disable();
       }
+    }
+  }
+
+  @Test
+  public void shouldGenerateBackoffInRangeExceptTheLastBackoff() {
+    int minBackoffInMilli = 1000;
+    int maxBackoffInMilli = 16000;
+    long backoffInMilli = minBackoffInMilli;
+    long elapsedMilliForTransientIssues = 0;
+    DecorrelatedJitterBackoff decorrelatedJitterBackoff =
+        new DecorrelatedJitterBackoff(minBackoffInMilli, maxBackoffInMilli);
+    int retryTimeoutInMilli = 5 * 60 * 1000;
+    while (true) {
+      backoffInMilli =
+          RestRequest.getNewBackoffInMilli(
+              backoffInMilli,
+              true,
+              decorrelatedJitterBackoff,
+              10,
+              retryTimeoutInMilli,
+              elapsedMilliForTransientIssues);
+
+      assertTrue(
+          "Backoff should be lower or equal to max backoff limit",
+          backoffInMilli <= maxBackoffInMilli);
+      if (elapsedMilliForTransientIssues + backoffInMilli >= retryTimeoutInMilli) {
+        assertEquals(
+            "Backoff should fill time till retry timeout",
+            retryTimeoutInMilli - elapsedMilliForTransientIssues,
+            backoffInMilli);
+        break;
+      } else {
+        assertTrue(
+            "Backoff should be higher or equal to min backoff limit",
+            backoffInMilli >= minBackoffInMilli);
+      }
+      elapsedMilliForTransientIssues += backoffInMilli;
     }
   }
 }


### PR DESCRIPTION
# Overview

SNOW-1503887

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
