### PR TITLE
SNOW-1663901: Enable terminal fallback for external browser authentication when browser launch fails

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
@@ -59,6 +59,9 @@ public class SessionUtilExternalBrowser {
 
     // output
     void output(String msg);
+
+    // input
+    String input();
   }
 
   static class DefaultAuthExternalBrowserHandlers implements AuthExternalBrowserHandlers {
@@ -96,6 +99,11 @@ public class SessionUtilExternalBrowser {
     @Override
     public void output(String msg) {
       System.out.println(msg);
+    }
+
+    @Override
+    public String input() {
+      return System.console().readLine();
     }
   }
 
@@ -275,40 +283,58 @@ public class SessionUtilExternalBrowser {
       int port = this.getLocalPort(ssocket);
       logger.debug("Listening localhost: {}", port);
 
+      String authUrl = getSSOUrl(port);
       if (loginInput.getDisableConsoleLogin()) {
         // Access GS to get SSO URL
-        String ssoUrl = getSSOUrl(port);
-        this.handlers.output(
-            "Initiating login request with your identity provider. A "
-                + "browser window should have opened for you to complete the "
-                + "login. If you can't see it, check existing browser windows, "
-                + "or your OS settings. Press CTRL+C to abort and try again...");
-        this.handlers.openBrowser(ssoUrl);
+        authUrl = getSSOUrl(port);
       } else {
         // Multiple SAML way to do authentication via console login
-        String consoleLoginUrl = getConsoleLoginUrl(port);
-        this.handlers.output(
-            "Initiating login request with your identity provider(s). A "
-                + "browser window should have opened for you to complete the "
-                + "login. If you can't see it, check existing browser windows, "
-                + "or your OS settings. Press CTRL+C to abort and try again...");
-        this.handlers.openBrowser(consoleLoginUrl);
+        authUrl = getConsoleLoginUrl(port);
       }
-
-      while (true) {
-        Socket socket = ssocket.accept(); // start accepting the request
-        try {
-          BufferedReader in =
-              new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF8_CHARSET));
-          char[] buf = new char[16384];
-          int strLen = in.read(buf);
-          String[] rets = new String(buf, 0, strLen).split("\r\n");
-          if (!processOptions(rets, socket)) {
-            processSamlToken(rets, socket);
-            break;
+      this.handlers.output(
+          "Initiating login request with your identity provider(s). A "
+              + "browser window should have opened for you to complete the "
+              + "login. If you can't see it, check existing browser windows, "
+              + "or your OS settings. Press CTRL+C to abort and try again...");
+      try {
+        this.handlers.openBrowser(authUrl);
+        while (true) {
+          Socket socket = ssocket.accept(); // start accepting the request
+          try {
+            BufferedReader in =
+                new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF8_CHARSET));
+            char[] buf = new char[16384];
+            int strLen = in.read(buf);
+            String[] rets = new String(buf, 0, strLen).split("\r\n");
+            if (!processOptions(rets, socket)) {
+              processSamlToken(rets, socket);
+              break;
+            }
+          } finally {
+            socket.close();
           }
-        } finally {
-          socket.close();
+        }
+      } catch (SFException e) {
+        this.handlers.output(authUrl);
+        this.handlers.output(
+          "We were unable to open a browser window for you, " 
+          + "please open the url above manually then paste the "
+          + "URL you are redirected to into the terminal.");
+        String redirectUrl = this.handlers.input();
+        try {
+          URI inputParameter = new URI(redirectUrl);
+          for (NameValuePair urlParam : URLEncodedUtils.parse(inputParameter, UTF8_CHARSET)) {
+            if ("token".equals(urlParam.getName())) {
+              this.token = urlParam.getValue();
+              break;
+            }
+          }
+        } catch (URISyntaxException ex0) {
+          throw new SFException(
+              ErrorCode.NETWORK_ERROR,
+              String.format(
+                  "Invalid redirect url. No token is given from the browser. %s, err: %s",
+                  redirectUrl, ex0));
         }
       }
     } catch (SocketTimeoutException e) {

--- a/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
@@ -317,9 +317,9 @@ public class SessionUtilExternalBrowser {
       } catch (SFException e) {
         this.handlers.output(authUrl);
         this.handlers.output(
-          "We were unable to open a browser window for you, " 
-          + "please open the url above manually then paste the "
-          + "URL you are redirected to into the terminal.");
+            "We were unable to open a browser window for you, "
+                + "please open the url above manually then paste the "
+                + "URL you are redirected to into the terminal.");
         String redirectUrl = this.handlers.input();
         try {
           URI inputParameter = new URI(redirectUrl);

--- a/src/test/java/net/snowflake/client/core/SessionUtilExternalBrowserTest.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilExternalBrowserTest.java
@@ -55,6 +55,12 @@ class MockAuthExternalBrowserHandlers
   public void output(String msg) {
     // nop. No output
   }
+
+  @Override
+  public String input() {
+    // nop. No input
+    return null;
+  }
 }
 
 /** Simulates SessionUtilExternalBrower without popping up a browser window */

--- a/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
@@ -63,6 +63,12 @@ class MockAuthExternalBrowserHandlers
   public void output(String msg) {
     // nop. No output
   }
+  
+  @Override
+  public String input() {
+    // nop. No input
+    return null;
+  }
 }
 
 class FakeSessionUtilExternalBrowser extends SessionUtilExternalBrowser {

--- a/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SSOConnectionTest.java
@@ -63,7 +63,7 @@ class MockAuthExternalBrowserHandlers
   public void output(String msg) {
     // nop. No output
   }
-  
+
   @Override
   public String input() {
     // nop. No input


### PR DESCRIPTION
# Overview

SNOW-1663901

## Pre-review self checklist
- [X] PR branch is updated with all the changes from `master` branch
- [X] The code is correctly formatted (run `mvn -P check-style validate`)
- [X] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [X] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #1893


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.
When browser launch fails, the user is prompted to paste the URL into a browser and return the redirect URL to the JDBC connector via the terminal.  This is the behavior of the Python connector.
