### PR TITLE
SNOW-1016468: Set last query id for all failed statements updated

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFException.java
+++ b/src/main/java/net/snowflake/client/core/SFException.java
@@ -36,6 +36,18 @@ public class SFException extends Throwable {
     this.params = params;
   }
 
+  public SFException(String queryID, ErrorCode errorCode, Object... params) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(
+            String.valueOf(errorCode.getMessageCode()), params));
+
+    this.cause = null;
+    this.queryId = queryID;
+    this.sqlState = errorCode.getSqlState();
+    this.vendorCode = errorCode.getMessageCode();
+    this.params = params;
+  }
+
   public SFException(Throwable cause, ErrorCode errorCode, Object... params) {
     super(
         errorResourceBundleManager.getLocalizedMessage(
@@ -44,6 +56,19 @@ public class SFException extends Throwable {
 
     this.cause = null;
     this.queryId = null;
+    this.sqlState = errorCode.getSqlState();
+    this.vendorCode = errorCode.getMessageCode();
+    this.params = params;
+  }
+
+  public SFException(String queryId, Throwable cause, ErrorCode errorCode, Object... params) {
+    super(
+        errorResourceBundleManager.getLocalizedMessage(
+            String.valueOf(errorCode.getMessageCode()), params),
+        cause);
+
+    this.cause = null;
+    this.queryId = queryId;
     this.sqlState = errorCode.getSqlState();
     this.vendorCode = errorCode.getMessageCode();
     this.params = params;

--- a/src/main/java/net/snowflake/client/core/SFException.java
+++ b/src/main/java/net/snowflake/client/core/SFException.java
@@ -24,41 +24,22 @@ public class SFException extends Throwable {
   private int vendorCode;
   private Object[] params;
 
+  /** use {@link SFException#SFException(String, Throwable, ErrorCode, Object...)} */
+  @Deprecated
   public SFException(ErrorCode errorCode, Object... params) {
-    super(
-        errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(errorCode.getMessageCode()), params));
-
-    this.cause = null;
-    this.queryId = null;
-    this.sqlState = errorCode.getSqlState();
-    this.vendorCode = errorCode.getMessageCode();
-    this.params = params;
+    this(null, null, errorCode, params);
   }
 
+  /** use {@link SFException#SFException(String, Throwable, ErrorCode, Object...)} */
+  @Deprecated
   public SFException(String queryID, ErrorCode errorCode, Object... params) {
-    super(
-        errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(errorCode.getMessageCode()), params));
-
-    this.cause = null;
-    this.queryId = queryID;
-    this.sqlState = errorCode.getSqlState();
-    this.vendorCode = errorCode.getMessageCode();
-    this.params = params;
+    this(queryID, null, errorCode, params);
   }
 
+  /** use {@link SFException#SFException(String, Throwable, ErrorCode, Object...)} */
+  @Deprecated
   public SFException(Throwable cause, ErrorCode errorCode, Object... params) {
-    super(
-        errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(errorCode.getMessageCode()), params),
-        cause);
-
-    this.cause = null;
-    this.queryId = null;
-    this.sqlState = errorCode.getSqlState();
-    this.vendorCode = errorCode.getMessageCode();
-    this.params = params;
+    this(null, cause, errorCode, params);
   }
 
   public SFException(String queryId, Throwable cause, ErrorCode errorCode, Object... params) {

--- a/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFFixedViewResultSet.java
@@ -67,6 +67,7 @@ public class SFFixedViewResultSet extends SFJsonResultSet {
 
     } catch (Exception ex) {
       throw new SnowflakeSQLLoggedException(
+          queryID,
           session,
           SqlState.INTERNAL_ERROR,
           ErrorCode.INTERNAL_ERROR.getMessageCode(),
@@ -91,6 +92,7 @@ public class SFFixedViewResultSet extends SFJsonResultSet {
       nextRowList = fixedView.getNextRow();
     } catch (Exception ex) {
       throw new SFException(
+          queryID,
           ErrorCode.INTERNAL_ERROR,
           IncidentUtil.oneLiner("Error getting next row from " + "fixed view:", ex));
     }
@@ -115,11 +117,11 @@ public class SFFixedViewResultSet extends SFJsonResultSet {
     logger.trace("Object getObjectInternal(int columnIndex)", false);
 
     if (nextRow == null) {
-      throw new SFException(ErrorCode.ROW_DOES_NOT_EXIST);
+      throw new SFException(queryID, ErrorCode.ROW_DOES_NOT_EXIST);
     }
 
     if (columnIndex <= 0 || columnIndex > nextRow.length) {
-      throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
+      throw new SFException(queryID, ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
 
     wasNull = nextRow[columnIndex - 1] == null;

--- a/src/main/java/net/snowflake/client/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSet.java
@@ -191,6 +191,7 @@ public class SFResultSet extends SFJsonResultSet {
       // we don't support sort result when there are offline chunks
       if (chunkCount > 0) {
         throw new SnowflakeSQLLoggedException(
+            queryId,
             session,
             ErrorCode.CLIENT_SIDE_SORTING_NOT_SUPPORTED.getMessageCode(),
             SqlState.FEATURE_NOT_SUPPORTED);
@@ -242,6 +243,7 @@ public class SFResultSet extends SFJsonResultSet {
 
         if (nextChunk == null) {
           throw new SnowflakeSQLLoggedException(
+              queryId,
               session,
               ErrorCode.INTERNAL_ERROR.getMessageCode(),
               SqlState.INTERNAL_ERROR,
@@ -260,7 +262,7 @@ public class SFResultSet extends SFJsonResultSet {
         return true;
       } catch (InterruptedException ex) {
         throw new SnowflakeSQLLoggedException(
-            session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
+            queryId, session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
       }
     } else if (chunkCount > 0) {
       try {
@@ -269,7 +271,7 @@ public class SFResultSet extends SFJsonResultSet {
         logChunkDownloaderMetrics(metrics);
       } catch (InterruptedException ex) {
         throw new SnowflakeSQLLoggedException(
-            session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
+            queryId, session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
       }
     }
 
@@ -319,7 +321,7 @@ public class SFResultSet extends SFJsonResultSet {
           || Boolean.TRUE
               .toString()
               .equalsIgnoreCase(systemGetProperty("snowflake.enable_incident_test2"))) {
-        throw new SFException(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED);
+        throw new SFException(queryId, ErrorCode.MAX_RESULT_LIMIT_EXCEEDED);
       }
 
       // mark end of result
@@ -330,7 +332,7 @@ public class SFResultSet extends SFJsonResultSet {
   @Override
   protected Object getObjectInternal(int columnIndex) throws SFException {
     if (columnIndex <= 0 || columnIndex > resultSetMetaData.getColumnCount()) {
-      throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
+      throw new SFException(queryId, ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
 
     final int internalColumnIndex = columnIndex - 1;
@@ -343,7 +345,7 @@ public class SFResultSet extends SFJsonResultSet {
     } else if (currentChunk != null) {
       retValue = currentChunk.getCell(currentChunkRowIndex, internalColumnIndex);
     } else {
-      throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
+      throw new SFException(queryId, ErrorCode.COLUMN_DOES_NOT_EXIST, columnIndex);
     }
     wasNull = retValue == null;
     return retValue;
@@ -422,7 +424,7 @@ public class SFResultSet extends SFJsonResultSet {
       }
     } catch (InterruptedException ex) {
       throw new SnowflakeSQLLoggedException(
-          session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
+          queryId, session, ErrorCode.INTERRUPTED.getMessageCode(), SqlState.QUERY_CANCELED);
     }
   }
 

--- a/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
+++ b/src/main/java/net/snowflake/client/core/SFResultSetMetaData.java
@@ -375,11 +375,12 @@ public class SFResultSetMetaData {
   public int getInternalColumnType(int column) throws SFException {
     int columnIdx = column - 1;
     if (column < 1 || column > columnTypes.size()) {
-      throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, column);
+      throw new SFException(queryId, ErrorCode.COLUMN_DOES_NOT_EXIST, column);
     }
 
     if (columnTypes.get(columnIdx) == null) {
-      throw new SFException(ErrorCode.INTERNAL_ERROR, "Missing column type for column " + column);
+      throw new SFException(
+          queryId, ErrorCode.INTERNAL_ERROR, "Missing column type for column " + column);
     }
 
     return columnTypes.get(columnIdx);
@@ -387,11 +388,12 @@ public class SFResultSetMetaData {
 
   public String getColumnTypeName(int column) throws SFException {
     if (column < 1 || column > columnTypeNames.size()) {
-      throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, column);
+      throw new SFException(queryId, ErrorCode.COLUMN_DOES_NOT_EXIST, column);
     }
 
     if (columnTypeNames.get(column - 1) == null) {
-      throw new SFException(ErrorCode.INTERNAL_ERROR, "Missing column type for column " + column);
+      throw new SFException(
+          queryId, ErrorCode.INTERNAL_ERROR, "Missing column type for column " + column);
     }
 
     return columnTypeNames.get(column - 1);
@@ -497,11 +499,12 @@ public class SFResultSetMetaData {
   @SnowflakeJdbcInternalApi
   public List<FieldMetadata> getColumnFields(int column) throws SFException {
     if (column < 1 || column > columnMetadata.size()) {
-      throw new SFException(ErrorCode.COLUMN_DOES_NOT_EXIST, column);
+      throw new SFException(queryId, ErrorCode.COLUMN_DOES_NOT_EXIST, column);
     }
 
     if (columnMetadata.get(column - 1) == null) {
-      throw new SFException(ErrorCode.INTERNAL_ERROR, "Missing column fields for column " + column);
+      throw new SFException(
+          queryId, ErrorCode.INTERNAL_ERROR, "Missing column fields for column " + column);
     }
 
     return columnMetadata.get(column - 1).getFields();

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -223,7 +223,10 @@ public class SFSession extends SFBaseSession {
         jsonNode = OBJECT_MAPPER.readTree(response);
       } catch (Exception e) {
         throw new SnowflakeSQLLoggedException(
-            this, e.getMessage(), "No response or invalid response from GET request. Error: {}");
+            queryID,
+            this,
+            e.getMessage(),
+            "No response or invalid response from GET request. Error: {}");
       }
 
       // Get response as JSON and parse it to get the query status
@@ -257,7 +260,7 @@ public class SFSession extends SFBaseSession {
             else if (ex instanceof SFException) {
               throw new SnowflakeSQLException((SFException) ex);
             }
-            throw new SnowflakeSQLException(ex.getMessage());
+            throw new SnowflakeSQLException(queryID, ex.getMessage());
           }
           sessionRenewed = true;
           // If the error code was not due to session renewal issues, throw an exception

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeResultSetSerializableV1.java
@@ -954,6 +954,7 @@ public class SnowflakeResultSetSerializableV1
             (this.firstChunkStringData != null) ? mapper.readTree(this.firstChunkStringData) : null;
       } catch (IOException ex) {
         throw new SnowflakeSQLLoggedException(
+            queryId,
             possibleSession.orElse(/* session = */ null),
             "The JSON data is invalid. The error is: " + ex.getMessage());
       }
@@ -995,6 +996,7 @@ public class SnowflakeResultSetSerializableV1
 
     if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null) {
       throw new SnowflakeSQLLoggedException(
+          queryId,
           this.possibleSession.orElse(/* session = */ null),
           "The Result Set serializable is invalid.");
     }
@@ -1053,6 +1055,7 @@ public class SnowflakeResultSetSerializableV1
       SessionUtil.resetOCSPUrlIfNecessary(resultSetRetrieveConfig.getSfFullURL());
     } catch (IOException e) {
       throw new SnowflakeSQLLoggedException(
+          queryId,
           /*session = */ null, // There is no connection
           ErrorCode.INTERNAL_ERROR,
           "Hit exception when adjusting OCSP cache server. The original message is: "
@@ -1125,6 +1128,7 @@ public class SnowflakeResultSetSerializableV1
         }
       default:
         throw new SnowflakeSQLLoggedException(
+            queryId,
             this.possibleSession.orElse(/*session = */ null),
             ErrorCode.INTERNAL_ERROR,
             "Unsupported query result format: " + getQueryResultFormat().name());
@@ -1168,6 +1172,7 @@ public class SnowflakeResultSetSerializableV1
         logger.debug("Interrupted when loading Arrow first chunk row count.", cbie);
       } catch (Exception ex) {
         throw new SnowflakeSQLLoggedException(
+            queryId,
             possibleSession.orElse(/* session = */ null),
             ErrorCode.INTERNAL_ERROR,
             "Fail to retrieve row count for first arrow chunk: " + ex.getMessage());
@@ -1179,6 +1184,7 @@ public class SnowflakeResultSetSerializableV1
     } else {
       // This shouldn't happen
       throw new SnowflakeSQLLoggedException(
+          queryId,
           this.possibleSession.orElse(/*session = */ null),
           ErrorCode.INTERNAL_ERROR,
           "setFirstChunkRowCountForArrow() should only be called for Arrow.");

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -57,6 +57,13 @@ public class SnowflakeSQLException extends SQLException {
     logger.debug("Snowflake exception: {}, sqlState: {}", reason, sqlState);
   }
 
+  public SnowflakeSQLException(String queryId, String reason, String sqlState) {
+    super(reason, sqlState);
+    this.queryId = queryId;
+    // log user error from GS at fine level
+    logger.debug("Snowflake exception: {}, sqlState:{}", reason, sqlState);
+  }
+
   /** use {@link SnowflakeSQLException#SnowflakeSQLException(String, String, int)} */
   @Deprecated
   public SnowflakeSQLException(String sqlState, int vendorCode) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLException.java
@@ -51,10 +51,10 @@ public class SnowflakeSQLException extends SQLException {
         queryId);
   }
 
+  /** use {@link SnowflakeSQLException#SnowflakeSQLException(String, String, String)} */
+  @Deprecated
   public SnowflakeSQLException(String reason, String sqlState) {
-    super(reason, sqlState);
-    // log user error from GS at fine level
-    logger.debug("Snowflake exception: {}, sqlState: {}", reason, sqlState);
+    this((String) null, reason, sqlState);
   }
 
   public SnowflakeSQLException(String queryId, String reason, String sqlState) {

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -247,6 +247,12 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
   }
 
   public SnowflakeSQLLoggedException(
+      String queryId, SFBaseSession session, String SQLState, String reason) {
+    super(reason, SQLState);
+    sendTelemetryData(queryId, SQLState, -1, session, this);
+  }
+
+  public SnowflakeSQLLoggedException(
       SFBaseSession session, int vendorCode, String SQLState, Object... params) {
     this(null, session, vendorCode, SQLState, params);
   }
@@ -285,6 +291,12 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     sendTelemetryData(null, null, -1, session, this);
   }
 
+  public SnowflakeSQLLoggedException(
+      String queryId, SFBaseSession session, ErrorCode errorCode, Object... params) {
+    super(queryId, errorCode, params);
+    sendTelemetryData(queryId, null, -1, session, this);
+  }
+
   public SnowflakeSQLLoggedException(SFBaseSession session, SFException e) {
     super(e);
     sendTelemetryData(null, null, -1, session, this);
@@ -293,5 +305,10 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
   public SnowflakeSQLLoggedException(SFBaseSession session, String reason) {
     super(reason);
     sendTelemetryData(null, null, -1, session, this);
+  }
+
+  public SnowflakeSQLLoggedException(String queryId, SFBaseSession session, String reason) {
+    super(queryId, reason, null);
+    sendTelemetryData(queryId, null, -1, session, this);
   }
 }

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeSQLLoggedException.java
@@ -241,9 +241,13 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     sendTelemetryData(queryId, SQLState, vendorCode, session, this);
   }
 
+  /**
+   * use {@link SnowflakeSQLLoggedException#SnowflakeSQLLoggedException(String, SFBaseSession,
+   * String, String)}
+   */
+  @Deprecated
   public SnowflakeSQLLoggedException(SFBaseSession session, String SQLState, String reason) {
-    super(reason, SQLState);
-    sendTelemetryData(null, SQLState, -1, session, this);
+    this(null, session, SQLState, reason);
   }
 
   public SnowflakeSQLLoggedException(
@@ -286,9 +290,13 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     sendTelemetryData(queryId, SQLState, vendorCode, session, this);
   }
 
+  /**
+   * use {@link SnowflakeSQLLoggedException#SnowflakeSQLLoggedException(String, SFBaseSession,
+   * ErrorCode, Object...)}
+   */
+  @Deprecated
   public SnowflakeSQLLoggedException(SFBaseSession session, ErrorCode errorCode, Object... params) {
-    super(errorCode, params);
-    sendTelemetryData(null, null, -1, session, this);
+    this(null, session, errorCode, params);
   }
 
   public SnowflakeSQLLoggedException(
@@ -302,9 +310,13 @@ public class SnowflakeSQLLoggedException extends SnowflakeSQLException {
     sendTelemetryData(null, null, -1, session, this);
   }
 
+  /**
+   * use {@link SnowflakeSQLLoggedException#SnowflakeSQLLoggedException(String, SFBaseSession,
+   * String)}
+   */
+  @Deprecated
   public SnowflakeSQLLoggedException(SFBaseSession session, String reason) {
-    super(reason);
-    sendTelemetryData(null, null, -1, session, this);
+    this(null, session, reason);
   }
 
   public SnowflakeSQLLoggedException(String queryId, SFBaseSession session, String reason) {


### PR DESCRIPTION
# Overview

SNOW-1016468

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
