### PR TITLE
NO-SNOW: Restore S3 client's multipart threshold to 16MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Fix bug with malformed file during S3 upload
     - Added periodic closure of sockets closed by the remote end (snowflakedb/snowflake-jdbc#2481).
     - Add internal API usage telemetry tracker
+    - Change S3 Client's multipart threshold to 16MB
 
 - v4.0.1
     - Add /etc/os-release data to Minicore telemetry

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -65,6 +65,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
@@ -195,6 +196,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
             .readTimeout(Duration.ofMillis(clientConfig.socketTimeout))
             .writeTimeout(Duration.ofMillis(clientConfig.socketTimeout)));
     clientBuilder.multipartEnabled(true);
+    clientBuilder.multipartConfiguration(
+        MultipartConfiguration.builder().thresholdInBytes(16L * 1024 * 1024).build());
 
     ClientOverrideConfiguration.Builder configurationBuilder =
         ClientOverrideConfiguration.builder();


### PR DESCRIPTION
# Overview

This PR explicitly sets the SDK v2 multipart threshold to 16MB to restore the pre-upgrade behavior.
-
The AWS SDK v1 TransferManager used a default multipart upload threshold of 16MB — files smaller than this were uploaded with a single PutObject call. When migrating to AWS SDK v2, the multipart logic moved from the TransferManager into the S3AsyncClient itself (enabled via multipartEnabled(true)), which uses a default threshold of 8MB. This meant that files in the 8–16MB range — including our 12MB performance test payloads — silently switched from single-part uploads to multipart uploads (CreateMultipartUpload + UploadPart(s) + CompleteMultipartUpload), incurring additional API round trips per file. 
