### PR TITLE
SNOW-1926811: Update netty version to 4.1.118.Final

### DIFF
--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -21,6 +21,7 @@
     <junit.version>5.11.1</junit.version>
     <surefire.version>3.5.1</surefire.version>
     <mockito.version>3.5.6</mockito.version>
+    <netty.version>4.1.118.Final</netty.version>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>
   </properties>
 
@@ -28,12 +29,12 @@
     <dependency> <!-- netty is not a direct dependency. It is used by arrow-vector -->
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.115.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>4.1.115.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -68,7 +68,7 @@
     <logback.version>1.3.6</logback.version>
     <metrics.version>2.2.0</metrics.version>
     <mockito.version>4.11.0</mockito.version>
-    <netty.version>4.1.115.Final</netty.version>
+    <netty.version>4.1.118.Final</netty.version>
     <nimbusds.version>9.37.3</nimbusds.version>
     <opencensus.version>0.31.1</opencensus.version>
     <plexus.container.version>1.0-alpha-9-stable-1</plexus.container.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -58,7 +58,7 @@
     <json.smart.version>2.4.9</json.smart.version>
     <jsoup.version>1.15.3</jsoup.version>
     <metrics.version>2.2.0</metrics.version>
-    <netty.version>4.1.115.Final</netty.version>
+    <netty.version>4.1.118.Final</netty.version>
     <nimbusds.version>9.37.3</nimbusds.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
# Overview

SNOW-1926811

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
