### PR TITLE
NO-SNOW bump netty for CVE-2025-58056

### DIFF
--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -21,7 +21,7 @@
     <junit.version>5.11.1</junit.version>
     <surefire.version>3.5.1</surefire.version>
     <mockito.version>3.5.6</mockito.version>
-    <netty.version>4.1.124.Final</netty.version>
+    <netty.version>4.1.127.Final</netty.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -67,7 +67,7 @@
     <metrics.version>2.2.0</metrics.version>
     <mockito.version>4.11.0</mockito.version>
     <nimbusds.oauth2.version>11.20.1</nimbusds.oauth2.version>
-    <netty.version>4.1.124.Final</netty.version>
+    <netty.version>4.1.127.Final</netty.version>
     <nimbusds.version>10.3.1</nimbusds.version>
     <opencensus.version>0.31.1</opencensus.version>
     <plexus.container.version>1.0-alpha-9-stable-1</plexus.container.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -57,7 +57,7 @@
     <json.smart.version>2.5.2</json.smart.version>
     <jsoup.version>1.15.3</jsoup.version>
     <metrics.version>2.2.0</metrics.version>
-    <netty.version>4.1.124.Final</netty.version>
+    <netty.version>4.1.127.Final</netty.version>
     <nimbusds.version>10.3.1</nimbusds.version>
     <nimbusds.oauth2.version>11.20.1</nimbusds.oauth2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
# Description
In versions 4.1.124.Final, and 4.2.0.Alpha3 through 4.2.4.Final, Netty incorrectly accepts standalone newline characters (LF) as a chunk-size line terminator, regardless of a preceding carriage return (CR), instead of requiring CRLF per HTTP/1.1 standards. When combined with reverse proxies that parse LF differently (treating it as part of the chunk extension), attackers can craft requests that the proxy sees as one request but Netty processes as two, enabling request smuggling attacks. This is fixed in versions 4.1.125.Final and 4.2.5.Final.

https://nvd.nist.gov/vuln/detail/CVE-2025-58056