### PR TITLE
SNOW-1898856: Make test getMaxBinaryLiteralLength and getMaxCharLiteralLength more robust

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataIT.java
@@ -677,9 +677,10 @@ public class DatabaseMetaDataIT extends BaseJDBCWithSharedConnectionIT {
     assertEquals("$", metaData.getExtraNameCharacters());
     assertEquals("\"", metaData.getIdentifierQuoteString());
     assertEquals(0, getSizeOfResultSet(metaData.getIndexInfo(null, null, null, true, true)));
-    assertEquals(EXPECTED_MAX_BINARY_LENGTH, metaData.getMaxBinaryLiteralLength());
+    assertThat(
+        metaData.getMaxBinaryLiteralLength(), greaterThanOrEqualTo(EXPECTED_MAX_BINARY_LENGTH));
     assertEquals(255, metaData.getMaxCatalogNameLength());
-    assertEquals(EXPECTED_MAX_CHAR_LENGTH, metaData.getMaxCharLiteralLength());
+    assertThat(metaData.getMaxCharLiteralLength(), greaterThanOrEqualTo(EXPECTED_MAX_CHAR_LENGTH));
     assertEquals(255, metaData.getMaxColumnNameLength());
     assertEquals(0, metaData.getMaxColumnsInGroupBy());
     assertEquals(0, metaData.getMaxColumnsInIndex());


### PR DESCRIPTION
# Overview

SNOW-1898856

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
