### PR TITLE
SNOW-2249717: Force Proxy Basic Auth in S3 Client

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/cloud/storage/S3HttpUtil.java
+++ b/src/main/java/net/snowflake/client/jdbc/cloud/storage/S3HttpUtil.java
@@ -4,6 +4,8 @@ import static net.snowflake.client.jdbc.SnowflakeUtil.isNullOrEmpty;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
+import com.amazonaws.ProxyAuthenticationMethod;
+import java.util.Arrays;
 import java.util.Properties;
 import net.snowflake.client.core.HttpClientSettingsKey;
 import net.snowflake.client.core.HttpProtocol;
@@ -50,6 +52,10 @@ public class S3HttpUtil {
                 + SFLoggerUtil.isVariableProvided(key.getProxyPassword());
         clientConfig.setProxyUsername(key.getProxyUser());
         clientConfig.setProxyPassword(key.getProxyPassword());
+        // Force the use of BASIC authentication only for proxy authentication
+        // This ensures that when multiple authentication schemes are offered by the proxy
+        // (e.g., NEGOTIATE, NTLM, BASIC), we only use BASIC authentication
+        clientConfig.setProxyAuthenticationMethods(Arrays.asList(ProxyAuthenticationMethod.BASIC));
       }
       logger.debug(logMessage);
     } else {
@@ -116,6 +122,11 @@ public class S3HttpUtil {
           logMessage += ", user: " + proxyUser + " with password provided";
           clientConfig.setProxyUsername(proxyUser);
           clientConfig.setProxyPassword(proxyPassword);
+          // Force the use of BASIC authentication only for proxy authentication
+          // This ensures that when multiple authentication schemes are offered by the proxy
+          // (e.g., NEGOTIATE, NTLM, BASIC), we only use BASIC authentication
+          clientConfig.setProxyAuthenticationMethods(
+              Arrays.asList(ProxyAuthenticationMethod.BASIC));
         }
         logger.debug(logMessage);
       } else {


### PR DESCRIPTION
We explicitly set BASIC as the authentication method for Proxy connections made by the S3 client when a proxy user and password are provided. Previously, the AWS S3 client could potentially attempt to connect using other methods if those were provided by the Proxy server in the Proxy-Authenticate headers