### PR TITLE
SNOW-1708383 fix opening external browser on win

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 - repo: git@github.com:snowflakedb/casec_precommit.git
-  rev: v1.11
+  rev: v1.35.5
   hooks:
   - id: secret-scanner

--- a/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilExternalBrowser.java
@@ -6,6 +6,7 @@ package net.snowflake.client.core;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import java.awt.Desktop;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -69,24 +70,22 @@ public class SessionUtilExternalBrowser {
 
     @Override
     public void openBrowser(String ssoUrl) throws SFException {
+      if (!URLUtil.isValidURL(ssoUrl)) {
+        throw new SFException(ErrorCode.INVALID_CONNECTION_URL, "Invalid SSOUrl found - " + ssoUrl);
+      }
       try {
         // start web browser
-        if (!URLUtil.isValidURL(ssoUrl)) {
-          throw new SFException(
-              ErrorCode.INVALID_CONNECTION_URL, "Invalid SSOUrl found - " + ssoUrl);
-        }
-        if (java.awt.Desktop.isDesktopSupported()) {
-          URI uri = new URI(ssoUrl);
-          java.awt.Desktop.getDesktop().browse(uri);
+        Runtime runtime = Runtime.getRuntime();
+        Constants.OS os = Constants.getOS();
+        if (Desktop.isDesktopSupported()
+            && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+          Desktop.getDesktop().browse(new URI(ssoUrl));
+        } else if (os == Constants.OS.MAC) {
+          runtime.exec("open " + ssoUrl);
+        } else if (os == Constants.OS.WINDOWS) {
+          runtime.exec(new String[] {"rundll32", "url.dll,FileProtocolHandler", ssoUrl});
         } else {
-          Runtime runtime = Runtime.getRuntime();
-          Constants.OS os = Constants.getOS();
-          if (os == Constants.OS.MAC) {
-            runtime.exec("open " + ssoUrl);
-          } else {
-            // linux?
-            runtime.exec("xdg-open " + ssoUrl);
-          }
+          runtime.exec("xdg-open " + ssoUrl);
         }
       } catch (URISyntaxException | IOException ex) {
         throw new SFException(ex, ErrorCode.NETWORK_ERROR, ex.getMessage());


### PR DESCRIPTION
Fix will rely on awt.desktop whenever possible and prevent falling back to xdg-open on Windows when java.awt.headless is enabled

# Overview

SNOW-1708383

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
