### PR TITLE
Delete unused variable DEFAULT_GCP_METADATA_SERVICE_BASE_URL

### DIFF
--- a/src/main/java/net/snowflake/client/core/auth/wif/GcpIdentityAttestationCreator.java
+++ b/src/main/java/net/snowflake/client/core/auth/wif/GcpIdentityAttestationCreator.java
@@ -16,7 +16,6 @@ public class GcpIdentityAttestationCreator implements WorkloadIdentityAttestatio
   private static final String METADATA_FLAVOR_HEADER_NAME = "Metadata-Flavor";
   private static final String METADATA_FLAVOR = "Google";
   private static final String EXPECTED_GCP_TOKEN_ISSUER = "https://accounts.google.com";
-  private static final String DEFAULT_GCP_METADATA_SERVICE_BASE_URL = "http://169.254.169.254";
 
   private final String gcpMetadataServiceBaseUrl;
 


### PR DESCRIPTION
# Overview

Usage of `DEFAULT_GCP_METADATA_SERVICE_BASE_URL` was replaced by `DEFAULT_METADATA_SERVICE_BASE_URL in PR #2154, but the variable wasn't removed. This PR just removes the dead variable.
