### PR TITLE
SNOW-2172062: Fix access token expiration handling for legacy OAuth flow

### DIFF
--- a/src/test/java/net/snowflake/client/core/OAuthLegacyFlowLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/OAuthLegacyFlowLatestIT.java
@@ -1,0 +1,56 @@
+package net.snowflake.client.core;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.HashMap;
+import net.snowflake.client.category.TestTags;
+import net.snowflake.client.core.auth.AuthenticatorType;
+import net.snowflake.client.jdbc.BaseWiremockTest;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(TestTags.AUTHENTICATION)
+public class OAuthLegacyFlowLatestIT extends BaseWiremockTest {
+
+  private static final String SCENARIOS_BASE_DIR = MAPPINGS_BASE_DIR + "/oauth/legacy_oauth";
+  private static final String EXPIRED_TOKEN_SCENARIO = SCENARIOS_BASE_DIR + "/token_expired.json";
+
+  @Test
+  public void shouldThrowExpirationExceptionUponExpiredTokenResponse() {
+    SFLoginInput loginInput = createLoginInputStub();
+    importMappingFromResources(EXPIRED_TOKEN_SCENARIO);
+    SnowflakeSQLException e =
+        assertThrows(
+            SnowflakeSQLException.class,
+            () -> SessionUtil.openSession(loginInput, new HashMap<>(), "INFO"));
+    assertTrue(
+        e.getMessage().contains("OAuth access token expired. [1172527951366]"),
+        "Expected expiration error message, but got: " + e.getMessage());
+  }
+
+  private SFLoginInput createLoginInputStub() {
+    SFLoginInput input = new SFLoginInput();
+    input.setAuthenticator(AuthenticatorType.OAUTH.name());
+    input.setOriginalAuthenticator(AuthenticatorType.OAUTH.name());
+    input.setServerUrl(String.format("http://%s:%d/", WIREMOCK_HOST, wiremockHttpPort));
+    input.setUserName("MOCK_USERNAME");
+    input.setAccountName("MOCK_ACCOUNT_NAME");
+    input.setAppId("MOCK_APP_ID");
+    input.setAppVersion("MOCK_APP_VERSION");
+    input.setToken("expired-access-token-123");
+    input.setOCSPMode(OCSPMode.FAIL_OPEN);
+    input.setHttpClientSettingsKey(new HttpClientSettingsKey(OCSPMode.FAIL_OPEN));
+    input.setBrowserResponseTimeout(Duration.ofSeconds(5));
+    input.setBrowserHandler(
+        new OAuthAuthorizationCodeFlowLatestIT.WiremockProxyRequestBrowserHandler());
+    input.setLoginTimeout(1000);
+    HashMap<String, Object> sessionParameters = new HashMap<>();
+    sessionParameters.put("CLIENT_STORE_TEMPORARY_CREDENTIAL", "true");
+    input.setSessionParameters(sessionParameters);
+    input.setOauthLoginInput(new SFOauthLoginInput(null, null, null, null, null, null));
+    return input;
+  }
+}

--- a/src/test/resources/wiremock/mappings/oauth/legacy_oauth/token_expired.json
+++ b/src/test/resources/wiremock/mappings/oauth/legacy_oauth/token_expired.json
@@ -1,0 +1,58 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "Throwing expired access token exception in legacy OAuth flow",
+      "request": {
+        "urlPathPattern": "/session/v1/login-request.*",
+        "method": "POST",
+        "headers": {
+          "CLIENT_APP_ID": {
+            "equalTo": "MOCK_APP_ID"
+          },
+          "CLIENT_APP_VERSION": {
+            "equalTo": "MOCK_APP_VERSION"
+          },
+          "Authorization": {
+            "equalTo": "Basic"
+          },
+          "accept": {
+            "equalTo": "application/json"
+          }
+        },
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "data": {
+                "ACCOUNT_NAME": "MOCK_ACCOUNT_NAME",
+                "CLIENT_APP_ID": "MOCK_APP_ID",
+                "CLIENT_ENVIRONMENT": {
+                  "tracing": "INFO",
+                  "OCSP_MODE": "FAIL_OPEN"
+                },
+                "CLIENT_APP_VERSION": "MOCK_APP_VERSION",
+                "TOKEN": "expired-access-token-123",
+                "LOGIN_NAME": "MOCK_USERNAME",
+                "AUTHENTICATOR": "OAUTH"
+              }
+            },
+            "ignoreExtraElements": true
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "data": {
+            "nextAction": "RETRY_LOGIN",
+            "authnMethod": "OAUTH",
+            "signInOptions": {}
+          },
+          "code": "390318",
+          "message": "OAuth access token expired. [1172527951366]",
+          "success": false,
+          "headers": null
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Overview

SNOW-2172062

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
