### PR TITLE
SNOW-1804062: Explicitly exclude old netty-common from transitive dependencies

### DIFF
--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -481,10 +481,14 @@
         <version>${arrow.version}</version>
         <scope>runtime</scope>
         <exclusions>
-          <!-- We explicitly add netty-common in higher version, here only excluding for removing snyk issue since snyk does not understand our dependency tree -->
+          <!-- We explicitly add netty dependencies in higher version, here only excluding for removing snyk issue since snyk does not understand our dependency tree -->
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -480,6 +480,13 @@
         <artifactId>arrow-memory-netty-buffer-patch</artifactId>
         <version>${arrow.version}</version>
         <scope>runtime</scope>
+        <exclusions>
+          <!-- We explicitly add netty-common in higher version, here only excluding for removing snyk issue since snyk does not understand our dependency tree -->
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.arrow</groupId>


### PR DESCRIPTION
# Overview

SNOW-1804062

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements
