### PR TITLE
NO-SNOW: Allow StreamLoader to use more performant metadata queries

### DIFF
--- a/src/main/java/net/snowflake/client/loader/StreamLoader.java
+++ b/src/main/java/net/snowflake/client/loader/StreamLoader.java
@@ -154,9 +154,12 @@ public class StreamLoader implements Loader, Runnable {
       Connection processConnection) {
     _putConn = putConnection;
     _processConn = processConnection;
-    for (Map.Entry<LoaderProperty, Object> e : properties.entrySet()) {
-      setProperty(e.getKey(), e.getValue());
-    }
+
+    // Sort properties by ordinal to ensure columns is processed after table, schema and db to
+    // execute more performant metadata queries
+    properties.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey(Enum::compareTo))
+        .forEach(e -> setProperty(e.getKey(), e.getValue()));
 
     _noise = SnowflakeUtil.randomAlphaNumeric(6);
   }

--- a/src/test/java/net/snowflake/client/loader/LoaderBase.java
+++ b/src/test/java/net/snowflake/client/loader/LoaderBase.java
@@ -2,6 +2,7 @@ package net.snowflake.client.loader;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 import net.snowflake.client.AbstractDriverIT;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -15,8 +16,12 @@ public class LoaderBase {
 
   @BeforeAll
   public static void setUpClass() throws Throwable {
-    testConnection = AbstractDriverIT.getConnection();
-    putConnection = AbstractDriverIT.getConnection();
+    Properties props = new Properties();
+    // Disable wildcards in SHOW METADATA commands to run more performant queries without need to
+    // escape wildcards
+    props.put("ENABLE_WILDCARDS_IN_SHOW_METADATA_COMMANDS", false);
+    testConnection = AbstractDriverIT.getConnection(props);
+    putConnection = AbstractDriverIT.getConnection(props);
 
     SCHEMA_NAME = testConnection.getSchema();
     testConnection

--- a/src/test/java/net/snowflake/client/loader/TestDataConfigBuilder.java
+++ b/src/test/java/net/snowflake/client/loader/TestDataConfigBuilder.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
-import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 
 class TestDataConfigBuilder {
   static final String TARGET_TABLE_NAME = "LOADER_test_TABLE";
@@ -276,9 +275,6 @@ class TestDataConfigBuilder {
 
     // causes upload to fail
     streamLoader.setTestMode(testMode);
-
-    // Wait for 5 seconds on first put to buffer everything up.
-    putConnection.unwrap(SnowflakeConnectionV1.class).setInjectedDelay(5000);
 
     return _resultListener;
   }


### PR DESCRIPTION
# Overview
Previously it was executing queries like `show columns like 'C1' in account` which would produce 1.5 million rows in our case. Time it takes is heavily warehouse dependent (many minutes?). After the fix it can narrow query down to table eg. `show columns like 'C1' in db_name.schema_name.table_name` which takes milliseconds.

Before
```
Time elapsed: 8025 s -- in net.snowflake.client.suites.LoaderTestSuite
```

After
```
Time elapsed: 265.9 s -- in net.snowflake.client.suites.LoaderTestSuite
```

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
