### PR TITLE
SNOW-1955810 Support client-side opt-in of Refresh Token Rotation in Snowflake OAuth

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFOauthLoginInput.java
+++ b/src/main/java/net/snowflake/client/core/SFOauthLoginInput.java
@@ -9,6 +9,7 @@ public class SFOauthLoginInput {
   private final String authorizationUrl;
   private final String tokenRequestUrl;
   private final String scope;
+  private final boolean enableSingleUseRefreshTokens;
 
   public SFOauthLoginInput(
       String clientId,
@@ -17,12 +18,24 @@ public class SFOauthLoginInput {
       String authorizationUrl,
       String tokenRequestUrl,
       String scope) {
+    this(clientId, clientSecret, redirectUri, authorizationUrl, tokenRequestUrl, scope, false);
+  }
+
+  public SFOauthLoginInput(
+      String clientId,
+      String clientSecret,
+      String redirectUri,
+      String authorizationUrl,
+      String tokenRequestUrl,
+      String scope,
+      boolean enableSingleUseRefreshTokens) {
     this.redirectUri = redirectUri;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.authorizationUrl = authorizationUrl;
     this.tokenRequestUrl = tokenRequestUrl;
     this.scope = scope;
+    this.enableSingleUseRefreshTokens = enableSingleUseRefreshTokens;
   }
 
   public String getRedirectUri() {
@@ -47,5 +60,9 @@ public class SFOauthLoginInput {
 
   public String getScope() {
     return scope;
+  }
+
+  public boolean getEnableSingleUseRefreshTokens() {
+    return enableSingleUseRefreshTokens;
   }
 }

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -680,7 +680,10 @@ public class SFSession extends SFBaseSession {
             (String) connectionPropertiesMap.get(SFSessionProperty.OAUTH_REDIRECT_URI),
             (String) connectionPropertiesMap.get(SFSessionProperty.OAUTH_AUTHORIZATION_URL),
             (String) connectionPropertiesMap.get(SFSessionProperty.OAUTH_TOKEN_REQUEST_URL),
-            (String) connectionPropertiesMap.get(SFSessionProperty.OAUTH_SCOPE));
+            (String) connectionPropertiesMap.get(SFSessionProperty.OAUTH_SCOPE),
+            getBooleanValue(
+                connectionPropertiesMap.get(
+                    SFSessionProperty.OAUTH_ENABLE_SINGLE_USE_REFRESH_TOKENS)));
 
     loginInput
         .setServerUrl((String) connectionPropertiesMap.get(SFSessionProperty.SERVER_URL))

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -26,6 +26,7 @@ public enum SFSessionProperty {
   OAUTH_SCOPE("oauthScope", false, String.class),
   OAUTH_AUTHORIZATION_URL("oauthAuthorizationUrl", false, String.class),
   OAUTH_TOKEN_REQUEST_URL("oauthTokenRequestUrl", false, String.class),
+  OAUTH_ENABLE_SINGLE_USE_REFRESH_TOKENS("oauthEnableSingleUseRefreshTokens", false, Boolean.class),
   WORKLOAD_IDENTITY_PROVIDER("workloadIdentityProvider", false, String.class),
   WORKLOAD_IDENTITY_ENTRA_RESOURCE("workloadIdentityEntraResource", false, String.class),
   WAREHOUSE("warehouse", false, String.class),

--- a/src/main/java/net/snowflake/client/core/auth/oauth/OAuthAuthorizationCodeAccessTokenProvider.java
+++ b/src/main/java/net/snowflake/client/core/auth/oauth/OAuthAuthorizationCodeAccessTokenProvider.java
@@ -215,13 +215,17 @@ public class OAuthAuthorizationCodeAccessTokenProvider implements AccessTokenPro
             new Secret(loginInput.getOauthLoginInput().getClientSecret()));
     Scope scope =
         new Scope(OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole()));
-    TokenRequest tokenRequest =
-        new TokenRequest(
-            OAuthUtil.getTokenRequestUrl(
-                loginInput.getOauthLoginInput(), loginInput.getServerUrl()),
-            clientAuthentication,
-            codeGrant,
-            scope);
+    TokenRequest.Builder tokenRequestBuilder =
+        new TokenRequest.Builder(
+                OAuthUtil.getTokenRequestUrl(
+                    loginInput.getOauthLoginInput(), loginInput.getServerUrl()),
+                clientAuthentication,
+                codeGrant)
+            .scope(scope);
+    if (loginInput.getOauthLoginInput().getEnableSingleUseRefreshTokens()) {
+      tokenRequestBuilder.customParameter("enable_single_use_refresh_tokens", "true");
+    }
+    TokenRequest tokenRequest = tokenRequestBuilder.build();
     HTTPRequest tokenHttpRequest = tokenRequest.toHTTPRequest();
     HttpRequestBase convertedTokenRequest = OAuthUtil.convertToBaseRequest(tokenHttpRequest);
 

--- a/src/test/resources/wiremock/mappings/oauth/authorization_code/successful_flow_with_single_use_refresh_tokens.json
+++ b/src/test/resources/wiremock/mappings/oauth/authorization_code/successful_flow_with_single_use_refresh_tokens.json
@@ -1,0 +1,80 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "Successful OAuth authorization code flow",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "Authorized",
+      "request": {
+        "urlPathPattern": "/oauth/authorize",
+        "queryParameters": {
+          "response_type": {
+            "equalTo": "code"
+          },
+          "scope": {
+            "equalTo": "session:role:ANALYST"
+          },
+          "code_challenge_method": {
+            "equalTo": "S256"
+          },
+          "redirect_uri": {
+            "equalTo": "http://localhost:8009/snowflake/oauth-redirect"
+          },
+          "code_challenge": {
+            "matches": ".*"
+          },
+          "state": {
+            "matches": ".*"
+          },
+          "client_id": {
+            "equalTo": "123"
+          }
+        },
+        "method": "GET"
+      },
+      "response": {
+        "status": 302,
+        "headers": {
+          "Location": "http://localhost:8009/snowflake/oauth-redirect?code=123&state=abc123"
+        }
+      }
+    },
+    {
+      "scenarioName": "Successful OAuth authorization code flow",
+      "requiredScenarioState": "Authorized",
+      "newScenarioState": "Acquired access token",
+      "request": {
+        "urlPathPattern": "/oauth/token-request.*",
+        "method": "POST",
+        "headers": {
+          "Authorization": {
+            "contains": "Basic"
+          },
+          "Content-Type": {
+            "contains": "application/x-www-form-urlencoded; charset=UTF-8"
+          }
+        },
+        "bodyPatterns": [
+          {
+            "contains": "grant_type=authorization_code&code=123&redirect_uri=http%3A%2F%2Flocalhost%3A8009%2Fsnowflake%2Foauth-redirect"
+          },
+          {
+            "contains": "&enable_single_use_refresh_tokens=true"
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "access_token": "access-token-123",
+          "refresh_token": "refresh-token-123",
+          "token_type": "Bearer",
+          "username": "user",
+          "scope": "refresh_token session:role:ANALYST",
+          "expires_in": 600,
+          "refresh_token_expires_in": 86399,
+          "idpInitiated": false
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Overview

SNOW-1955810

A Snowflake OAuth client can optionally include `enable_single_use_refresh_tokens=true` in the request body of the authorization code flow to opt-in to single-use refresh token semantics. This is part of a new security feature in Snowflake's native OAuth implementation.

To enable this, a user can set the `oauthEnableSingleUseRefreshTokens` session property.

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
