### PR TITLE
SNOW-2999722: Add internal API external usage telemetry coverage

### DIFF
--- a/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.api.implementation.connection;
 import static net.snowflake.client.api.exception.ErrorCode.FEATURE_UNSUPPORTED;
 import static net.snowflake.client.api.exception.ErrorCode.INVALID_CONNECT_STRING;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.recordIfExternal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -279,7 +280,7 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
     isClosed = true;
     try {
       if (sfSession != null && sfSession.isSafeToClose()) {
-        sfSession.close();
+        sfSession.close(internalCallMarker());
         sfSession = null;
       }
       // make sure to close all created statements

--- a/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -187,7 +187,7 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
     this.metadataRequestUseConnectionCtx = session.getMetadataRequestUseConnectionCtx();
     this.metadataRequestUseSessionDatabase = session.getMetadataRequestUseSessionDatabase();
     this.stringsQuoted = session.isStringQuoted();
-    this.ibInstance = session.getTelemetryClient();
+    this.ibInstance = session.getTelemetryClient(internalCallMarker());
     this.procedureResultsetColumnNum = -1;
     this.isPatternMatchingEnabled = session.getEnablePatternSearch();
     this.exactSchemaSearchEnabled = session.getEnableExactSchemaSearch();

--- a/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -1135,13 +1135,13 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
         }
       }
       if (this.getSFBaseStatement()
-          .getSFBaseSession()
+          .getSFBaseSession(internalCallMarker())
           .getClearBatchOnlyAfterSuccessfulExecution()) {
         clearBatch();
       }
     } finally {
       if (!this.getSFBaseStatement()
-          .getSFBaseSession()
+          .getSFBaseSession(internalCallMarker())
           .getClearBatchOnlyAfterSuccessfulExecution()) {
         clearBatch();
       }

--- a/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -583,7 +583,9 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
           updateCounts.intArr,
           exceptionReturned);
     }
-    if (this.getSFBaseStatement().getSFBaseSession().getClearBatchOnlyAfterSuccessfulExecution()) {
+    if (this.getSFBaseStatement()
+        .getSFBaseSession(internalCallMarker())
+        .getClearBatchOnlyAfterSuccessfulExecution()) {
       clearBatch();
     }
     return updateCounts;

--- a/src/main/java/net/snowflake/client/internal/core/SFArrowResultSet.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFArrowResultSet.java
@@ -2,6 +2,7 @@ package net.snowflake.client.internal.core;
 
 import static net.snowflake.client.internal.core.StmtUtil.eventHandler;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.systemGetProperty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -133,7 +134,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
       SFBaseStatement statement,
       boolean sortResult)
       throws SQLException {
-    this(resultSetSerializable, session.getTelemetryClient(), sortResult);
+    this(resultSetSerializable, session.getTelemetryClient(internalCallMarker()), sortResult);
     this.converters =
         new Converters(
             resultSetSerializable.getTimeZone(),
@@ -161,7 +162,8 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     useSessionTimezone = resultSetSerializable.getUseSessionTimezone();
 
     // update the driver/session with common parameters from GS
-    SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSFBaseSession());
+    SessionUtil.updateSfDriverParamValues(
+        this.parameters, statement.getSFBaseSession(internalCallMarker()));
 
     // if server gives a send time, log time it took to arrive
     if (resultSetSerializable.getSendResultTime() != 0) {
@@ -211,7 +213,7 @@ public class SFArrowResultSet extends SFBaseResultSet implements DataConversionC
     this.timeFormatter = resultSetSerializable.getTimeFormatter();
     this.sessionTimeZone = resultSetSerializable.getTimeZone();
     this.binaryFormatter = resultSetSerializable.getBinaryFormatter();
-    this.resultSetMetaData = resultSetSerializable.getSFResultSetMetaData();
+    this.resultSetMetaData = resultSetSerializable.getSFResultSetMetaData(internalCallMarker());
     this.treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
     this.formatDateWithTimezone = resultSetSerializable.getFormatDateWithTimeZone();
     this.useSessionTimezone = resultSetSerializable.getUseSessionTimezone();

--- a/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java
@@ -25,6 +25,7 @@ import net.snowflake.client.api.resultset.SnowflakeType;
 import net.snowflake.client.internal.core.crl.CertRevocationCheckMode;
 import net.snowflake.client.internal.jdbc.SFConnectionHandler;
 import net.snowflake.client.internal.jdbc.SnowflakeConnectString;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
@@ -1300,13 +1301,27 @@ public abstract class SFBaseSession {
    * @throws SnowflakeSQLException if failed to close the connection
    * @throws SFException if failed to close the connection
    */
-  public abstract void close() throws SFException, SnowflakeSQLException;
+  public void close() throws SFException, SnowflakeSQLException {
+    close(null);
+  }
+
+  /** Marker-aware overload for internal call paths. */
+  public abstract void close(InternalCallMarker internalCallMarker)
+      throws SFException, SnowflakeSQLException;
 
   /**
    * @return Returns the telemetry client, if supported, by this session. If not, should return a
    *     NoOpTelemetryClient.
    */
-  public abstract Telemetry getTelemetryClient();
+  public Telemetry getTelemetryClient() {
+    return getTelemetryClient(null);
+  }
+
+  /**
+   * Marker-aware overload for internal call paths. Implementations may override to bypass
+   * external-usage telemetry tracking.
+   */
+  public abstract Telemetry getTelemetryClient(InternalCallMarker internalCallMarker);
 
   /**
    * Makes a heartbeat call to check for session validity.

--- a/src/main/java/net/snowflake/client/internal/core/SFBaseStatement.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFBaseStatement.java
@@ -1,10 +1,13 @@
 package net.snowflake.client.internal.core;
 
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
+
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import net.snowflake.client.api.exception.ErrorCode;
 import net.snowflake.client.internal.jdbc.telemetry.ExecTimeTelemetryData;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 
@@ -148,10 +151,10 @@ public abstract class SFBaseStatement {
       if (tokens.length >= 3 && "on".equalsIgnoreCase(tokens[2])) {
         logger.debug("Setting sort on", false);
 
-        this.getSFBaseSession().setSessionPropertyByKey("sort", true);
+        this.getSFBaseSession(internalCallMarker()).setSessionPropertyByKey("sort", true);
       } else {
         logger.debug("Setting sort off", false);
-        this.getSFBaseSession().setSessionPropertyByKey("sort", false);
+        this.getSFBaseSession(internalCallMarker()).setSessionPropertyByKey("sort", false);
       }
     }
   }
@@ -181,6 +184,12 @@ public abstract class SFBaseStatement {
    * @return The SFBaseSession associated with this SFBaseStatement.
    */
   public abstract SFBaseSession getSFBaseSession();
+
+  /**
+   * Marker-aware overload for internal call paths. Implementations may override to bypass
+   * external-usage telemetry tracking.
+   */
+  public abstract SFBaseSession getSFBaseSession(InternalCallMarker internalCallMarker);
 
   /**
    * Retrieves the current result as a ResultSet, if any. This is invoked by SnowflakeStatement and

--- a/src/main/java/net/snowflake/client/internal/core/SFResultSet.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFResultSet.java
@@ -2,6 +2,7 @@ package net.snowflake.client.internal.core;
 
 import static net.snowflake.client.internal.core.StmtUtil.eventHandler;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.systemGetProperty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.sql.SQLException;
@@ -85,12 +86,12 @@ public class SFResultSet extends SFJsonResultSet {
       throws SQLException {
     this(
         resultSetSerializable,
-        statement.getSFBaseSession(),
-        statement.getSFBaseSession().getTelemetryClient(),
+        statement.getSFBaseSession(internalCallMarker()),
+        statement.getSFBaseSession(internalCallMarker()).getTelemetryClient(internalCallMarker()),
         sortResult);
 
     this.statement = statement;
-    SFBaseSession session = statement.getSFBaseSession();
+    SFBaseSession session = statement.getSFBaseSession(internalCallMarker());
     session.setDatabase(resultSetSerializable.getFinalDatabaseName());
     session.setSchema(resultSetSerializable.getFinalSchemaName());
     session.setRole(resultSetSerializable.getFinalRoleName());
@@ -99,7 +100,8 @@ public class SFResultSet extends SFJsonResultSet {
     this.formatDateWithTimezone = resultSetSerializable.getFormatDateWithTimeZone();
 
     // update the driver/session with common parameters from GS
-    SessionUtil.updateSfDriverParamValues(this.parameters, statement.getSFBaseSession());
+    SessionUtil.updateSfDriverParamValues(
+        this.parameters, statement.getSFBaseSession(internalCallMarker()));
 
     // if server gives a send time, log time it took to arrive
     if (resultSetSerializable.getSendResultTime() != 0) {
@@ -172,7 +174,7 @@ public class SFResultSet extends SFJsonResultSet {
     this.numberOfBinds = resultSetSerializable.getNumberOfBinds();
     this.arrayBindSupported = resultSetSerializable.isArrayBindSupported();
     this.metaDataOfBinds = resultSetSerializable.getMetaDataOfBinds();
-    this.resultSetMetaData = resultSetSerializable.getSFResultSetMetaData();
+    this.resultSetMetaData = resultSetSerializable.getSFResultSetMetaData(internalCallMarker());
     this.treatNTZAsUTC = resultSetSerializable.getTreatNTZAsUTC();
     this.formatDateWithTimezone = resultSetSerializable.getFormatDateWithTimeZone();
 

--- a/src/main/java/net/snowflake/client/internal/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSession.java
@@ -2,6 +2,8 @@ package net.snowflake.client.internal.core;
 
 import static net.snowflake.client.internal.core.SFLoginInput.getBooleanValue;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.recordIfExternal;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,6 +42,7 @@ import net.snowflake.client.internal.jdbc.SnowflakeReauthenticationRequest;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
 import net.snowflake.client.internal.jdbc.diagnostic.DiagnosticContext;
 import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
@@ -262,7 +265,7 @@ public class SFSession extends SFBaseSession {
             if (ex instanceof SnowflakeReauthenticationRequest
                 && this.isExternalbrowserOrOAuthFullFlowAuthenticator()) {
               try {
-                this.open();
+                this.open(internalCallMarker());
               } catch (SFException e) {
                 throw new SnowflakeSQLException(e);
               }
@@ -597,6 +600,12 @@ public class SFSession extends SFBaseSession {
    * @throws SnowflakeSQLException exception raised from Snowflake components
    */
   public synchronized void open() throws SFException, SnowflakeSQLException {
+    open(null);
+  }
+
+  public synchronized void open(InternalCallMarker internalCallMarker)
+      throws SFException, SnowflakeSQLException {
+    recordIfExternal("SFSession", "open", internalCallMarker);
     Stopwatch stopwatch = new Stopwatch();
     stopwatch.start();
     performSanityCheckOnProperties();
@@ -852,10 +861,10 @@ public class SFSession extends SFBaseSession {
 
     // start heartbeat for this session so that the master token will not expire
     startHeartbeatForThisSession();
-    this.getTelemetryClient();
+    this.getTelemetryClient(internalCallMarker());
 
     // Flush any internal API usage telemetry that accumulated before session login
-    InternalApiTelemetryTracker.flush(getTelemetryClient());
+    InternalApiTelemetryTracker.flush(getTelemetryClient(internalCallMarker()));
 
     // Send minicore telemetry after session is established
     sendMinicoreTelemetry();
@@ -866,7 +875,7 @@ public class SFSession extends SFBaseSession {
 
   private void sendMinicoreTelemetry() {
     try {
-      Telemetry telemetry = getTelemetryClient();
+      Telemetry telemetry = getTelemetryClient(internalCallMarker());
       if (!(telemetry instanceof TelemetryClient)) {
         logger.trace("Telemetry client not available, skipping minicore telemetry");
         return;
@@ -981,17 +990,17 @@ public class SFSession extends SFBaseSession {
    * @return session token
    */
   public String getSessionToken() {
+    return getSessionToken(null);
+  }
+
+  public String getSessionToken(InternalCallMarker internalCallMarker) {
+    recordIfExternal("SFSession", "getSessionToken", internalCallMarker);
     return sessionToken;
   }
 
-  /**
-   * Close the connection
-   *
-   * @throws SnowflakeSQLException if failed to close the connection
-   * @throws SFException if failed to close the connection
-   */
-  @Override
-  public void close() throws SFException, SnowflakeSQLException {
+  public void close(InternalCallMarker internalCallMarker)
+      throws SFException, SnowflakeSQLException {
+    recordIfExternal("SFSession", "close", internalCallMarker);
     logger.debug("Closing session {}", getSessionId());
 
     // stop heartbeat for this session
@@ -1014,7 +1023,7 @@ public class SFSession extends SFBaseSession {
         .setHttpClientSettingsKey(getHttpClientKey());
 
     SessionUtil.closeSession(loginInput, this);
-    InternalApiTelemetryTracker.flush(getTelemetryClient());
+    InternalApiTelemetryTracker.flush(getTelemetryClient(internalCallMarker()));
     closeTelemetryClient();
     getClientInfo().clear();
 
@@ -1274,8 +1283,8 @@ public class SFSession extends SFBaseSession {
     this.enableCombineDescribe = enable;
   }
 
-  @Override
-  public synchronized Telemetry getTelemetryClient() {
+  public synchronized Telemetry getTelemetryClient(InternalCallMarker internalCallMarker) {
+    recordIfExternal("SFSession", "getTelemetryClient", internalCallMarker);
     // initialize for the first time. this should only be done after session
     // properties have been set, else the client won't properly resolve the URL.
     if (telemetryClient == null) {
@@ -1303,14 +1312,29 @@ public class SFSession extends SFBaseSession {
   }
 
   public String getIdToken() {
+    return getIdToken(null);
+  }
+
+  public String getIdToken(InternalCallMarker internalCallMarker) {
+    recordIfExternal("SFSession", "getIdToken", internalCallMarker);
     return idToken;
   }
 
   public String getAccessToken() {
+    return getAccessToken(null);
+  }
+
+  public String getAccessToken(InternalCallMarker internalCallMarker) {
+    recordIfExternal("SFSession", "getAccessToken", internalCallMarker);
     return oauthAccessToken;
   }
 
   public String getMfaToken() {
+    return getMfaToken(null);
+  }
+
+  public String getMfaToken(InternalCallMarker internalCallMarker) {
+    recordIfExternal("SFSession", "getMfaToken", internalCallMarker);
     return mfaToken;
   }
 

--- a/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
@@ -4,6 +4,7 @@ import static net.snowflake.client.internal.core.SFTrustManager.resetOCSPRespons
 import static net.snowflake.client.internal.core.SFTrustManager.setOCSPResponseCacheServerURL;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.systemGetProperty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.recordIfExternal;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -52,6 +53,7 @@ import net.snowflake.client.internal.jdbc.RetryContextManager;
 import net.snowflake.client.internal.jdbc.SnowflakeReauthenticationRequest;
 import net.snowflake.client.internal.jdbc.SnowflakeSQLExceptionWithRetryContext;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.internal.jdbc.util.DriverUtil;
 import net.snowflake.client.internal.log.ArgSupplier;
@@ -2074,6 +2076,20 @@ public class SessionUtil {
       String accountName,
       String userName)
       throws SFException {
+    return generateJWTToken(
+        privateKey, privateKeyFile, privateKeyBase64, privateKeyPwd, accountName, userName, null);
+  }
+
+  public static String generateJWTToken(
+      PrivateKey privateKey,
+      String privateKeyFile,
+      String privateKeyBase64,
+      String privateKeyPwd,
+      String accountName,
+      String userName,
+      InternalCallMarker internalCallMarker)
+      throws SFException {
+    recordIfExternal("SessionUtil", "generateJWTToken", internalCallMarker);
     SessionUtilKeyPair s =
         new SessionUtilKeyPair(
             privateKey, privateKeyFile, privateKeyBase64, privateKeyPwd, accountName, userName);
@@ -2101,7 +2117,7 @@ public class SessionUtil {
       String userName)
       throws SFException {
     return generateJWTToken(
-        privateKey, privateKeyFile, null, privateKeyFilePwd, accountName, userName);
+        privateKey, privateKeyFile, null, privateKeyFilePwd, accountName, userName, null);
   }
 
   /**

--- a/src/main/java/net/snowflake/client/internal/core/StmtUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/StmtUtil.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.internal.core;
 
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -715,7 +716,7 @@ public class StmtUtil {
     StmtInput stmtInput =
         new StmtInput()
             .setServerUrl(session.getServerUrl())
-            .setSessionToken(session.getSessionToken())
+            .setSessionToken(session.getSessionToken(internalCallMarker()))
             .setNetworkTimeoutInMillis(session.getNetworkTimeoutInMilli())
             .setSocketTimeout(session.getHttpClientSocketTimeout())
             .setMediaType(SF_MEDIA_TYPE)

--- a/src/main/java/net/snowflake/client/internal/jdbc/DefaultSFConnectionHandler.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/DefaultSFConnectionHandler.java
@@ -5,6 +5,7 @@ import static net.snowflake.client.internal.core.SessionUtil.CLIENT_SFSQL;
 import static net.snowflake.client.internal.core.SessionUtil.JVM_PARAMS_TO_PARAMS;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isWindows;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.systemGetProperty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -145,7 +146,7 @@ public class DefaultSFConnectionHandler implements SFConnectionHandler {
       initHttpHeaderCustomizers(properties);
       logger.debug("Trying to establish session, JDBC driver: {}", DriverUtil.getJdbcJarname());
       if (!skipOpen) {
-        sfSession.open();
+        sfSession.open(internalCallMarker());
       }
 
     } catch (SFException ex) {
@@ -407,7 +408,8 @@ public class DefaultSFConnectionHandler implements SFConnectionHandler {
           "getFileTransferAgent() called with an incompatible SFBaseStatement type. Requires an"
               + " SFStatement.");
     }
-    return new SnowflakeFileTransferAgent(command, sfSession, (SFStatement) statement);
+    return new SnowflakeFileTransferAgent(
+        command, sfSession, (SFStatement) statement, internalCallMarker());
   }
 
   private void initHttpHeaderCustomizers(Properties properties) {

--- a/src/main/java/net/snowflake/client/internal/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/RestRequest.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.internal.jdbc;
 
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1543,7 +1544,7 @@ public class RestRequest {
             errorMessage,
             null);
     TelemetryData td = TelemetryUtil.buildJobData(ibValue);
-    session.getTelemetryClient().addLogToBatch(td);
+    session.getTelemetryClient(internalCallMarker()).addLogToBatch(td);
   }
 
   private static void sendIBOCSPErrorEvent(
@@ -1564,7 +1565,7 @@ public class RestRequest {
             errorMessage,
             ex.toString());
     TelemetryData td = TelemetryUtil.buildJobData(ibValue);
-    session.getTelemetryClient().addLogToBatch(td);
+    session.getTelemetryClient(internalCallMarker()).addLogToBatch(td);
   }
 
   private static boolean handleMaxRetriesExceeded(

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeChunkDownloader.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeChunkDownloader.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.internal.jdbc;
 
 import static net.snowflake.client.internal.core.Constants.MB;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
@@ -227,8 +228,8 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
     this.chunkHeadersMap = resultSetSerializable.getChunkHeadersMap();
     // session may be null. Its only use is for in-band telemetry in this class
     this.session =
-        (resultSetSerializable.getSession() != null)
-            ? resultSetSerializable.getSession().orElse(null)
+        (resultSetSerializable.getSession(internalCallMarker()) != null)
+            ? resultSetSerializable.getSession(internalCallMarker()).orElse(null)
             : null;
     if (this.session != null) {
       Object prefetchMaxRetry =
@@ -255,7 +256,7 @@ public class SnowflakeChunkDownloader implements ChunkDownloader {
     // create the chunks array
     this.chunks = new ArrayList<>(resultSetSerializable.getChunkFileCount());
 
-    this.resultStreamProvider = resultSetSerializable.getResultStreamProvider();
+    this.resultStreamProvider = resultSetSerializable.getResultStreamProvider(internalCallMarker());
 
     if (resultSetSerializable.getChunkFileCount() < 1) {
       throw new SnowflakeSQLLoggedException(

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
@@ -4,6 +4,7 @@ import static net.snowflake.client.internal.core.Constants.NO_SPACE_LEFT_ON_DEVI
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.createOwnerOnlyPermissionDir;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.systemGetProperty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.recordIfExternal;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -67,6 +68,7 @@ import net.snowflake.client.internal.jdbc.cloud.storage.StorageObjectSummary;
 import net.snowflake.client.internal.jdbc.cloud.storage.StorageObjectSummaryCollection;
 import net.snowflake.client.internal.jdbc.cloud.storage.StorageProviderException;
 import net.snowflake.client.internal.jdbc.telemetry.ExecTimeTelemetryData;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.internal.log.ArgSupplier;
 import net.snowflake.client.internal.log.SFLogger;
@@ -884,6 +886,16 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
   public SnowflakeFileTransferAgent(String command, SFSession session, SFStatement statement)
       throws SnowflakeSQLException {
+    this(command, session, statement, null);
+  }
+
+  public SnowflakeFileTransferAgent(
+      String command,
+      SFSession session,
+      SFStatement statement,
+      InternalCallMarker internalCallMarker)
+      throws SnowflakeSQLException {
+    recordIfExternal("SnowflakeFileTransferAgent", "<init>", internalCallMarker);
     this.command = command;
     this.session = session;
     this.statement = statement;
@@ -1394,6 +1406,12 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    */
   public List<SnowflakeFileTransferMetadata> getFileTransferMetadatas()
       throws SnowflakeSQLException {
+    return getFileTransferMetadatas((InternalCallMarker) null);
+  }
+
+  public List<SnowflakeFileTransferMetadata> getFileTransferMetadatas(
+      InternalCallMarker internalCallMarker) throws SnowflakeSQLException {
+    recordIfExternal("SnowflakeFileTransferAgent", "getFileTransferMetadatas", internalCallMarker);
     List<SnowflakeFileTransferMetadata> result = new ArrayList<>();
     if (stageInfo.getStageType() != StageInfo.StageType.GCS
         && stageInfo.getStageType() != StageInfo.StageType.AZURE
@@ -1444,7 +1462,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    */
   public static List<SnowflakeFileTransferMetadata> getFileTransferMetadatas(JsonNode jsonNode)
       throws SnowflakeSQLException {
-    return getFileTransferMetadatas(jsonNode, null);
+    return getFileTransferMetadatas(jsonNode, null, null);
   }
 
   /**
@@ -1461,6 +1479,13 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    */
   public static List<SnowflakeFileTransferMetadata> getFileTransferMetadatas(
       JsonNode jsonNode, String queryId) throws SnowflakeSQLException {
+    return getFileTransferMetadatas(jsonNode, queryId, null);
+  }
+
+  public static List<SnowflakeFileTransferMetadata> getFileTransferMetadatas(
+      JsonNode jsonNode, String queryId, InternalCallMarker internalCallMarker)
+      throws SnowflakeSQLException {
+    recordIfExternal("SnowflakeFileTransferAgent", "getFileTransferMetadatas", internalCallMarker);
     CommandType commandType =
         !jsonNode.path("data").path("command").isMissingNode()
             ? CommandType.valueOf(jsonNode.path("data").path("command").asText())

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/SqlExceptionTelemetryHandler.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/SqlExceptionTelemetryHandler.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.internal.jdbc.telemetry;
 
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
+import static net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.internalCallMarker;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.PrintWriter;
@@ -42,7 +43,7 @@ public class SqlExceptionTelemetryHandler {
     Telemetry ibInstance = null;
     // if session is not null, try sending data using in-band telemetry
     if (session != null) {
-      ibInstance = session.getTelemetryClient();
+      ibInstance = session.getTelemetryClient(internalCallMarker());
     }
     // if in-band instance is successfully created, compile sql exception data into an in-band
     // telemetry log

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryClient.java
@@ -353,7 +353,7 @@ public class TelemetryClient implements Telemetry {
       } else {
         post.setHeader(
             HttpHeaders.AUTHORIZATION,
-            "Snowflake Token=\"" + this.session.getSessionToken() + "\"");
+            "Snowflake Token=\"" + this.session.getSessionToken(internalCallMarker()) + "\"");
       }
 
       String response = null;

--- a/src/test/java/net/snowflake/client/internal/core/SFStatementTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SFStatementTest.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.when;
 import java.sql.SQLException;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.jdbc.SnowflakeReauthenticationRequest;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.common.core.SqlState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,7 +78,7 @@ class SFStatementTest {
     // Should call session.open() and not throw
     statement.renewSessionOnExpiry(sessionExpiredException, "old-token");
 
-    verify(mockSession).open();
+    verify(mockSession).open(any(InternalCallMarker.class));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/internal/jdbc/MockConnectionTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/MockConnectionTest.java
@@ -55,6 +55,7 @@ import net.snowflake.client.internal.core.SessionUtil;
 import net.snowflake.client.internal.core.json.Converters;
 import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
 import net.snowflake.client.internal.jdbc.telemetry.ExecTimeTelemetryData;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryData;
 import net.snowflake.common.core.SnowflakeDateTimeFormat;
@@ -619,6 +620,11 @@ public class MockConnectionTest extends BaseJDBCTest {
     }
 
     @Override
+    public SFBaseSession getSFBaseSession(InternalCallMarker internalCallMarker) {
+      return getSFBaseSession();
+    }
+
+    @Override
     public boolean getMoreResults(int current) {
       return false;
     }
@@ -729,15 +735,14 @@ public class MockConnectionTest extends BaseJDBCTest {
     }
 
     @Override
-    public void close() {}
+    public void close(InternalCallMarker internalCallMarker) {}
 
     @Override
     public QueryStatus getQueryStatus(String queryID) {
       return null;
     }
 
-    @Override
-    public Telemetry getTelemetryClient() {
+    private Telemetry mockTelemetryClient() {
       return new Telemetry() {
         @Override
         public void addLogToBatch(TelemetryData log) {}
@@ -756,6 +761,11 @@ public class MockConnectionTest extends BaseJDBCTest {
           errorsEncountered.add(ex.getMessage() + "_" + sqlState);
         }
       };
+    }
+
+    @Override
+    public Telemetry getTelemetryClient(InternalCallMarker internalCallMarker) {
+      return mockTelemetryClient();
     }
 
     @Override

--- a/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
@@ -47,6 +47,7 @@ import net.snowflake.client.internal.core.SFBaseSession;
 import net.snowflake.client.internal.core.SFTrustManager;
 import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
 import net.snowflake.client.internal.jdbc.telemetry.ExecTimeTelemetryData;
+import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryData;
@@ -996,7 +997,8 @@ public class RestRequestTest {
     Telemetry mockTelemetryClient = mock(Telemetry.class);
 
     when(mockContext.getSfSession()).thenReturn(mockSession);
-    when(mockSession.getTelemetryClient()).thenReturn(mockTelemetryClient);
+    when(mockSession.getTelemetryClient(any(InternalCallMarker.class)))
+        .thenReturn(mockTelemetryClient);
     when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
     when(mockStatusLine.getStatusCode()).thenReturn(500);
     when(mockStatusLine.getReasonPhrase()).thenReturn("Internal Server Error");
@@ -1029,7 +1031,7 @@ public class RestRequestTest {
       method.invoke(null, mockRequest, mockResponse, mockContext);
 
       Mockito.verify(mockContext).getSfSession();
-      Mockito.verify(mockSession).getTelemetryClient();
+      Mockito.verify(mockSession).getTelemetryClient(any(InternalCallMarker.class));
       Mockito.verify(mockResponse).getStatusLine();
       Mockito.verify(mockStatusLine, Mockito.atLeast(1)).getStatusCode();
       Mockito.verify(mockStatusLine, Mockito.atLeast(1)).getReasonPhrase();
@@ -1066,7 +1068,8 @@ public class RestRequestTest {
     SFBaseSession mockSession = mock(SFBaseSession.class);
     TelemetryClient mockTelemetryClient = mock(TelemetryClient.class);
 
-    when(mockSession.getTelemetryClient()).thenReturn(mockTelemetryClient);
+    when(mockSession.getTelemetryClient(any(InternalCallMarker.class)))
+        .thenReturn(mockTelemetryClient);
     when(mockContext.getSfSession()).thenReturn(mockSession);
 
     HttpExecutingContext mockHttpExecutingContext = mock(HttpExecutingContext.class);
@@ -1096,7 +1099,7 @@ public class RestRequestTest {
 
     ArgumentCaptor<TelemetryData> telemetryDataCaptor =
         ArgumentCaptor.forClass(TelemetryData.class);
-    Mockito.verify(mockSession).getTelemetryClient();
+    Mockito.verify(mockSession).getTelemetryClient(any(InternalCallMarker.class));
     Mockito.verify(mockTelemetryClient).addLogToBatch(telemetryDataCaptor.capture());
 
     TelemetryData capturedData = telemetryDataCaptor.getValue();
@@ -1135,7 +1138,8 @@ public class RestRequestTest {
     try {
       SFBaseSession mockSession = mock(SFBaseSession.class);
       TelemetryClient mockTelemetryClient = mock(TelemetryClient.class);
-      when(mockSession.getTelemetryClient()).thenReturn(mockTelemetryClient);
+      when(mockSession.getTelemetryClient(any(InternalCallMarker.class)))
+          .thenReturn(mockTelemetryClient);
 
       HttpClientSettingsKey settingsKey = new HttpClientSettingsKey(OCSPMode.FAIL_CLOSED);
       CloseableHttpClient httpClient = HttpUtil.buildHttpClient(settingsKey, null, false);
@@ -1162,7 +1166,7 @@ public class RestRequestTest {
 
       ArgumentCaptor<TelemetryData> telemetryDataCaptor =
           ArgumentCaptor.forClass(TelemetryData.class);
-      Mockito.verify(mockSession).getTelemetryClient();
+      Mockito.verify(mockSession).getTelemetryClient(any(InternalCallMarker.class));
       Mockito.verify(mockTelemetryClient).addLogToBatch(telemetryDataCaptor.capture());
 
       TelemetryData capturedData = telemetryDataCaptor.getValue();


### PR DESCRIPTION
# Overview

SNOW-2999722

This PR adds telemetry tracking for internal API usage by introducing `InternalCallMarker` parameters to key methods across the codebase. The changes enable differentiation between external and internal API calls for telemetry purposes.

### Key Changes:

- **SFSession**: Added overloaded methods with `InternalCallMarker` parameters for `open()`, `close()`, `getSessionToken()`, `getTelemetryClient()`, `getIdToken()`, `getAccessToken()`, and `getMfaToken()`
- **SFStatement**: Added `getSFBaseSession()` overload with telemetry tracking
- **SessionUtil**: Enhanced `generateJWTToken()` with internal call marker support
- **File Transfer Components**: Updated `SnowflakeFileTransferAgent` constructor and `getFileTransferMetadatas()` methods to accept internal call markers
- **Result Set Components**: Modified `SnowflakeResultSetSerializableV1` methods including `create()`, `getResultSet()`, `getSFResultSetMetaData()`, `getResultStreamProvider()`, and `getSession()` to support telemetry tracking
- **TelemetryClient**: Updated to use internal call marker when accessing session tokens

All existing public methods remain unchanged for backward compatibility, with new overloaded versions handling the telemetry tracking internally. The implementation uses `recordIfExternal()` calls to track API usage when methods are called without internal markers.