### PR TITLE
SNOW-2021007: disable prod tests

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -139,6 +139,7 @@ public class ConnectionIT extends BaseJDBCWithSharedConnectionIT {
    * password but correct url Expectation is receiving incorrect username or password response from
    * server
    */
+  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
   @Test
   public void testProdConnectivity() throws SQLException {
     String[] deploymentUrls = {
@@ -566,6 +567,7 @@ public class ConnectionIT extends BaseJDBCWithSharedConnectionIT {
   }
 
   /** Test production connectivity with insecure mode enabled. */
+  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testInsecureMode(boolean insecureModeInProperties) {

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -1653,6 +1653,7 @@ public class ConnectionLatestIT extends BaseJDBCTest {
    * Test production connectivity with disableOCSPChecksMode enabled. This test applies to driver
    * versions after 3.21.0
    */
+  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
   @Test
   public void testDisableOCSPChecksMode() throws SQLException {
 

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionWithDisableOCSPModeLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionWithDisableOCSPModeLatestIT.java
@@ -12,6 +12,7 @@ import net.snowflake.client.category.TestTags;
 import net.snowflake.client.core.SFTrustManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,7 @@ public class ConnectionWithDisableOCSPModeLatestIT extends BaseJDBCTest {
    * Test connectivity with disableOCSPChecksMode and insecure mode enabled. This test applies to
    * driver versions after 3.21.0
    */
+  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
   @Test
   public void testDisableOCSPChecksModeAndInsecureModeSet() throws SQLException {
 
@@ -50,6 +52,7 @@ public class ConnectionWithDisableOCSPModeLatestIT extends BaseJDBCTest {
    * Test production connectivity with only disableOCSPChecksMode enabled. This test applies to
    * driver versions after 3.21.0
    */
+  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
   @Test
   public void testDisableOCSPChecksModeSet() throws SQLException {
     boolean disableOCSPChecks = true;
@@ -62,6 +65,7 @@ public class ConnectionWithDisableOCSPModeLatestIT extends BaseJDBCTest {
    * Test production connectivity with only insecureMode enabled. This test applies to driver
    * versions after 3.21.0
    */
+  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
   @Test
   public void testInsecureModeSet() throws SQLException {
     boolean insecureMode = true;
@@ -74,6 +78,7 @@ public class ConnectionWithDisableOCSPModeLatestIT extends BaseJDBCTest {
    * Test production connectivity with disableOCSPChecksMode enabled AND insecureMode disabled. This
    * test applies to driver versions after 3.21.0
    */
+  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
   @Test
   public void testDisableOCSPChecksModeAndInsecureModeMismatched() throws SQLException {
     boolean disableOCSPChecks = true;


### PR DESCRIPTION
# Overview

SNOW-2021007
Disable prod tests that fail due to changes in backend error responses, those tests will be changed in next quarter to be independent of backend.

## Pre-review self checklist
- [X] PR branch is updated with all the changes from `master` branch
- [X] The code is correctly formatted (run `mvn -P check-style validate`)
- [X] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [X] The pull request name is prefixed with `SNOW-XXXX: `
- [X] Code is in compliance with internal logging requirements
