### PR TITLE
SNOW-2999722: Add internal API usage telemetry coverage

### DIFF
--- a/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java
@@ -25,6 +25,7 @@ import net.snowflake.client.api.resultset.SnowflakeType;
 import net.snowflake.client.internal.core.crl.CertRevocationCheckMode;
 import net.snowflake.client.internal.jdbc.SFConnectionHandler;
 import net.snowflake.client.internal.jdbc.SnowflakeConnectString;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
@@ -217,6 +218,7 @@ public abstract class SFBaseSession {
    * @return Map of common parameters
    */
   public Map<String, Object> getCommonParameters() {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFBaseSession", "getCommonParameters");
     return this.commonParameters;
   }
 
@@ -236,6 +238,7 @@ public abstract class SFBaseSession {
    * @return unique id for session
    */
   public String getSessionId() {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFBaseSession", "getSessionId");
     return sessionId;
   }
 
@@ -472,6 +475,7 @@ public abstract class SFBaseSession {
    */
   public void addProperty(SFSessionProperty sfSessionProperty, Object propertyValue)
       throws SFException {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFBaseSession", "addProperty");
     addProperty(sfSessionProperty.getPropertyKey(), propertyValue);
   }
 
@@ -487,6 +491,7 @@ public abstract class SFBaseSession {
    *     if the value is invalid.
    */
   public void addProperty(String propertyName, Object propertyValue) throws SFException {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFBaseSession", "addProperty");
     SFSessionProperty connectionProperty = SFSessionProperty.lookupByKey(propertyName);
     // check if the value type is as expected
     propertyValue = SFSessionProperty.checkPropertyValue(connectionProperty, propertyValue);
@@ -517,6 +522,8 @@ public abstract class SFBaseSession {
    * @return the connection properties map
    */
   public Map<SFSessionProperty, Object> getConnectionPropertiesMap() {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SFBaseSession", "getConnectionPropertiesMap");
     return connectionPropertiesMap;
   }
 
@@ -527,6 +534,7 @@ public abstract class SFBaseSession {
    * @throws SnowflakeSQLException if exception encountered
    */
   public HttpClientSettingsKey getHttpClientKey() throws SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFBaseSession", "getHttpClientKey");
     // if key is already created, return it without making a new one
     if (ocspAndProxyAndGzipKey != null) {
       return ocspAndProxyAndGzipKey;

--- a/src/main/java/net/snowflake/client/internal/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSession.java
@@ -597,6 +597,7 @@ public class SFSession extends SFBaseSession {
    * @throws SnowflakeSQLException exception raised from Snowflake components
    */
   public synchronized void open() throws SFException, SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFSession", "open");
     Stopwatch stopwatch = new Stopwatch();
     stopwatch.start();
     performSanityCheckOnProperties();
@@ -981,6 +982,7 @@ public class SFSession extends SFBaseSession {
    * @return session token
    */
   public String getSessionToken() {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFSession", "getSessionToken");
     return sessionToken;
   }
 
@@ -992,6 +994,7 @@ public class SFSession extends SFBaseSession {
    */
   @Override
   public void close() throws SFException, SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFSession", "close");
     logger.debug("Closing session {}", getSessionId());
 
     // stop heartbeat for this session
@@ -1276,6 +1279,7 @@ public class SFSession extends SFBaseSession {
 
   @Override
   public synchronized Telemetry getTelemetryClient() {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFSession", "getTelemetryClient");
     // initialize for the first time. this should only be done after session
     // properties have been set, else the client won't properly resolve the URL.
     if (telemetryClient == null) {
@@ -1303,14 +1307,17 @@ public class SFSession extends SFBaseSession {
   }
 
   public String getIdToken() {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFSession", "getIdToken");
     return idToken;
   }
 
   public String getAccessToken() {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFSession", "getAccessToken");
     return oauthAccessToken;
   }
 
   public String getMfaToken() {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFSession", "getMfaToken");
     return mfaToken;
   }
 

--- a/src/main/java/net/snowflake/client/internal/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFStatement.java
@@ -29,6 +29,7 @@ import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
 import net.snowflake.client.internal.jdbc.SnowflakeFileTransferAgent;
 import net.snowflake.client.internal.jdbc.SnowflakeReauthenticationRequest;
 import net.snowflake.client.internal.jdbc.telemetry.ExecTimeTelemetryData;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryData;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryField;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryUtil;
@@ -886,6 +887,7 @@ public class SFStatement extends SFBaseStatement {
 
   @Override
   public SFBaseSession getSFBaseSession() {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SFStatement", "getSFBaseSession");
     return session;
   }
 

--- a/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
@@ -52,6 +52,7 @@ import net.snowflake.client.internal.jdbc.RetryContextManager;
 import net.snowflake.client.internal.jdbc.SnowflakeReauthenticationRequest;
 import net.snowflake.client.internal.jdbc.SnowflakeSQLExceptionWithRetryContext;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.internal.jdbc.util.DriverUtil;
 import net.snowflake.client.internal.log.ArgSupplier;
@@ -2074,6 +2075,7 @@ public class SessionUtil {
       String accountName,
       String userName)
       throws SFException {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SessionUtil", "generateJWTToken");
     SessionUtilKeyPair s =
         new SessionUtilKeyPair(
             privateKey, privateKeyFile, privateKeyBase64, privateKeyPwd, accountName, userName);
@@ -2100,6 +2102,7 @@ public class SessionUtil {
       String accountName,
       String userName)
       throws SFException {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SessionUtil", "generateJWTToken");
     return generateJWTToken(
         privateKey, privateKeyFile, null, privateKeyFilePwd, accountName, userName);
   }

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
@@ -67,6 +67,7 @@ import net.snowflake.client.internal.jdbc.cloud.storage.StorageObjectSummary;
 import net.snowflake.client.internal.jdbc.cloud.storage.StorageObjectSummaryCollection;
 import net.snowflake.client.internal.jdbc.cloud.storage.StorageProviderException;
 import net.snowflake.client.internal.jdbc.telemetry.ExecTimeTelemetryData;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.internal.log.ArgSupplier;
 import net.snowflake.client.internal.log.SFLogger;
@@ -884,6 +885,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
   public SnowflakeFileTransferAgent(String command, SFSession session, SFStatement statement)
       throws SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally("SnowflakeFileTransferAgent", "<init>");
     this.command = command;
     this.session = session;
     this.statement = statement;
@@ -1394,6 +1396,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    */
   public List<SnowflakeFileTransferMetadata> getFileTransferMetadatas()
       throws SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeFileTransferAgent", "getFileTransferMetadatas");
     List<SnowflakeFileTransferMetadata> result = new ArrayList<>();
     if (stageInfo.getStageType() != StageInfo.StageType.GCS
         && stageInfo.getStageType() != StageInfo.StageType.AZURE
@@ -1444,6 +1448,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    */
   public static List<SnowflakeFileTransferMetadata> getFileTransferMetadatas(JsonNode jsonNode)
       throws SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeFileTransferAgent", "getFileTransferMetadatas");
     return getFileTransferMetadatas(jsonNode, null);
   }
 
@@ -1461,6 +1467,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    */
   public static List<SnowflakeFileTransferMetadata> getFileTransferMetadatas(
       JsonNode jsonNode, String queryId) throws SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeFileTransferAgent", "getFileTransferMetadatas");
     CommandType commandType =
         !jsonNode.path("data").path("command").isMissingNode()
             ? CommandType.valueOf(jsonNode.path("data").path("command").asText())

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeResultSetSerializableV1.java
@@ -48,6 +48,7 @@ import net.snowflake.client.internal.core.SFSession;
 import net.snowflake.client.internal.core.SFStatementType;
 import net.snowflake.client.internal.core.SessionUtil;
 import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker;
 import net.snowflake.client.internal.jdbc.telemetry.NoOpTelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.log.ArgSupplier;
@@ -502,10 +503,14 @@ public class SnowflakeResultSetSerializableV1
   }
 
   public ResultStreamProvider getResultStreamProvider() {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeResultSetSerializableV1", "getResultStreamProvider");
     return resultStreamProvider;
   }
 
   public SFResultSetMetaData getSFResultSetMetaData() {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeResultSetSerializableV1", "getSFResultSetMetaData");
     return resultSetMetaData;
   }
 
@@ -716,6 +721,8 @@ public class SnowflakeResultSetSerializableV1
   }
 
   public Optional<SFBaseSession> getSession() {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeResultSetSerializableV1", "getSession");
     return possibleSession;
   }
 
@@ -732,6 +739,8 @@ public class SnowflakeResultSetSerializableV1
   public static SnowflakeResultSetSerializableV1 create(
       JsonNode rootNode, SFBaseSession sfSession, SFBaseStatement sfStatement)
       throws SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeResultSetSerializableV1", "create");
     return create(rootNode, sfSession, sfStatement, new DefaultResultStreamProvider());
   }
 
@@ -753,6 +762,8 @@ public class SnowflakeResultSetSerializableV1
       SFBaseStatement sfStatement,
       ResultStreamProvider resultStreamProvider)
       throws SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeResultSetSerializableV1", "create");
     logger.trace("Entering create()", false);
     return new SnowflakeResultSetSerializableV1(
         rootNode, sfSession, sfStatement, resultStreamProvider, false);
@@ -771,6 +782,8 @@ public class SnowflakeResultSetSerializableV1
   public static SnowflakeResultSetSerializableV1 createWithChunksPrefetchDisabled(
       JsonNode rootNode, SFBaseSession sfSession, SFBaseStatement sfStatement)
       throws SnowflakeSQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeResultSetSerializableV1", "createWithChunksPrefetchDisabled");
     logger.trace("Entering create()", false);
     return new SnowflakeResultSetSerializableV1(
         rootNode, sfSession, sfStatement, new DefaultResultStreamProvider(), true);
@@ -1036,6 +1049,8 @@ public class SnowflakeResultSetSerializableV1
    * @throws SQLException if fails to split objects.
    */
   public List<SnowflakeResultSetSerializable> splitBySize(long maxSizeInBytes) throws SQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeResultSetSerializableV1", "splitBySize");
     List<SnowflakeResultSetSerializable> resultSetSerializables = new ArrayList<>();
 
     if (this.chunkFileMetadatas.isEmpty() && this.firstChunkStringData == null) {
@@ -1094,6 +1109,8 @@ public class SnowflakeResultSetSerializableV1
    */
   public ResultSet getResultSet(ResultSetRetrieveConfig resultSetRetrieveConfig)
       throws SQLException {
+    InternalApiTelemetryTracker.recordIfCalledExternally(
+        "SnowflakeResultSetSerializableV1", "getResultSet");
     // Adjust OCSP cache server if necessary.
     try {
       SessionUtil.resetOCSPUrlIfNecessary(resultSetRetrieveConfig.getSfFullURL());


### PR DESCRIPTION
# Add telemetry tracking for internal API usage

This change adds telemetry tracking to monitor when internal APIs are called from external code (outside the driver package). The tracking helps identify which internal methods are being used by customer applications.

## Changes

- Added `InternalApiTelemetryTracker.recordIfCalledExternally()` calls to internal methods across multiple classes:
  - `SnowflakeConnectionImpl`: `getHandler()`, `getSFBaseSession()`, `getSfSession()`
  - `SFBaseSession`: `getCommonParameters()`, `getSessionId()`, `addProperty()`, `getConnectionPropertiesMap()`, `getHttpClientKey()`
  - `SFSession`: `open()`, `getSessionToken()`, `close()`, `getTelemetryClient()`, `getIdToken()`, `getAccessToken()`, `getMfaToken()`
  - `SFStatement`: `getSFBaseSession()`
  - `SessionUtil`: `generateJWTToken()` methods
  - `SnowflakeFileTransferAgent`: constructor and `getFileTransferMetadatas()` methods
  - `SnowflakeResultSetSerializableV1`: `getResultStreamProvider()`, `getSFResultSetMetaData()`, `getSession()`, `create()` methods, `splitBySize()`, `getResultSet()`

- Enhanced `InternalApiTelemetryTracker` with:
  - `recordIfCalledExternally()` method that checks the call stack to determine if the caller is external
  - `isExternalClass()` method to identify non-driver package classes
  - Stack trace inspection to only record calls from external packages

- Added comprehensive unit tests covering:
  - External vs internal class detection
  - Conditional recording based on caller package
  - Stack trace analysis functionality

The telemetry only records usage when internal APIs are called from code outside the `net.snowflake.client.` package, helping track potential misuse of internal APIs by external applications.