### PR TITLE
SNOW-1902245: Accept v1 and v2 Entra ID issuers

### DIFF
--- a/src/main/java/net/snowflake/client/core/auth/wif/AzureIdentityAttestationCreator.java
+++ b/src/main/java/net/snowflake/client/core/auth/wif/AzureIdentityAttestationCreator.java
@@ -4,13 +4,12 @@ import static net.snowflake.client.core.auth.wif.WorkloadIdentityUtil.DEFAULT_ME
 import static net.snowflake.client.core.auth.wif.WorkloadIdentityUtil.SubjectAndIssuer;
 import static net.snowflake.client.core.auth.wif.WorkloadIdentityUtil.extractClaimsWithoutVerifyingSignature;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import net.snowflake.client.core.SFLoginInput;
 import net.snowflake.client.core.SnowflakeJdbcInternalApi;
 import net.snowflake.client.log.SFLogger;
@@ -25,9 +24,8 @@ public class AzureIdentityAttestationCreator implements WorkloadIdentityAttestat
   public static final ObjectMapper objectMapper = new ObjectMapper();
 
   private static final Set<String> ALLOWED_AZURE_TOKEN_ISSUER_PREFIXES =
-      new HashSet<>(Arrays.asList(
-        "https://sts.windows.net/",
-        "https://login.microsoftonline.com/"));
+      new HashSet<>(
+          Arrays.asList("https://sts.windows.net/", "https://login.microsoftonline.com/"));
   private static final String DEFAULT_WORKLOAD_IDENTITY_ENTRA_RESOURCE =
       "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad";
 

--- a/src/main/java/net/snowflake/client/core/auth/wif/AzureIdentityAttestationCreator.java
+++ b/src/main/java/net/snowflake/client/core/auth/wif/AzureIdentityAttestationCreator.java
@@ -4,6 +4,10 @@ import static net.snowflake.client.core.auth.wif.WorkloadIdentityUtil.DEFAULT_ME
 import static net.snowflake.client.core.auth.wif.WorkloadIdentityUtil.SubjectAndIssuer;
 import static net.snowflake.client.core.auth.wif.WorkloadIdentityUtil.extractClaimsWithoutVerifyingSignature;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
@@ -20,7 +24,10 @@ public class AzureIdentityAttestationCreator implements WorkloadIdentityAttestat
       SFLoggerFactory.getLogger(AzureIdentityAttestationCreator.class);
   public static final ObjectMapper objectMapper = new ObjectMapper();
 
-  private static final String EXPECTED_AZURE_TOKEN_ISSUER_PREFIX = "https://sts.windows.net/";
+  private static final Set<String> ALLOWED_AZURE_TOKEN_ISSUER_PREFIXES =
+      new HashSet<>(Arrays.asList(
+        "https://sts.windows.net/",
+        "https://login.microsoftonline.com/"));
   private static final String DEFAULT_WORKLOAD_IDENTITY_ENTRA_RESOURCE =
       "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad";
 
@@ -80,7 +87,14 @@ public class AzureIdentityAttestationCreator implements WorkloadIdentityAttestat
       logger.error("Could not extract claims from token");
       return null;
     }
-    if (!claims.getIssuer().startsWith(EXPECTED_AZURE_TOKEN_ISSUER_PREFIX)) {
+    boolean hasAllowedPrefix = false;
+    for (String prefix : ALLOWED_AZURE_TOKEN_ISSUER_PREFIXES) {
+      if (claims.getIssuer().startsWith(prefix)) {
+        hasAllowedPrefix = true;
+        break;
+      }
+    }
+    if (!hasAllowedPrefix) {
       logger.error("Unexpected Azure token issuer: {}", claims.getIssuer());
       return null;
     }

--- a/src/main/java/net/snowflake/client/core/auth/wif/AzureIdentityAttestationCreator.java
+++ b/src/main/java/net/snowflake/client/core/auth/wif/AzureIdentityAttestationCreator.java
@@ -85,13 +85,9 @@ public class AzureIdentityAttestationCreator implements WorkloadIdentityAttestat
       logger.error("Could not extract claims from token");
       return null;
     }
-    boolean hasAllowedPrefix = false;
-    for (String prefix : ALLOWED_AZURE_TOKEN_ISSUER_PREFIXES) {
-      if (claims.getIssuer().startsWith(prefix)) {
-        hasAllowedPrefix = true;
-        break;
-      }
-    }
+    boolean hasAllowedPrefix =
+        ALLOWED_AZURE_TOKEN_ISSUER_PREFIXES.stream()
+            .anyMatch(prefix -> claims.getIssuer().startsWith(prefix));
     if (!hasAllowedPrefix) {
       logger.error("Unexpected Azure token issuer: {}", claims.getIssuer());
       return null;

--- a/src/test/java/net/snowflake/client/core/auth/wif/AzureIdentityAttestationCreatorLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/auth/wif/AzureIdentityAttestationCreatorLatestIT.java
@@ -123,7 +123,10 @@ public class AzureIdentityAttestationCreatorLatestIT extends BaseWiremockTest {
     importMappingFromResources(SUCCESSFUL_FLOW_V2_ISSUER_SCENARIO_MAPPINGS);
     SFLoginInput loginInput = createLoginInputStub();
     AzureAttestationService attestationServiceMock = createAttestationServiceSpyForBasicFLow();
-    executeAndAssertCorrectAttestationWithIssuer(attestationServiceMock, loginInput, "https://login.microsoftonline.com/fa15d692-e9c7-4460-a743-29f29522229/");
+    executeAndAssertCorrectAttestationWithIssuer(
+        attestationServiceMock,
+        loginInput,
+        "https://login.microsoftonline.com/fa15d692-e9c7-4460-a743-29f29522229/");
   }
 
   @Test
@@ -151,7 +154,10 @@ public class AzureIdentityAttestationCreatorLatestIT extends BaseWiremockTest {
         .thenReturn("some-identity-header-from-env");
     Mockito.when(attestationServiceSpy.getClientId()).thenReturn("managed-client-id-from-env");
 
-    executeAndAssertCorrectAttestationWithIssuer(attestationServiceSpy, loginInput, "https://login.microsoftonline.com/fa15d692-e9c7-4460-a743-29f29522229/");
+    executeAndAssertCorrectAttestationWithIssuer(
+        attestationServiceSpy,
+        loginInput,
+        "https://login.microsoftonline.com/fa15d692-e9c7-4460-a743-29f29522229/");
   }
 
   @Test
@@ -244,11 +250,16 @@ public class AzureIdentityAttestationCreatorLatestIT extends BaseWiremockTest {
 
   private void executeAndAssertCorrectAttestation(
       AzureAttestationService attestationServiceMock, SFLoginInput loginInput) {
-    executeAndAssertCorrectAttestationWithIssuer(attestationServiceMock, loginInput, "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f29522229/");
+    executeAndAssertCorrectAttestationWithIssuer(
+        attestationServiceMock,
+        loginInput,
+        "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f29522229/");
   }
 
   private void executeAndAssertCorrectAttestationWithIssuer(
-      AzureAttestationService attestationServiceMock, SFLoginInput loginInput, String expectedIssuer) {
+      AzureAttestationService attestationServiceMock,
+      SFLoginInput loginInput,
+      String expectedIssuer) {
     AzureIdentityAttestationCreator attestationCreator =
         new AzureIdentityAttestationCreator(attestationServiceMock, loginInput, getBaseUrl());
 

--- a/src/test/resources/wiremock/mappings/wif/azure/successful_flow_azure_functions_v2_issuer.json
+++ b/src/test/resources/wiremock/mappings/wif/azure/successful_flow_azure_functions_v2_issuer.json
@@ -1,0 +1,32 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "urlPattern": "/metadata/identity/endpoint/from/env.*",
+        "queryParameters": {
+          "api-version": {
+            "equalTo": "2019-08-01"
+          },
+          "resource": {
+            "equalTo": "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad"
+          },
+          "client_id": {
+            "equalTo": "managed-client-id-from-env"
+          }
+        },
+        "method": "GET",
+        "headers": {
+          "X-IDENTITY-HEADER": {
+            "equalTo": "some-identity-header-from-env"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhcGk6Ly9mZDNmNzUzYi1lZWQzLTQ2MmMtYjZhNy1hNGI1YmI2NTBhYWQiLCJleHAiOjE3NDQ3MTYwNTEsImlhdCI6MTc0NDcxMjQ1MSwiaXNzIjoiaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2ZhMTVkNjkyLWU5YzctNDQ2MC1hNzQzLTI5ZjI5NTIyMjI5LyIsImp0aSI6Ijg3MTMzNzcwMDk0MTZmYmFhNDM0MmFkMjMxZGUwMDBkIiwic3ViIjoiNzcyMTNFMzAtRThDQi00NTk1LUIxQjYtNUYwNTBFODMwOEZEIn0.5mAlEPkzHLR7YbllpKgk-8ZEd88XfzA15DUK8u1rLWs"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/wiremock/mappings/wif/azure/successful_flow_v2_issuer.json
+++ b/src/test/resources/wiremock/mappings/wif/azure/successful_flow_v2_issuer.json
@@ -1,0 +1,29 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "urlPattern": "/metadata/identity/oauth2/token.*",
+        "queryParameters": {
+          "api-version": {
+            "equalTo": "2018-02-01"
+          },
+          "resource": {
+            "equalTo": "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad"
+          }
+        },
+        "method": "GET",
+        "headers": {
+          "Metadata": {
+            "equalTo": "True"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhcGk6Ly9mZDNmNzUzYi1lZWQzLTQ2MmMtYjZhNy1hNGI1YmI2NTBhYWQiLCJleHAiOjE3NDQ3MTYwNTEsImlhdCI6MTc0NDcxMjQ1MSwiaXNzIjoiaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2ZhMTVkNjkyLWU5YzctNDQ2MC1hNzQzLTI5ZjI5NTIyMjI5LyIsImp0aSI6Ijg3MTMzNzcwMDk0MTZmYmFhNDM0MmFkMjMxZGUwMDBkIiwic3ViIjoiNzcyMTNFMzAtRThDQi00NTk1LUIxQjYtNUYwNTBFODMwOEZEIn0.5mAlEPkzHLR7YbllpKgk-8ZEd88XfzA15DUK8u1rLWs"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Overview

SNOW-1902245 Accept both v1 and v2 formats of Entra ID issuers

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
