### PR TITLE
NO-SNOW: Add specific unit test jobs to CI suite

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,8 +39,56 @@ jobs:
                 WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
               run: ./ci/build.sh
 
+    unit-test-linux:
+        name: Unit Tests Linux java 8
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-java@v5
+              with:
+                java-version: '8'
+                distribution: 'temurin'
+                cache: maven
+            - name: Unit Tests
+              shell: bash
+              env:
+                JAVA_TOOL_OPTIONS: "-Xms1g -Xmx2g"
+              run: ./mvnw -B -DjenkinsIT -Dskip.unitTests=false -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn test --batch-mode --show-version
+
+    unit-test-windows:
+        name: Unit Tests Windows java 8
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-java@v5
+              with:
+                java-version: '8'
+                distribution: 'temurin'
+                cache: maven
+            - name: Unit Tests
+              shell: cmd
+              env:
+                JAVA_TOOL_OPTIONS: "-Xms1g -Xmx2g"
+              run: .\mvnw.cmd -B -DjenkinsIT -Dskip.unitTests=false -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn test --batch-mode --show-version
+
+    unit-test-mac:
+        name: Unit Tests Mac java 8
+        runs-on: macos-latest
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-java@v5
+              with:
+                java-version: '8'
+                distribution: 'zulu'
+                cache: maven
+            - name: Unit Tests
+              shell: bash
+              env:
+                JAVA_TOOL_OPTIONS: "-Xms1g -Xmx2g"
+              run: ./mvnw -B -DjenkinsIT -Dskip.unitTests=false -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn test --batch-mode --show-version
+
     test-windows:
-        needs: build
+        needs: [build, unit-test-linux, unit-test-windows, unit-test-mac]
         name: ${{ matrix.runConfig.cloud }} Windows java ${{ matrix.runConfig.javaVersion }} JDBC${{ matrix.additionalMavenProfile }} ${{ matrix.category.name }}
         runs-on: windows-latest
         strategy:
@@ -75,7 +123,7 @@ jobs:
               run: ci\\test_windows.bat
 
     test-mac:
-        needs: build
+        needs: [build, unit-test-linux, unit-test-windows, unit-test-mac]
         name: ${{ matrix.runConfig.cloud }} Mac java ${{ matrix.runConfig.javaVersion }} JDBC${{ matrix.additionalMavenProfile }} ${{ matrix.category.name }}
         runs-on: macos-latest
         strategy:
@@ -112,7 +160,7 @@ jobs:
               run: /opt/homebrew/bin/bash ./ci/test_mac.sh
 
     test-rocky:
-        needs: build
+        needs: [build, unit-test-linux, unit-test-windows, unit-test-mac]
         name: ${{ matrix.runConfig.cloud }} Rocky9 java ${{ matrix.runConfig.javaVersion }} JDBC${{ matrix.additionalMavenProfile }} ${{ matrix.category.name }}
         runs-on: ubuntu-latest
         strategy:
@@ -139,7 +187,7 @@ jobs:
               run: ./ci/test.sh
 
     test-linux:
-        needs: build
+        needs: [build, unit-test-linux, unit-test-windows, unit-test-mac]
         name: ${{ matrix.cloud }} Linux java on ${{ matrix.image }} JDBC${{ matrix.additionalMavenProfile }} ${{ matrix.category.name }}
         runs-on: ubuntu-latest
         strategy:


### PR DESCRIPTION
# Overview

Added unit test jobs for Linux, Windows, and macOS platforms running Java 8 to the GitHub Actions build-test workflow. These jobs run after the build job completes and execute Maven unit tests across all three operating systems.