### PR TITLE
 SNOW-1491028 : Snowflake JDBC Driver 4.2 compliant issue.

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -597,14 +597,14 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   @Override
   public void setHoldability(int holdability) throws SQLException {
     raiseSQLExceptionIfConnectionIsClosed();
-    if ((holdability != ResultSet.CLOSE_CURSORS_AT_COMMIT &&
-            holdability != ResultSet.HOLD_CURSORS_OVER_COMMIT)) {
-        throw new SQLException("The given parameter is not a ResultSet holdability constant.");
+    if ((holdability != ResultSet.CLOSE_CURSORS_AT_COMMIT
+        && holdability != ResultSet.HOLD_CURSORS_OVER_COMMIT)) {
+      throw new SQLException("The given parameter is not a ResultSet holdability constant.");
     }
     // HOLD_CURSORS_OVER_COMMIT holdability is currently not supported.
     // no-op if the holdability is CLOSE_CURSORS_AT_COMMIT
     if (holdability == ResultSet.HOLD_CURSORS_OVER_COMMIT) {
-        throw new SnowflakeLoggedFeatureNotSupportedException(sfSession);
+      throw new SnowflakeLoggedFeatureNotSupportedException(sfSession);
     }
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -596,8 +596,16 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
 
   @Override
   public void setHoldability(int holdability) throws SQLException {
-
-    throw new SnowflakeLoggedFeatureNotSupportedException(sfSession);
+    raiseSQLExceptionIfConnectionIsClosed();
+    if ((holdability != ResultSet.CLOSE_CURSORS_AT_COMMIT &&
+            holdability != ResultSet.HOLD_CURSORS_OVER_COMMIT)) {
+        throw new SQLException("The given parameter is not a ResultSet holdability constant.");
+    }
+    // HOLD_CURSORS_OVER_COMMIT holdability is currently not supported.
+    // no-op if the holdability is CLOSE_CURSORS_AT_COMMIT
+    if (holdability == ResultSet.HOLD_CURSORS_OVER_COMMIT) {
+        throw new SnowflakeLoggedFeatureNotSupportedException(sfSession);
+    }
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionAlreadyClosedIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionAlreadyClosedIT.java
@@ -4,6 +4,7 @@
 package net.snowflake.client.jdbc;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.util.Properties;
 import net.snowflake.client.category.TestCategoryConnection;
 import org.junit.Test;
@@ -34,6 +35,8 @@ public class ConnectionAlreadyClosedIT extends BaseJDBCTest {
     expectConnectionAlreadyClosedException(() -> connection.setSchema("fakedb"));
     expectConnectionAlreadyClosedException(
         () -> connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED));
+    expectConnectionAlreadyClosedException(
+        () -> connection.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT));
     expectSQLClientInfoException(() -> connection.setClientInfo(new Properties()));
     expectSQLClientInfoException(() -> connection.setClientInfo("name", "value"));
   }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionFeatureNotSupportedIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionFeatureNotSupportedIT.java
@@ -43,6 +43,7 @@ public class ConnectionFeatureNotSupportedIT extends BaseJDBCTest {
       expectFeatureNotSupportedException(connection::createSQLXML);
       expectFeatureNotSupportedException(
           () -> connection.createStruct("fakeType", new Object[] {}));
+      expectFeatureNotSupportedException(() -> connection.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT));
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionFeatureNotSupportedIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionFeatureNotSupportedIT.java
@@ -43,7 +43,8 @@ public class ConnectionFeatureNotSupportedIT extends BaseJDBCTest {
       expectFeatureNotSupportedException(connection::createSQLXML);
       expectFeatureNotSupportedException(
           () -> connection.createStruct("fakeType", new Object[] {}));
-      expectFeatureNotSupportedException(() -> connection.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT));
+      expectFeatureNotSupportedException(
+          () -> connection.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT));
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -731,9 +731,9 @@ public class ConnectionIT extends BaseJDBCTest {
   public void testHolderbility() throws Throwable {
     try (Connection connection = getConnection()) {
       try {
-        connection.setHoldability(0);
+        connection.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
       } catch (SQLFeatureNotSupportedException ex) {
-        // nop
+        fail("should not fail");
       }
       // return an empty type map. setTypeMap is not supported.
       assertEquals(ResultSet.CLOSE_CURSORS_AT_COMMIT, connection.getHoldability());

--- a/src/test/java/net/snowflake/client/pooling/LogicalConnectionFeatureNotSupportedLatestIT.java
+++ b/src/test/java/net/snowflake/client/pooling/LogicalConnectionFeatureNotSupportedLatestIT.java
@@ -67,8 +67,6 @@ public class LogicalConnectionFeatureNotSupportedLatestIT extends BaseJDBCTest {
     expectFeatureNotSupportedException(logicalConnection::createNClob);
     expectFeatureNotSupportedException(logicalConnection::createSQLXML);
     expectFeatureNotSupportedException(
-        () -> logicalConnection.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT));
-    expectFeatureNotSupportedException(
         () -> logicalConnection.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT));
     expectFeatureNotSupportedException(
         () -> logicalConnection.createStruct("fakeType", new Object[] {}));


### PR DESCRIPTION
# Overview

SNOW-1491028

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

Issue 1016 - https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/1016
1) Currently the setHoldability method always throws the exception. According to the [docs](https://docs.oracle.com/javase%2F8%2Fdocs%2Fapi%2F%2F/java/sql/Connection.html#setHoldability-int-) we should throw the exception only when the given holdability is no supported - in other cases it should be no-op.
Now Driver will throw SnowflakeLoggedFeatureNotSupportedException only when holdability parameter is HOLD_CURSORS_OVER_COMMIT 
2) If the connection is closed or given value is outside of the possible range in the standard, the driver will throw SQLException.

