### PR TITLE
SNOW-1479614: Fix conversion of OBJECT column nested fields metadata

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -395,7 +395,13 @@ public class SnowflakeUtil {
       throws SnowflakeSQLLoggedException {
     List<FieldMetadata> fields = new ArrayList<>();
     for (JsonNode node : fieldsJson) {
-      String colName = node.path("name").asText();
+      String colName;
+      if (!node.path("fieldType").isEmpty()) {
+        colName = node.path("fieldName").asText();
+        node = node.path("fieldType");
+      } else {
+        colName = node.path("name").asText();
+      }
       int scale = node.path("scale").asInt();
       int precision = node.path("precision").asInt();
       String internalColTypeName = node.path("type").asText();

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
@@ -7,7 +7,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
@@ -36,7 +36,7 @@ public class DatabaseMetaDataResultSetLatestIT extends BaseJDBCTest {
     }
   }
 
-  /** Added in > 3.17.0 */
+  /** Added in > 3.17.1 */
   @Test
   public void testObjectColumn() throws SQLException {
     try (Connection connection = getConnection();
@@ -53,6 +53,7 @@ public class DatabaseMetaDataResultSetLatestIT extends BaseJDBCTest {
           metaData.getColumns(
               connection.getCatalog(), connection.getSchema(), "TABLEWITHOBJECTCOLUMN", null)) {
         assertTrue(resultSet.next());
+        assertEquals("OBJECT", resultSet.getObject(6)); // column type
         assertFalse(resultSet.next());
       }
     }

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
@@ -3,12 +3,19 @@
  */
 package net.snowflake.client.jdbc;
 
-import java.sql.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 public class DatabaseMetaDataResultSetLatestIT extends BaseJDBCTest {
 
@@ -33,21 +40,18 @@ public class DatabaseMetaDataResultSetLatestIT extends BaseJDBCTest {
   @Test
   public void testObjectColumn() throws SQLException {
     try (Connection connection = getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
       statement.execute(
-              "CREATE OR REPLACE TABLE TABLEWITHOBJECTCOLUMN ("
-                      + "    col3 OBJECT("
-                      + "      str VARCHAR,"
-                      + "      num NUMBER(38,0)"
-                      + "      )"
-                      + "   )");
+          "CREATE OR REPLACE TABLE TABLEWITHOBJECTCOLUMN ("
+              + "    col3 OBJECT("
+              + "      str VARCHAR,"
+              + "      num NUMBER(38,0)"
+              + "      )"
+              + "   )");
       DatabaseMetaData metaData = connection.getMetaData();
       try (ResultSet resultSet =
-                   metaData.getColumns(
-                           connection.getCatalog(),
-                           connection.getSchema(),
-                           "TABLEWITHOBJECTCOLUMN",
-                           null)) {
+          metaData.getColumns(
+              connection.getCatalog(), connection.getSchema(), "TABLEWITHOBJECTCOLUMN", null)) {
         assertTrue(resultSet.next());
         assertFalse(resultSet.next());
       }

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
@@ -7,12 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Types;
+import java.sql.*;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -36,14 +31,14 @@ public class DatabaseMetaDataResultSetLatestIT extends BaseJDBCTest {
     }
   }
 
-  /** Added in > 3.17.1 */
+  /** Added in > 3.17.0 */
   @Test
   public void testObjectColumn() throws SQLException {
     try (Connection connection = getConnection();
         Statement statement = connection.createStatement()) {
       statement.execute(
           "CREATE OR REPLACE TABLE TABLEWITHOBJECTCOLUMN ("
-              + "    col3 OBJECT("
+              + "    col OBJECT("
               + "      str VARCHAR,"
               + "      num NUMBER(38,0)"
               + "      )"
@@ -53,7 +48,7 @@ public class DatabaseMetaDataResultSetLatestIT extends BaseJDBCTest {
           metaData.getColumns(
               connection.getCatalog(), connection.getSchema(), "TABLEWITHOBJECTCOLUMN", null)) {
         assertTrue(resultSet.next());
-        assertEquals("OBJECT", resultSet.getObject(6)); // column type
+        assertEquals("OBJECT", resultSet.getObject("TYPE_NAME"));
         assertFalse(resultSet.next());
       }
     }

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataResultSetLatestIT.java
@@ -3,16 +3,12 @@
  */
 package net.snowflake.client.jdbc;
 
-import static org.junit.Assert.assertEquals;
-
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Types;
+import java.sql.*;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class DatabaseMetaDataResultSetLatestIT extends BaseJDBCTest {
 
@@ -29,6 +25,31 @@ public class DatabaseMetaDataResultSetLatestIT extends BaseJDBCTest {
               columnNames, columnTypeNames, columnTypes, rows, st)) {
         resultSet.next();
         assertEquals(1.2F, resultSet.getObject(1));
+      }
+    }
+  }
+
+  /** Added in > 3.17.0 */
+  @Test
+  public void testObjectColumn() throws SQLException {
+    try (Connection connection = getConnection();
+         Statement statement = connection.createStatement()) {
+      statement.execute(
+              "CREATE OR REPLACE TABLE TABLEWITHOBJECTCOLUMN ("
+                      + "    col3 OBJECT("
+                      + "      str VARCHAR,"
+                      + "      num NUMBER(38,0)"
+                      + "      )"
+                      + "   )");
+      DatabaseMetaData metaData = connection.getMetaData();
+      try (ResultSet resultSet =
+                   metaData.getColumns(
+                           connection.getCatalog(),
+                           connection.getSchema(),
+                           "TABLEWITHOBJECTCOLUMN",
+                           null)) {
+        assertTrue(resultSet.next());
+        assertFalse(resultSet.next());
       }
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeUtilTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeUtilTest.java
@@ -55,10 +55,10 @@ public class SnowflakeUtilTest extends BaseJDBCTest {
     ArrayNode fields = OBJECT_MAPPER.createArrayNode();
     fields.add(
         OBJECT_MAPPER.readTree(
-            "{\"fieldName\":\"name1\", \"fieldType\": {\"type\":\"text\",\"precision\":null,\"byteLength\":256,\"scale\":null,\"nullable\":false,\"collation\":\"collation\",\"length\":256}}"));
+            "{\"fieldName\":\"name1\", \"fieldType\": {\"type\":\"text\",\"precision\":null,\"length\":256,\"scale\":null,\"nullable\":false}}"));
     fields.add(
         OBJECT_MAPPER.readTree(
-            "{\"fieldName\":\"name2\", \"fieldType\": {\"type\":\"real\",\"precision\":5,\"byteLength\":128,\"scale\":null,\"nullable\":true,\"collation\":\"collation\",\"length\":256}}"));
+            "{\"fieldName\":\"name2\", \"fieldType\": {\"type\":\"real\",\"precision\":5,\"length\":128,\"scale\":null,\"nullable\":true}}"));
     rootNode.putIfAbsent("fields", fields);
 
     // when
@@ -77,7 +77,7 @@ public class SnowflakeUtilTest extends BaseJDBCTest {
     FieldMetadata secondField = columnMetadata.getFields().get(1);
     assertEquals("name2", secondField.getName());
     assertEquals(SnowflakeType.REAL, secondField.getBase());
-    assertEquals(256, secondField.getByteLength());
+    assertEquals(128, secondField.getByteLength());
     assertEquals(5, secondField.getPrecision());
     assertTrue(secondField.isNullable());
   }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeUtilTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeUtilTest.java
@@ -4,7 +4,10 @@
 package net.snowflake.client.jdbc;
 
 import static net.snowflake.client.jdbc.SnowflakeUtil.getSnowflakeType;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,13 +53,17 @@ public class SnowflakeUtilTest extends BaseJDBCTest {
     // given
     ObjectNode rootNode = createRootNode();
     ArrayNode fields = OBJECT_MAPPER.createArrayNode();
-    fields.add(OBJECT_MAPPER.readTree("{\"fieldName\":\"name1\", \"fieldType\": {\"type\":\"text\",\"precision\":null,\"byteLength\":256,\"scale\":null,\"nullable\":false,\"collation\":\"collation\",\"length\":256}}"));
-    fields.add(OBJECT_MAPPER.readTree("{\"fieldName\":\"name2\", \"fieldType\": {\"type\":\"real\",\"precision\":5,\"byteLength\":128,\"scale\":null,\"nullable\":true,\"collation\":\"collation\",\"length\":256}}"));
+    fields.add(
+        OBJECT_MAPPER.readTree(
+            "{\"fieldName\":\"name1\", \"fieldType\": {\"type\":\"text\",\"precision\":null,\"byteLength\":256,\"scale\":null,\"nullable\":false,\"collation\":\"collation\",\"length\":256}}"));
+    fields.add(
+        OBJECT_MAPPER.readTree(
+            "{\"fieldName\":\"name2\", \"fieldType\": {\"type\":\"real\",\"precision\":5,\"byteLength\":128,\"scale\":null,\"nullable\":true,\"collation\":\"collation\",\"length\":256}}"));
     rootNode.putIfAbsent("fields", fields);
 
     // when
     SnowflakeColumnMetadata columnMetadata =
-            SnowflakeUtil.extractColumnMetadata(rootNode, false, null);
+        SnowflakeUtil.extractColumnMetadata(rootNode, false, null);
     // then
     assertNotNull(columnMetadata);
     assertEquals("OBJECT", columnMetadata.getTypeName());


### PR DESCRIPTION
# Overview

SNOW-1479614: Fix conversion of OBJECT column nested fields metadata

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
