### PR TITLE
NO-SNOW: Remove obsolete flaky test

### DIFF
--- a/src/test/java/net/snowflake/client/internal/jdbc/ConnectionIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/ConnectionIT.java
@@ -159,30 +159,6 @@ public class ConnectionIT extends BaseJDBCWithSharedConnectionIT {
   }
 
   @Test
-  public void testDataCompletenessInLowMemory() throws Exception {
-    try (Connection connection = getConnection();
-        Statement statement = connection.createStatement()) {
-      for (int i = 0; i < 6; i++) {
-        int resultSize = 1000000 + i;
-        statement.execute("ALTER SESSION SET CLIENT_MEMORY_LIMIT=100");
-        try (ResultSet resultSet =
-            statement.executeQuery(
-                "select randstr(80, random()) from table(generator(rowcount => "
-                    + resultSize
-                    + "))")) {
-
-          int size = 0;
-          while (resultSet.next()) {
-            size++;
-          }
-          System.out.println("Total records: " + size);
-          assertEquals(size, resultSize);
-        }
-      }
-    }
-  }
-
-  @Test
   @DontRunOnGithubActions
   public void testConnectionGetAndSetDBAndSchema() throws SQLException {
     final String SECOND_DATABASE = "SECOND_DATABASE";


### PR DESCRIPTION
# Overview

Remove testDataCompletenessInLowMemory from ConnectionIT — the test uses CLIENT_MEMORY_LIMIT=10 (10MB), which is far below the minimum chunk size (48MB). Existing chunk download and memory limit tests (testClientMemoryParameters, testClientMemoryJvmParameters, testClientMixedMemoryJvmParameters) continue to validate memory parameter handling.

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
