### PR TITLE
SNOW-1903631 Add more explicit error message when username or password is missing id DataSource

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
@@ -94,12 +94,20 @@ public class SnowflakeBasicDataSource implements DataSource, Serializable {
   public Connection getConnection(String username, String password) throws SQLException {
     if (!AUTHENTICATOR_OAUTH.equalsIgnoreCase(
         authenticator)) { // For OAuth, no username is required
+      if (username == null) {
+        throw new SQLException(
+            "Cannot create connection because username is missing in DataSource properties.");
+      }
       properties.put(SFSessionProperty.USER.getPropertyKey(), username);
     }
 
     // The driver needs password for OAUTH as part of SNOW-533673 feature request.
     if (!AUTHENTICATOR_SNOWFLAKE_JWT.equalsIgnoreCase(authenticator)
         && !AUTHENTICATOR_EXTERNAL_BROWSER.equalsIgnoreCase(authenticator)) {
+      if (password == null) {
+        throw new SQLException(
+            "Cannot create connection because password is missing in DataSource properties.");
+      }
       properties.put(SFSessionProperty.PASSWORD.getPropertyKey(), password);
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeBasicDataSource.java
@@ -95,7 +95,7 @@ public class SnowflakeBasicDataSource implements DataSource, Serializable {
     if (!AUTHENTICATOR_OAUTH.equalsIgnoreCase(
         authenticator)) { // For OAuth, no username is required
       if (username == null) {
-        throw new SQLException(
+        throw new SnowflakeSQLException(
             "Cannot create connection because username is missing in DataSource properties.");
       }
       properties.put(SFSessionProperty.USER.getPropertyKey(), username);
@@ -105,7 +105,7 @@ public class SnowflakeBasicDataSource implements DataSource, Serializable {
     if (!AUTHENTICATOR_SNOWFLAKE_JWT.equalsIgnoreCase(authenticator)
         && !AUTHENTICATOR_EXTERNAL_BROWSER.equalsIgnoreCase(authenticator)) {
       if (password == null) {
-        throw new SQLException(
+        throw new SnowflakeSQLException(
             "Cannot create connection because password is missing in DataSource properties.");
       }
       properties.put(SFSessionProperty.PASSWORD.getPropertyKey(), password);

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeBasicDataSourceTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeBasicDataSourceTest.java
@@ -6,6 +6,7 @@ package net.snowflake.client.jdbc;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.SQLException;
 import java.util.Properties;
@@ -111,5 +112,23 @@ public class SnowflakeBasicDataSourceTest {
     assertEquals("fake_key", props.get(SFSessionProperty.PRIVATE_KEY_BASE64.getPropertyKey()));
     assertEquals("pwd", props.get(SFSessionProperty.PRIVATE_KEY_PWD.getPropertyKey()));
     assertEquals("SNOWFLAKE_JWT", props.get(SFSessionProperty.AUTHENTICATOR.getPropertyKey()));
+  }
+
+  @Test
+  public void testDataSourceWithoutUsernameOrPasswordThrowsExplicitException() {
+    SnowflakeBasicDataSource ds = new SnowflakeBasicDataSource();
+
+    ds.setAccount("testaccount");
+    ds.setAuthenticator("snowflake");
+    assertThrows(
+        SnowflakeSQLException.class,
+        ds::getConnection,
+        "Cannot create connection because username is missing in DataSource properties.");
+
+    ds.setUser("testuser");
+    assertThrows(
+        SnowflakeSQLException.class,
+        ds::getConnection,
+        "Cannot create connection because password is missing in DataSource properties.");
   }
 }


### PR DESCRIPTION
# Overview

SNOW-1903631

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #2055


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

Simply check the parameter (username and password) before putting them into the ConcurrentHashMap so we get a clearer error message instead of a NullPointerException.
