### PR TITLE
NO-SNOW Rollback timeouts to original values in the test

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/ConnectionLatestIT.java
@@ -1603,6 +1603,8 @@ public class ConnectionLatestIT extends BaseJDBCTest {
   /** Added in > 3.14.5 and modified in > 3.18.0 */
   @Test
   public void shouldGetOverridenConnectionAndSocketTimeouts() throws Exception {
+    Duration origConnectionTimeout = HttpUtil.getConnectionTimeout();
+    Duration origSocketTimeout = HttpUtil.getSocketTimeout();
     Properties paramProperties = new Properties();
     paramProperties.put("HTTP_CLIENT_CONNECTION_TIMEOUT", 100);
     paramProperties.put("HTTP_CLIENT_SOCKET_TIMEOUT", 200);
@@ -1610,6 +1612,10 @@ public class ConnectionLatestIT extends BaseJDBCTest {
     try (Connection connection = getConnection(paramProperties)) {
       assertEquals(Duration.ofMillis(100), HttpUtil.getConnectionTimeout());
       assertEquals(Duration.ofMillis(200), HttpUtil.getSocketTimeout());
+    } finally {
+      // reset to original values
+      HttpUtil.setConnectionTimeout((int) origConnectionTimeout.toMillis());
+      HttpUtil.setSocketTimeout((int) origSocketTimeout.toMillis());
     }
   }
 


### PR DESCRIPTION
# Overview

NO-SNOW Rollback timeouts to original values in the test. Otherwise the socket timeout of 200ms was set for the next couple of tests (unitl HttpUtilTest rolls it back), and those tests very often fail with `JWT Token is invalid`. Reasoning - Snowflake created the session correctly, but driver timed out on read auth response. After many retries, Snowflake observed expired JWT and answered quicker (below 200ms), so driver only make it to read the already expired auth response.
