### PR TITLE
SNOW-1346234 add automated external browser tests

### DIFF
--- a/.github/workflows/parameters_aws_auth_tests.json.gpg
+++ b/.github/workflows/parameters_aws_auth_tests.json.gpg
@@ -1,0 +1,4 @@
+Œ	×.T³ÛQÀQÿÒé_éž‹ftS„o­ÔC€”öe…ÌƒÇœÅ'ÚÀÏŽÉWþÄøã"­#Z8\1j—^?+èØhÍqGRö,³=éûòŒÄèÒàÐûI«zc8Kð×=Z©äp2µÃ+ÂkU5ÔwxÆ³
+R¡Wœ÷ÄÜ—*‹pàW¸\JÅvîýÛÂ½|/uâð^8ù®%ô¤ÆJ³›ç@L+²ë.º’ÉÇûçe²™#ZßÐ~²¤ËWõ Õ^CÎv÷}ñÛ’ÿ¦‘]4pkÏ^r'
+íhÅš>””Û;X:¼7"@³;~Z†Ezkv‚2ØnNS0ªŽ9èò=õUöŸwÙD0±8<­—ý”o¹ðˆ‘«ë¥f“o&¢¬3»ôrãŠ:_ˆÓ"K=­ŠÈå:=\9ü­XÉá(\ÏÿJ\Ê’'ã€?××lüwÙÜ?¢)átô*[ýÜápP8gÇÍ –çí\teê>qà§íz­Ùñ4›?Ògj‡«¸Ä²78*uß-"™*'{ih|¼/LÎÃ¾ #S‡–bæè•®–iŽJ$’LFûc*AÝøB÷n†ð©&q=rïjbn¾6Ih
+Rd»ìŒ”¿ËùDi5†ÙXÑÖ,×þ÷+ÜzhËÊ»Ãì9žøOe<>[u–>›ÄãËvÑÕs·˜cf?cÞlðÕ‹,rSÙrhúÎ™ì

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,10 @@ timestamps {
 
     jobDefinitions.put('JDBC-AIX-Unit', { build job: 'JDBC-AIX-UnitTests', parameters: [ string(name: 'BRANCH', value: scmInfo.GIT_BRANCH ) ] } )
     jobDefinitions.put('Test Authentication', {
-      withCredentials([string(credentialsId: 'sfctest0-parameters-secret', variable: 'PARAMETERS_SECRET')]) {
+      withCredentials([
+        string(credentialsId: 'sfctest0-parameters-secret', variable: 'PARAMETERS_SECRET'),
+        string(credentialsId: 'a791118f-a1ea-46cd-b876-56da1b9bc71c', variable: 'NEXUS_PASSWORD')
+      ]) {
         sh '''\
       |#!/bin/bash
       |set -e

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,16 @@ timestamps {
     }
 
     jobDefinitions.put('JDBC-AIX-Unit', { build job: 'JDBC-AIX-UnitTests', parameters: [ string(name: 'BRANCH', value: scmInfo.GIT_BRANCH ) ] } )
+    jobDefinitions.put('Test Authentication', {
+      withCredentials([string(credentialsId: 'sfctest0-parameters-secret', variable: 'PARAMETERS_SECRET')]) {
+        sh '''\
+      |#!/bin/bash
+      |set -e
+      |ci/test_authentication.sh
+    '''.stripMargin()
+      }
+    })
+
     stage('Test') {
       parallel (jobDefinitions)
     }

--- a/ci/container/test_authentication.sh
+++ b/ci/container/test_authentication.sh
@@ -12,7 +12,7 @@ eval $(jq -r '.authtestparams | to_entries | map("export \(.key)=\(.value|tostri
 $MVNW_EXE -DjenkinsIT \
     -Djava.io.tmpdir=$WORKSPACE \
     -Djacoco.skip.instrument=true \
-    -Dskip.ut=true \
+    -Dskip.unitTests=true \
     -DintegrationTestSuites=AuthenticationTestSuite \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     -Dnot-self-contained-jar \

--- a/ci/container/test_authentication.sh
+++ b/ci/container/test_authentication.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+export WORKSPACE=${WORKSPACE:-/mnt/workspace}
+export SOURCE_ROOT=${SOURCE_ROOT:-/mnt/host}
+MVNW_EXE=$SOURCE_ROOT/mvnw
+
+AUTH_PARAMETER_FILE=./.github/workflows/parameters_aws_auth_tests.json
+eval $(jq -r '.authtestparams | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' $AUTH_PARAMETER_FILE)
+
+$MVNW_EXE -DjenkinsIT \
+    -Djava.io.tmpdir=$WORKSPACE \
+    -Djacoco.skip.instrument=true \
+    -Dskip.ut=true \
+    -DintegrationTestSuites=AuthenticationTestSuite \
+    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+    -Dnot-self-contained-jar \
+    verify \
+    --batch-mode --show-version

--- a/ci/test_authentication.sh
+++ b/ci/test_authentication.sh
@@ -3,6 +3,7 @@
 set -o pipefail
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export WORKSPACE=${WORKSPACE:-/tmp}
+export INTERNAL_REPO=nexus.int.snowflakecomputing.com:8086
 
 source $THIS_DIR/scripts/login_internal_docker.sh
 gpg --quiet --batch --yes --decrypt --passphrase="$PARAMETERS_SECRET" --output $THIS_DIR/../.github/workflows/parameters_aws_auth_tests.json "$THIS_DIR/../.github/workflows/parameters_aws_auth_tests.json.gpg"

--- a/ci/test_authentication.sh
+++ b/ci/test_authentication.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+set -o pipefail
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export WORKSPACE=${WORKSPACE:-/tmp}
+
+gpg --quiet --batch --yes --decrypt --passphrase="$PARAMETERS_SECRET" --output $THIS_DIR/../.github/workflows/parameters_aws_auth_tests.json "$THIS_DIR/../.github/workflows/parameters_aws_auth_tests.json.gpg"
+
+docker run \
+  -v $(cd $THIS_DIR/.. && pwd):/mnt/host \
+  -v $WORKSPACE:/mnt/workspace \
+  --rm \
+  nexus.int.snowflakecomputing.com:8086/docker/snowdrivers-test-external-browser-jdbc:1 \
+  "/mnt/host/ci/container/test_authentication.sh"

--- a/ci/test_authentication.sh
+++ b/ci/test_authentication.sh
@@ -4,6 +4,7 @@ set -o pipefail
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export WORKSPACE=${WORKSPACE:-/tmp}
 
+source $THIS_DIR/scripts/login_internal_docker.sh
 gpg --quiet --batch --yes --decrypt --passphrase="$PARAMETERS_SECRET" --output $THIS_DIR/../.github/workflows/parameters_aws_auth_tests.json "$THIS_DIR/../.github/workflows/parameters_aws_auth_tests.json.gpg"
 
 docker run \

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -78,6 +78,7 @@
     <relocationBase>net/snowflake/client/jdbc/internal</relocationBase>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>
     <shadeNativeBase>net_snowflake_client_jdbc_internal</shadeNativeBase>
+    <skip.ut>false</skip.ut>
     <slf4j.version>2.0.13</slf4j.version>
     <snowflake.common.version>5.1.4</snowflake.common.version>
     <integrationTestSuites>UnitTestSuite</integrationTestSuites>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -78,7 +78,7 @@
     <relocationBase>net/snowflake/client/jdbc/internal</relocationBase>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>
     <shadeNativeBase>net_snowflake_client_jdbc_internal</shadeNativeBase>
-    <skip.ut>false</skip.ut>
+    <skip.unitTests>false</skip.unitTests>
     <slf4j.version>2.0.13</slf4j.version>
     <snowflake.common.version>5.1.4</snowflake.common.version>
     <integrationTestSuites>UnitTestSuite</integrationTestSuites>

--- a/pom.xml
+++ b/pom.xml
@@ -1162,6 +1162,7 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <skipTests>${skip.ut}</skipTests>
               <argLine>--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED</argLine>
             </configuration>
           </plugin>
@@ -1214,6 +1215,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <test>UnitTestSuite</test>
+              <skipTests>${skip.ut}</skipTests>
             </configuration>
             <dependencies>
               <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1162,7 +1162,7 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <skipTests>${skip.ut}</skipTests>
+              <skipTests>${skip.unitTests}</skipTests>
               <argLine>--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED</argLine>
             </configuration>
           </plugin>
@@ -1215,7 +1215,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <test>UnitTestSuite</test>
-              <skipTests>${skip.ut}</skipTests>
+              <skipTests>${skip.unitTests}</skipTests>
             </configuration>
             <dependencies>
               <dependency>

--- a/src/test/java/net/snowflake/client/authentication/AuthConnectionParameters.java
+++ b/src/test/java/net/snowflake/client/authentication/AuthConnectionParameters.java
@@ -1,0 +1,37 @@
+package net.snowflake.client.authentication;
+
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetEnv;
+
+import java.util.Properties;
+
+public class AuthConnectionParameters {
+
+  static final String SSO_USER = systemGetEnv("SNOWFLAKE_AUTH_TEST_BROWSER_USER");
+  static final String HOST = systemGetEnv("SNOWFLAKE_AUTH_TEST_HOST");
+  static final String SSO_PASSWORD = systemGetEnv("SNOWFLAKE_AUTH_TEST_OKTA_PASS");
+
+  static Properties getBaseConnectionParameters() {
+    Properties properties = new Properties();
+    properties.put("host", HOST);
+    properties.put("port", systemGetEnv("SNOWFLAKE_AUTH_TEST_PORT"));
+    properties.put("role", systemGetEnv("SNOWFLAKE_AUTH_TEST_ROLE"));
+    properties.put("account", systemGetEnv("SNOWFLAKE_AUTH_TEST_ACCOUNT"));
+    properties.put("db", systemGetEnv("SNOWFLAKE_AUTH_TEST_DATABASE"));
+    properties.put("schema", systemGetEnv("SNOWFLAKE_AUTH_TEST_SCHEMA"));
+    properties.put("warehouse", systemGetEnv("SNOWFLAKE_AUTH_TEST_WAREHOUSE"));
+    return properties;
+  }
+
+  static Properties getExternalBrowserConnectionParameters() {
+    Properties properties = getBaseConnectionParameters();
+    properties.put("user", SSO_USER);
+    properties.put("authenticator", "externalbrowser");
+    return properties;
+  }
+
+  static Properties getStoreIDTokenConnectionParameters() {
+    Properties properties = getExternalBrowserConnectionParameters();
+    properties.put("CLIENT_STORE_TEMPORARY_CREDENTIAL", true);
+    return properties;
+  }
+}

--- a/src/test/java/net/snowflake/client/authentication/AuthTest.java
+++ b/src/test/java/net/snowflake/client/authentication/AuthTest.java
@@ -13,6 +13,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
 import net.snowflake.client.core.SessionUtil;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
@@ -62,7 +64,7 @@ public class AuthTest {
       ProcessBuilder processBuilder =
           new ProcessBuilder("node", provideBrowserCredentialsPath, scenario, login, password);
       Process process = processBuilder.start();
-      process.waitFor();
+      process.waitFor(15, TimeUnit.SECONDS);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -74,7 +76,7 @@ public class AuthTest {
       ProcessBuilder processBuilder = new ProcessBuilder("node", cleanBrowserProcessesPath);
       try {
         Process process = processBuilder.start();
-        process.waitFor();
+        process.waitFor(15, TimeUnit.SECONDS);
       } catch (InterruptedException | IOException e) {
         throw new RuntimeException(e);
       }

--- a/src/test/java/net/snowflake/client/authentication/AuthTest.java
+++ b/src/test/java/net/snowflake/client/authentication/AuthTest.java
@@ -14,7 +14,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-
 import net.snowflake.client.core.SessionUtil;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.SnowflakeSQLException;

--- a/src/test/java/net/snowflake/client/authentication/AuthTest.java
+++ b/src/test/java/net/snowflake/client/authentication/AuthTest.java
@@ -50,11 +50,11 @@ public class AuthTest {
   }
 
   public void verifyExceptionIsThrown(String message) {
-    assertThat(this.exception.getMessage(), is(message));
+    assertThat("Expected exception not thrown", this.exception.getMessage(), is(message));
   }
 
   public void verifyExceptionIsNotThrown() {
-    assertThat(this.exception, nullValue());
+    assertThat("Unexpected exception thrown", this.exception, nullValue());
   }
 
   public void connectAndProvideCredentials(Thread provideCredentialsThread, Thread connectThread)

--- a/src/test/java/net/snowflake/client/authentication/AuthTest.java
+++ b/src/test/java/net/snowflake/client/authentication/AuthTest.java
@@ -28,25 +28,11 @@ public class AuthTest {
   }
 
   public Thread getConnectAndExecuteSimpleQueryThread(Properties props, String sessionParameters) {
-    return new Thread(
-        () -> {
-          try {
-            connectAndExecuteSimpleQuery(props, sessionParameters);
-          } catch (Exception e) {
-            this.exception = e;
-          }
-        });
+    return new Thread(() -> connectAndExecuteSimpleQuery(props, sessionParameters));
   }
 
   public Thread getConnectAndExecuteSimpleQueryThread(Properties props) {
-    return new Thread(
-        () -> {
-          try {
-            connectAndExecuteSimpleQuery(props, null);
-          } catch (Exception e) {
-            this.exception = e;
-          }
-        });
+    return new Thread(() -> connectAndExecuteSimpleQuery(props, null));
   }
 
   public void verifyExceptionIsThrown(String message) {
@@ -100,8 +86,7 @@ public class AuthTest {
         AuthConnectionParameters.HOST, AuthConnectionParameters.SSO_USER);
   }
 
-  public void connectAndExecuteSimpleQuery(Properties props, String sessionParameters)
-      throws SQLException {
+  public void connectAndExecuteSimpleQuery(Properties props, String sessionParameters) {
     String url = String.format("jdbc:snowflake://%s:%s", props.get("host"), props.get("port"));
     if (sessionParameters != null) {
       url += "?" + sessionParameters;
@@ -112,6 +97,8 @@ public class AuthTest {
       assertTrue(rs.next());
       assertEquals(1, rs.getInt(1));
       saveToken(con);
+    } catch (SQLException e) {
+      this.exception = e;
     }
   }
 

--- a/src/test/java/net/snowflake/client/authentication/AuthTest.java
+++ b/src/test/java/net/snowflake/client/authentication/AuthTest.java
@@ -1,0 +1,126 @@
+package net.snowflake.client.authentication;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import net.snowflake.client.core.SessionUtil;
+import net.snowflake.client.jdbc.SnowflakeConnectionV1;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+
+public class AuthTest {
+
+  private Exception exception;
+  private String idToken;
+  private final boolean runAuthTestsManually;
+
+  public AuthTest() {
+    this.runAuthTestsManually = Boolean.parseBoolean(System.getenv("RUN_AUTH_TESTS_MANUALLY"));
+  }
+
+  public Thread getConnectAndExecuteSimpleQueryThread(Properties props, String sessionParameters) {
+    return new Thread(
+        () -> {
+          try {
+            connectAndExecuteSimpleQuery(props, sessionParameters);
+          } catch (Exception e) {
+            this.exception = e;
+          }
+        });
+  }
+
+  public Thread getConnectAndExecuteSimpleQueryThread(Properties props) {
+    return new Thread(
+        () -> {
+          try {
+            connectAndExecuteSimpleQuery(props, null);
+          } catch (Exception e) {
+            this.exception = e;
+          }
+        });
+  }
+
+  public void verifyExceptionIsThrown(String message) {
+    assertThat(this.exception.getMessage(), is(message));
+  }
+
+  public void verifyExceptionIsNotThrown() {
+    assertThat(this.exception, nullValue());
+  }
+
+  public void connectAndProvideCredentials(Thread provideCredentialsThread, Thread connectThread)
+      throws InterruptedException {
+    if (runAuthTestsManually) {
+      connectThread.start();
+      connectThread.join();
+    } else {
+      provideCredentialsThread.start();
+      connectThread.start();
+      provideCredentialsThread.join();
+      connectThread.join();
+    }
+  }
+
+  public void provideCredentials(String scenario, String login, String password) {
+    try {
+      String provideBrowserCredentialsPath = "/externalbrowser/provideBrowserCredentials.js";
+      ProcessBuilder processBuilder =
+          new ProcessBuilder("node", provideBrowserCredentialsPath, scenario, login, password);
+      Process process = processBuilder.start();
+      process.waitFor();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void cleanBrowserProcesses() {
+    if (!runAuthTestsManually) {
+      String cleanBrowserProcessesPath = "/externalbrowser/cleanBrowserProcesses.js";
+      ProcessBuilder processBuilder = new ProcessBuilder("node", cleanBrowserProcessesPath);
+      try {
+        Process process = processBuilder.start();
+        process.waitFor();
+      } catch (InterruptedException | IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public static void deleteIdToken() {
+    SessionUtil.deleteIdTokenCache(
+        AuthConnectionParameters.HOST, AuthConnectionParameters.SSO_USER);
+  }
+
+  public void connectAndExecuteSimpleQuery(Properties props, String sessionParameters)
+      throws SQLException {
+    String url = String.format("jdbc:snowflake://%s:%s", props.get("host"), props.get("port"));
+    if (sessionParameters != null) {
+      url += "?" + sessionParameters;
+    }
+    try (Connection con = DriverManager.getConnection(url, props);
+        Statement stmt = con.createStatement();
+        ResultSet rs = stmt.executeQuery("select 1")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+      saveToken(con);
+    }
+  }
+
+  private void saveToken(Connection con) throws SnowflakeSQLException {
+    SnowflakeConnectionV1 sfcon = (SnowflakeConnectionV1) con;
+    this.idToken = sfcon.getSfSession().getIdToken();
+  }
+
+  public String getIdToken() {
+    return idToken;
+  }
+}

--- a/src/test/java/net/snowflake/client/authentication/ExternalBrowserIT.java
+++ b/src/test/java/net/snowflake/client/authentication/ExternalBrowserIT.java
@@ -1,0 +1,83 @@
+package net.snowflake.client.authentication;
+
+import static net.snowflake.client.authentication.AuthConnectionParameters.getExternalBrowserConnectionParameters;
+
+import java.io.IOException;
+import java.util.Properties;
+import net.snowflake.client.category.TestTags;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(TestTags.AUTHENTICATION)
+class ExternalBrowserIT {
+
+  String login = AuthConnectionParameters.SSO_USER;
+  String password = AuthConnectionParameters.SSO_PASSWORD;
+  AuthTest authTest;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    authTest = new AuthTest();
+    AuthTest.deleteIdToken();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    authTest.cleanBrowserProcesses();
+    AuthTest.deleteIdToken();
+  }
+
+  @Test
+  void shouldAuthenticateUsingExternalBrowser() throws InterruptedException {
+    Thread provideCredentialsThread =
+        new Thread(() -> authTest.provideCredentials("success", login, password));
+    Thread connectThread =
+        authTest.getConnectAndExecuteSimpleQueryThread(getExternalBrowserConnectionParameters());
+
+    authTest.connectAndProvideCredentials(provideCredentialsThread, connectThread);
+    authTest.verifyExceptionIsNotThrown();
+  }
+
+  @Test
+  void shouldThrowErrorForMismatchedUsername() throws InterruptedException {
+    Properties properties = getExternalBrowserConnectionParameters();
+    properties.put("user", "differentUsername");
+    Thread provideCredentialsThread =
+        new Thread(() -> authTest.provideCredentials("success", login, password));
+    Thread connectThread = authTest.getConnectAndExecuteSimpleQueryThread(properties);
+
+    authTest.connectAndProvideCredentials(provideCredentialsThread, connectThread);
+    authTest.verifyExceptionIsThrown(
+        "The user you were trying to authenticate as differs from the user currently logged in at the IDP.");
+  }
+
+  @Test
+  void shouldThrowErrorForWrongCredentials() throws InterruptedException {
+    String login = "itsnotanaccount.com";
+    String password = "fakepassword";
+    Thread provideCredentialsThread =
+        new Thread(() -> authTest.provideCredentials("fail", login, password));
+    Thread connectThread =
+        authTest.getConnectAndExecuteSimpleQueryThread(
+            getExternalBrowserConnectionParameters(), "BROWSER_RESPONSE_TIMEOUT=10");
+
+    authTest.connectAndProvideCredentials(provideCredentialsThread, connectThread);
+    authTest.verifyExceptionIsThrown(
+        "JDBC driver encountered communication error. Message: External browser authentication failed within timeout of 10000 milliseconds.");
+  }
+
+  @Test
+  void shouldThrowErrorForBrowserTimeout() throws InterruptedException {
+    Thread provideCredentialsThread =
+        new Thread(() -> authTest.provideCredentials("timeout", login, password));
+    Thread connectThread =
+        authTest.getConnectAndExecuteSimpleQueryThread(
+            getExternalBrowserConnectionParameters(), "BROWSER_RESPONSE_TIMEOUT=1");
+
+    authTest.connectAndProvideCredentials(provideCredentialsThread, connectThread);
+    authTest.verifyExceptionIsThrown(
+        "JDBC driver encountered communication error. Message: External browser authentication failed within timeout of 1000 milliseconds.");
+  }
+}

--- a/src/test/java/net/snowflake/client/authentication/ExternalBrowserIT.java
+++ b/src/test/java/net/snowflake/client/authentication/ExternalBrowserIT.java
@@ -15,11 +15,10 @@ class ExternalBrowserIT {
 
   String login = AuthConnectionParameters.SSO_USER;
   String password = AuthConnectionParameters.SSO_PASSWORD;
-  AuthTest authTest;
+  AuthTest authTest = new AuthTest();
 
   @BeforeEach
   public void setUp() throws IOException {
-    authTest = new AuthTest();
     AuthTest.deleteIdToken();
   }
 

--- a/src/test/java/net/snowflake/client/authentication/IdTokenIT.java
+++ b/src/test/java/net/snowflake/client/authentication/IdTokenIT.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.IOException;
-import java.sql.SQLException;
 import net.snowflake.client.category.TestTags;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,7 +56,7 @@ class IdTokenIT {
 
   @Test
   @Order(2)
-  void shouldAuthenticateUsingTokenWithoutBrowser() throws SQLException {
+  void shouldAuthenticateUsingTokenWithoutBrowser() {
     verifyFirstTokenWasSaved();
     authTest.connectAndExecuteSimpleQuery(getStoreIDTokenConnectionParameters(), null);
     authTest.verifyExceptionIsNotThrown();

--- a/src/test/java/net/snowflake/client/authentication/IdTokenIT.java
+++ b/src/test/java/net/snowflake/client/authentication/IdTokenIT.java
@@ -1,0 +1,80 @@
+package net.snowflake.client.authentication;
+
+import static net.snowflake.client.authentication.AuthConnectionParameters.getStoreIDTokenConnectionParameters;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import net.snowflake.client.category.TestTags;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@Tag(TestTags.AUTHENTICATION)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class IdTokenIT {
+
+  String login = AuthConnectionParameters.SSO_USER;
+  String password = AuthConnectionParameters.SSO_PASSWORD;
+  AuthTest authTest;
+  private String firstToken;
+
+  @BeforeAll
+  public static void globalSetUp() throws IOException {
+    AuthTest.deleteIdToken();
+  }
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    authTest = new AuthTest();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    authTest.cleanBrowserProcesses();
+  }
+
+  @Test
+  @Order(1)
+  void shouldAuthenticateUsingExternalBrowserAndSaveToken() throws InterruptedException {
+    Thread provideCredentialsThread =
+        new Thread(() -> authTest.provideCredentials("success", login, password));
+    Thread connectThread =
+        authTest.getConnectAndExecuteSimpleQueryThread(getStoreIDTokenConnectionParameters());
+
+    authTest.connectAndProvideCredentials(provideCredentialsThread, connectThread);
+    authTest.verifyExceptionIsNotThrown();
+    firstToken = authTest.getIdToken();
+    assertThat(firstToken, notNullValue());
+  }
+
+  @Test
+  @Order(2)
+  void shouldAuthenticateUsingTokenWithoutBrowser() throws SQLException {
+    authTest.connectAndExecuteSimpleQuery(getStoreIDTokenConnectionParameters(), null);
+    authTest.verifyExceptionIsNotThrown();
+  }
+
+  @Test
+  @Order(3)
+  void shouldOpenBrowserAgainWhenTokenIsDeleted() throws InterruptedException {
+    AuthTest.deleteIdToken();
+    Thread provideCredentialsThread =
+        new Thread(() -> authTest.provideCredentials("success", login, password));
+    Thread connectThread =
+        authTest.getConnectAndExecuteSimpleQueryThread(getStoreIDTokenConnectionParameters());
+
+    authTest.connectAndProvideCredentials(provideCredentialsThread, connectThread);
+    authTest.verifyExceptionIsNotThrown();
+    String secondToken = authTest.getIdToken();
+    assertThat(secondToken, notNullValue());
+    assertThat(secondToken, not(firstToken));
+  }
+}

--- a/src/test/java/net/snowflake/client/authentication/IdTokenIT.java
+++ b/src/test/java/net/snowflake/client/authentication/IdTokenIT.java
@@ -4,12 +4,11 @@ import static net.snowflake.client.authentication.AuthConnectionParameters.getSt
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.IOException;
 import net.snowflake.client.category.TestTags;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -22,17 +21,12 @@ class IdTokenIT {
 
   String login = AuthConnectionParameters.SSO_USER;
   String password = AuthConnectionParameters.SSO_PASSWORD;
-  AuthTest authTest;
+  AuthTest authTest = new AuthTest();
   private static String firstToken;
 
   @BeforeAll
   public static void globalSetUp() {
     AuthTest.deleteIdToken();
-  }
-
-  @BeforeEach
-  public void setUp() throws IOException {
-    authTest = new AuthTest();
   }
 
   @AfterEach
@@ -51,7 +45,7 @@ class IdTokenIT {
     authTest.connectAndProvideCredentials(provideCredentialsThread, connectThread);
     authTest.verifyExceptionIsNotThrown();
     firstToken = authTest.getIdToken();
-    verifyFirstTokenWasSaved();
+    assertThat("Id token was not saved", firstToken, notNullValue());
   }
 
   @Test
@@ -80,6 +74,6 @@ class IdTokenIT {
   }
 
   private void verifyFirstTokenWasSaved() {
-    assertThat("Id token was not saved", firstToken, notNullValue());
+    assumeTrue(firstToken != null, "token was not saved, skipping test");
   }
 }

--- a/src/test/java/net/snowflake/client/category/TestTags.java
+++ b/src/test/java/net/snowflake/client/category/TestTags.java
@@ -14,4 +14,5 @@ public class TestTags {
   public static final String OTHERS = "others";
   public static final String RESULT_SET = "resultSet";
   public static final String STATEMENT = "statement";
+  public static final String AUTHENTICATION = "authentication";
 }

--- a/src/test/java/net/snowflake/client/suites/AuthenticationTestSuite.java
+++ b/src/test/java/net/snowflake/client/suites/AuthenticationTestSuite.java
@@ -1,0 +1,8 @@
+package net.snowflake.client.suites;
+
+import net.snowflake.client.category.TestTags;
+import org.junit.platform.suite.api.IncludeTags;
+
+@BaseTestSuite
+@IncludeTags(TestTags.AUTHENTICATION)
+public class AuthenticationTestSuite {}

--- a/src/test/java/net/snowflake/client/suites/UnitTestSuite.java
+++ b/src/test/java/net/snowflake/client/suites/UnitTestSuite.java
@@ -17,6 +17,7 @@ import org.junit.platform.suite.api.ExcludeTags;
   TestTags.LOADER,
   TestTags.OTHERS,
   TestTags.RESULT_SET,
-  TestTags.STATEMENT
+  TestTags.STATEMENT,
+  TestTags.AUTHENTICATION
 })
 public class UnitTestSuite {}


### PR DESCRIPTION
# Overview

SNOW-1346234

I'm not sure if `src/test/java/net/snowflake/client/jdbc/ConnectionManual.java` should be deleted after adding those tests as it operates on account parameters i.e.: `alter account testaccount set ALLOW_ID_TOKEN=false` , so it may still be valid to keep it.

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
