### PR TITLE
Added additional parameter TELEMETRY_SERVICE_AVAILABLE to support disabling Telemetry

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -78,6 +78,7 @@ public abstract class SFBaseSession {
   private boolean formatDateWithTimezone;
   private boolean enableCombineDescribe;
   private boolean clientTelemetryEnabled = false;
+  private boolean isTelemetryServiceAvailable = true;
   private boolean useSessionTimezone;
   private boolean defaultFormatDateWithTimezone = true;
   private boolean getDateUseNullTimezone = true;
@@ -987,6 +988,14 @@ public abstract class SFBaseSession {
 
   public void setClientTelemetryEnabled(boolean clientTelemetryEnabled) {
     this.clientTelemetryEnabled = clientTelemetryEnabled;
+  }
+
+  public boolean isTelemetryServiceAvailable() {
+    return isTelemetryServiceAvailable;
+  }
+
+  public void setTelemetryServiceAvailable(boolean isTelemetryServiceAvailable) {
+    this.isTelemetryServiceAvailable = isTelemetryServiceAvailable;
   }
 
   public int getArrayBindStageThreshold() {

--- a/src/main/java/net/snowflake/client/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtil.java
@@ -83,6 +83,7 @@ public class SessionUtil {
   private static final String CLIENT_REQUEST_MFA_TOKEN = "CLIENT_REQUEST_MFA_TOKEN";
   private static final String SERVICE_NAME = "SERVICE_NAME";
   private static final String CLIENT_IN_BAND_TELEMETRY_ENABLED = "CLIENT_TELEMETRY_ENABLED";
+  private static final String TELEMETRY_SERVICE_AVAILABLE = "TELEMETRY_SERVICE_AVAILABLE";
   private static final String CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED =
       "CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED";
   private static final String CLIENT_RESULT_COLUMN_CASE_INSENSITIVE =
@@ -184,6 +185,7 @@ public class SessionUtil {
               "CLIENT_SESSION_KEEP_ALIVE",
               CLIENT_ENABLE_LOG_INFO_STATEMENT_PARAMETERS,
               CLIENT_IN_BAND_TELEMETRY_ENABLED,
+              TELEMETRY_SERVICE_AVAILABLE,
               CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED,
               CLIENT_STORE_TEMPORARY_CREDENTIAL,
               CLIENT_REQUEST_MFA_TOKEN,
@@ -1636,6 +1638,10 @@ public class SessionUtil {
       } else if (CLIENT_IN_BAND_TELEMETRY_ENABLED.equalsIgnoreCase(entry.getKey())) {
         if (session != null) {
           session.setClientTelemetryEnabled((boolean) entry.getValue());
+        }
+      } else if (TELEMETRY_SERVICE_AVAILABLE.equalsIgnoreCase(entry.getKey())) {
+        if (session != null) {
+          session.setTelemetryServiceAvailable((boolean) entry.getValue());
         }
       } else if ("CLIENT_STAGE_ARRAY_BINDING_THRESHOLD".equalsIgnoreCase(entry.getKey())) {
         if (session != null) {

--- a/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/jdbc/telemetry/TelemetryClient.java
@@ -74,6 +74,7 @@ public class TelemetryClient implements Telemetry {
   private TelemetryClient(SFSession session, int flushSize) {
     this.session = session;
     this.serverUrl = session.getUrl();
+    this.isTelemetryServiceAvailable = session.isTelemetryServiceAvailable();
     this.httpClient = null;
 
     if (this.serverUrl.endsWith("/")) {

--- a/src/test/java/net/snowflake/client/jdbc/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SessionUtilTest.java
@@ -70,5 +70,17 @@ public class SessionUtilTest {
         SessionUtil.getCommonParams(
             mapper.readTree("[{\"name\": \"TIMEZONE\", \"value\": \"value\"}]"));
     assertEquals("value", result.get("TIMEZONE"));
+
+    result =
+            SessionUtil.getCommonParams(
+                    mapper.readTree(
+                            "[{\"name\": \"TELEMETRY_SERVICE_AVAILABLE\", \"value\": true}]"));
+    assertTrue((boolean) result.get("TELEMETRY_SERVICE_AVAILABLE"));
+
+    result =
+            SessionUtil.getCommonParams(
+                    mapper.readTree(
+                            "[{\"name\": \"TELEMETRY_SERVICE_AVAILABLE\", \"value\": false}]"));
+    assertFalse((boolean) result.get("TELEMETRY_SERVICE_AVAILABLE"));
   }
 }


### PR DESCRIPTION
Added additional parameter TELEMETRY_SERVICE_AVAILABLE to support disabling Telemetry

# Overview

SNOW-1881874

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #2029


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   So basically additional variable TELEMETRY_SERVICE_AVAILABLE was added to have control over isTelemetryServiceAvailable variable in TelemetryClient that was hardcoded.
