### PR TITLE
SNOW-0000: [APPS-53008] SnowflakeFileTransferAgent avoid query history clutter and enable test mocks 

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeFileTransferAgent.java
@@ -80,8 +80,6 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
   private static final SFLogger logger =
       SFLoggerFactory.getLogger(SnowflakeFileTransferAgent.class);
 
-  static final StorageClientFactory storageFactory = StorageClientFactory.getFactory();
-
   private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
 
   // We will allow buffering of upto 128M data before spilling to disk during
@@ -891,7 +889,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     parseCommand();
 
     if (stageInfo.getStageType() != StageInfo.StageType.LOCAL_FS) {
-      storageClient = storageFactory.createClient(stageInfo, parallel, null, session);
+      storageClient =
+          StorageClientFactory.getFactory().createClient(stageInfo, parallel, null, session);
     }
   }
 
@@ -1627,7 +1626,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
                     fileMetadata,
                     (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
                         ? null
-                        : storageFactory.createClient(stageInfo, parallel, encMat, session),
+                        : StorageClientFactory.getFactory()
+                            .createClient(stageInfo, parallel, encMat, session),
                     session,
                     command,
                     sourceStream,
@@ -1728,7 +1728,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     RemoteStoreFileEncryptionMaterial encMat = srcFileToEncMat.get(sourceLocation);
     String presignedUrl = srcFileToPresignedUrl.get(sourceLocation);
 
-    return storageFactory
+    return StorageClientFactory.getFactory()
         .createClient(stageInfo, parallel, encMat, session)
         .downloadToStream(
             session,
@@ -1772,7 +1772,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
                     fileMetadataMap,
                     (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
                         ? null
-                        : storageFactory.createClient(stageInfo, parallel, encMat, session),
+                        : StorageClientFactory.getFactory()
+                            .createClient(stageInfo, parallel, encMat, session),
                     session,
                     command,
                     parallel,
@@ -1878,8 +1879,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
                     fileMetadata,
                     (stageInfo.getStageType() == StageInfo.StageType.LOCAL_FS)
                         ? null
-                        : storageFactory.createClient(
-                            stageInfo, parallel, encryptionMaterial.get(0), session),
+                        : StorageClientFactory.getFactory()
+                            .createClient(stageInfo, parallel, encryptionMaterial.get(0), session),
                     session,
                     command,
                     null,
@@ -2174,7 +2175,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         (ArgSupplier)
             () -> (encMat == null ? "NULL" : encMat.getSmkId() + "|" + encMat.getQueryId()));
 
-    StorageObjectMetadata meta = storageFactory.createStorageMetadataObj(stage.getStageType());
+    StorageObjectMetadata meta =
+        StorageClientFactory.getFactory().createStorageMetadataObj(stage.getStageType());
     meta.setContentLength(uploadSize);
     if (digest != null) {
       initialClient.addDigestMetadata(meta, digest);
@@ -2312,7 +2314,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           uploadSize);
 
       SnowflakeStorageClient initialClient =
-          storageFactory.createClient(stageInfo, 1, encMat, /* session= */ null);
+          StorageClientFactory.getFactory().createClient(stageInfo, 1, encMat, /* session= */ null);
 
       // Normal flow will never hit here. This is only for testing purposes
       if (isInjectedFileTransferExceptionEnabled()) {
@@ -2428,7 +2430,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         (ArgSupplier)
             () -> (encMat == null ? "NULL" : encMat.getSmkId() + "|" + encMat.getQueryId()));
 
-    StorageObjectMetadata meta = storageFactory.createStorageMetadataObj(stage.getStageType());
+    StorageObjectMetadata meta =
+        StorageClientFactory.getFactory().createStorageMetadataObj(stage.getStageType());
     meta.setContentLength(uploadSize);
     if (digest != null) {
       initialClient.addDigestMetadata(meta, digest);


### PR DESCRIPTION
# Overview

Addresses point B of [APPS-53008](https://snowflakecomputing.atlassian.net/browse/APPS-53008)
* B. deep test SnowflakeTransferAgent functionality
  * we cannot easily mock the StorageClient which is static final initialized on the class
  * modifying the final qualifier is not safe and was deemed impractical, see [PR](https://github.com/snowflakedb/snapps/pull/68290), [discarded test](https://github.com/snowflakedb/snapps/blob/jc/cb_sf_proxy_deep_tests/src/coldbrew/file-io-utils/src/test/java/net/snowflake/client/core/SnowflakeFileTransferAgentTest.java#L297-L299) due to unsafe reflection

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.


[APPS-53008]: https://snowflakecomputing.atlassian.net/browse/APPS-53008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ