### PR TITLE
SNOW-1943242 JDBC Caches CloseableHttpClient Indefinitely After Connection Pool Shut Down Error

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/RestRequestTest.java
@@ -667,4 +667,33 @@ public class RestRequestTest {
       elapsedMilliForTransientIssues += backoffInMilli;
     }
   }
+  
+	/*
+	 * @Test public void testIllegalStateExceptionHandling() throws IOException {
+	 * boolean telemetryEnabled = TelemetryService.getInstance().isEnabled();
+	 * 
+	 * CloseableHttpClient client = mock(CloseableHttpClient.class);
+	 * when(client.execute(any(HttpUriRequest.class))) .thenAnswer( new
+	 * Answer<CloseableHttpResponse>() { int callCount = 0;
+	 * 
+	 * @Override public CloseableHttpResponse answer(InvocationOnMock invocation)
+	 * throws Throwable { return IllegalStateExceptionResponse(); } });
+	 * 
+	 * try { TelemetryService.disable(); assertThrows( SnowflakeSQLException.class,
+	 * () -> execute(client, "fakeurl.com/?requestId=abcd-1234", 0, 0, 0, true,
+	 * false, 1)); } finally { if (telemetryEnabled) { TelemetryService.enable(); }
+	 * else { TelemetryService.disable(); } } }
+	   
+  private CloseableHttpResponse IllegalStateExceptionResponse() throws IllegalStateException {
+	    StatusLine successStatusLine = mock(StatusLine.class);
+	    when(successStatusLine.getStatusCode()).thenThrow(new IllegalStateException("Connection pool is closed"));
+
+	    CloseableHttpResponse successResponse = mock(CloseableHttpResponse.class);
+	    when(successStatusLine.getStatusCode()).thenThrow(new IllegalStateException("Connection pool is closed"));
+
+	    return successResponse;
+	  }
+
+  
+	 */
 }


### PR DESCRIPTION
# Overview

SNOW-1943242 

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
