### PR TITLE
NO-SNOW: Fix flaky CLR test

### DIFF
--- a/src/test/java/net/snowflake/client/internal/core/crl/CRLCacheManagerLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/crl/CRLCacheManagerLatestIT.java
@@ -151,9 +151,9 @@ public class CRLCacheManagerLatestIT {
   void testCacheManagerPeriodicCleanup() throws Exception {
     CRLCacheManager managerWithCleanup =
         CRLCacheManager.build(
-            true, true, tempCacheDir, Duration.ofMillis(100), Duration.ofMillis(10));
-    managerWithCleanup.put(TEST_CRL_URL, testCRL, downloadTime.minus(200, ChronoUnit.MILLIS));
-    managerWithCleanup.put(TEST_CRL_URL_2, testCRL2, downloadTime);
+            true, true, tempCacheDir, Duration.ofSeconds(1), Duration.ofMillis(10));
+    managerWithCleanup.put(TEST_CRL_URL, testCRL, downloadTime.minus(2, ChronoUnit.SECONDS));
+    managerWithCleanup.put(TEST_CRL_URL_2, testCRL2, downloadTime.minus(2, ChronoUnit.SECONDS));
 
     assertNotNull(managerWithCleanup.get(TEST_CRL_URL));
     assertNotNull(managerWithCleanup.get(TEST_CRL_URL_2));


### PR DESCRIPTION
# Overview

Fix flaky testCacheManagerPeriodicCleanup test by increasing the cleanup interval from 100ms to 1s and making cache entries clearly older than the removal delay, preventing a race condition where the periodic cleanup task fires before the initial assertions can execute.

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
