### PR TITLE
SNOW-3046829 Fix external browser authenticator name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
     - Fixed fat jar with S3 iteration, the problem of not finding class `software.amazon.awssdk.transfer.s3.internal.ApplyUserAgentInterceptor` (snowflakedb/snowflake-jdbc#2474).
     - Removed Conscrypt from shading to prevent `failed to find class org/conscrypt/CryptoUpcalls` native error (snowflakedb/snowflake-jdbc#2474).
     - Update BouncyCastle dependencies to fix CVE-2025-8916 CVE-2025-8885 (snowflakedb/snowflake-jdbc#2479)
+    - Fix external browser authentication after changing enum name. Manifested with `Invalid connection URL: Invalid SSOUrl found` error (snowflakedb/snowflake-jdbc#2475).
+    - Rolled back external browser authenticator name to `externalbrowser` (snowflakedb/snowflake-jdbc#2475).
+    -
     -
     -
     -

--- a/src/main/java/net/snowflake/client/api/auth/AuthenticatorType.java
+++ b/src/main/java/net/snowflake/client/api/auth/AuthenticatorType.java
@@ -12,7 +12,7 @@ package net.snowflake.client.api.auth;
  * <pre>{@code
  * Properties props = new Properties();
  * props.put("user", "myuser");
- * props.put("authenticator", "EXTERNAL_BROWSER");
+ * props.put("authenticator", "EXTERNALBROWSER");
  * Connection conn = DriverManager.getConnection(url, props);
  * }</pre>
  */
@@ -24,7 +24,7 @@ public enum AuthenticatorType {
   OKTA,
 
   /** Web-browser-based authenticator for SAML 2.0 compliant service/application */
-  EXTERNAL_BROWSER,
+  EXTERNALBROWSER,
 
   /** OAuth 2.0 authentication flow */
   OAUTH,

--- a/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSource.java
+++ b/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSource.java
@@ -65,7 +65,7 @@ public interface SnowflakeDataSource extends DataSource {
   /** Sets whether to use SSL (default: true). */
   void setSsl(boolean ssl);
 
-  /** Sets the authenticator type (e.g., "snowflake", "external_browser", "oauth"). */
+  /** Sets the authenticator type (e.g., "snowflake", "externalbrowser", "oauth"). */
   void setAuthenticator(String authenticator);
 
   /** Sets the token for OAuth/PAT authentication. */

--- a/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
@@ -38,7 +38,7 @@ public class SnowflakeBasicDataSource implements SnowflakeDataSource, Serializab
   private static final String AUTHENTICATOR_SNOWFLAKE_JWT = "SNOWFLAKE_JWT";
   private static final String AUTHENTICATOR_OAUTH = "OAUTH";
 
-  private static final String AUTHENTICATOR_EXTERNAL_BROWSER = "EXTERNAL_BROWSER";
+  private static final String AUTHENTICATOR_EXTERNAL_BROWSER = "EXTERNALBROWSER";
 
   private static final String AUTHENTICATOR_USERNAME_PASSWORD_MFA = "USERNAME_PASSWORD_MFA";
 

--- a/src/main/java/net/snowflake/client/internal/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSession.java
@@ -903,7 +903,7 @@ public class SFSession extends SFBaseSession {
   boolean isExternalbrowserOrOAuthFullFlowAuthenticator() {
     Map<SFSessionProperty, Object> connectionPropertiesMap = getConnectionPropertiesMap();
     String authenticator = (String) connectionPropertiesMap.get(SFSessionProperty.AUTHENTICATOR);
-    return AuthenticatorType.EXTERNAL_BROWSER.name().equalsIgnoreCase(authenticator)
+    return AuthenticatorType.EXTERNALBROWSER.name().equalsIgnoreCase(authenticator)
         || AuthenticatorType.OAUTH_AUTHORIZATION_CODE.name().equalsIgnoreCase(authenticator)
         || AuthenticatorType.OAUTH_CLIENT_CREDENTIALS.name().equalsIgnoreCase(authenticator);
   }

--- a/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
@@ -238,9 +238,9 @@ public class SessionUtil {
     if (loginInput.getAuthenticator() != null) {
       if (loginInput
           .getAuthenticator()
-          .equalsIgnoreCase(AuthenticatorType.EXTERNAL_BROWSER.name())) {
+          .equalsIgnoreCase(AuthenticatorType.EXTERNALBROWSER.name())) {
         // SAML 2.0 compliant service/application
-        return AuthenticatorType.EXTERNAL_BROWSER;
+        return AuthenticatorType.EXTERNALBROWSER;
       } else if (loginInput
           .getAuthenticator()
           .equalsIgnoreCase(AuthenticatorType.OAUTH_AUTHORIZATION_CODE.name())) {
@@ -408,7 +408,7 @@ public class SessionUtil {
   }
 
   private static boolean isEligibleForTokenCaching(AuthenticatorType authenticator) {
-    return authenticator.equals(AuthenticatorType.EXTERNAL_BROWSER)
+    return authenticator.equals(AuthenticatorType.EXTERNALBROWSER)
         || authenticator.equals(AuthenticatorType.OAUTH_AUTHORIZATION_CODE)
         || authenticator.equals(AuthenticatorType.OAUTH_CLIENT_CREDENTIALS);
   }
@@ -588,7 +588,7 @@ public class SessionUtil {
         uriBuilder.addParameter(SF_QUERY_ROLE, loginInput.getRole());
       }
 
-      if (authenticatorType == AuthenticatorType.EXTERNAL_BROWSER) {
+      if (authenticatorType == AuthenticatorType.EXTERNALBROWSER) {
         // try to reuse id_token if exists
         if (loginInput.getIdToken() == null) {
           // SAML 2.0 compliant service/application
@@ -647,13 +647,13 @@ public class SessionUtil {
        */
       if (authenticatorType == AuthenticatorType.SNOWFLAKE) {
         data.put(ClientAuthnParameter.PASSWORD.name(), loginInput.getPassword());
-      } else if (authenticatorType == AuthenticatorType.EXTERNAL_BROWSER) {
+      } else if (authenticatorType == AuthenticatorType.EXTERNALBROWSER) {
         if (loginInput.getIdToken() != null) {
           data.put(ClientAuthnParameter.AUTHENTICATOR.name(), ID_TOKEN_AUTHENTICATOR);
           data.put(ClientAuthnParameter.TOKEN.name(), loginInput.getIdToken());
         } else {
           data.put(
-              ClientAuthnParameter.AUTHENTICATOR.name(), AuthenticatorType.EXTERNAL_BROWSER.name());
+              ClientAuthnParameter.AUTHENTICATOR.name(), AuthenticatorType.EXTERNALBROWSER.name());
           data.put(ClientAuthnParameter.PROOF_KEY.name(), samlProofKey);
           data.put(ClientAuthnParameter.TOKEN.name(), tokenOrSamlResponse);
         }

--- a/src/main/resources/net/snowflake/client/jdbc/jdbc_error_messages.properties
+++ b/src/main/resources/net/snowflake/client/jdbc/jdbc_error_messages.properties
@@ -91,7 +91,7 @@ Error message={3}, Extended error info={4}
 200070=Error during obtaining OAuth access token using refresh token: {0}
 200071=Error during Workload Identity authentication: {0}
 200072=MFA enabled in Okta is not supported with this authenticator type. \
-  Please use 'external_browser' instead or a different authentication method.
+  Please use 'externalbrowser' instead or a different authentication method.
 200073=Invalid certificate revocation mode: {0}.
 200074=OCSP and certificate revocation mode checks cannot be enabled at the same time.
 253000=Error during file transfer: {0}

--- a/src/test/java/net/snowflake/client/authentication/AuthConnectionParameters.java
+++ b/src/test/java/net/snowflake/client/authentication/AuthConnectionParameters.java
@@ -32,7 +32,7 @@ public class AuthConnectionParameters {
   static Properties getExternalBrowserConnectionParameters() {
     Properties properties = getBaseConnectionParameters();
     properties.put("user", SSO_USER);
-    properties.put("authenticator", "external_browser");
+    properties.put("authenticator", "externalbrowser");
     return properties;
   }
 

--- a/src/test/java/net/snowflake/client/internal/core/SessionUtilExternalBrowserTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SessionUtilExternalBrowserTest.java
@@ -269,7 +269,7 @@ public class SessionUtilExternalBrowserTest {
     // mock SFLoginInput
     SFLoginInput loginInput = mock(SFLoginInput.class);
     when(loginInput.getServerUrl()).thenReturn("https://testaccount.snowflakecomputing.com/");
-    when(loginInput.getAuthenticator()).thenReturn("external_browser");
+    when(loginInput.getAuthenticator()).thenReturn("externalbrowser");
     when(loginInput.getAccountName()).thenReturn("testaccount");
     when(loginInput.getUserName()).thenReturn("testuser");
     when(loginInput.getDisableConsoleLogin()).thenReturn(true);

--- a/src/test/java/net/snowflake/client/internal/core/SessionUtilWiremockIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/SessionUtilWiremockIT.java
@@ -263,7 +263,7 @@ public class SessionUtilWiremockIT extends BaseWiremockTest {
     assertThat(
         thrown.getMessage(),
         equalTo(
-            "MFA enabled in Okta is not supported with this authenticator type. Please use 'external_browser' instead or a different authentication method."));
+            "MFA enabled in Okta is not supported with this authenticator type. Please use 'externalbrowser' instead or a different authentication method."));
   }
 
   private void assertThatTotalLoginTimeoutIsKeptWhenRetrying(

--- a/src/test/java/net/snowflake/client/internal/jdbc/ConnectionManual.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/ConnectionManual.java
@@ -60,7 +60,7 @@ public class ConnectionManual {
     properties.put("account", account);
     properties.put("ssl", ssl);
     properties.put("tracing", "FINEST");
-    properties.put("authenticator", "external_browser");
+    properties.put("authenticator", "externalbrowser");
     properties.put("CLIENT_STORE_TEMPORARY_CREDENTIAL", true);
     return properties;
   }

--- a/src/test/java/net/snowflake/client/internal/jdbc/SSOConnectionTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/SSOConnectionTest.java
@@ -261,7 +261,7 @@ public class SSOConnectionTest {
                   assertThat(
                       "authenticator",
                       jsonNode.path("data").path("AUTHENTICATOR").asText(),
-                      equalTo("EXTERNAL_BROWSER"));
+                      equalTo("EXTERNALBROWSER"));
                   resp = retInitialAuthentication;
                 } else if (callCount == 2) {
                   jsonNode = parseRequest((HttpPost) args[0]);
@@ -321,7 +321,7 @@ public class SSOConnectionTest {
       properties.put("password", "testpassword");
       properties.put("account", "testaccount");
       properties.put("insecureMode", true);
-      properties.put("authenticator", "EXTERNAL_BROWSER");
+      properties.put("authenticator", "EXTERNALBROWSER");
       properties.put("CLIENT_STORE_TEMPORARY_CREDENTIAL", true);
 
       // connect url


### PR DESCRIPTION
Fixed external browser authenticator name. After migrating to JDBC v4, the enum name was changed, and it was sent to backend incorrectly.