### PR TITLE
SNOW-2999725: Reduce number of thin-jar tests on CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -203,6 +203,18 @@ jobs:
                            {suites: 'ArrowTestSuite,ConnectionTestSuite,CoreTestSuite,DiagnosticTestSuite', name: 'TestCategoryArrow,TestCategoryConnection,TestCategoryCore,TestCategoryDiagnostic'},
                            {suites: 'FipsTestSuite', name: "TestCategoryFips"}]
                 additionalMavenProfile: ['', '-Dthin-jar']
+                exclude:
+                    # Keep thin-jar only for AWS on JDK 8 and 21 (all categories).
+                    - cloud: 'AZURE'
+                      additionalMavenProfile: '-Dthin-jar'
+                    - cloud: 'GCP'
+                      additionalMavenProfile: '-Dthin-jar'
+                    - cloud: 'AWS'
+                      image: 'jdbc-centos7-openjdk11'
+                      additionalMavenProfile: '-Dthin-jar'
+                    - cloud: 'AWS'
+                      image: 'jdbc-centos7-openjdk17'
+                      additionalMavenProfile: '-Dthin-jar'
         steps:
             - uses: actions/checkout@v5
             - name: Tests


### PR DESCRIPTION
# Overview

Reduced CI duplication by limiting -Dthin-jar runs in test-linux to AWS + JDK 8/21 only, while keeping all categories covered for those lanes.

### Thin-jar scope reduction rationale

We limited `-Dthin-jar` runs to AWS on JDK 8 and 21 because thin-jar coverage is primarily validating **packaging/classpath behavior** (shading, dependency resolution, startup/runtime loading), not cloud-specific SQL semantics.  
Those checks are largely cloud-agnostic once the driver is exercised end-to-end.
AWS remains the thin-jar canary because:

- it is the most stable/high-signal environment in this workflow,
- it already carries the broadest compatibility surface in CI,
- it gives fast feedback with lower flakiness and lower matrix cost.

Also, we want to introdue the FULL-MATRIX-TESTS label that runs full matrix on demand.