### PR TITLE
SNOW-2021007 refactor OCSP tests

### DIFF
--- a/src/test/java/net/snowflake/client/AbstractDriverIT.java
+++ b/src/test/java/net/snowflake/client/AbstractDriverIT.java
@@ -1,6 +1,8 @@
 package net.snowflake.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Strings;
 import java.net.URISyntaxException;
@@ -388,6 +390,18 @@ public class AbstractDriverIT {
       }
     } else {
       throw new RuntimeException("No file is found: " + fileName);
+    }
+  }
+
+  public static void connectAndVerifySimpleQuery(Properties props) throws SQLException {
+    try (Connection con =
+            DriverManager.getConnection(
+                String.format("jdbc:snowflake://%s:%s", props.get("host"), props.get("port")),
+                props);
+        Statement stmt = con.createStatement();
+        ResultSet rs = stmt.executeQuery("select 1")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionIT.java
@@ -2,7 +2,6 @@ package net.snowflake.client.jdbc;
 
 import static net.snowflake.client.AssumptionUtils.assumeRunningOnGithubActions;
 import static net.snowflake.client.core.SessionUtil.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY;
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,7 +50,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /** Connection integration tests */
 @Tag(TestTags.CONNECTION)
@@ -132,38 +130,6 @@ public class ConnectionIT extends BaseJDBCWithSharedConnectionIT {
     long endLoginTime = System.currentTimeMillis();
 
     assertTrue(endLoginTime - startLoginTime < 30000);
-  }
-
-  /**
-   * Test production connectivity in case cipher suites or tls protocol change Use fake username and
-   * password but correct url Expectation is receiving incorrect username or password response from
-   * server
-   */
-  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
-  @Test
-  public void testProdConnectivity() throws SQLException {
-    String[] deploymentUrls = {
-      "jdbc:snowflake://sfcsupport.snowflakecomputing.com",
-      "jdbc:snowflake://sfcsupportva.us-east-1.snowflakecomputing.com",
-      "jdbc:snowflake://sfcsupporteu.eu-central-1.snowflakecomputing.com"
-    };
-
-    Properties properties = new Properties();
-
-    properties.put("user", "fakeuser");
-    properties.put("password", "fakepwd");
-    properties.put("account", "fakeaccount");
-
-    for (String url : deploymentUrls) {
-      SQLException e =
-          assertThrows(
-              SQLException.class,
-              () -> {
-                DriverManager.getConnection(url, properties);
-              });
-      assertThat(
-          e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
-    }
   }
 
   @Test
@@ -564,33 +530,6 @@ public class ConnectionIT extends BaseJDBCWithSharedConnectionIT {
         statement.execute(String.format("alter user %s unset rsa_public_key", testUser));
       }
     }
-  }
-
-  /** Test production connectivity with insecure mode enabled. */
-  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testInsecureMode(boolean insecureModeInProperties) {
-    String deploymentUrl;
-
-    Properties properties = new Properties();
-
-    properties.put("user", "fakeuser");
-    properties.put("password", "fakepwd");
-    properties.put("account", "fakeaccount");
-    if (insecureModeInProperties) {
-      properties.put("insecureMode", true);
-      deploymentUrl = "jdbc:snowflake://sfcsupport.snowflakecomputing.com";
-    } else {
-      deploymentUrl = "jdbc:snowflake://sfcsupport.snowflakecomputing.com?insecureMode=true";
-    }
-    SQLException e =
-        assertThrows(
-            SQLException.class,
-            () -> {
-              DriverManager.getConnection(deploymentUrl, properties);
-            });
-    assertThat(e.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
   }
 
   /** Verify the passed memory parameters are set in the session */

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -1648,30 +1648,4 @@ public class ConnectionLatestIT extends BaseJDBCTest {
             .contains(
                 "https://docs.snowflake.com/en/user-guide/client-connectivity-troubleshooting/overview"));
   }
-
-  /**
-   * Test production connectivity with disableOCSPChecksMode enabled. This test applies to driver
-   * versions after 3.21.0
-   */
-  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
-  @Test
-  public void testDisableOCSPChecksMode() throws SQLException {
-
-    String deploymentUrl = "jdbc:snowflake://sfcsupport.snowflakecomputing.com";
-    Properties properties = new Properties();
-
-    properties.put("user", "fakeuser");
-    properties.put("password", "fakepwd");
-    properties.put("account", "fakeaccount");
-    properties.put("disableOCSPChecks", true);
-    SQLException thrown =
-        assertThrows(
-            SQLException.class,
-            () -> {
-              DriverManager.getConnection(deploymentUrl, properties);
-            });
-
-    assertThat(
-        thrown.getErrorCode(), anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
-  }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ConnectionWithDisableOCSPModeLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionWithDisableOCSPModeLatestIT.java
@@ -1,27 +1,26 @@
 package net.snowflake.client.jdbc;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Stream;
 import net.snowflake.client.category.TestTags;
 import net.snowflake.client.core.SFTrustManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /** Tests for connection with DisableOCSPchecks and insecuremode settings. */
 @Tag(TestTags.CONNECTION)
 public class ConnectionWithDisableOCSPModeLatestIT extends BaseJDBCTest {
-  public static final int INVALID_CONNECTION_INFO_CODE = 390100;
   private static final int DISABLE_OCSP_INSECURE_MODE_MISMATCH = 200064;
-  public static final int BAD_REQUEST_GS_CODE = 390400;
 
   @BeforeEach
   public void setUp() {
@@ -33,91 +32,56 @@ public class ConnectionWithDisableOCSPModeLatestIT extends BaseJDBCTest {
     SFTrustManager.cleanTestSystemParameters();
   }
 
-  /**
-   * Test connectivity with disableOCSPChecksMode and insecure mode enabled. This test applies to
-   * driver versions after 3.21.0
-   */
-  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
-  @Test
-  public void testDisableOCSPChecksModeAndInsecureModeSet() throws SQLException {
-
-    boolean disableOCSPChecks = true;
-    boolean insecureMode = true;
-    assertThat(
-        returnErrorCodeFromConnection(disableOCSPChecks, insecureMode),
-        anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
+  private static Stream<Arguments> testParameters() {
+    return Stream.of(Arguments.of(true, true), Arguments.of(true, null), Arguments.of(null, true));
   }
 
-  /**
-   * Test production connectivity with only disableOCSPChecksMode enabled. This test applies to
-   * driver versions after 3.21.0
-   */
-  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
-  @Test
-  public void testDisableOCSPChecksModeSet() throws SQLException {
-    boolean disableOCSPChecks = true;
-    assertThat(
-        returnErrorCodeFromConnection(disableOCSPChecks, null),
-        anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
+  @ParameterizedTest
+  @MethodSource("testParameters")
+  public void shouldConnectIfDisableOCSPChecksAndInsecureModeAreSet(
+      Boolean disableOCSPChecks, Boolean insecureMode) throws SQLException {
+    Properties properties = getProperties(disableOCSPChecks, insecureMode);
+    connectAndVerifySimpleQuery(properties);
   }
 
-  /**
-   * Test production connectivity with only insecureMode enabled. This test applies to driver
-   * versions after 3.21.0
-   */
-  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
-  @Test
-  public void testInsecureModeSet() throws SQLException {
-    boolean insecureMode = true;
-    assertThat(
-        returnErrorCodeFromConnection(null, insecureMode),
-        anyOf(is(INVALID_CONNECTION_INFO_CODE), is(BAD_REQUEST_GS_CODE)));
+  private static Stream<Arguments> testParametersMismatch() {
+    return Stream.of(Arguments.of(true, false), Arguments.of(false, true));
   }
 
-  /**
-   * Test production connectivity with disableOCSPChecksMode enabled AND insecureMode disabled. This
-   * test applies to driver versions after 3.21.0
-   */
-  @Disabled("Disable due to changed error response in backend. Follow up: SNOW-2021007")
-  @Test
-  public void testDisableOCSPChecksModeAndInsecureModeMismatched() throws SQLException {
-    boolean disableOCSPChecks = true;
-    boolean insecureMode = false;
-    assertThat(
-        returnErrorCodeFromConnection(disableOCSPChecks, insecureMode),
-        anyOf(is(DISABLE_OCSP_INSECURE_MODE_MISMATCH)));
-  }
-
-  /**
-   * Helper method to return error code from connection.
-   *
-   * @param disableOSCPChecks
-   * @param isInsecureMode
-   * @return SF Error code
-   * @throws SQLException
-   */
-  public int returnErrorCodeFromConnection(Boolean disableOSCPChecks, Boolean isInsecureMode)
-      throws SQLException {
-    String deploymentUrl = "jdbc:snowflake://sfcsupport.snowflakecomputing.com";
-    Properties properties = new Properties();
-
-    properties.put("user", "fakeuser");
-    properties.put("password", "fakepwd");
-    properties.put("account", "fakeaccount");
-    if (disableOSCPChecks != null) {
-      properties.put("disableOCSPChecks", disableOSCPChecks);
-    }
-    if (isInsecureMode != null) {
-      properties.put("insecureMode", isInsecureMode);
-    }
-
-    SQLException thrown =
+  @ParameterizedTest
+  @MethodSource("testParametersMismatch")
+  public void shouldThrowWhenThereIsMismatchInDisableOCSPChecksAndInsecureMode(
+      Boolean disableOCSPChecks, Boolean insecureMode) {
+    Properties properties = getProperties(disableOCSPChecks, insecureMode);
+    SQLException e =
         assertThrows(
             SQLException.class,
-            () -> {
-              DriverManager.getConnection(deploymentUrl, properties);
-            });
+            () ->
+                DriverManager.getConnection(
+                    String.format(
+                        "jdbc:snowflake://%s:%s", properties.get("host"), properties.get("port")),
+                    properties));
+    assertEquals(DISABLE_OCSP_INSECURE_MODE_MISMATCH, e.getErrorCode());
+  }
 
-    return (thrown.getErrorCode());
+  private Properties getProperties(Boolean disableOCSPChecks, Boolean insecureMode) {
+    Map<String, String> params = getConnectionParameters();
+    Properties props = new Properties();
+    props.put("host", params.get("host"));
+    props.put("port", params.get("port"));
+    props.put("account", params.get("account"));
+    props.put("user", params.get("user"));
+    props.put("role", params.get("role"));
+    props.put("password", params.get("password"));
+    props.put("warehouse", params.get("warehouse"));
+    props.put("db", params.get("database"));
+    props.put("ssl", params.get("ssl"));
+    if (disableOCSPChecks != null) {
+      props.put("disableOCSPChecks", disableOCSPChecks);
+    }
+    if (insecureMode != null) {
+      props.put("insecureMode", insecureMode);
+    }
+    return props;
   }
 }

--- a/src/test/java/net/snowflake/client/jdbc/ProxyLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ProxyLatestIT.java
@@ -1,16 +1,12 @@
 package net.snowflake.client.jdbc;
 
+import static net.snowflake.client.AbstractDriverIT.connectAndVerifySimpleQuery;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Objects;
 import java.util.Properties;
 import net.snowflake.client.category.TestTags;
@@ -99,18 +95,6 @@ public class ProxyLatestIT extends BaseWiremockTest {
 
   private void verifyProxyNotUsed() {
     verifyRequestToProxy(".*", 0);
-  }
-
-  private void connectAndVerifySimpleQuery(Properties props) throws SQLException {
-    try (Connection con =
-            DriverManager.getConnection(
-                String.format("jdbc:snowflake://%s:%s", props.get("host"), props.get("port")),
-                props);
-        Statement stmt = con.createStatement();
-        ResultSet rs = stmt.executeQuery("select 1")) {
-      assertTrue(rs.next());
-      assertEquals(1, rs.getInt(1));
-    }
   }
 
   private void verifyRequestToProxy(String pathPattern, int expectedCount) {


### PR DESCRIPTION
# Overview

SNOW-2021007
- redundant tests removed
- tests that verify disableOCSPChecks and insecureMode changed to verify successful connection - I don't see any reason for providing wrong credentials and verifying GS errors
- connectAndVerifySimpleQuery moved so it can be reused

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
