### PR TITLE
SNOW-2999725: Add FULL-TEST-MATRIX label for enforcing full test suite run

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ on:
             - master
             - SNOW-**
             - NO-SNOW-**
-        types: [opened, synchronize, reopened]
+        types: [opened, synchronize, reopened, labeled, unlabeled]
     workflow_dispatch:
         inputs:
           logLevel:
@@ -102,7 +102,7 @@ jobs:
                     ${{
                         fromJSON(
                             (
-                                github.event_name == 'pull_request' &&
+                                github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'FULL-TEST-MATRIX') &&
                                 '[
                                     {"cloud":"AWS","javaVersion":"8"},
                                     {"cloud":"GCP","javaVersion":"17"},
@@ -155,7 +155,7 @@ jobs:
                     ${{
                         fromJSON(
                             (
-                                github.event_name == 'pull_request' &&
+                                github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'FULL-TEST-MATRIX') &&
                                 '[
                                     {"cloud":"AWS","javaVersion":"8"},
                                     {"cloud":"GCP","javaVersion":"17"},
@@ -211,7 +211,7 @@ jobs:
                     ${{
                         fromJSON(
                             (
-                                github.event_name == 'pull_request' &&
+                                github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'FULL-TEST-MATRIX') &&
                                 '[
                                     {"cloud":"AWS","javaVersion":"17","image":"jdbc-rockylinux9-openjdk17"}
                                   ]'
@@ -254,7 +254,7 @@ jobs:
                     ${{
                         fromJSON(
                             (
-                                github.event_name == 'pull_request' &&
+                                github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'FULL-TEST-MATRIX') &&
                                 '[
                                     {"image":"jdbc-centos7-openjdk8","cloud":"AWS","additionalMavenProfile":""},
                                     {"image":"jdbc-centos7-openjdk11","cloud":"AWS","additionalMavenProfile":""},


### PR DESCRIPTION
# Overview

Add support for `FULL-TEST-MATRIX` label to control GitHub Actions test execution scope

# Description

   This change introduces a `FULL-TEST-MATRIX` label that allows pull requests to run the complete test matrix instead of the reduced subset. When this label is present on a PR, all test configurations will execute. When absent, the workflow continues to use the reduced test matrix for faster CI execution. The workflow now triggers on label events (`labeled`, `unlabeled`) to respond to label changes, and the exclude conditions are dynamically evaluated based on the label presence.