### PR TITLE
NO-SNOW: Exclude any region information from the account locator

### DIFF
--- a/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
+++ b/src/main/java/net/snowflake/client/core/SessionUtilKeyPair.java
@@ -83,7 +83,7 @@ class SessionUtilKeyPair {
       String userName)
       throws SFException {
     this.userName = userName.toUpperCase();
-    this.accountName = accountName.toUpperCase();
+    this.accountName = excludeRegionInformation(accountName).toUpperCase();
     String enableBouncyCastleJvm =
         System.getProperty(SecurityUtil.ENABLE_BOUNCYCASTLE_PROVIDER_JVM);
     if (enableBouncyCastleJvm != null) {
@@ -340,5 +340,10 @@ class SessionUtilKeyPair {
         return keyFactory.generatePrivate(encodedKeySpec);
       }
     }
+  }
+
+  private static String excludeRegionInformation(String accountName) {
+    int dotIndex = accountName.indexOf('.');
+    return dotIndex > 0 ? accountName.substring(0, dotIndex) : accountName;
   }
 }

--- a/src/test/java/net/snowflake/client/core/SessionUtilKeyPairTest.java
+++ b/src/test/java/net/snowflake/client/core/SessionUtilKeyPairTest.java
@@ -1,0 +1,55 @@
+package net.snowflake.client.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class SessionUtilKeyPairTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "name.azure.deployment,NAME",
+    "account.region-cloud,ACCOUNT",
+    "multi.part.long.name,MULTI",
+    "single,SINGLE"
+  })
+  public void testAccountNameWithDotsInJwtToken(String testName, String expected)
+      throws SFException, Exception {
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    keyPairGenerator.initialize(2048, new SecureRandom());
+    KeyPair keyPair = keyPairGenerator.generateKeyPair();
+    PrivateKey privateKey = keyPair.getPrivate();
+
+    String userName = "testuser";
+
+    SessionUtilKeyPair sessionUtil =
+        new SessionUtilKeyPair(privateKey, null, null, null, testName, userName);
+    String jwtToken = sessionUtil.issueJwtToken();
+
+    assertNotNull(jwtToken);
+
+    SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+    JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+    String expectedSubject = expected + "." + userName.toUpperCase();
+
+    assertEquals(expectedSubject, claims.getSubject());
+
+    String issuer = claims.getIssuer();
+
+    assertTrue(issuer.startsWith(expectedSubject));
+
+    if (testName.contains(".")) {
+      assertFalse(issuer.contains(testName.toUpperCase()));
+    }
+  }
+}


### PR DESCRIPTION
# Overview
https://docs.snowflake.com/en/developer-guide/sql-api/authenticating#using-key-pair-authentication
```
If you are using the [account locator](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#label-account-locator), exclude any region information from the account locator.
```

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
