### PR TITLE
SNOW-1229142: Improve commons logging wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ wss*.config
 wss-unified-agent.jar
 whitesource/
 *.swp
+
+#created in some tests
+placeholder

--- a/src/main/java/net/snowflake/client/log/CommonsLoggingWrapper.java
+++ b/src/main/java/net/snowflake/client/log/CommonsLoggingWrapper.java
@@ -12,10 +12,10 @@ import org.apache.commons.logging.Log;
  * messages.
  */
 @SnowflakeJdbcInternalApi
-public class JCLWrapper implements Log {
+public class CommonsLoggingWrapper implements Log {
   private final SFLogger logger;
 
-  public JCLWrapper(String className) {
+  public CommonsLoggingWrapper(String className) {
     this.logger = SFLoggerFactory.getLogger(className);
   }
 

--- a/src/main/java/net/snowflake/client/log/CommonsLoggingWrapperMode.java
+++ b/src/main/java/net/snowflake/client/log/CommonsLoggingWrapperMode.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Snowflake Computing Inc. All rights reserved.
+ */
+package net.snowflake.client.log;
+
+import static net.snowflake.client.jdbc.SnowflakeUtil.systemGetProperty;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+enum CommonsLoggingWrapperMode {
+  ALL,
+  DEFAULT,
+  OFF;
+
+  static final String JAVA_PROPERTY = "net.snowflake.jdbc.commons_logging_wrapper";
+
+  static CommonsLoggingWrapperMode detect() {
+    String value = systemGetProperty(JAVA_PROPERTY);
+    if (value == null) {
+      return DEFAULT;
+    }
+    try {
+      return CommonsLoggingWrapperMode.valueOf(value);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Unknown commons logging wrapper value '"
+              + value
+              + "', expected one of: "
+              + Stream.of(CommonsLoggingWrapperMode.values())
+                  .map(Enum::name)
+                  .collect(Collectors.joining(", ")));
+    }
+  }
+}

--- a/src/main/java/net/snowflake/client/log/CommonsLoggingWrapperMode.java
+++ b/src/main/java/net/snowflake/client/log/CommonsLoggingWrapperMode.java
@@ -9,8 +9,18 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 enum CommonsLoggingWrapperMode {
+  /** All logs from commons logging are passed to SFLogger (check {@link CommonsLoggingWrapper}) */
   ALL,
+  /**
+   * The default behaviour is forwarding all logs to java.util.logging from commons logging (check
+   * {@link JDK14JCLWrapper}), no logs are forwarded to SLF4J logger (check {@link SLF4JJCLWrapper})
+   */
   DEFAULT,
+  /**
+   * Logs from commons logging are not forwarded and commons logging is not reconfigured - may be
+   * the option when if you need to replace commons logging with the SLF4J bridge when thin jar is
+   * used
+   */
   OFF;
 
   static final String JAVA_PROPERTY = "net.snowflake.jdbc.commons_logging_wrapper";

--- a/src/main/java/net/snowflake/client/log/JCLWrapper.java
+++ b/src/main/java/net/snowflake/client/log/JCLWrapper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Snowflake Computing Inc. All rights reserved.
+ */
+package net.snowflake.client.log;
+
+import net.snowflake.client.core.SnowflakeJdbcInternalApi;
+import org.apache.commons.logging.Log;
+
+/**
+ * This is a wrapper class of apache commons logging which uses SFLogger to use driver configuration
+ * (via java.util.logging or SLF4J) and mask secrets. Wrapper does not hide trace and debug
+ * messages.
+ */
+@SnowflakeJdbcInternalApi
+public class JCLWrapper implements Log {
+  private final SFLogger logger;
+
+  public JCLWrapper(String className) {
+    this.logger = SFLoggerFactory.getLogger(className);
+  }
+
+  public void debug(Object msg) {
+    logger.debug(String.valueOf(msg), true);
+  }
+
+  public void debug(Object msg, Throwable t) {
+    logger.debug(String.valueOf(msg), t);
+  }
+
+  public void error(Object msg) {
+    logger.error(String.valueOf(msg), true);
+  }
+
+  public void error(Object msg, Throwable t) {
+    logger.error(String.valueOf(msg), t);
+  }
+
+  public void fatal(Object msg) {
+    this.error(msg);
+  }
+
+  public void fatal(Object msg, Throwable t) {
+    this.error(msg, t);
+  }
+
+  public void info(Object msg) {
+    logger.info(String.valueOf(msg), true);
+  }
+
+  public void info(Object msg, Throwable t) {
+    logger.info(String.valueOf(msg), t);
+  }
+
+  public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+  public boolean isErrorEnabled() {
+    return logger.isErrorEnabled();
+  }
+
+  public boolean isFatalEnabled() {
+    return logger.isErrorEnabled();
+  }
+
+  public boolean isInfoEnabled() {
+    return logger.isInfoEnabled();
+  }
+
+  public boolean isTraceEnabled() {
+    return logger.isTraceEnabled();
+  }
+
+  public boolean isWarnEnabled() {
+    return logger.isWarnEnabled();
+  }
+
+  public void trace(Object msg) {
+    logger.debug(String.valueOf(msg), true);
+  }
+
+  public void trace(Object msg, Throwable t) {
+    logger.trace(String.valueOf(msg), t);
+  }
+
+  public void warn(Object msg) {
+    logger.warn(String.valueOf(msg));
+  }
+
+  public void warn(Object msg, Throwable t) {
+    logger.warn(String.valueOf(msg), t);
+  }
+}

--- a/src/main/java/net/snowflake/client/log/SFLoggerUtil.java
+++ b/src/main/java/net/snowflake/client/log/SFLoggerUtil.java
@@ -20,9 +20,18 @@ public class SFLoggerUtil {
       loggerImplementation = SFLoggerFactory.LoggerImpl.JDK14LOGGER;
     }
 
+    CommonsLoggingWrapperMode commonsLoggingWrapperMode = CommonsLoggingWrapperMode.detect();
+    if (commonsLoggingWrapperMode == CommonsLoggingWrapperMode.OFF) {
+      return;
+    }
+
     System.setProperty(
         "org.apache.commons.logging.LogFactory", "org.apache.commons.logging.impl.LogFactoryImpl");
     LogFactory logFactory = LogFactory.getFactory();
+    if (commonsLoggingWrapperMode == CommonsLoggingWrapperMode.ALL) {
+      logFactory.setAttribute("org.apache.commons.logging.Log", JCLWrapper.class.getName());
+      return;
+    }
     switch (loggerImplementation) {
       case SLF4JLOGGER:
         logFactory.setAttribute(

--- a/src/main/java/net/snowflake/client/log/SFLoggerUtil.java
+++ b/src/main/java/net/snowflake/client/log/SFLoggerUtil.java
@@ -29,7 +29,8 @@ public class SFLoggerUtil {
         "org.apache.commons.logging.LogFactory", "org.apache.commons.logging.impl.LogFactoryImpl");
     LogFactory logFactory = LogFactory.getFactory();
     if (commonsLoggingWrapperMode == CommonsLoggingWrapperMode.ALL) {
-      logFactory.setAttribute("org.apache.commons.logging.Log", JCLWrapper.class.getName());
+      logFactory.setAttribute(
+          "org.apache.commons.logging.Log", CommonsLoggingWrapper.class.getName());
       return;
     }
     switch (loggerImplementation) {

--- a/src/test/java/net/snowflake/client/log/CommonsLoggingWrapperModeTest.java
+++ b/src/test/java/net/snowflake/client/log/CommonsLoggingWrapperModeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Snowflake Computing Inc. All rights reserved.
+ */
+package net.snowflake.client.log;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class CommonsLoggingWrapperModeTest {
+
+  private String propertyValue;
+
+  @BeforeEach
+  public void setUp() {
+    propertyValue = System.getProperty(CommonsLoggingWrapperMode.JAVA_PROPERTY);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (propertyValue != null) {
+      System.setProperty(CommonsLoggingWrapperMode.JAVA_PROPERTY, propertyValue);
+    } else {
+      System.clearProperty(CommonsLoggingWrapperMode.JAVA_PROPERTY);
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(CommonsLoggingWrapperMode.class)
+  public void shouldDetectMode(CommonsLoggingWrapperMode value) {
+    System.setProperty(CommonsLoggingWrapperMode.JAVA_PROPERTY, value.name());
+    assertEquals(value, CommonsLoggingWrapperMode.detect());
+  }
+
+  @Test
+  public void shouldPickDefaultMode() {
+    System.clearProperty(CommonsLoggingWrapperMode.JAVA_PROPERTY);
+    assertEquals(CommonsLoggingWrapperMode.DEFAULT, CommonsLoggingWrapperMode.detect());
+  }
+
+  @Test
+  public void shouldThrowOnUnknownMode() {
+    System.setProperty(CommonsLoggingWrapperMode.JAVA_PROPERTY, "bla");
+    IllegalArgumentException illegalArgumentException =
+        assertThrows(IllegalArgumentException.class, CommonsLoggingWrapperMode::detect);
+    assertEquals(
+        "Unknown commons logging wrapper value 'bla', expected one of: ALL, DEFAULT, OFF",
+        illegalArgumentException.getMessage());
+  }
+}

--- a/src/test/java/net/snowflake/client/log/CommonsLoggingWrapperModeTest.java
+++ b/src/test/java/net/snowflake/client/log/CommonsLoggingWrapperModeTest.java
@@ -45,11 +45,11 @@ public class CommonsLoggingWrapperModeTest {
 
   @Test
   public void shouldThrowOnUnknownMode() {
-    System.setProperty(CommonsLoggingWrapperMode.JAVA_PROPERTY, "bla");
+    System.setProperty(CommonsLoggingWrapperMode.JAVA_PROPERTY, "invalid");
     IllegalArgumentException illegalArgumentException =
         assertThrows(IllegalArgumentException.class, CommonsLoggingWrapperMode::detect);
     assertEquals(
-        "Unknown commons logging wrapper value 'bla', expected one of: ALL, DEFAULT, OFF",
+        "Unknown commons logging wrapper value 'invalid', expected one of: ALL, DEFAULT, OFF",
         illegalArgumentException.getMessage());
   }
 }


### PR DESCRIPTION
# Overview

SNOW-1229142

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
