### PR TITLE
SNOW-2107220: Add null check for write cache file

### DIFF
--- a/src/main/java/net/snowflake/client/core/FileCacheManager.java
+++ b/src/main/java/net/snowflake/client/core/FileCacheManager.java
@@ -265,7 +265,7 @@ class FileCacheManager {
   synchronized JsonNode readCacheFile() {
     try {
       if (!FileUtil.exists(cacheFile)) {
-        logger.debug("Cache file doesn't exist. File: {}", cacheFile);
+        logger.debug("Cache file doesn't exist. Ignoring read.");
         return null;
       }
 
@@ -290,7 +290,8 @@ class FileCacheManager {
   synchronized void writeCacheFile(JsonNode input) {
     logger.debug("Writing cache file. File: {}", cacheFile);
     try {
-      if (input == null) {
+      if (input == null || !FileUtil.exists(cacheFile)) {
+        logger.debug("Cache file doesn't exist. Ignoring write.");
         return;
       }
       try (Writer writer =

--- a/src/test/java/net/snowflake/client/core/FileCacheManagerTest.java
+++ b/src/test/java/net/snowflake/client/core/FileCacheManagerTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.stream.Collectors;
@@ -106,7 +107,7 @@ class FileCacheManagerTest extends BaseJDBCTest {
 
   @Test
   @RunOnLinuxOrMac
-  public void notThrowExceptionWhenCacheFolderIsNotAccessible() throws IOException {
+  public void notThrowExceptionWhenCacheFolderIsNotAccessibleWhenReadFromCache() throws IOException {
     try {
       Files.setPosixFilePermissions(
           cacheFile.getParentFile().toPath(), PosixFilePermissions.fromString("---------"));
@@ -121,6 +122,31 @@ class FileCacheManagerTest extends BaseJDBCTest {
     } finally {
       Files.setPosixFilePermissions(
           cacheFile.getParentFile().toPath(), PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @RunOnLinuxOrMac
+  public void notThrowExceptionWhenCacheFolderIsNotAccessibleWhenWriteToCache() throws IOException {
+    String tmpDirPath = System.getProperty("java.io.tmpdir");
+    String cacheDirPath = tmpDirPath + File.separator + "snowflake-cache-dir-noaccess";
+    System.setProperty("FILE_CACHE_MANAGER_CACHE_PATH", cacheDirPath);
+    try {
+      Files.createDirectory(
+              Paths.get(cacheDirPath),
+              PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("---------")));
+
+      FileCacheManager fcm =
+              FileCacheManager.builder()
+                      .setOnlyOwnerPermissions(false)
+                      .setCacheDirectorySystemProperty("FILE_CACHE_MANAGER_CACHE_PATH")
+                      .setCacheDirectoryEnvironmentVariable("NONEXISTENT")
+                      .setBaseCacheFileName("cache-file")
+                      .build();
+      assertDoesNotThrow(() -> fcm.writeCacheFile(mapper.createObjectNode()));
+    } finally {
+      Files.deleteIfExists(Paths.get(cacheDirPath));
+      System.clearProperty("FILE_CACHE_MANAGER_CACHE_PATH");
     }
   }
 


### PR DESCRIPTION
# Overview

SNOW-2107220

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: SNOW-2107220


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Do not attempt to write to the cache file if it does not exist.
