### PR TITLE
SNOW-1894342: Add flag for using patterns in metadata SHOW ... IN ... commands

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/core/SFBaseSession.java
@@ -140,6 +140,10 @@ public abstract class SFBaseSession {
   // value is false for backwards compatibility.
   private boolean enableExactSchemaSearch = false;
 
+  // This is true by default, but can be set to false to disable pattern matching in cases when
+  // wildcards are used as a part of identifiers eg. "my_table" or "my_schema"
+  private boolean enableWildcardsInShowMetadataCommands = true;
+
   /** Disable lookup for default credentials by GCS library */
   private boolean disableGcsDefaultCredentials = true;
 
@@ -1103,6 +1107,14 @@ public abstract class SFBaseSession {
 
   void setEnableExactSchemaSearch(boolean enableExactSchemaSearch) {
     this.enableExactSchemaSearch = enableExactSchemaSearch;
+  }
+
+  public boolean getEnableWildcardsInShowMetadataCommands() {
+    return enableWildcardsInShowMetadataCommands;
+  }
+
+  void setEnableWildcardsInShowMetadataCommands(boolean enableWildcardsInShowMetadataCommands) {
+    this.enableWildcardsInShowMetadataCommands = enableWildcardsInShowMetadataCommands;
   }
 
   public boolean getDisableGcsDefaultCredentials() {

--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -518,6 +518,12 @@ public class SFSession extends SFBaseSession {
           }
           break;
 
+        case ENABLE_WILDCARDS_IN_SHOW_METADATA_COMMANDS:
+          if (propertyValue != null) {
+            setEnableWildcardsInShowMetadataCommands(getBooleanValue(propertyValue));
+          }
+          break;
+
         case DISABLE_GCS_DEFAULT_CREDENTIALS:
           if (propertyValue != null) {
             setDisableGcsDefaultCredentials(getBooleanValue(propertyValue));

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -142,7 +142,10 @@ public enum SFSessionProperty {
   // Used to enable the owner-only stage file permissions feature. This feature will be enabled by
   // default in the next major release.
   OWNER_ONLY_STAGE_FILE_PERMISSIONS_ENABLED(
-      "ownerOnlyStageFilePermissionsEnabled", false, Boolean.class);
+      "ownerOnlyStageFilePermissionsEnabled", false, Boolean.class),
+
+  ENABLE_WILDCARDS_IN_SHOW_METADATA_COMMANDS(
+      "ENABLE_WILDCARDS_IN_SHOW_METADATA_COMMANDS", false, Boolean.class);
 
   // property key in string
   private String propertyKey;

--- a/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/DatabaseMetaDataLatestIT.java
@@ -39,6 +39,7 @@ import net.snowflake.client.annotations.DontRunOnGithubActions;
 import net.snowflake.client.category.TestTags;
 import net.snowflake.client.core.SFBaseSession;
 import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.util.ThrowingFunction;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -2894,13 +2895,7 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCWithSharedConnectionIT {
     }
   }
 
-  @FunctionalInterface
-  interface ThrowingFunction<T, R> {
-    R apply(T t) throws SQLException;
-  }
-
-  // 2. Create the static helper method to wrap the exception
-  static <T, R> Function<T, R> handleException(ThrowingFunction<T, R> f) {
+  static <T, R> Function<T, R> handleException(ThrowingFunction<T, R, SQLException> f) {
     return t -> {
       try {
         return f.apply(t);


### PR DESCRIPTION
# Overview

SNOW-1894342
Allows to disable treating SQL wildcards characters (`_` and `%`) as patterns in identifier names which allows for narrower metadata searches. 

When `true` (default)
```java
DatabaseMetaData.getColumns("MY_DB", "MY_SCHEMA", "MY_TABLE", null)
```
is translated to
```sql
show columns in database "MY_DB";
```

When `false`
```java
DatabaseMetaData.getColumns("MY_DB", "MY_SCHEMA", "MY_TABLE", null)
```
is translated to
```sql
show columns in table "MY_DB"."MY_SCHEMA"."MY_TABLE";
```


## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
