### PR TITLE
SNOW-1844765 Make createArrayOf case-insensitive

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeConnectionV1.java
@@ -726,7 +726,7 @@ public class SnowflakeConnectionV1 implements Connection, SnowflakeConnection {
   @Override
   public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
     logger.trace("Array createArrayOf(String typeName, Object[] " + "elements)", false);
-    return new SfSqlArray(JDBCType.valueOf(typeName).getVendorTypeNumber(), elements);
+    return new SfSqlArray(JDBCType.valueOf(typeName.toUpperCase()).getVendorTypeNumber(), elements);
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/jdbc/BindingAndInsertingStructuredTypesLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/BindingAndInsertingStructuredTypesLatestIT.java
@@ -272,7 +272,10 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
       statement.execute(" CREATE OR REPLACE TABLE array_of_integers(arrayInt ARRAY(INTEGER))");
 
       Array array = connection.createArrayOf("INTEGER", new Integer[] {1, 2, 3});
+      Array arrayFromLowerCaseType = connection.createArrayOf("integer", new Integer[] {1, 2, 3});
       stmt.setArray(1, array);
+      stmt.executeUpdate();
+      stmt.setArray(1, arrayFromLowerCaseType);
       stmt.executeUpdate();
 
       try (ResultSet resultSet = statement.executeQuery("SELECT * from array_of_integers"); ) {
@@ -282,6 +285,10 @@ public class BindingAndInsertingStructuredTypesLatestIT extends BaseJDBCTest {
         assertEquals(Long.valueOf(1), resultArray[0]);
         assertEquals(Long.valueOf(2), resultArray[1]);
         assertEquals(Long.valueOf(3), resultArray[2]);
+
+        resultSet.next();
+        Long[] resultArrayFromLowerCaseType = (Long[]) resultSet.getArray(1).getArray();
+        assertArrayEquals(resultArray, resultArrayFromLowerCaseType);
       }
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeConnectionV1Test.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeConnectionV1Test.java
@@ -3,16 +3,9 @@ package net.snowflake.client.jdbc;
 import static net.snowflake.client.jdbc.DefaultSFConnectionHandler.mergeProperties;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import java.sql.Array;
-import java.sql.JDBCType;
-import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Properties;
-import net.snowflake.client.core.SFBaseSession;
 import org.junit.jupiter.api.Test;
 
 /** Created by hyu on 2/2/18. */
@@ -204,20 +197,5 @@ public class SnowflakeConnectionV1Test {
     result = mergeProperties(conStr);
     assertThat(result.get("PROP1"), is("value1|value2"));
     assertThat(result.get("PROP2"), is("carrot^"));
-  }
-
-  @Test
-  public void testCreateArrayOfIsCaseInsensitive() throws SQLException {
-    SFConnectionHandler mockConnectionHandler = mock(SFConnectionHandler.class);
-    SFBaseSession sfBaseSession = mock(SFBaseSession.class);
-    when(mockConnectionHandler.getSFSession()).thenReturn(sfBaseSession);
-    when(sfBaseSession.checkProperties()).thenReturn(new ArrayList<>());
-    try (SnowflakeConnectionV1 connectionV1 = new SnowflakeConnectionV1(mockConnectionHandler)) {
-      Array arrayLowerCase = connectionV1.createArrayOf("integer", new Integer[] {1, 2, 3});
-      Array arrayUpperCase = connectionV1.createArrayOf("VARCHAR", new String[] {"one", "two"});
-
-      assertThat(arrayLowerCase.getBaseTypeName(), is(JDBCType.INTEGER.getName()));
-      assertThat(arrayUpperCase.getBaseTypeName(), is(JDBCType.VARCHAR.getName()));
-    }
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeConnectionV1Test.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeConnectionV1Test.java
@@ -3,9 +3,16 @@ package net.snowflake.client.jdbc;
 import static net.snowflake.client.jdbc.DefaultSFConnectionHandler.mergeProperties;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.sql.Array;
+import java.sql.JDBCType;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Properties;
+import net.snowflake.client.core.SFBaseSession;
 import org.junit.jupiter.api.Test;
 
 /** Created by hyu on 2/2/18. */
@@ -197,5 +204,20 @@ public class SnowflakeConnectionV1Test {
     result = mergeProperties(conStr);
     assertThat(result.get("PROP1"), is("value1|value2"));
     assertThat(result.get("PROP2"), is("carrot^"));
+  }
+
+  @Test
+  public void testCreateArrayOfIsCaseInsensitive() throws SQLException {
+    SFConnectionHandler mockConnectionHandler = mock(SFConnectionHandler.class);
+    SFBaseSession sfBaseSession = mock(SFBaseSession.class);
+    when(mockConnectionHandler.getSFSession()).thenReturn(sfBaseSession);
+    when(sfBaseSession.checkProperties()).thenReturn(new ArrayList<>());
+    try (SnowflakeConnectionV1 connectionV1 = new SnowflakeConnectionV1(mockConnectionHandler)) {
+      Array arrayLowerCase = connectionV1.createArrayOf("integer", new Integer[] {1, 2, 3});
+      Array arrayUpperCase = connectionV1.createArrayOf("VARCHAR", new String[] {"one", "two"});
+
+      assertThat(arrayLowerCase.getBaseTypeName(), is(JDBCType.INTEGER.getName()));
+      assertThat(arrayUpperCase.getBaseTypeName(), is(JDBCType.VARCHAR.getName()));
+    }
   }
 }


### PR DESCRIPTION
# Overview

[SNOW-1844765](https://snowflakecomputing.atlassian.net/browse/SNOW-1844765)

As noticed in #1982 - apache spark may turn the type name lowerCase. This behaviour is incompatible with the current createArrayOf implementation in SnowflakeConnectionV1 since it infers the JDBCType from the exact string type name. 
- This change adds `toUpperCase` call to `JDBCType.valueOf` invocation to allow passing lower/random case strings as type names. 
- Adds unit tests to emphasise that this is a desired behaviour

[SNOW-1844765]: https://snowflakecomputing.atlassian.net/browse/SNOW-1844765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ