### PR TITLE
NO-SNOW: minicore: fix missing async initialization in DriverInitializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Changelog
 - Upcoming release (TBD)
     - Fix expired session token renewal when polling results (snowflakedb/snowflake-jdbc#2489)   
+    - Fix missing minicore async initialization that was dropped during public API restructuring in v4.0.0
 
 - v4.0.1
     - Add /etc/os-release data to Minicore telemetry

--- a/src/main/java/net/snowflake/client/internal/driver/DriverInitializer.java
+++ b/src/main/java/net/snowflake/client/internal/driver/DriverInitializer.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.driver;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import net.snowflake.client.internal.core.SecurityUtil;
+import net.snowflake.client.internal.core.minicore.Minicore;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.internal.log.SFLogger;
@@ -51,6 +52,7 @@ public final class DriverInitializer {
     initializeArrowSupport();
     initializeSecurityProvider();
     initializeTelemetry();
+    initializeMinicore();
 
     initialized = true;
     logger.info("Snowflake JDBC Driver initialization complete");
@@ -164,6 +166,21 @@ public final class DriverInitializer {
       logger.debug("Out-of-band telemetry disabled");
     } catch (Throwable t) {
       logger.warn("Failed to configure telemetry: {}", t.getMessage());
+    }
+  }
+
+  /**
+   * Start asynchronous minicore native library loading.
+   *
+   * <p>Minicore is loaded in the background so it can overlap with connection setup. The loading
+   * result is reported via telemetry during session establishment.
+   */
+  private static void initializeMinicore() {
+    try {
+      Minicore.initializeAsync();
+      logger.debug("Minicore async initialization started");
+    } catch (Throwable t) {
+      logger.trace("Failed to start minicore initialization", t);
     }
   }
 


### PR DESCRIPTION
The call to `Minicore.initializeAsync()` was accidentally dropped during the public API restructuring in ea681a0c (SNOW-1050490). The original `initializeMinicore()` method in SnowflakeDriver's static block was not carried over to the new `DriverInitializer` class, causing minicore to never load and telemetry to always report `STILL_LOADING`.

Restore the initialization call in `DriverInitializer.initialize()` so the native library loads asynchronously at driver startup, is intended.

## Pre-review self checklist
- [X] PR branch is updated with all the changes from `master` branch
- [X] The code is correctly formatted (run `mvn -P check-style validate`)
- [X] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [X] The pull request name is prefixed with `SNOW-XXXX: `
- [X] Code is in compliance with internal logging requirements
