### PR TITLE
SNOW-2133570 Fix trust manager algorithm name and bump to new version 3.18.1

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,12 +4,14 @@ on:
     push:
         branches:
             - master
+            - release_3_18_1
         tags:
             - v*
     pull_request:
         branches:
             - master
             - prep-**
+            - release_3_18_1
     workflow_dispatch:
         inputs:
           logLevel:
@@ -27,7 +29,7 @@ concurrency:
 jobs:
     build:
         name: Build
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
             - name: Build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,14 +4,14 @@ on:
     push:
         branches:
             - master
-            - release_3_18_1
+            - release_3_18_1_hotfix
         tags:
             - v*
     pull_request:
         branches:
             - master
             - prep-**
-            - release_3_18_1
+            - release_3_18_1_hotfix
     workflow_dispatch:
         inputs:
           logLevel:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**JDBC Driver 3.18.1**
+
+- \||Please Refer to Release Notes at https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc
+
 **JDBC Driver 3.18.0**
 
 - \||Please Refer to Release Notes at https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-jdbc-parent</artifactId>
-    <version>3.18.0</version>
+    <version>3.18.1</version>
     <relativePath>../parent-pom.xml</relativePath>
   </parent>
 
   <artifactId>snowflake-jdbc-fips</artifactId>
-  <version>3.18.0</version>
+  <version>3.18.1</version>
   <packaging>jar</packaging>
 
   <name>snowflake-jdbc-fips</name>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ timestamps {
     }
 
     def commit_hash = "main" // default which we want to override
-    def bptp_tag = "bptp-built"
+    def bptp_tag = "bptp-stable"
     try {
         def response = authenticatedGithubCall("https://api.github.com/repos/snowflakedb/snowflake/git/ref/tags/${bptp_tag}")
         commit_hash = response.object.sha

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-jdbc-parent</artifactId>
-  <version>3.18.0</version>
+  <version>3.18.1</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-jdbc-parent</artifactId>
-    <version>3.18.0</version>
+    <version>3.18.1</version>
     <relativePath>./parent-pom.xml</relativePath>
   </parent>
 
   <!-- Maven complains about using property here, but it makes install and deploy process easier to override final package names and localization -->
   <artifactId>${artifactId}</artifactId>
-  <version>3.18.0</version>
+  <version>3.18.1</version>
   <packaging>jar</packaging>
 
   <name>${artifactId}</name>

--- a/src/main/java/net/snowflake/client/core/SFTrustManager.java
+++ b/src/main/java/net/snowflake/client/core/SFTrustManager.java
@@ -47,7 +47,6 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -270,10 +269,10 @@ public class SFTrustManager extends X509ExtendedTrustManager {
   SFTrustManager(HttpClientSettingsKey key, File cacheFile) {
     this.ocspMode = key.getOcspMode();
     this.proxySettingsKey = key;
-    this.trustManager = getTrustManager(KeyManagerFactory.getDefaultAlgorithm());
+    this.trustManager = getTrustManager(TrustManagerFactory.getDefaultAlgorithm());
 
     this.exTrustManager =
-        (X509ExtendedTrustManager) getTrustManager(KeyManagerFactory.getDefaultAlgorithm());
+        (X509ExtendedTrustManager) getTrustManager(TrustManagerFactory.getDefaultAlgorithm());
 
     checkNewOCSPEndpointAvailability();
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -37,7 +37,7 @@ public class SnowflakeDriver implements Driver {
   static SnowflakeDriver INSTANCE;
 
   public static final Properties EMPTY_PROPERTIES = new Properties();
-  public static String implementVersion = "3.18.0";
+  public static String implementVersion = "3.18.1";
 
   static int majorVersion = 0;
   static int minorVersion = 0;


### PR DESCRIPTION
# Overview

SNOW-2133570 Fix trust manager algorithm name and bump to new version 3.18.1

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
