### PR TITLE
SNOW-1614292: java.lang.ClassNotFoundException: org.slf4j.LoggerFactor

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -75,8 +75,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class for uploading/downloading files
@@ -100,7 +98,6 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
   private static final String localFSFileSep = systemGetProperty("file.separator");
   private static final int DEFAULT_PARALLEL = 10;
-  private static final Logger log = LoggerFactory.getLogger(SnowflakeFileTransferAgent.class);
 
   private final String command;
 


### PR DESCRIPTION
Fixes issue where the absence of the slf4j-api library from the classpath results in a NoClassDefFoundError/ClassNotFoundException because the class org.slf4j.LoggerFactory can't be loaded