### PR TITLE
SNOW-799391: Ignore badssl timeouts in tests

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -1635,7 +1635,7 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     } catch (SQLException e) {
       // *.badssl.com may fail with timeout
       if (!(e.getCause() instanceof SSLHandshakeException)
-          && e.getCause().getMessage().toLowerCase().contains("timeout")) {
+          && e.getCause().getMessage().toLowerCase().contains("timed out")) {
         return;
       }
       assertThat(e.getCause(), instanceOf(SSLHandshakeException.class));

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -49,7 +49,6 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
 import net.snowflake.client.ConditionalIgnoreRule;
@@ -1630,28 +1629,20 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     properties.put("password", "testpassword");
     properties.put("ocspFailOpen", Boolean.FALSE.toString());
 
-    int maxRetries = 5;
-    int retry = 0;
-
-    // *.badssl.com may fail on timeouts
-    while (retry < maxRetries) {
-      try {
-        DriverManager.getConnection("jdbc:snowflake://expired.badssl.com/", properties);
-        fail("should fail");
-      } catch (SQLException e) {
-        if (!(e.getCause() instanceof SSLHandshakeException)) {
-          retry++;
-          Thread.sleep(1000 * new Random().nextInt(3));
-          continue;
-        }
-        assertThat(e.getCause(), instanceOf(SSLHandshakeException.class));
-        assertTrue(
-            e.getMessage()
-                .contains(
-                    "https://docs.snowflake.com/en/user-guide/client-connectivity-troubleshooting/overview"));
+    try {
+      DriverManager.getConnection("jdbc:snowflake://expired.badssl.com/", properties);
+      fail("should fail");
+    } catch (SQLException e) {
+      // *.badssl.com may fail with timeout
+      if (!(e.getCause() instanceof SSLHandshakeException)
+          && e.getCause().getMessage().toLowerCase().contains("timeout")) {
         return;
       }
+      assertThat(e.getCause(), instanceOf(SSLHandshakeException.class));
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "https://docs.snowflake.com/en/user-guide/client-connectivity-troubleshooting/overview"));
     }
-    fail("All retries failed");
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionWithOCSPModeIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionWithOCSPModeIT.java
@@ -17,7 +17,6 @@ import java.security.cert.CertificateExpiredException;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.Random;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import net.snowflake.client.ConditionalIgnoreRule;
@@ -414,38 +413,32 @@ public class ConnectionWithOCSPModeIT extends BaseJDBCTest {
   /** Test Wrong host. Will fail in both FAIL_OPEN and FAIL_CLOSED. */
   @Test
   public void testWrongHost() throws InterruptedException {
-    int maxRetries = 5;
-    int retry = 0;
-
-    // *.badssl.com may fail on timeouts
-    while (retry < maxRetries) {
-      try {
-        DriverManager.getConnection(
-            "jdbc:snowflake://wrong.host.badssl.com/", OCSPFailClosedProperties());
-        fail("should fail");
-      } catch (SQLException ex) {
-        if (!(ex.getCause() instanceof SSLPeerUnverifiedException)
-            && !(ex.getCause() instanceof SSLHandshakeException)) {
-          retry++;
-          Thread.sleep(1000 * new Random().nextInt(3));
-          continue;
-        }
-        assertThat(ex, instanceOf(SnowflakeSQLException.class));
-
-        // The certificates used by badssl.com expired around 05/17/2022,
-        // https://github.com/chromium/badssl.com/issues/504. After the certificates had been
-        // updated,
-        // the exception seems to be changed from SSLPeerUnverifiedException to
-        // SSLHandshakeException.
-        assertThat(
-            ex.getCause(),
-            anyOf(
-                instanceOf(SSLPeerUnverifiedException.class),
-                instanceOf(SSLHandshakeException.class)));
+    try {
+      DriverManager.getConnection(
+          "jdbc:snowflake://wrong.host.badssl.com/", OCSPFailClosedProperties());
+      fail("should fail");
+    } catch (SQLException ex) {
+      // *.badssl.com may fail with timeout
+      if (!(ex.getCause() instanceof SSLPeerUnverifiedException)
+          && !(ex.getCause() instanceof SSLHandshakeException)
+          && ex.getCause().getMessage().toLowerCase().contains("timeout")) {
         return;
       }
-      fail("All retries failed");
+      assertThat(ex, instanceOf(SnowflakeSQLException.class));
+
+      // The certificates used by badssl.com expired around 05/17/2022,
+      // https://github.com/chromium/badssl.com/issues/504. After the certificates had been
+      // updated,
+      // the exception seems to be changed from SSLPeerUnverifiedException to
+      // SSLHandshakeException.
+      assertThat(
+          ex.getCause(),
+          anyOf(
+              instanceOf(SSLPeerUnverifiedException.class),
+              instanceOf(SSLHandshakeException.class)));
+      return;
     }
+    fail("All retries failed");
   }
 
   private static Matcher<String> httpStatus403Or404Or513() {

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionWithOCSPModeIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionWithOCSPModeIT.java
@@ -421,7 +421,7 @@ public class ConnectionWithOCSPModeIT extends BaseJDBCTest {
       // *.badssl.com may fail with timeout
       if (!(ex.getCause() instanceof SSLPeerUnverifiedException)
           && !(ex.getCause() instanceof SSLHandshakeException)
-          && ex.getCause().getMessage().toLowerCase().contains("timeout")) {
+          && ex.getCause().getMessage().toLowerCase().contains("timed out")) {
         return;
       }
       assertThat(ex, instanceOf(SnowflakeSQLException.class));


### PR DESCRIPTION
# Overview

SNOW-799391

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
