### PR TITLE
SNOW-1958601: Fix NPE when cache folder is inaccessible

### DIFF
--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -264,7 +264,7 @@ class FileCacheManager {
   /** Reads the cache file. */
   synchronized JsonNode readCacheFile() {
     try {
-      if (!cacheFile.exists()) {
+      if (cacheFile == null || !cacheFile.exists()) {
         logger.debug("Cache file doesn't exists. File: {}", cacheFile);
         return null;
       }

--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -91,8 +91,8 @@ class FileCacheManager {
    * @param newCacheFile a file object to override the default one.
    */
   synchronized void overrideCacheFile(File newCacheFile) {
-    if (!newCacheFile.exists()) {
-      logger.debug("Cache file doesn't exists. File: {}", newCacheFile);
+    if (!FileUtil.exists(newCacheFile)) {
+      logger.debug("Cache file doesn't exist. File: {}", newCacheFile);
     }
     if (onlyOwnerPermissions) {
       FileUtil.handleWhenFilePermissionsWiderThanUserOnly(newCacheFile, "Override cache file");
@@ -264,8 +264,8 @@ class FileCacheManager {
   /** Reads the cache file. */
   synchronized JsonNode readCacheFile() {
     try {
-      if (cacheFile == null || !cacheFile.exists()) {
-        logger.debug("Cache file doesn't exists. File: {}", cacheFile);
+      if (!FileUtil.exists(cacheFile)) {
+        logger.debug("Cache file doesn't exist. File: {}", cacheFile);
         return null;
       }
 
@@ -373,8 +373,8 @@ class FileCacheManager {
    * @return epoch time in ms
    */
   private static synchronized long fileCreationTime(File targetFile) {
-    if (!targetFile.exists()) {
-      logger.debug("File not exists. File: {}", targetFile);
+    if (!FileUtil.exists(targetFile)) {
+      logger.debug("File does not exist. File: {}", targetFile);
       return -1;
     }
     try {

--- a/src/main/java/net/snowflake/client/core/FileUtil.java
+++ b/src/main/java/net/snowflake/client/core/FileUtil.java
@@ -134,14 +134,14 @@ public class FileUtil {
       boolean isReadableByOthers = isPermPresent(filePermissions, READ_BY_OTHERS);
       boolean isExecutable = isPermPresent(filePermissions, EXECUTABLE);
 
-      if (isWritableByOthers || (isReadableByOthers || isExecutable)) {
+      if (isWritableByOthers || (isReadableByOthers && logReadAccess) || isExecutable) {
         logger.warn(
             "{}File {} is accessible by others to:{}{}",
             getContextStr(context),
             filePath,
             isReadableByOthers && logReadAccess ? " read" : "",
             isWritableByOthers ? " write" : "",
-            isExecutable ? " executable" : "");
+            isExecutable ? " execute" : "");
       }
     } catch (IOException e) {
       logger.warn(

--- a/src/main/java/net/snowflake/client/core/FileUtil.java
+++ b/src/main/java/net/snowflake/client/core/FileUtil.java
@@ -198,7 +198,7 @@ public class FileUtil {
       return false;
     }
     try {
-    return file.exists();
+      return file.exists();
     } catch (Exception e) {
       return false;
     }

--- a/src/main/java/net/snowflake/client/core/FileUtil.java
+++ b/src/main/java/net/snowflake/client/core/FileUtil.java
@@ -192,4 +192,15 @@ public class FileUtil {
   private static String getContextStr(String context) {
     return Strings.isNullOrEmpty(context) ? "" : context + ": ";
   }
+
+  public static boolean exists(File file) {
+    if (file == null) {
+      return false;
+    }
+    try {
+    return file.exists();
+    } catch (Exception e) {
+      return false;
+    }
+  }
 }

--- a/src/main/java/net/snowflake/client/core/FileUtil.java
+++ b/src/main/java/net/snowflake/client/core/FileUtil.java
@@ -197,10 +197,6 @@ public class FileUtil {
     if (file == null) {
       return false;
     }
-    try {
-      return file.exists();
-    } catch (Exception e) {
-      return false;
-    }
+    return file.exists();
   }
 }

--- a/src/test/java/net/snowflake/client/core/FileCacheManagerTest.java
+++ b/src/test/java/net/snowflake/client/core/FileCacheManagerTest.java
@@ -106,6 +106,26 @@ class FileCacheManagerTest extends BaseJDBCTest {
 
   @Test
   @RunOnLinuxOrMac
+  public void notThrowExceptionWhenCacheFolderIsNotAccessible() throws IOException {
+    try {
+      Files.setPosixFilePermissions(
+          cacheFile.getParentFile().toPath(), PosixFilePermissions.fromString("---------"));
+      FileCacheManager fcm =
+          FileCacheManager.builder()
+              .setCacheDirectorySystemProperty(CACHE_DIR_PROP)
+              .setCacheDirectoryEnvironmentVariable(CACHE_DIR_ENV)
+              .setBaseCacheFileName(CACHE_FILE_NAME)
+              .setCacheFileLockExpirationInSeconds(CACHE_FILE_LOCK_EXPIRATION_IN_SECONDS)
+              .build();
+      assertDoesNotThrow(fcm::readCacheFile);
+    } finally {
+      Files.setPosixFilePermissions(
+          cacheFile.getParentFile().toPath(), PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @RunOnLinuxOrMac
   public void throwWhenOverrideCacheFileHasDifferentOwnerThanCurrentUserTest() {
     try (MockedStatic<FileUtil> fileUtilMock =
         Mockito.mockStatic(FileUtil.class, Mockito.CALLS_REAL_METHODS)) {


### PR DESCRIPTION
# Overview

SNOW-1958601

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
