### PR TITLE
NO-SNOW bump netty to 4.1.130.Final to address CVE-2025-67735

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v3.28.1-SNAPSHOT
+  - - Bumped netty to 4.1.130.Final to address CVE-2025-67735
 - v3.28.0
     - Ability to choose connection configuration in auto configuration file by a parameter in JDBC url. (snowflakedb/snowflake-jdbc#2369)
     - Bumped grpc-java to 1.77.0 to address CVE-2025-58057 from transient dep (snowflakedb/snowflake-jdbc#2415)

--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -21,7 +21,7 @@
     <junit.version>5.11.1</junit.version>
     <surefire.version>3.5.1</surefire.version>
     <mockito.version>3.5.6</mockito.version>
-    <netty.version>4.1.128.Final</netty.version>
+    <netty.version>4.1.130.Final</netty.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -67,7 +67,7 @@
     <metrics.version>2.2.0</metrics.version>
     <mockito.version>4.11.0</mockito.version>
     <nimbusds.oauth2.version>11.20.1</nimbusds.oauth2.version>
-    <netty.version>4.1.128.Final</netty.version>
+    <netty.version>4.1.130.Final</netty.version>
     <nimbusds.version>10.3.1</nimbusds.version>
     <opencensus.version>0.31.1</opencensus.version>
     <plexus.container.version>1.0-alpha-9-stable-1</plexus.container.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -57,7 +57,7 @@
     <json.smart.version>2.5.2</json.smart.version>
     <jsoup.version>1.15.3</jsoup.version>
     <metrics.version>2.2.0</metrics.version>
-    <netty.version>4.1.128.Final</netty.version>
+    <netty.version>4.1.130.Final</netty.version>
     <nimbusds.version>10.3.1</nimbusds.version>
     <nimbusds.oauth2.version>11.20.1</nimbusds.oauth2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
#### Description
See https://github.com/netty/netty/security/advisories/GHSA-84h7-rjj3-6jx4 . It's fixed in 4.1.129.Final but 4.1.130.Final has some fix for a new regression introduced by .129