### PR TITLE
SNOW-2021007 refactor error codes usage in tests 

### DIFF
--- a/src/test/java/net/snowflake/client/AbstractDriverIT.java
+++ b/src/test/java/net/snowflake/client/AbstractDriverIT.java
@@ -41,13 +41,6 @@ public class AbstractDriverIT {
 
   protected final int ERROR_CODE_BIND_VARIABLE_NOT_ALLOWED_IN_VIEW_OR_UDF_DEF = 2210;
 
-  protected final int ERROR_CODE_DOMAIN_OBJECT_DOES_NOT_EXIST = 2003;
-
-  private static String getConnPropKeyFromEnv(String connectionType, String propKey) {
-    String envKey = String.format("SNOWFLAKE_%s_%s", connectionType, propKey);
-    return envKey;
-  }
-
   private static String getConnPropValueFromEnv(String connectionType, String propKey) {
     String envKey = String.format("SNOWFLAKE_%s_%s", connectionType, propKey);
     return TestUtil.systemGetEnv(envKey);

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
@@ -79,7 +79,7 @@ public class FileUploaderExpandFileNamesTest {
         assertThrows(
             SnowflakeSQLException.class,
             () -> SnowflakeFileTransferAgent.expandFileNames(locations, null));
-    assertEquals(ErrorCode.FILE_NOT_FOUND.getMessageCode(), err.getErrorCode());
+    assertEquals(ErrorCode.FAIL_LIST_FILES.getMessageCode(), err.getErrorCode());
     assertEquals(SqlState.DATA_EXCEPTION, err.getSQLState());
     SnowflakeFileTransferAgent.setInjectedFileTransferException(null);
   }

--- a/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/FileUploaderExpandFileNamesTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import net.snowflake.client.core.OCSPMode;
+import net.snowflake.common.core.SqlState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -78,8 +79,8 @@ public class FileUploaderExpandFileNamesTest {
         assertThrows(
             SnowflakeSQLException.class,
             () -> SnowflakeFileTransferAgent.expandFileNames(locations, null));
-    assertEquals(200007, err.getErrorCode());
-    assertEquals("22000", err.getSQLState());
+    assertEquals(ErrorCode.FILE_NOT_FOUND.getMessageCode(), err.getErrorCode());
+    assertEquals(SqlState.DATA_EXCEPTION, err.getSQLState());
     SnowflakeFileTransferAgent.setInjectedFileTransferException(null);
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/PreparedMultiStmtIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedMultiStmtIT.java
@@ -1,5 +1,6 @@
 package net.snowflake.client.jdbc;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -99,7 +100,7 @@ public class PreparedMultiStmtIT extends BaseJDBCWithSharedConnectionIT {
           // first statement
           SQLException e =
               assertThrows(SQLException.class, () -> preparedStatement.executeUpdate());
-          assertThat(e.getErrorCode(), is(100132));
+          assertThat(e.getMessage(), containsString("Bind variable ? not set"));
         }
       } finally {
         statement.execute("drop table if exists test_multi_bind");

--- a/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/PreparedStatement2LatestIT.java
@@ -68,9 +68,7 @@ public class PreparedStatement2LatestIT extends PreparedStatement0IT {
             connection.prepareStatement("select * from table(employee_detail(?, 123))"); ) {
           // second argument is invalid
           prepStatement.setInt(1, 1);
-          SQLException e = assertThrows(SQLException.class, prepStatement::execute);
-          // failed because argument type did not match
-          assertThat(e.getErrorCode(), is(1044));
+          assertThrows(SQLException.class, prepStatement::execute);
         }
 
         // create a udf with same name but different arguments and return type

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
@@ -182,7 +182,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getShort(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
       assertTrue(resultSet.next());
       // certain column types can only have certain values when called by getShort() or else a
@@ -193,7 +193,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getShort(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
     }
   }
@@ -221,7 +221,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getInt(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
       assertTrue(resultSet.next());
       // certain column types can only have certain values when called by getInt() or else a
@@ -231,7 +231,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getInt(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
     }
   }
@@ -259,7 +259,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getLong(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
       assertTrue(resultSet.next());
       // certain column types can only have certain values when called by getLong() or else a
@@ -269,7 +269,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getLong(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
     }
   }
@@ -297,7 +297,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getFloat(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
       assertTrue(resultSet.next());
       // certain column types can only have certain values when called by getFloat() or else a
@@ -307,7 +307,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getFloat(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
     }
   }
@@ -335,7 +335,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getDouble(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
       assertTrue(resultSet.next());
       // certain column types can only have certain values when called by getDouble() or else a
@@ -345,7 +345,7 @@ public class ResultSetIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getDouble(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
     }
   }
@@ -393,7 +393,7 @@ public class ResultSetIT extends ResultSet0IT {
         SQLException ex =
             assertThrows(
                 SQLException.class, () -> resultSet.getBigDecimal(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
       assertTrue(resultSet.next());
       for (int i = 5; i < 7; i++) {
@@ -401,7 +401,7 @@ public class ResultSetIT extends ResultSet0IT {
         SQLException ex =
             assertThrows(
                 SQLException.class, () -> resultSet.getBigDecimal(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
     }
   }
@@ -423,7 +423,7 @@ public class ResultSetIT extends ResultSet0IT {
             assertTrue(resultSet.next());
             SQLException ex =
                 assertThrows(SQLException.class, () -> resultSet.getBigDecimal(2, 38));
-            assertEquals(200032, ex.getErrorCode());
+            assertEquals(ErrorCode.COLUMN_DOES_NOT_EXIST.getMessageCode(), ex.getErrorCode());
           }
         }
       } finally {
@@ -701,7 +701,7 @@ public class ResultSetIT extends ResultSet0IT {
           SQLException ex =
               assertThrows(
                   SQLException.class, () -> resultSet.getBoolean(finalI), "Failing on " + i);
-          assertEquals(200038, ex.getErrorCode());
+          assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
         }
 
         assertTrue(resultSet.next());
@@ -710,7 +710,7 @@ public class ResultSetIT extends ResultSet0IT {
           SQLException ex =
               assertThrows(
                   SQLException.class, () -> resultSet.getBoolean(finalI), "Failing on " + i);
-          assertEquals(200038, ex.getErrorCode());
+          assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
         }
       }
     }
@@ -842,9 +842,9 @@ public class ResultSetIT extends ResultSet0IT {
 
       assertTrue(resultSet.next());
       SQLException e = assertThrows(SQLException.class, () -> resultSet.getString(0));
-      assertEquals(200032, e.getErrorCode());
+      assertEquals(ErrorCode.COLUMN_DOES_NOT_EXIST.getMessageCode(), e.getErrorCode());
       e = assertThrows(SQLException.class, () -> resultSet.getString(2));
-      assertEquals(200032, e.getErrorCode());
+      assertEquals(ErrorCode.COLUMN_DOES_NOT_EXIST.getMessageCode(), e.getErrorCode());
     }
   }
 

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetIT.java
@@ -1011,7 +1011,7 @@ public class ResultSetIT extends ResultSet0IT {
       assertTrue(rs.next());
       System.setProperty("snowflake.enable_incident_test2", "true");
       SQLException ex = assertThrows(SQLException.class, rs::next);
-      assertEquals(200014, ex.getErrorCode());
+      assertEquals(ErrorCode.MAX_RESULT_LIMIT_EXCEEDED.getMessageCode(), ex.getErrorCode());
       System.setProperty("snowflake.enable_incident_test2", "false");
     }
   }

--- a/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ResultSetLatestIT.java
@@ -531,7 +531,7 @@ public class ResultSetLatestIT extends ResultSet0IT {
         int finalI = i;
         SQLException ex =
             assertThrows(SQLException.class, () -> resultSet.getBytes(finalI), "Failing on " + i);
-        assertEquals(200038, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_CONVERT.getMessageCode(), ex.getErrorCode());
       }
 
       byte[] decoded = SFBinary.fromHex("48454C4C4F").getBytes();

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java
@@ -1888,22 +1888,11 @@ public class SnowflakeDriverIT extends BaseJDBCTest {
 
           preparedStatement.clearBatch();
 
-          // this test causes query count in GS not to be decremented because
-          // the exception is thrown before registerQC. Discuss with Johnston
-          // to resolve the issue before enabling the test.
-          preparedStatement.setObject(1, "Null", Types.DOUBLE);
-          preparedStatement.addBatch();
-          SnowflakeSQLException ex =
-              assertThrows(SnowflakeSQLException.class, preparedStatement::executeBatch);
-          assertEquals(2086, ex.getErrorCode());
-
-          preparedStatement.clearBatch();
-
           preparedStatement.setString(1, "hello");
           preparedStatement.addBatch();
-
           preparedStatement.setDouble(1, 1.2);
-          ex = assertThrows(SnowflakeSQLException.class, preparedStatement::addBatch);
+          SnowflakeSQLException ex =
+              assertThrows(SnowflakeSQLException.class, preparedStatement::addBatch);
           assertEquals(
               (int) ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
               ex.getErrorCode());

--- a/src/test/java/net/snowflake/client/jdbc/StatementIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/StatementIT.java
@@ -330,8 +330,8 @@ public class StatementIT extends BaseJDBCWithSharedConnectionIT {
           assertThat(resultSet.getInt("B"), is(7));
           statement.clearBatch();
 
-          // one of the batch is query instead of ddl/dml
-          // it should continuing processing
+          // one of the batch query returns error
+          // it should continue processing
           statement.addBatch("insert into test_batch values('str3', 3)");
           statement.addBatch("select * from test_batch");
           statement.addBatch("select * from test_batch_not_exist");
@@ -339,7 +339,6 @@ public class StatementIT extends BaseJDBCWithSharedConnectionIT {
           BatchUpdateException e =
               assertThrows(BatchUpdateException.class, statement::executeBatch);
           rowCounts = e.getUpdateCounts();
-          assertThat(e.getErrorCode(), is(ERROR_CODE_DOMAIN_OBJECT_DOES_NOT_EXIST));
           assertThat(rowCounts[0], is(1));
           assertThat(rowCounts[1], is(Statement.SUCCESS_NO_INFO));
           assertThat(rowCounts[2], is(Statement.EXECUTE_FAILED));

--- a/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClientLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/cloud/storage/SnowflakeAzureClientLatestIT.java
@@ -15,6 +15,7 @@ import net.snowflake.client.category.TestTags;
 import net.snowflake.client.core.SFSession;
 import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.BaseJDBCTest;
+import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
 import net.snowflake.client.jdbc.SnowflakeSQLLoggedException;
@@ -42,7 +43,7 @@ public class SnowflakeAzureClientLatestIT extends BaseJDBCTest {
               () ->
                   SnowflakeAzureClient.createSnowflakeAzureClient(
                       sfAgent.getStageInfo(), content, sfSession));
-      assertEquals(200001, ex.getErrorCode());
+      assertEquals(ErrorCode.INTERNAL_ERROR.getMessageCode(), ex.getErrorCode());
     }
   }
 


### PR DESCRIPTION
# Overview

SNOW-2021007

- use error code from ErrorCode whenever possible, to make it clear it's jdbc driver error code
- remove GS error code details in cases when it's not relevant to the test case
- minor fixes

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
