### PR TITLE
SNOW-3099029: Fix storage client resource leak

### DIFF
--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
@@ -713,6 +713,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           if (inputStream == null) {
             IOUtils.closeQuietly(uploadStream);
           }
+          if (client != null) {
+            client.shutdown();
+          }
         }
 
         logger.debug("FilePath: {}", srcFilePath);
@@ -864,6 +867,10 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           metadata.resultStatus = ResultStatus.ERROR;
           metadata.errorDetails = ex.getMessage();
           throw ex;
+        } finally {
+          if (client != null) {
+            client.shutdown();
+          }
         }
 
         logger.debug("FilePath: {}", srcFilePath);


### PR DESCRIPTION
# Overview

   This change adds proper client shutdown calls in the SnowflakeFileTransferAgent to prevent resource leaks. The client.shutdown() method is now called in finally blocks to ensure the client is properly closed even when exceptions occur during file transfer operations.