### PR TITLE
SNOW-1700248 Revert turning native arrow boolean primitives lowercase

### DIFF
--- a/src/main/java/net/snowflake/client/core/ResultUtil.java
+++ b/src/main/java/net/snowflake/client/core/ResultUtil.java
@@ -251,7 +251,7 @@ public class ResultUtil {
    * @return boolean in string
    */
   public static String getBooleanAsString(boolean bool) {
-    return bool ? "true" : "false";
+    return bool ? "TRUE" : "FALSE";
   }
 
   /**

--- a/src/main/java/net/snowflake/client/core/arrow/BitToBooleanConverter.java
+++ b/src/main/java/net/snowflake/client/core/arrow/BitToBooleanConverter.java
@@ -58,7 +58,7 @@ public class BitToBooleanConverter extends AbstractArrowVectorConverter {
 
   @Override
   public String toString(int index) {
-    return isNull(index) ? null : toBoolean(index) ? "true" : "false";
+    return isNull(index) ? null : toBoolean(index) ? "TRUE" : "FALSE";
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/arrow/tostringhelpers/ArrowStringRepresentationBuilderBase.java
+++ b/src/main/java/net/snowflake/client/core/arrow/tostringhelpers/ArrowStringRepresentationBuilderBase.java
@@ -7,10 +7,9 @@ import net.snowflake.client.core.SnowflakeJdbcInternalApi;
 import net.snowflake.client.jdbc.SnowflakeType;
 
 /**
- * StringBuilder like class to aggregate the string representation of snowflake
- * Native ARROW structured types as JSON one-liners.
- * Provides some additional snowflake-specific logic in order to determine whether the value should be
- * quoted or case should be changed.
+ * StringBuilder like class to aggregate the string representation of snowflake Native ARROW
+ * structured types as JSON one-liners. Provides some additional snowflake-specific logic in order
+ * to determine whether the value should be quoted or case should be changed.
  */
 @SnowflakeJdbcInternalApi
 public abstract class ArrowStringRepresentationBuilderBase {

--- a/src/main/java/net/snowflake/client/core/arrow/tostringhelpers/ArrowStringRepresentationBuilderBase.java
+++ b/src/main/java/net/snowflake/client/core/arrow/tostringhelpers/ArrowStringRepresentationBuilderBase.java
@@ -6,6 +6,12 @@ import java.util.StringJoiner;
 import net.snowflake.client.core.SnowflakeJdbcInternalApi;
 import net.snowflake.client.jdbc.SnowflakeType;
 
+/**
+ * StringBuilder like class to aggregate the string representation of snowflake
+ * Native ARROW structured types as JSON one-liners.
+ * Provides some additional snowflake-specific logic in order to determine whether the value should be
+ * quoted or case should be changed.
+ */
 @SnowflakeJdbcInternalApi
 public abstract class ArrowStringRepresentationBuilderBase {
   private final StringJoiner joiner;
@@ -39,6 +45,13 @@ public abstract class ArrowStringRepresentationBuilderBase {
   }
 
   protected String quoteIfNeeded(String string, SnowflakeType type) {
+    // Turn Boolean string representations lowercase to make the output JSON-compatible
+    // this should be changed on the converter level, but it would be a breaking change thus
+    // for now only structured types will be valid JSONs while in NATIVE ARROW mode
+    if (type == SnowflakeType.BOOLEAN) {
+      string = string.toLowerCase();
+    }
+
     if (shouldQuoteValue(type)) {
       return '"' + string + '"';
     }

--- a/src/test/java/net/snowflake/client/core/arrow/BitToBooleanConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/arrow/BitToBooleanConverterTest.java
@@ -73,7 +73,7 @@ public class BitToBooleanConverterTest extends BaseConverterTest {
       } else {
         assertThat(boolVal, is(expectedValues.get(i)));
         assertThat(objectVal, is(expectedValues.get(i)));
-        assertThat(stringVal, is(expectedValues.get(i).toString()));
+        assertThat(stringVal, is(expectedValues.get(i).toString().toUpperCase()));
         if (boolVal) {
           assertThat((byte) 0x1, is(converter.toBytes(i)[0]));
         } else {

--- a/src/test/java/net/snowflake/client/core/json/StringConverterTest.java
+++ b/src/test/java/net/snowflake/client/core/json/StringConverterTest.java
@@ -59,10 +59,10 @@ public class StringConverterTest {
 
   @Test
   public void testConvertingBoolean() throws SFException {
-    assertEquals("true", stringConverter.getString(true, Types.BOOLEAN, Types.BOOLEAN, 0));
-    assertEquals("true", stringConverter.getString("true", Types.BOOLEAN, Types.BOOLEAN, 0));
-    assertEquals("false", stringConverter.getString(false, Types.BOOLEAN, Types.BOOLEAN, 0));
-    assertEquals("false", stringConverter.getString("false", Types.BOOLEAN, Types.BOOLEAN, 0));
+    assertEquals("TRUE", stringConverter.getString(true, Types.BOOLEAN, Types.BOOLEAN, 0));
+    assertEquals("TRUE", stringConverter.getString("true", Types.BOOLEAN, Types.BOOLEAN, 0));
+    assertEquals("FALSE", stringConverter.getString(false, Types.BOOLEAN, Types.BOOLEAN, 0));
+    assertEquals("FALSE", stringConverter.getString("false", Types.BOOLEAN, Types.BOOLEAN, 0));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetJsonVsArrowIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetJsonVsArrowIT.java
@@ -1501,12 +1501,12 @@ public class ResultSetJsonVsArrowIT extends BaseJDBCTest {
         ResultSet rs = statement.executeQuery("select * from " + table)) {
       assertTrue(rs.next());
       assertTrue(rs.getBoolean(1));
-      assertEquals("true", rs.getString(1));
+      assertEquals("TRUE", rs.getString(1));
       assertTrue(rs.next());
       assertFalse(rs.getBoolean(1));
       assertTrue(rs.next());
       assertFalse(rs.getBoolean(1));
-      assertEquals("false", rs.getString(1));
+      assertEquals("FALSE", rs.getString(1));
       assertFalse(rs.next());
       statement.execute("drop table if exists " + table);
     }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -1176,7 +1176,7 @@ public class ResultSetLatestIT extends ResultSet0IT {
       assertResultValueAndType(statement, Double.valueOf("1.1"), "f", Double.class);
       assertResultValueAndType(statement, Double.valueOf("2.2"), "d", Double.class);
       assertResultValueAndType(statement, BigDecimal.valueOf(3.3), "bd", BigDecimal.class);
-      assertResultValueAndType(statement, "false", "bool", String.class);
+      assertResultValueAndType(statement, "FALSE", "bool", String.class);
       assertResultValueAndType(statement, Boolean.FALSE, "bool", Boolean.class);
       assertResultValueAndType(statement, 0L, "bool", Long.class);
       assertResultValueAsString(

--- a/src/test/java/net/snowflake/client/jdbc/structuredtypes/StructuredTypesGetStringArrowJsonCompatibilityIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/structuredtypes/StructuredTypesGetStringArrowJsonCompatibilityIT.java
@@ -85,8 +85,8 @@ public class StructuredTypesGetStringArrowJsonCompatibilityIT
         "select [{'a':'a'}, {'b':'b'}]::array(map(string, string))",
         "[{\"a\":\"a\"}, {\"b\":\"b\"}]");
     samples.put(
-            "select [{'a':true}, {'b':false}]::array(map(string, boolean))",
-            "[{\"a\":true}, {\"b\":false}]");
+        "select [{'a':true}, {'b':false}]::array(map(string, boolean))",
+        "[{\"a\":true}, {\"b\":false}]");
     samples.put(
         "select [{'string':'a'}, {'string':'b'}]::array(object(string varchar))",
         "[{\"string\":\"a\"}, {\"string\":\"b\"}]");

--- a/src/test/java/net/snowflake/client/jdbc/structuredtypes/StructuredTypesGetStringArrowJsonCompatibilityIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/structuredtypes/StructuredTypesGetStringArrowJsonCompatibilityIT.java
@@ -85,6 +85,9 @@ public class StructuredTypesGetStringArrowJsonCompatibilityIT
         "select [{'a':'a'}, {'b':'b'}]::array(map(string, string))",
         "[{\"a\":\"a\"}, {\"b\":\"b\"}]");
     samples.put(
+            "select [{'a':true}, {'b':false}]::array(map(string, boolean))",
+            "[{\"a\":true}, {\"b\":false}]");
+    samples.put(
         "select [{'string':'a'}, {'string':'b'}]::array(object(string varchar))",
         "[{\"string\":\"a\"}, {\"string\":\"b\"}]");
     samples.put("select {'string':'a'}::object(string varchar)", "{\"string\":\"a\"}");


### PR DESCRIPTION
Revert turning native arrow boolean primitives lowercase (changed in [PR#1882](https://github.com/snowflakedb/snowflake-jdbc/pull/1882)) to prevent introducing a breaking change. 
Structured types' booleans string representation will remain lowercase to preserve JSON-compatibility

# Overview

SNOW-1374896
[SNOW-1700248](https://snowflakecomputing.atlassian.net/browse/SNOW-1700248)

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

3. Please describe how your code solves the related issue.

I reverted the global boolean case change and implemented a structured type string builder one. Primitive booleans will remain UPPERCASED while booleans within structured types will be lowercased to provide JSON compatibility


[SNOW-1700248]: https://snowflakecomputing.atlassian.net/browse/SNOW-1700248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ