### PR TITLE
SNOW-2266612: fix StmtUtil.execute:gzos free memory

### DIFF
--- a/src/main/java/net/snowflake/client/core/StmtUtil.java
+++ b/src/main/java/net/snowflake/client/core/StmtUtil.java
@@ -373,6 +373,8 @@ public class StmtUtil {
           gzos.write(bytes);
           gzos.finish();
           input = new ByteArrayEntity(baos.toByteArray());
+          //SNOW-2266612 fix the memory leak
+          gzos.close();
           httpRequest.addHeader("content-encoding", "gzip");
           execTimeData.setGzipEnd();
         } else {


### PR DESCRIPTION
# Overview

SNOW-2266612

## Pre-review self checklist
- [✅] PR branch is updated with all the changes from `master` branch
- [✅] The code is correctly formatted (run `mvn -P check-style validate`)
- [✅] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [✅] The pull request name is prefixed with `SNOW-XXXX: `
- [✅] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #2302


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

The OutputStream of gzos was not releasing memory properly. I added the close method to ensure it releases memory normally and prevents direct memory leaks.