### PR TITLE
SNOW-2258880 add autoconfig to acceptsURL + add a test for it

### DIFF
--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -196,7 +196,7 @@ public class SnowflakeDriver implements Driver {
    */
   @Override
   public boolean acceptsURL(String url) {
-    if (url != null && url.contains(AUTO_CONNECTION_STRING_PREFIX)) {
+    if (url != null && url.equalsIgnoreCase(AUTO_CONNECTION_STRING_PREFIX)) {
       return true;
     }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -182,18 +182,24 @@ public class SnowflakeDriver implements Driver {
   /**
    * Checks whether a given url is in a valid format.
    *
-   * <p>The current uri format is: jdbc:snowflake://[host[:port]]
+   * <p>The current uri format is: jdbc:snowflake://[host[:port]] or jdbc:snowflake:auto
    *
    * <p>jdbc:snowflake:// - run in embedded mode jdbc:snowflake://localhost - connect to localhost
    * default port (8080)
    *
    * <p>jdbc:snowflake://localhost:8080- connect to localhost port 8080
+   * 
+   * <p>jdbc:snowflake:auto - use connections.toml
    *
    * @param url url of the database including host and port
    * @return true if the url is valid
    */
   @Override
   public boolean acceptsURL(String url) {
+    if (url != null && url.contains(AUTO_CONNECTION_STRING_PREFIX)) {
+      return true;
+    }
+
     return SnowflakeConnectString.parse(url, EMPTY_PROPERTIES).isValid();
   }
 

--- a/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
+++ b/src/main/java/net/snowflake/client/jdbc/SnowflakeDriver.java
@@ -188,7 +188,7 @@ public class SnowflakeDriver implements Driver {
    * default port (8080)
    *
    * <p>jdbc:snowflake://localhost:8080- connect to localhost port 8080
-   * 
+   *
    * <p>jdbc:snowflake:auto - use connections.toml
    *
    * @param url url of the database including host and port

--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverTest.java
@@ -356,6 +356,9 @@ public class SnowflakeDriverTest {
       t.match(t.url, SnowflakeConnectString.parse(t.url, SnowflakeDriver.EMPTY_PROPERTIES));
     }
 
+    // autoconfig with connections.toml
+    assertTrue(snowflakeDriver.acceptsURL("jdbc:snowflake:auto"));
+
     // negative tests
     assertFalse(snowflakeDriver.acceptsURL("jdbc:"));
     assertFalse(snowflakeDriver.acceptsURL("jdbc:snowflake://"));


### PR DESCRIPTION
## Description

This is for https://github.com/snowflakedb/snowflake-jdbc/issues/2295. The auto detection of the `default` connection from `connections.toml` implemented in https://github.com/snowflakedb/snowflake-jdbc/pull/1780, tested using the driver and it works just fine.
Relevant documentation piece: https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure#connecting-using-the-connections-toml-file 

However apparently when used from HikariCP, the exact same setup leads to:
```
[main] INFO com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
java.lang.RuntimeException: Failed to get driver instance for jdbcUrl=jdbc:snowflake:auto
	at com.zaxxer.hikari.util.DriverDataSource.<init>(DriverDataSource.java:120)
	at com.zaxxer.hikari.pool.PoolBase.initializeDataSource(PoolBase.java:336)
	at com.zaxxer.hikari.pool.PoolBase.<init>(PoolBase.java:121)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:90)
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:80)
	at SnowflakeHikariCLI.main(SnowflakeHikariExampleAutoconfig.java:16)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.execute(Main.java:415)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.run(Main.java:192)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:132)
Caused by: java.sql.SQLException: No suitable driver
	at java.sql/java.sql.DriverManager.getDriver(DriverManager.java:298)
	at com.zaxxer.hikari.util.DriverDataSource.<init>(DriverDataSource.java:112)
	... 12 more
```

and driver fails to initialize with auto config; even though the exact same auto config is proven to work outside of the pooling setup.

This change aims to make the driver able to use the autoconfig in the pooling setup too. 

Manually tested with a minimal HikariCP + Snowflake JDBC using application; also for regression manually tested outside of HikariCP with a minimal Snowflake JDBC using application. (both cases: connect to Snowflake and issue a small query)


## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements
