### PR TITLE
NO-SNOW: Disable unit tests from IT shards on CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,6 +22,9 @@ on:
           tags:
             description: "Test scenario tags"
 
+permissions:
+  contents: read
+
 concurrency:
   # older builds for the same pull request numer or branch should be cancelled
   cancel-in-progress: true

--- a/ci/container/build_component.sh
+++ b/ci/container/build_component.sh
@@ -8,9 +8,9 @@ JDBC_ROOT=$(cd "${THIS_DIR}/../../" && pwd)
 
 cd $JDBC_ROOT
 rm -f lib/*.jar
-mvn clean install --batch-mode --show-version
+mvn clean install -DskipTests --batch-mode --show-version
 
 cd FIPS
 rm -f lib/*.jar
-mvn clean install -Dsurefire.argLine="-Djavax.net.debug=ssl:handshake" -Dfailsafe.argLine="-Djavax.net.debug=ssl:handshake" --batch-mode --show-version
+mvn clean install -DskipTests -Dsurefire.argLine="-Djavax.net.debug=ssl:handshake" -Dfailsafe.argLine="-Djavax.net.debug=ssl:handshake" --batch-mode --show-version
 $THIS_DIR/upload_artifact.sh

--- a/ci/container/test_component.sh
+++ b/ci/container/test_component.sh
@@ -92,6 +92,7 @@ if [[ "$is_old_driver" == "true" ]]; then
         JDBC_VERSION=$($MVNW_EXE org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version --batch-mode | grep -v "[INFO]")
         echo "[INFO] Run JDBC $JDBC_VERSION tests"
         $MVNW_EXE -DjenkinsIT \
+            -Dskip.unitTests=true \
             -Djava.io.tmpdir=$WORKSPACE \
             -Djacoco.skip.instrument=false \
             -DintegrationTestSuites="$JDBC_TEST_SUITES" \
@@ -103,6 +104,7 @@ elif [[ "$JDBC_TEST_SUITES" == "FipsTestSuite" ]]; then
     pushd FIPS >& /dev/null
         echo "[INFO] Run Fips tests"
         $MVNW_EXE -DjenkinsIT \
+            -Dskip.unitTests=true \
             -Djava.io.tmpdir=$WORKSPACE \
             -Djacoco.skip.instrument=false \
             -DintegrationTestSuites=FipsTestSuite \
@@ -114,6 +116,7 @@ elif [[ "$JDBC_TEST_SUITES" == "FipsTestSuite" ]]; then
 else
     echo "[INFO] Run $JDBC_TEST_SUITES tests"
     $MVNW_EXE -DjenkinsIT \
+        -Dskip.unitTests=true \
         -Djava.io.tmpdir=$WORKSPACE \
         -Djacoco.skip.instrument=false \
         -DintegrationTestSuites="$JDBC_TEST_SUITES" \

--- a/ci/test_windows.bat
+++ b/ci/test_windows.bat
@@ -124,6 +124,7 @@ if "%JDBC_TEST_SUITES%"=="FipsTestSuite" (
     pushd FIPS
     echo "[INFO] Run Fips tests"
     cmd /c %MVNW_EXE% -B -DjenkinsIT ^
+        -Dskip.unitTests=true ^
         -Djava.io.tmpdir=%GITHUB_WORKSPACE% ^
         -Djacoco.skip.instrument=false ^
         -DintegrationTestSuites=FipsTestSuite ^
@@ -144,6 +145,7 @@ if "%JDBC_TEST_SUITES%"=="FipsTestSuite" (
 ) else (
     echo "[INFO] Run %JDBC_TEST_SUITES% tests"
     cmd /c %MVNW_EXE% -B -DjenkinsIT ^
+        -Dskip.unitTests=true ^
         -Djava.io.tmpdir=%GITHUB_WORKSPACE% ^
         -Djacoco.skip.instrument=false ^
         -DintegrationTestSuites="%JDBC_TEST_SUITES%" ^


### PR DESCRIPTION
This PR removes duplicated unit-test execution from non-unit CI paths to reduce runtime and better isolate responsibilities.
Integration shard runs now skip unit tests by passing -Dskip.unitTests=true in:
- ci/container/test_component.sh
- ci/test_windows.bat

Build packaging path now skips tests (-DskipTests) in:
- ci/container/build_component.sh

CI ordering is updated so IT matrix jobs run only after build and dedicated unit jobs (unit-test-linux, unit-test-windows, unit-test-mac) complete successfully.