### PR TITLE
SNOW-2999722: Add internal API telemetry tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Add sanitization for nonProxyHosts RegEx patterns
     - Fix bug with malformed file during S3 upload
     - Added periodic closure of sockets closed by the remote end (snowflakedb/snowflake-jdbc#2481).
+    - Add internal API usage telemetry tracker
 
 - v4.0.1
     - Add /etc/os-release data to Minicore telemetry

--- a/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.api.implementation.connection;
 import static net.snowflake.client.api.exception.ErrorCode.FEATURE_UNSUPPORTED;
 import static net.snowflake.client.api.exception.ErrorCode.INVALID_CONNECT_STRING;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.recordIfExternal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -60,6 +61,7 @@ import net.snowflake.client.internal.jdbc.SFConnectionHandler;
 import net.snowflake.client.internal.jdbc.SnowflakeClob;
 import net.snowflake.client.internal.jdbc.SnowflakeConnectString;
 import net.snowflake.client.internal.jdbc.SnowflakeLoggedFeatureNotSupportedException;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.log.SFLoggerUtil;
@@ -848,6 +850,11 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
   }
 
   public SFConnectionHandler getHandler() {
+    return getHandler(null);
+  }
+
+  public SFConnectionHandler getHandler(InternalCallMarker internalCallMarker) {
+    recordIfExternal("SnowflakeConnectionImpl", "getHandler", internalCallMarker);
     return sfConnectionHandler;
   }
 
@@ -1086,12 +1093,23 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
   }
 
   public SFBaseSession getSFBaseSession() {
+    return getSFBaseSession(null);
+  }
+
+  public SFBaseSession getSFBaseSession(InternalCallMarker internalCallMarker) {
+    recordIfExternal("SnowflakeConnectionImpl", "getSFBaseSession", internalCallMarker);
     return sfSession;
   }
 
   // Convenience method to return an SFSession-typed SFBaseSession object, but
   // performs the type-checking as necessary.
   public SFSession getSfSession() throws SnowflakeSQLException {
+    return getSfSession(null);
+  }
+
+  public SFSession getSfSession(InternalCallMarker internalCallMarker)
+      throws SnowflakeSQLException {
+    recordIfExternal("SnowflakeConnectionImpl", "getSfSession", internalCallMarker);
     if (sfSession instanceof SFSession) {
       return (SFSession) sfSession;
     }

--- a/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -14,6 +14,7 @@ import static net.snowflake.client.internal.jdbc.DBMetadataResultSetMetadata.GET
 import static net.snowflake.client.internal.jdbc.DBMetadataResultSetMetadata.GET_TABLES;
 import static net.snowflake.client.internal.jdbc.DBMetadataResultSetMetadata.GET_TABLE_PRIVILEGES;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 import static net.snowflake.client.internal.jdbc.util.SnowflakeTypeHelper.convertStringToType;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -181,7 +182,8 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
     logger.trace("SnowflakeDatabaseMetaDataImpl(SnowflakeConnection connection)", false);
 
     this.connection = connection;
-    this.session = connection.unwrap(SnowflakeConnectionImpl.class).getSFBaseSession();
+    this.session =
+        connection.unwrap(SnowflakeConnectionImpl.class).getSFBaseSession(internalCallMarker());
     this.metadataRequestUseConnectionCtx = session.getMetadataRequestUseConnectionCtx();
     this.metadataRequestUseSessionDatabase = session.getMetadataRequestUseSessionDatabase();
     this.stringsQuoted = session.isStringQuoted();

--- a/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeBaseResultSet.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.internal.api.implementation.resultset;
 
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.mapSFExceptionToSQLException;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -88,7 +89,8 @@ public abstract class SnowflakeBaseResultSet implements ResultSet, SnowflakeResu
 
   private static SFBaseSession maybeGetSession(Statement statement) {
     try {
-      return ((SnowflakeConnectionImpl) statement.getConnection()).getSFBaseSession();
+      return ((SnowflakeConnectionImpl) statement.getConnection())
+          .getSFBaseSession(internalCallMarker());
     } catch (SQLException e) {
       // This exception shouldn't be hit. Statement class should be able to be unwrapped.
       logger.error(

--- a/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeCallableStatementImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeCallableStatementImpl.java
@@ -1,5 +1,7 @@
 package net.snowflake.client.internal.api.implementation.statement;
 
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -81,391 +83,455 @@ public final class SnowflakeCallableStatementImpl extends SnowflakePreparedState
   @Override
   public void registerOutParameter(int parameterIndex, int sqlType) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void registerOutParameter(int parameterIndex, int sqlType, int scale) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void registerOutParameter(int parameterIndex, int sqlType, String typeName)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void registerOutParameter(String parameterName, int sqlType) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void registerOutParameter(String parameterName, int sqlType, int scale)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void registerOutParameter(String parameterName, int sqlType, String typeName)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public boolean wasNull() throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public String getString(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public String getString(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public boolean getBoolean(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public boolean getBoolean(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public byte getByte(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public byte getByte(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public short getShort(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public short getShort(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public int getInt(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public int getInt(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public long getLong(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public long getLong(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public float getFloat(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public float getFloat(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public double getDouble(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public double getDouble(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   @Deprecated
   public BigDecimal getBigDecimal(int parameterIndex, int scale) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   @Deprecated
   public BigDecimal getBigDecimal(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   @Deprecated
   public BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public byte[] getBytes(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public byte[] getBytes(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Date getDate(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Date getDate(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Time getTime(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Time getTime(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Time getTime(String parameterName, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Timestamp getTimestamp(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Timestamp getTimestamp(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Timestamp getTimestamp(String parameterName, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Object getObject(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Object getObject(int parameterIndex, Map<String, Class<?>> map) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Object getObject(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Object getObject(String parameterName, Map<String, Class<?>> map) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Ref getRef(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Ref getRef(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Blob getBlob(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Blob getBlob(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Clob getClob(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Clob getClob(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Array getArray(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Array getArray(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Date getDate(String parameterName, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public URL getURL(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public URL getURL(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public RowId getRowId(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public RowId getRowId(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public SQLXML getSQLXML(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public SQLXML getSQLXML(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public String getNString(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public String getNString(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Reader getNCharacterStream(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Reader getNCharacterStream(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Reader getCharacterStream(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public Reader getCharacterStream(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   /*
@@ -476,300 +542,349 @@ public final class SnowflakeCallableStatementImpl extends SnowflakePreparedState
   @Override
   public void setSQLXML(String parameterName, SQLXML xmlObject) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setRowId(String parameterName, RowId x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNString(String parameterName, String value) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNCharacterStream(String parameterName, Reader value) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNCharacterStream(String parameterName, Reader value, long length)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNClob(String parameterName, NClob value) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setClob(String parameterName, Reader reader, long length) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setClob(String parameterName, Reader reader) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setClob(String parameterName, Clob x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBlob(String parameterName, InputStream inputStream, long length)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBlob(String parameterName, InputStream inputStream) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNClob(String parameterName, Reader reader) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBlob(String parameterName, Blob x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNClob(String parameterName, Reader reader, long length) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public NClob getNClob(int parameterIndex) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public NClob getNClob(String parameterName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setURL(String parameterName, URL val) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNull(String parameterName, int sqlType) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBoolean(String parameterName, boolean x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setByte(String parameterName, byte x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setShort(String parameterName, short x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setInt(String parameterName, int x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setLong(String parameterName, long x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setFloat(String parameterName, float x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setDouble(String parameterName, double x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBigDecimal(String parameterName, BigDecimal x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setString(String parameterName, String x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBytes(String parameterName, byte[] x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setDate(String parameterName, Date x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setTime(String parameterName, Time x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setTimestamp(String parameterName, Timestamp x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setAsciiStream(String parameterName, InputStream x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setAsciiStream(String parameterName, InputStream x, int length) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setAsciiStream(String parameterName, InputStream x, long length) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBinaryStream(String parameterName, InputStream x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBinaryStream(String parameterName, InputStream x, int length) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBinaryStream(String parameterName, InputStream x, long length)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setObject(String parameterName, Object x, int targetSqlType, int scale)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setObject(String parameterName, Object x, int targetSqlType) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setObject(String parameterName, Object x) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setCharacterStream(String parameterName, Reader reader, int length)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setCharacterStream(String parameterName, Reader reader, long length)
       throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setCharacterStream(String parameterName, Reader reader) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setDate(String parameterName, Date x, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setTime(String parameterName, Time x, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setTimestamp(String parameterName, Timestamp x, Calendar cal) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNull(String parameterName, int sqlType, String typeName) throws SQLException {
 
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 }

--- a/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -1,5 +1,7 @@
 package net.snowflake.client.internal.api.implementation.statement;
 
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
@@ -140,7 +142,9 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     this.sql = sql;
     this.preparedStatementMetaData = SFPreparedStatementMetaData.emptyMetaData();
     showStatementParameters = connection.getShowStatementParameters();
-    objectMapper = ObjectMapperFactory.getObjectMapperForSession(connection.getSFBaseSession());
+    objectMapper =
+        ObjectMapperFactory.getObjectMapperForSession(
+            connection.getSFBaseSession(internalCallMarker()));
   }
 
   /**
@@ -160,7 +164,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
               sql);
         }
       } catch (SFException e) {
-        throw new SnowflakeSQLLoggedException(connection.getSFBaseSession(), e);
+        throw new SnowflakeSQLLoggedException(connection.getSFBaseSession(internalCallMarker()), e);
       } catch (SnowflakeSQLException e) {
         if (!errorCodesIgnoredInDescribeMode.contains(e.getErrorCode())) {
           throw e;
@@ -245,7 +249,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     logger.trace("setBoolean(parameterIndex: {}, boolean x)", parameterIndex);
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BOOLEAN, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.BOOLEAN, connection.getSFBaseSession(internalCallMarker())),
             String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -255,7 +260,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     logger.trace("setByte(parameterIndex: {}, byte x)", parameterIndex);
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.TINYINT, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.TINYINT, connection.getSFBaseSession(internalCallMarker())),
             String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -266,7 +272,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.SMALLINT, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.SMALLINT, connection.getSFBaseSession(internalCallMarker())),
             String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -277,7 +284,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.INTEGER, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.INTEGER, connection.getSFBaseSession(internalCallMarker())),
             String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -288,7 +296,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.BIGINT, connection.getSFBaseSession(internalCallMarker())),
             String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -299,7 +308,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BIGINT, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.BIGINT, connection.getSFBaseSession(internalCallMarker())),
             String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -310,7 +320,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.FLOAT, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.FLOAT, connection.getSFBaseSession(internalCallMarker())),
             String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -321,7 +332,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.DOUBLE, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.DOUBLE, connection.getSFBaseSession(internalCallMarker())),
             String.valueOf(x));
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -335,7 +347,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     } else {
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.DECIMAL, connection.getSFBaseSession()),
+              SnowflakeUtil.javaTypeToSFTypeString(
+                  Types.DECIMAL, connection.getSFBaseSession(internalCallMarker())),
               String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
@@ -347,7 +360,9 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.VARCHAR, connection.getSFBaseSession()), x);
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.VARCHAR, connection.getSFBaseSession(internalCallMarker())),
+            x);
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
 
@@ -357,7 +372,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
-            SnowflakeUtil.javaTypeToSFTypeString(Types.BINARY, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.BINARY, connection.getSFBaseSession(internalCallMarker())),
             new SFBinary(x).toHex());
     parameterBindings.put(String.valueOf(parameterIndex), binding);
   }
@@ -365,12 +381,14 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   private void setObjectInternal(int parameterIndex, SQLData sqlData) throws SQLException {
     logger.debug("setObjectInternal(parameterIndex: {}, SqlData sqlData)", parameterIndex);
 
-    JsonSqlOutput stream = new JsonSqlOutput(sqlData, connection.getSFBaseSession());
+    JsonSqlOutput stream =
+        new JsonSqlOutput(sqlData, connection.getSFBaseSession(internalCallMarker()));
     sqlData.writeSQL(stream);
     ParameterBindingDTO binding =
         new ParameterBindingDTO(
             "json",
-            SnowflakeUtil.javaTypeToSFTypeString(Types.STRUCT, connection.getSFBaseSession()),
+            SnowflakeUtil.javaTypeToSFTypeString(
+                Types.STRUCT, connection.getSFBaseSession(internalCallMarker())),
             stream.getJsonString(),
             stream.getSchema());
     parameterBindings.put(String.valueOf(parameterIndex), binding);
@@ -385,7 +403,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     } else {
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.DATE, connection.getSFBaseSession()),
+              SnowflakeUtil.javaTypeToSFTypeString(
+                  Types.DATE, connection.getSFBaseSession(internalCallMarker())),
               String.valueOf(
                   x.getTime()
                       + TimeZone.getDefault().getOffset(x.getTime())
@@ -403,7 +422,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
       setNull(parameterIndex, Types.TIME);
     } else {
       String value;
-      if (connection.getSFBaseSession().getTreatTimeAsWallClockTime()) {
+      if (connection.getSFBaseSession(internalCallMarker()).getTreatTimeAsWallClockTime()) {
         value = String.valueOf(x.toLocalTime().toNanoOfDay());
       } else {
         value = String.valueOf(SfTimestampUtil.getTimeInNanoseconds(x));
@@ -411,7 +430,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.TIME, connection.getSFBaseSession()),
+              SnowflakeUtil.javaTypeToSFTypeString(
+                  Types.TIME, connection.getSFBaseSession(internalCallMarker())),
               value);
 
       parameterBindings.put(String.valueOf(parameterIndex), binding);
@@ -444,7 +464,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
         bindingTypeName = SnowflakeType.TIMESTAMP_NTZ.name();
         break;
       default:
-        bindingTypeName = connection.getSFBaseSession().getTimestampMappedType().name();
+        bindingTypeName =
+            connection.getSFBaseSession(internalCallMarker()).getTimestampMappedType().name();
         break;
     }
 
@@ -454,18 +475,21 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
   @Override
   public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   @Deprecated
   public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
@@ -500,7 +524,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(targetSqlType, connection.getSFBaseSession()),
+              SnowflakeUtil.javaTypeToSFTypeString(
+                  targetSqlType, connection.getSFBaseSession(internalCallMarker())),
               String.valueOf(x));
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
@@ -576,7 +601,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
       setObjectInternal(parameterIndex, (SQLData) x);
     } else {
       throw new SnowflakeSQLLoggedException(
-          connection.getSFBaseSession(),
+          connection.getSFBaseSession(internalCallMarker()),
           ErrorCode.DATA_TYPE_NOT_SUPPORTED.getMessageCode(),
           SqlState.FEATURE_NOT_SUPPORTED,
           "Object type: " + x.getClass());
@@ -649,7 +674,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
               row = Integer.toString(values.size() + 1);
             }
             throw new SnowflakeSQLLoggedException(
-                connection.getSFBaseSession(),
+                connection.getSFBaseSession(internalCallMarker()),
                 ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED.getMessageCode(),
                 SqlState.FEATURE_NOT_SUPPORTED,
                 SnowflakeTypeUtil.getJavaType(SnowflakeTypeUtil.fromString(prevType), false).name(),
@@ -677,17 +702,20 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, int length)
       throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setRef(int parameterIndex, Ref x) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBlob(int parameterIndex, Blob x) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
@@ -702,17 +730,23 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
               "json",
-              SnowflakeUtil.javaTypeToSFTypeString(Types.ARRAY, connection.getSFBaseSession()),
+              SnowflakeUtil.javaTypeToSFTypeString(
+                  Types.ARRAY, connection.getSFBaseSession(internalCallMarker())),
               sfArray.getJsonString(),
               sfArray.getSchema());
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     } else {
       SfSqlArray sfArray =
-          new SfSqlArray(Types.INTEGER, array, connection.getSFBaseSession(), objectMapper);
+          new SfSqlArray(
+              Types.INTEGER,
+              array,
+              connection.getSFBaseSession(internalCallMarker()),
+              objectMapper);
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
               "json",
-              SnowflakeUtil.javaTypeToSFTypeString(Types.ARRAY, connection.getSFBaseSession()),
+              SnowflakeUtil.javaTypeToSFTypeString(
+                  Types.ARRAY, connection.getSFBaseSession(internalCallMarker())),
               sfArray.getJsonString(),
               sfArray.getSchema());
       parameterBindings.put(String.valueOf(parameterIndex), binding);
@@ -724,7 +758,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     BindingParameterMetadata valueTypeSchema;
     if (Types.STRUCT == type) {
       SQLData sqlData = (SQLData) map.values().stream().findFirst().orElse(null);
-      JsonSqlOutput stream = new JsonSqlOutput(sqlData, connection.getSFBaseSession());
+      JsonSqlOutput stream =
+          new JsonSqlOutput(sqlData, connection.getSFBaseSession(internalCallMarker()));
       sqlData.writeSQL(stream);
       valueTypeSchema = stream.getSchema();
     } else {
@@ -744,7 +779,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
       binding =
           new ParameterBindingDTO(
               "json",
-              SnowflakeUtil.javaTypeToSFTypeString(Types.STRUCT, connection.getSFBaseSession()),
+              SnowflakeUtil.javaTypeToSFTypeString(
+                  Types.STRUCT, connection.getSFBaseSession(internalCallMarker())),
               SnowflakeUtil.mapJson(map),
               schema);
     } catch (JsonProcessingException e) {
@@ -780,7 +816,8 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
       ParameterBindingDTO binding =
           new ParameterBindingDTO(
-              SnowflakeUtil.javaTypeToSFTypeString(Types.DATE, connection.getSFBaseSession()),
+              SnowflakeUtil.javaTypeToSFTypeString(
+                  Types.DATE, connection.getSFBaseSession(internalCallMarker())),
               value);
       parameterBindings.put(String.valueOf(parameterIndex), binding);
     }
@@ -801,12 +838,13 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     // convert the time from being in UTC to be in local time zone
     String value = null;
     SnowflakeType sfType =
-        SnowflakeUtil.javaTypeToSFType(Types.TIMESTAMP, connection.getSFBaseSession());
+        SnowflakeUtil.javaTypeToSFType(
+            Types.TIMESTAMP, connection.getSFBaseSession(internalCallMarker()));
     if (x != null) {
       long milliSecSinceEpoch = x.getTime();
 
       if (sfType == SnowflakeType.TIMESTAMP) {
-        sfType = connection.getSFBaseSession().getTimestampMappedType();
+        sfType = connection.getSFBaseSession(internalCallMarker()).getTimestampMappedType();
       }
       // if type is timestamp_tz, keep the offset and the time value separate.
       // store the offset, in minutes, as amount it's off from UTC
@@ -843,55 +881,65 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
   @Override
   public void setURL(int parameterIndex, URL x) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public ParameterMetaData getParameterMetaData() throws SQLException {
     describeSqlIfNotTried();
-    return new SnowflakeParameterMetadata(preparedStatementMetaData, connection.getSFBaseSession());
+    return new SnowflakeParameterMetadata(
+        preparedStatementMetaData, connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setRowId(int parameterIndex, RowId x) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNString(int parameterIndex, String value) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNCharacterStream(int parameterIndex, Reader value, long length)
       throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNClob(int parameterIndex, NClob value) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBlob(int parameterIndex, InputStream inputStream, long length)
       throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
@@ -914,53 +962,63 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
   @Override
   public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, long length)
       throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setClob(int parameterIndex, Reader reader) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public void setNClob(int parameterIndex, Reader reader) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
@@ -1094,32 +1152,38 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
   @Override
   public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public int executeUpdate(String sql, String[] columnNames) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public boolean execute(String sql, int[] columnIndexes) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   @Override
   public boolean execute(String sql, String[] columnNames) throws SQLException {
-    throw new SnowflakeLoggedFeatureNotSupportedException(connection.getSFBaseSession());
+    throw new SnowflakeLoggedFeatureNotSupportedException(
+        connection.getSFBaseSession(internalCallMarker()));
   }
 
   // For testing use only

--- a/src/main/java/net/snowflake/client/internal/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSession.java
@@ -39,6 +39,7 @@ import net.snowflake.client.internal.jdbc.SnowflakeConnectString;
 import net.snowflake.client.internal.jdbc.SnowflakeReauthenticationRequest;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
 import net.snowflake.client.internal.jdbc.diagnostic.DiagnosticContext;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
@@ -853,6 +854,9 @@ public class SFSession extends SFBaseSession {
     startHeartbeatForThisSession();
     this.getTelemetryClient();
 
+    // Flush any internal API usage telemetry that accumulated before session login
+    InternalApiTelemetryTracker.flush(getTelemetryClient());
+
     // Send minicore telemetry after session is established
     sendMinicoreTelemetry();
 
@@ -1010,6 +1014,7 @@ public class SFSession extends SFBaseSession {
         .setHttpClientSettingsKey(getHttpClientKey());
 
     SessionUtil.closeSession(loginInput, this);
+    InternalApiTelemetryTracker.flush(getTelemetryClient());
     closeTelemetryClient();
     getClientInfo().clear();
 

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeDatabaseMetaDataResultSet.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeDatabaseMetaDataResultSet.java
@@ -1,5 +1,7 @@
 package net.snowflake.client.internal.jdbc;
 
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
@@ -57,7 +59,10 @@ public class SnowflakeDatabaseMetaDataResultSet extends SnowflakeBaseResultSet {
     this.showObjectResultSet = showObjectResultSet;
 
     SFBaseSession session =
-        statement.getConnection().unwrap(SnowflakeConnectionImpl.class).getSFBaseSession();
+        statement
+            .getConnection()
+            .unwrap(SnowflakeConnectionImpl.class)
+            .getSFBaseSession(internalCallMarker());
 
     SFResultSetMetaData sfset =
         new SFResultSetMetaData(
@@ -89,7 +94,10 @@ public class SnowflakeDatabaseMetaDataResultSet extends SnowflakeBaseResultSet {
     this.rows = rows;
 
     SFBaseSession session =
-        statement.getConnection().unwrap(SnowflakeConnectionImpl.class).getSFBaseSession();
+        statement
+            .getConnection()
+            .unwrap(SnowflakeConnectionImpl.class)
+            .getSFBaseSession(internalCallMarker());
 
     SFResultSetMetaData sfset =
         new SFResultSetMetaData(

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/InternalApiTelemetryTracker.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/InternalApiTelemetryTracker.java
@@ -1,0 +1,81 @@
+package net.snowflake.client.internal.jdbc.telemetry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import net.snowflake.client.internal.core.ObjectMapperFactory;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
+
+/** Tracks calls to public methods in internal packages and reports them as in-band telemetry. */
+public class InternalApiTelemetryTracker {
+  private static final SFLogger logger =
+      SFLoggerFactory.getLogger(InternalApiTelemetryTracker.class);
+  private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+
+  private static final ConcurrentHashMap<String, AtomicLong> methodCallCounts =
+      new ConcurrentHashMap<>();
+
+  /** Marker used by internal call paths to skip external-usage telemetry. */
+  public static final class InternalCallMarker {
+    private InternalCallMarker() {}
+  }
+
+  private static final InternalCallMarker INTERNAL_CALL_MARKER = new InternalCallMarker();
+
+  private InternalApiTelemetryTracker() {}
+
+  public static InternalCallMarker internalCallMarker() {
+    return INTERNAL_CALL_MARKER;
+  }
+
+  public static void recordIfExternal(
+      String className, String methodName, InternalCallMarker internalCallMarker) {
+    if (internalCallMarker == null) {
+      record(className, methodName);
+    }
+  }
+
+  static void record(String className, String methodName) {
+    methodCallCounts
+        .computeIfAbsent(className + "#" + methodName, k -> new AtomicLong(0))
+        .incrementAndGet();
+  }
+
+  public static void flush(Telemetry client) {
+    if (client == null || methodCallCounts.isEmpty()) {
+      return;
+    }
+
+    try {
+      ObjectNode message = mapper.createObjectNode();
+      message.put(TelemetryField.TYPE.toString(), TelemetryField.INTERNAL_API_USAGE.toString());
+      message.put("source", "JDBC");
+
+      ObjectNode methods = mapper.createObjectNode();
+      methodCallCounts.forEach(
+          (key, count) -> {
+            long value = count.getAndSet(0);
+            if (value > 0) {
+              methods.put(key, value);
+            }
+          });
+      methodCallCounts.entrySet().removeIf(e -> e.getValue().get() == 0);
+
+      if (methods.isEmpty()) {
+        return;
+      }
+
+      message.set("methods", methods);
+      client.addLogToBatch(new TelemetryData(message, System.currentTimeMillis()));
+      logger.debug("Flushed internal API usage telemetry with {} distinct methods", methods.size());
+    } catch (Exception e) {
+      logger.debug("Failed to flush internal API telemetry: {}", e.getMessage());
+    }
+  }
+
+  static void resetForTesting() {
+    methodCallCounts.clear();
+  }
+}

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryClient.java
@@ -1,5 +1,7 @@
 package net.snowflake.client.internal.jdbc.telemetry;
 
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -143,7 +145,9 @@ public class TelemetryClient implements Telemetry {
   public static Telemetry createTelemetry(Connection conn, int flushSize) {
     try {
       return createTelemetry(
-          (SFSession) conn.unwrap(SnowflakeConnectionImpl.class).getSFBaseSession(), flushSize);
+          (SFSession)
+              conn.unwrap(SnowflakeConnectionImpl.class).getSFBaseSession(internalCallMarker()),
+          flushSize);
     } catch (SQLException ex) {
       logger.debug("Input connection is not a SnowflakeConnection", false);
       return null;

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryField.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryField.java
@@ -38,7 +38,9 @@ public enum TelemetryField {
   METADATA_METRICS("client_metadata_api_metrics"),
 
   HTTP_EXCEPTION("client_http_exception"),
-  OCSP_EXCEPTION("client_ocsp_exception");
+  OCSP_EXCEPTION("client_ocsp_exception"),
+
+  INTERNAL_API_USAGE("client_internal_api_usage");
 
   public final String field;
 

--- a/src/test/java/net/snowflake/client/internal/jdbc/telemetry/InternalApiTelemetryTrackerTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/telemetry/InternalApiTelemetryTrackerTest.java
@@ -1,0 +1,136 @@
+package net.snowflake.client.internal.jdbc.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import net.snowflake.client.category.TestTags;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@Tag(TestTags.CORE)
+class InternalApiTelemetryTrackerTest {
+  private Telemetry mockClient;
+
+  @BeforeEach
+  void setUp() {
+    InternalApiTelemetryTracker.resetForTesting();
+    mockClient = mock(Telemetry.class);
+  }
+
+  @Test
+  void shouldFlushAggregatedDataThroughProvidedClient() {
+    InternalApiTelemetryTracker.record("SFSession", "getDatabase");
+    InternalApiTelemetryTracker.record("SFStatement", "execute");
+
+    InternalApiTelemetryTracker.flush(mockClient);
+
+    ArgumentCaptor<TelemetryData> captor = forClass(TelemetryData.class);
+    verify(mockClient, times(1)).addLogToBatch(captor.capture());
+
+    ObjectNode message = captor.getValue().getMessage();
+    assertEquals("client_internal_api_usage", message.get("type").asText());
+    assertEquals("JDBC", message.get("source").asText());
+
+    JsonNode methods = message.get("methods");
+    assertNotNull(methods);
+    assertEquals(1, methods.get("SFSession#getDatabase").asLong());
+    assertEquals(1, methods.get("SFStatement#execute").asLong());
+  }
+
+  @Test
+  void shouldAggregateMultipleCallsToSameMethod() {
+    InternalApiTelemetryTracker.record("SFSession", "getDatabase");
+    InternalApiTelemetryTracker.record("SFSession", "getDatabase");
+    InternalApiTelemetryTracker.record("SFSession", "getDatabase");
+
+    InternalApiTelemetryTracker.flush(mockClient);
+
+    ArgumentCaptor<TelemetryData> captor = forClass(TelemetryData.class);
+    verify(mockClient).addLogToBatch(captor.capture());
+
+    JsonNode methods = captor.getValue().getMessage().get("methods");
+    assertEquals(3, methods.get("SFSession#getDatabase").asLong());
+  }
+
+  @Test
+  void shouldNotFlushWhenNoCallsRecorded() {
+    InternalApiTelemetryTracker.flush(mockClient);
+
+    verify(mockClient, never()).addLogToBatch(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void shouldDrainCountsOnFlushAndAccumulateAgain() {
+    InternalApiTelemetryTracker.record("SFSession", "getDatabase");
+    InternalApiTelemetryTracker.flush(mockClient);
+
+    InternalApiTelemetryTracker.record("SFSession", "getDatabase");
+    InternalApiTelemetryTracker.record("SFStatement", "execute");
+    InternalApiTelemetryTracker.flush(mockClient);
+
+    ArgumentCaptor<TelemetryData> captor = forClass(TelemetryData.class);
+    verify(mockClient, times(2)).addLogToBatch(captor.capture());
+
+    JsonNode firstMethods = captor.getAllValues().get(0).getMessage().get("methods");
+    assertEquals(1, firstMethods.get("SFSession#getDatabase").asLong());
+    assertNull(firstMethods.get("SFStatement#execute"));
+
+    JsonNode secondMethods = captor.getAllValues().get(1).getMessage().get("methods");
+    assertEquals(1, secondMethods.get("SFSession#getDatabase").asLong());
+    assertEquals(1, secondMethods.get("SFStatement#execute").asLong());
+  }
+
+  @Test
+  void concurrentSessionsEachFlushIndependently() {
+    Telemetry clientA = mock(Telemetry.class);
+    Telemetry clientB = mock(Telemetry.class);
+
+    InternalApiTelemetryTracker.record("SFSession", "getDatabase");
+    InternalApiTelemetryTracker.flush(clientA);
+
+    InternalApiTelemetryTracker.record("SFStatement", "execute");
+    InternalApiTelemetryTracker.flush(clientB);
+
+    ArgumentCaptor<TelemetryData> captorA = forClass(TelemetryData.class);
+    verify(clientA, times(1)).addLogToBatch(captorA.capture());
+    assertEquals(
+        1, captorA.getValue().getMessage().get("methods").get("SFSession#getDatabase").asLong());
+
+    ArgumentCaptor<TelemetryData> captorB = forClass(TelemetryData.class);
+    verify(clientB, times(1)).addLogToBatch(captorB.capture());
+    assertEquals(
+        1, captorB.getValue().getMessage().get("methods").get("SFStatement#execute").asLong());
+  }
+
+  @Test
+  void markerAwareRecordingShouldRecordWhenMarkerIsMissing() {
+    InternalApiTelemetryTracker.recordIfExternal("SFSession", "getRole", null);
+
+    InternalApiTelemetryTracker.flush(mockClient);
+
+    ArgumentCaptor<TelemetryData> captor = forClass(TelemetryData.class);
+    verify(mockClient).addLogToBatch(captor.capture());
+    assertEquals(
+        1, captor.getValue().getMessage().get("methods").get("SFSession#getRole").asLong());
+  }
+
+  @Test
+  void markerAwareRecordingShouldNotRecordWhenMarkerIsProvided() {
+    InternalApiTelemetryTracker.recordIfExternal(
+        "SFSession", "getRole", InternalApiTelemetryTracker.internalCallMarker());
+
+    InternalApiTelemetryTracker.flush(mockClient);
+
+    verify(mockClient, never()).addLogToBatch(org.mockito.ArgumentMatchers.any());
+  }
+}


### PR DESCRIPTION
# Overview

This PR implements a telemetry tracking system for internal API usage in the JDBC driver. It adds:

1. A new `InternalApiTelemetryTracker` class that records and aggregates calls to internal API methods
2. Integration with the session lifecycle to flush telemetry data at session open and close
3. A new telemetry field type `INTERNAL_API_USAGE` to identify this telemetry data
4. Comprehensive unit tests for the new tracking functionality

The tracker collects method call counts in a thread-safe manner and sends aggregated data through the existing telemetry system. This will help monitor usage patterns of internal APIs and inform future development decisions.