### PR TITLE
SNOW-1660409: Fix directory permission for GET

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java
@@ -73,8 +73,8 @@ public class SnowflakeUtil {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeUtil.class);
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
 
-  private static final Set<PosixFilePermission> ownerOnlyPermission =
-      PosixFilePermissions.fromString("rw-------");
+  private static final Set<PosixFilePermission> directoryOwnerOnlyPermission =
+      PosixFilePermissions.fromString("rwx------");
 
   /** Additional data types not covered by standard JDBC */
   public static final int EXTRA_TYPES_TIMESTAMP_LTZ = 50000;
@@ -922,7 +922,8 @@ public class SnowflakeUtil {
     boolean isDirCreated = true;
     Path dir = Paths.get(location);
     try {
-      Files.createDirectory(dir, PosixFilePermissions.asFileAttribute(ownerOnlyPermission));
+      Files.createDirectory(
+          dir, PosixFilePermissions.asFileAttribute(directoryOwnerOnlyPermission));
     } catch (IOException e) {
       logger.error(
           "Failed to set OwnerOnly permission for {}. This may cause the file download to fail ",

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeUtilTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeUtilTest.java
@@ -139,7 +139,7 @@ public class SnowflakeUtilTest extends BaseJDBCTest {
     assertTrue(tmp.toFile().isDirectory());
     PosixFileAttributes attributes = Files.readAttributes(tmp, PosixFileAttributes.class);
     Set<PosixFilePermission> permissions = attributes.permissions();
-    assertEquals(PosixFilePermissions.toString(permissions), "rw-------");
+    assertEquals(PosixFilePermissions.toString(permissions), "rwx------");
   }
 
   @Test


### PR DESCRIPTION
# Overview

SNOW-1660409

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
