### PR TITLE
SNOW-3042412 Fix S3 client encrypting with incorrect algorithm when 256 key is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Changelog
 - v4.0.1-SNAPSHOT
     - Add /etc/os-release data to Minicore telemetry
-    - 
+    - Fix incorrect encryption algorithm chosen when a file was put to S3 with client_encryption_key_size account parameter set to 256 (snowflakedb/snowflake-jdbc#2472) 
     -
     -
     -

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ timestamps {
         string(name: 'parent_build_number', value: env.BUILD_NUMBER),
         string(name: 'timeout_value', value: '420'),
         string(name: 'PR_Key', value: scmInfo.GIT_BRANCH.substring(3)),
-        string(name: 'svn_revision', value: 'bptp-stable')
+        string(name: 'svn_revision', value: 'main')
       ]]
     }
 

--- a/linkage-checker-exclusion-rules.xml
+++ b/linkage-checker-exclusion-rules.xml
@@ -70,6 +70,11 @@
         <Source><Package name="com.nimbusds"/></Source>
         <Reason>?</Reason>
     </LinkageError>
+    <LinkageError>
+        <Target><Package name="org.joda.time"/></Target>
+        <Source><Package name="com.nimbusds.oauth2.sdk.assertions.saml2"/></Source>
+        <Reason>Optional</Reason>
+    </LinkageError>
     <!-- AWS SDK v1 exclusions - com.amazonaws.util is not used in runtime -->
     <LinkageError>
         <Target><Package name="com.amazonaws.util"/></Target>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -608,11 +608,6 @@
         <version>${version.plugin.wiremock}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>software.amazon.encryption.s3</groupId>
-        <artifactId>amazon-s3-encryption-client-java</artifactId>
-        <version>${awssdk.encryption.s3.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -686,10 +681,6 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.encryption.s3</groupId>
-      <artifactId>amazon-s3-encryption-client-java</artifactId>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/src/test/resources/test_encryption_256.csv
+++ b/src/test/resources/test_encryption_256.csv
@@ -1,0 +1,3 @@
+1,hello
+2,world
+3,test

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -106,11 +106,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>software.amazon.encryption.s3</groupId>
-        <artifactId>amazon-s3-encryption-client-java</artifactId>
-        <version>${awssdk.encryption.s3.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -199,10 +194,6 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.encryption.s3</groupId>
-      <artifactId>amazon-s3-encryption-client-java</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
When client_encryption_key_size parameter was set to 256, new AWS SDK v2 used AES-GCM instead of old AES-CBC, make put files unconsumable by the backend and other tools.