### PR TITLE
SNOW-3010074 Fix incorrect closing of HTTP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - Adjust level of logging during Driver initialization
     - Add sanitization for nonProxyHosts RegEx patterns
     - Fix bug with malformed file during S3 upload
+    - Added periodic closure of sockets closed by the remote end (snowflakedb/snowflake-jdbc#2481).
 
 - v4.0.1
     - Add /etc/os-release data to Minicore telemetry

--- a/src/main/java/net/snowflake/client/internal/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/RestRequest.java
@@ -973,6 +973,11 @@ public class RestRequest {
                   + " The HttpClient was shut down due to connection closure. "
                   + "Attempting to rebuild the HttpClient and retry the request.");
           // Clear the httpClient cache.
+          try {
+            httpClient.close();
+          } catch (IOException e) {
+            logger.warn("Cannot close http client", e);
+          }
           HttpUtil.httpClient.remove(key);
           // rebuild the http client.
           if (isHttpClientWithoutDecompression) {

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeChunkDownloader.java
@@ -720,7 +720,6 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
         if (downloaderFuture != null) {
           downloaderFuture.cancel(true);
         }
-        HttpUtil.closeExpiredAndIdleConnections();
 
         chunks.get(nextChunkToConsume).getLock().lock();
         try {

--- a/src/test/java/net/snowflake/client/internal/core/HttpUtilWiremockLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/HttpUtilWiremockLatestIT.java
@@ -102,7 +102,11 @@ public class HttpUtilWiremockLatestIT extends BaseWiremockTest {
         };
 
     try (CloseableHttpClient httpClient =
-        HttpUtil.buildHttpClient(null, null, false, Collections.singletonList(customizer))) {
+        HttpUtil.buildHttpClient(
+            new HttpClientSettingsKey(OCSPMode.DISABLE_OCSP_CHECKS),
+            null,
+            false,
+            Collections.singletonList(customizer))) {
       CloseableHttpResponse response =
           httpClient.execute(
               new HttpGet(

--- a/src/test/java/net/snowflake/client/internal/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/SessionUtilLatestIT.java
@@ -109,14 +109,9 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
 
   @Test
   public void testConvertSystemPropertyToIntValue() {
-    // SNOW-760642 - Test that new default for net.snowflake.jdbc.ttl is 60 seconds.
-    assertEquals(
-        60, SystemUtil.convertSystemPropertyToIntValue(HttpUtil.JDBC_TTL, HttpUtil.DEFAULT_TTL));
-
-    // Test that TTL can be disabled
-    System.setProperty(HttpUtil.JDBC_TTL, "-1");
-    assertEquals(
-        -1, SystemUtil.convertSystemPropertyToIntValue(HttpUtil.JDBC_TTL, HttpUtil.DEFAULT_TTL));
+    assertEquals(1, SystemUtil.convertSystemPropertyToIntValue("test.property", 1));
+    System.setProperty("test.property", "-1");
+    assertEquals(-1, SystemUtil.convertSystemPropertyToIntValue("test.property", 1));
   }
 
   /**

--- a/src/test/java/net/snowflake/client/internal/jdbc/BaseWiremockTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/BaseWiremockTest.java
@@ -75,7 +75,7 @@ public abstract class BaseWiremockTest {
   public void tearDown() {
     restoreTrustStorePathProperty();
     resetWiremock();
-    HttpUtil.httpClient.clear();
+    HttpUtil.reset();
   }
 
   @AfterAll

--- a/src/test/java/net/snowflake/client/internal/jdbc/PrivateKeyAuthenticationExceptionHandlingLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/PrivateKeyAuthenticationExceptionHandlingLatestIT.java
@@ -16,6 +16,7 @@ import net.snowflake.client.category.TestTags;
 import net.snowflake.client.internal.core.HttpUtil;
 import net.snowflake.client.internal.core.SecurityUtil;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,6 +30,11 @@ public class PrivateKeyAuthenticationExceptionHandlingLatestIT {
 
   static Stream<String> timeOutSettings() {
     return Stream.of("HTTP_CLIENT_CONNECTION_TIMEOUT", "HTTP_CLIENT_SOCKET_TIMEOUT");
+  }
+
+  @BeforeEach
+  void setup() {
+    HttpUtil.reset();
   }
 
   @AfterEach


### PR DESCRIPTION
# Overview

SNOW-3010074 Fixes a couple of problems related to HTTP connections closing.

1. Run a background thread, that monitors idle or expired connections and close them by setting `evictIdleConnections` and `evictExpiredConnections`. This one creates a thread that actively monitors such connections. This thread is closed on either JVM shutdown (daemon) or when HTTP client is explicitly closed.
2. Close HTTP client correctly. We cache HTTP clients, but in case of specific exceptions, we remove a connection from the cache. Added the code that closes HTTP client then, to prevent thread leaks.
3. Use `setValidateAfterInactivity` on a pool. With this setting, before retrieving a connection from a pool, the pool checks if the connection is still valid (i.e. it is not closed on the remote end).
4. Introduced `net.snowflake.jdbc.idle_connection_timeout` (default 30s) that is used as a timeout in all three mentioned functions.