### PR TITLE
Update HttpClient to use LaxRedirectStrategy to handle `307` on `POST`

### DIFF
--- a/src/main/java/net/snowflake/client/core/HttpUtil.java
+++ b/src/main/java/net/snowflake/client/core/HttpUtil.java
@@ -54,7 +54,7 @@ import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
@@ -392,7 +392,7 @@ public class HttpUtil {
               .setConnectionManager(connectionManager)
               // Support JVM proxy settings
               .useSystemProperties()
-              .setRedirectStrategy(new DefaultRedirectStrategy())
+              .setRedirectStrategy(new LaxRedirectStrategy())
               .setUserAgent(buildUserAgent(userAgentSuffix)) // needed for Okta
               .disableCookieManagement() // SNOW-39748
               .setDefaultRequestConfig(DefaultRequestConfig);


### PR DESCRIPTION
Currently used `DefaultRedirectStrategy` will not redirect on `POST` requests when a `307` is received. `LaxRedirectStrategy`, on the other hand, will accept redirects regardless of the method. 

Snowflake service sometimes returns `307` on `POST`. Discussions with support indicated that while this shouldn't happen it can be returned to the client and should be retried in user code. If the retry strategy in the http client is updated to `LaxRedirectStrategy` there would be no need for users to handle this explicitly.

# Overview

SNOW-XXXXX

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: This is both the report and the solution to an issue. 


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
