### PR TITLE
SNOW-2177175 Fix casting to ExtendedX509TrustManager

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 import net.snowflake.client.jdbc.ErrorCode;
 import net.snowflake.client.jdbc.HttpHeadersCustomizer;
 import net.snowflake.client.jdbc.RestRequest;
@@ -333,7 +334,12 @@ public class HttpUtil {
         } else {
           logger.debug("Instantiating trust manager with ocsp cache file: {}", ocspCacheFile);
         }
-        TrustManager[] tm = {new SFTrustManager(key, ocspCacheFile)};
+        TrustManager[] tm = {
+          new SFTrustManager(
+              key,
+              ocspCacheFile,
+              TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()))
+        };
         trustManagers = tm;
       } catch (Exception | Error err) {
         // dump error stack

--- a/src/main/java/net/snowflake/client/core/SFTrustManager.java
+++ b/src/main/java/net/snowflake/client/core/SFTrustManager.java
@@ -262,13 +262,13 @@ public class SFTrustManager extends X509ExtendedTrustManager {
    * @param key HttpClientSettingsKey
    * @param cacheFile cache file.
    */
-  SFTrustManager(HttpClientSettingsKey key, File cacheFile) {
+  SFTrustManager(HttpClientSettingsKey key, File cacheFile, TrustManagerFactory trustManagerFactory)
+      throws IOException {
     this.ocspMode = key.getOcspMode();
     this.proxySettingsKey = key;
-    this.trustManager = getTrustManager(TrustManagerFactory.getDefaultAlgorithm());
+    this.trustManager = getTrustManager(trustManagerFactory);
 
-    this.exTrustManager =
-        (X509ExtendedTrustManager) getTrustManager(TrustManagerFactory.getDefaultAlgorithm());
+    this.exTrustManager = getExtendedTrustManager(trustManager);
 
     checkNewOCSPEndpointAvailability();
 
@@ -678,12 +678,11 @@ public class SFTrustManager extends X509ExtendedTrustManager {
    * @param algorithm algorithm.
    * @return TrustManager object.
    */
-  private X509TrustManager getTrustManager(String algorithm) {
+  private X509TrustManager getTrustManager(TrustManagerFactory trustManagerFactory) {
     try {
-      TrustManagerFactory factory = TrustManagerFactory.getInstance(algorithm);
-      factory.init((KeyStore) null);
+      trustManagerFactory.init((KeyStore) null);
       X509TrustManager ret = null;
-      for (TrustManager tm : factory.getTrustManagers()) {
+      for (TrustManager tm : trustManagerFactory.getTrustManagers()) {
         // Multiple TrustManager may be attached. We just need X509 Trust
         // Manager here.
         if (tm instanceof X509TrustManager) {
@@ -704,8 +703,17 @@ public class SFTrustManager extends X509ExtendedTrustManager {
         }
       }
       return ret;
-    } catch (NoSuchAlgorithmException | KeyStoreException | CertificateEncodingException ex) {
+    } catch (KeyStoreException | CertificateEncodingException ex) {
       throw new SSLInitializationException(ex.getMessage(), ex);
+    }
+  }
+
+  private X509ExtendedTrustManager getExtendedTrustManager(X509TrustManager trustManager) {
+    if (trustManager instanceof X509ExtendedTrustManager) {
+      return (X509ExtendedTrustManager) trustManager;
+    } else {
+      logger.debug("Default JVM TrustManager is not an instance of X509ExtendedTrustManager. ");
+      return null;
     }
   }
 

--- a/src/test/java/net/snowflake/client/core/CertificateChainTrustValidationTestLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/CertificateChainTrustValidationTestLatestIT.java
@@ -140,7 +140,11 @@ public class CertificateChainTrustValidationTestLatestIT {
         "Trust store content verified: only rootca1_self_signed_for_ts is present as a trust anchor.");
 
     logger.debug("Initializing PKIX X509TrustManager...");
-    sfTrustManager = new SFTrustManager(new HttpClientSettingsKey(OCSPMode.FAIL_CLOSED), null);
+    sfTrustManager =
+        new SFTrustManager(
+            new HttpClientSettingsKey(OCSPMode.FAIL_CLOSED),
+            null,
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()));
     assertNotNull(sfTrustManager, "PKIX X509TrustManager should be initialized.");
     logger.debug("PKIX X509TrustManager initialized successfully.");
 

--- a/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
+++ b/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
@@ -6,13 +6,17 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AnyOf.anyOf;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
@@ -23,6 +27,9 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 import net.snowflake.client.SystemPropertyOverrider;
 import net.snowflake.client.category.TestTags;
 import net.snowflake.client.jdbc.BaseJDBCTest;
@@ -36,6 +43,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -314,6 +322,44 @@ public class SFTrustManagerIT extends BaseJDBCTest {
       Arrays.asList(useProxyOverrider, proxyHostOverrider, proxyPortOverrider)
           .forEach(SystemPropertyOverrider::rollback);
     }
+  }
+
+  @Test
+  void shouldNotFailIfDefaultTrustManagerIsNotX509TrustManager() throws Exception {
+    TrustManagerFactory trustManagerFactory = mock(TrustManagerFactory.class);
+    when(trustManagerFactory.getTrustManagers())
+        .thenReturn(new TrustManager[] {new TrustManager() {}});
+    assertDoesNotThrow(
+        () ->
+            new SFTrustManager(
+                new HttpClientSettingsKey(OCSPMode.FAIL_CLOSED), null, trustManagerFactory));
+  }
+
+  @Test
+  void shouldNotFailIfDefaultTrustManagerIsNotExtendedX509TrustManager() throws Exception {
+    TrustManagerFactory trustManagerFactory = mock(TrustManagerFactory.class);
+    when(trustManagerFactory.getTrustManagers())
+        .thenReturn(
+            new TrustManager[] {
+              new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType)
+                    throws CertificateException {}
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType)
+                    throws CertificateException {}
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                  return new X509Certificate[0];
+                }
+              }
+            });
+    assertDoesNotThrow(
+        () ->
+            new SFTrustManager(
+                new HttpClientSettingsKey(OCSPMode.FAIL_CLOSED), null, trustManagerFactory));
   }
 
   @BeforeEach

--- a/src/test/java/net/snowflake/client/core/SFTrustManagerMockitoMockLatestIT.java
+++ b/src/test/java/net/snowflake/client/core/SFTrustManagerMockitoMockLatestIT.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import net.snowflake.client.TestUtil;
@@ -29,7 +28,7 @@ public class SFTrustManagerMockitoMockLatestIT {
    */
   @Test
   @Disabled("static initialization block of SFTrustManager class doesn't run sometimes")
-  public void testUnitOCSPWithCustomCacheDirectory() throws IOException {
+  public void testUnitOCSPWithCustomCacheDirectory() throws Exception {
     try (MockedStatic<TrustManagerFactory> mockedTrustManagerFactory =
             mockStatic(TrustManagerFactory.class);
         MockedStatic<SnowflakeUtil> mockedSnowflakeUtil = mockStatic(SnowflakeUtil.class)) {
@@ -48,7 +47,9 @@ public class SFTrustManagerMockitoMockLatestIT {
           .thenReturn(tested);
 
       new SFTrustManager(
-          new HttpClientSettingsKey(OCSPMode.FAIL_CLOSED), null); // cache file location
+          new HttpClientSettingsKey(OCSPMode.FAIL_CLOSED),
+          null, // cache file location
+          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()));
 
       // The goal is to check if the cache file location is changed to the specified
       // directory, so it doesn't need to do OCSP check in this test.

--- a/src/test/java/net/snowflake/client/core/SFTrustManagerTest.java
+++ b/src/test/java/net/snowflake/client/core/SFTrustManagerTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.util.Base64;
 import java.util.Properties;
+import javax.net.ssl.TrustManagerFactory;
 import net.snowflake.client.jdbc.SnowflakeResultSetSerializable;
 import net.snowflake.client.jdbc.SnowflakeResultSetSerializableV1;
 import org.junit.jupiter.api.AfterAll;
@@ -75,14 +76,16 @@ public class SFTrustManagerTest {
   }
 
   @Test
-  public void testBuildNewRetryURL() {
+  public void testBuildNewRetryURL() throws Exception {
     try {
       System.setProperty("net.snowflake.jdbc.ocsp_activate_new_endpoint", Boolean.TRUE.toString());
 
       SFTrustManager tManager =
           new SFTrustManager(
-              new HttpClientSettingsKey(OCSPMode.FAIL_OPEN), null // OCSP Cache file custom location
-              ); // Use OCSP Cache Server
+              new HttpClientSettingsKey(OCSPMode.FAIL_OPEN),
+              null, // OCSP Cache file custom location
+              TrustManagerFactory.getInstance(
+                  TrustManagerFactory.getDefaultAlgorithm())); // Use OCSP Cache Server
       tManager.ocspCacheServer.resetOCSPResponseCacheServer("a1.snowflakecomputing.com");
       assertThat(
           tManager.ocspCacheServer.SF_OCSP_RESPONSE_CACHE_SERVER,


### PR DESCRIPTION
# Overview

SNOW-2177175 Driver tried to always cast default trust manager to ExtendedX509TrustManager. Now it does it only if this interface is implemented.
