### PR TITLE
SNOW-3021048: Increase flaky Minicore loading init timeout in test

### DIFF
--- a/src/test/java/net/snowflake/client/internal/core/minicore/MinicoreTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/minicore/MinicoreTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 @Tag(TestTags.CORE)
 public class MinicoreTest {
 
-  private static final long MAX_MINICORE_INIT_TIME_MS = 1000;
+  private static final long MAX_MINICORE_INIT_TIME_MS = 5000;
   private static final int NUM_TIMING_RUNS = 5;
 
   @Test


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
