### PR TITLE
NO-SNOW: Fix internal markers ArchUnit test

### DIFF
--- a/src/test/java/net/snowflake/client/internal/jdbc/telemetry/InternalApiMarkerUsageArchTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/telemetry/InternalApiMarkerUsageArchTest.java
@@ -8,7 +8,6 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
 import net.snowflake.client.api.resultset.SnowflakeResultSetSerializable;
-import net.snowflake.client.category.TestTags;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.core.SFBaseSession;
 import net.snowflake.client.internal.core.SFBaseStatement;
@@ -17,10 +16,8 @@ import net.snowflake.client.internal.core.SFStatement;
 import net.snowflake.client.internal.core.SessionUtil;
 import net.snowflake.client.internal.jdbc.SnowflakeFileTransferAgent;
 import net.snowflake.client.internal.jdbc.SnowflakeResultSetSerializableV1;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag(TestTags.CORE)
 class InternalApiMarkerUsageArchTest {
   private static final String INTERNAL_PACKAGE = "net.snowflake.client.internal..";
 
@@ -120,7 +117,8 @@ class InternalApiMarkerUsageArchTest {
         .should()
         .callMethod(ownerClass, methodName, parameterTypes)
         .because(
-            "internal call sites must use marker-aware overloads to avoid external telemetry false positives");
+            "internal call sites must use marker-aware overloads to avoid external telemetry false positives")
+        .allowEmptyShould(true);
   }
 
   private static ArchRule noInternalCallsToConstructor(
@@ -133,6 +131,7 @@ class InternalApiMarkerUsageArchTest {
         .should()
         .callConstructor(ownerClass, parameterTypes)
         .because(
-            "internal call sites must use marker-aware overloads to avoid external telemetry false positives");
+            "internal call sites must use marker-aware overloads to avoid external telemetry false positives")
+        .allowEmptyShould(true);
   }
 }


### PR DESCRIPTION
# Overview

SNOW-XXXXX

Remove test tag and add allowEmptyShould configuration to InternalApiMarkerUsageArchTest

This change removes the `@Tag(TestTags.CORE)` annotation and its associated import from the `InternalApiMarkerUsageArchTest` class. Additionally, it adds `.allowEmptyShould(true)` to both `noInternalCallsTo` and `noInternalCallsToConstructor` methods to allow ArchUnit rules to pass when no matching code is found.