### PR TITLE
SNOW-1618131: Remove error_on_generic_pruner integration test

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -1294,40 +1294,6 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
   }
 
   @Test
-  @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnGithubAction.class)
-  public void test31448() throws Throwable {
-    try (Connection connection = getConnection();
-        Statement statement = connection.createStatement()) {
-
-      statement.execute(
-          "alter session set enable_fix_31448_2=2, " + "error_on_generic_pruner=true;");
-
-      statement.execute("alter session set timestamp_type_mapping=timestamp_ntz");
-
-      statement.execute("create or replace table " + "bug56658(iv number, tsv timestamp_ntz)");
-      statement.execute(
-          "insert into bug56658 select seq8(), "
-              + "timestampadd(day, seq8(), '1970-01-13 00:00:00'::timestamp_ntz)\n"
-              + "from table(generator(rowcount=>20))");
-
-      connection
-          .unwrap(SnowflakeConnectionV1.class)
-          .getSfSession()
-          .setTimestampMappedType(SnowflakeType.TIMESTAMP_NTZ);
-      Timestamp ts = buildTimestamp(1970, 0, 15, 10, 14, 30, 0);
-      try (PreparedStatement preparedStatement =
-          connection.prepareStatement(
-              "select iv, tsv from bug56658 where tsv" + " >= ? and tsv <= ? order by iv;")) {
-        statement.execute("alter session set timestamp_type_mapping=timestamp_ntz");
-        Timestamp ts2 = buildTimestamp(1970, 0, 18, 10, 14, 30, 0);
-        preparedStatement.setTimestamp(1, ts);
-        preparedStatement.setTimestamp(2, ts2);
-        preparedStatement.executeQuery();
-      }
-    }
-  }
-
-  @Test
   public void testBind() throws Throwable {
     ResultSetMetaData resultSetMetaData = null;
     Timestamp ts = null;


### PR DESCRIPTION
# Overview

SNOW-1618131

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
