### PR TITLE
SNOW-2183215: Bump maven-gpg-plugin version to latest

### DIFF
--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -95,7 +95,7 @@
     <version.plugin.exec>3.1.0</version.plugin.exec>
     <version.plugin.failsafe>3.5.1</version.plugin.failsafe>
     <version.plugin.fmt>2.19</version.plugin.fmt>
-    <version.plugin.gpg>3.0.1</version.plugin.gpg>
+    <version.plugin.gpg>3.2.7</version.plugin.gpg>
     <version.plugin.install>3.1.1</version.plugin.install>
     <version.plugin.jacoco>0.8.8</version.plugin.jacoco>
     <version.plugin.japicmp>0.23.0</version.plugin.japicmp>


### PR DESCRIPTION
# Overview

SNOW-2183215

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   This PR bumps the version of the `maven-gpg-plugin` to the latest version
