### PR TITLE
SNOW-2442756: Cleanup ENABLE_UDT_EXTERNAL_TYPE_NAMES that has been default true for several releases

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -799,20 +799,20 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
             "insert into t_geo values ('POINT(0 0)'), ('LINESTRING(1 1, 2 2)')");
 
         testGeoOutputTypeSingle(
-            regularStatement, false, "geoJson", "OBJECT", "java.lang.String", Types.VARCHAR);
+            regularStatement, "geoJson", "OBJECT", "java.lang.String", Types.VARCHAR);
 
         testGeoOutputTypeSingle(
-            regularStatement, true, "geoJson", "GEOGRAPHY", "java.lang.String", Types.VARCHAR);
+            regularStatement, "geoJson", "GEOGRAPHY", "java.lang.String", Types.VARCHAR);
 
         testGeoOutputTypeSingle(
-            regularStatement, false, "wkt", "VARCHAR", "java.lang.String", Types.VARCHAR);
+            regularStatement, "wkt", "VARCHAR", "java.lang.String", Types.VARCHAR);
 
         testGeoOutputTypeSingle(
-            regularStatement, true, "wkt", "GEOGRAPHY", "java.lang.String", Types.VARCHAR);
+            regularStatement, "wkt", "GEOGRAPHY", "java.lang.String", Types.VARCHAR);
 
-        testGeoOutputTypeSingle(regularStatement, false, "wkb", "BINARY", "[B", Types.BINARY);
+        testGeoOutputTypeSingle(regularStatement, "wkb", "BINARY", "[B", Types.BINARY);
 
-        testGeoOutputTypeSingle(regularStatement, true, "wkb", "GEOGRAPHY", "[B", Types.BINARY);
+        testGeoOutputTypeSingle(regularStatement, "wkb", "GEOGRAPHY", "[B", Types.BINARY);
       } finally {
         regularStatement.execute("drop table t_geo");
       }
@@ -821,7 +821,6 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
 
   private void testGeoOutputTypeSingle(
       Statement regularStatement,
-      boolean enableExternalTypeNames,
       String outputFormat,
       String expectedColumnTypeName,
       String expectedColumnClassName,
@@ -910,10 +909,10 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
             "insert into t_geo2 values ('POINT(0 0)'), ('LINESTRING(1 1, 2 2)')");
 
         testGeometryOutputTypeSingle(
-            regularStatement, true, "geoJson", "GEOMETRY", "java.lang.String", Types.VARCHAR);
+            regularStatement, "geoJson", "GEOMETRY", "java.lang.String", Types.VARCHAR);
 
         testGeometryOutputTypeSingle(
-            regularStatement, true, "wkt", "GEOMETRY", "java.lang.String", Types.VARCHAR);
+            regularStatement, "wkt", "GEOMETRY", "java.lang.String", Types.VARCHAR);
       } finally {
         regularStatement.execute("drop table t_geo2");
       }
@@ -922,7 +921,6 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
 
   private void testGeometryOutputTypeSingle(
       Statement regularStatement,
-      boolean enableExternalTypeNames,
       String outputFormat,
       String expectedColumnTypeName,
       String expectedColumnClassName,


### PR DESCRIPTION
# Overview

SNOW-2442756

This PR cleans up the parameter ENABLE_UDT_EXTERNAL_TYPE_NAMES since it has been default true for several releases. The affected file is only a test that explicitly sets it to true.

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements
