### PR TITLE
SNOW-2514497: Remove obsolete test statements

### DIFF
--- a/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
+++ b/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverLatestIT.java
@@ -799,18 +799,10 @@ public class SnowflakeDriverLatestIT extends BaseJDBCTest {
             "insert into t_geo values ('POINT(0 0)'), ('LINESTRING(1 1, 2 2)')");
 
         testGeoOutputTypeSingle(
-            regularStatement, "geoJson", "OBJECT", "java.lang.String", Types.VARCHAR);
-
-        testGeoOutputTypeSingle(
             regularStatement, "geoJson", "GEOGRAPHY", "java.lang.String", Types.VARCHAR);
 
         testGeoOutputTypeSingle(
-            regularStatement, "wkt", "VARCHAR", "java.lang.String", Types.VARCHAR);
-
-        testGeoOutputTypeSingle(
             regularStatement, "wkt", "GEOGRAPHY", "java.lang.String", Types.VARCHAR);
-
-        testGeoOutputTypeSingle(regularStatement, "wkb", "BINARY", "[B", Types.BINARY);
 
         testGeoOutputTypeSingle(regularStatement, "wkb", "GEOGRAPHY", "[B", Types.BINARY);
       } finally {


### PR DESCRIPTION
# Overview

SNOW-2514497

This PR removes obsolete tests that were missed out when cleaning up a default true param ENABLE_UDT_EXTERNAL_TYPE_NAMES (#2380). The tests being removed are ones that depend on the false value of the param.

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

