### PR TITLE
SNOW-2889840: Fix OCSP cache URL initialisation in SFTrustManagerIT

### DIFF
--- a/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
+++ b/src/test/java/net/snowflake/client/core/SFTrustManagerIT.java
@@ -154,6 +154,7 @@ public class SFTrustManagerIT extends BaseJDBCTest {
   public void testOcspWithServerCache(String host) throws Throwable {
     System.setProperty(
         SFTrustManager.SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED, Boolean.TRUE.toString());
+    SFTrustManager.setOCSPResponseCacheServerURL(String.format("http://%s", host));
     File ocspCacheFile = new File(tmpFolder, "ocsp-cache");
     ocspCacheFile.createNewFile();
     HttpClient client =
@@ -191,6 +192,7 @@ public class SFTrustManagerIT extends BaseJDBCTest {
   public void testInvalidCacheFile(String host) throws Throwable {
     System.setProperty(
         SFTrustManager.SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED, Boolean.TRUE.toString());
+    SFTrustManager.setOCSPResponseCacheServerURL(String.format("http://%s", host));
     // a file under never exists.
     File ocspCacheFile = new File("NEVER_EXISTS", "NEVER_EXISTS");
     HttpClient client =


### PR DESCRIPTION
# Overview

SNOW-2889840

Reason of failures:
1. Test starts
2. cleanup() runs: SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE = null
3. Test enables cache server: SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED = true
4. Test does NOT call setOCSPResponseCacheServerURL()
5. HTTP request triggers SSL handshake
6. SSL triggers OCSP check → validateRevocationStatus()
7. validateRevocationStatus() calls readOcspResponseCacheServer()
8. new_endpoint_enabled is FALSE (no env var)
9. Code uses: ocspCacheServerInUse = SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE  // NULL!
10. new URI(null) → NullPointerException

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
