### PR TITLE
SNOW-3194008: Add logging implementation to CLIENT_ENVIRONMENT telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Change S3 Client's multipart threshold to 16MB
     - Fixed fat jar with S3 iteration, the problem of not finding class `software.amazon.awssdk.transfer.s3.internal.ApplyUserAgentInterceptor` (snowflakedb/snowflake-jdbc#2519).
     - Removed Conscrypt from shading to prevent `failed to find class org/conscrypt/CryptoUpcalls` native error (snowflakedb/snowflake-jdbc#2519).
+    - Add logging implementation to CLIENT_ENVIRONMENT telemetry
 
 - v4.0.1
     - Add /etc/os-release data to Minicore telemetry

--- a/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
@@ -1173,6 +1173,7 @@ public class SessionUtil {
     }
 
     clientEnv.put("JDBC_JAR_NAME", DriverUtil.getJdbcJarname());
+    clientEnv.put("LOGGING_IMPLEMENTATION", SFLoggerFactory.getLoggerImplementationName());
 
     // Add platform detection (if not disabled)
     if (!loginInput.isDisablePlatformDetection()) {

--- a/src/main/java/net/snowflake/client/internal/log/SFLoggerFactory.java
+++ b/src/main/java/net/snowflake/client/internal/log/SFLoggerFactory.java
@@ -58,6 +58,20 @@ public class SFLoggerFactory {
     }
   }
 
+  public static String getLoggerImplementationName() {
+    // Ensure the implementation is initialized
+    if (loggerImplementation == null) {
+      getLogger(SFLoggerFactory.class);
+    }
+    switch (loggerImplementation) {
+      case SLF4JLOGGER:
+        return "SLF4J";
+      case JDK14LOGGER:
+      default:
+        return "JUL";
+    }
+  }
+
   /**
    * A replacement for getLogger function, whose parameter is Class&lt;?&gt;, when Class&lt;?&gt; is
    * inaccessible. For example, the name we have is an alias name of a class, we can't get the

--- a/src/test/java/net/snowflake/client/internal/core/SessionUtilTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SessionUtilTest.java
@@ -351,6 +351,14 @@ public class SessionUtilTest {
     String applicationPath = (String) clientEnv.get("APPLICATION_PATH");
     assertThat("APPLICATION_PATH should not be empty", !applicationPath.isEmpty());
     assertThat("APPLICATION_PATH should contain file path", isValidPath(applicationPath));
+
+    // Verify logging implementation is reported
+    assertThat(
+        "LOGGING_IMPLEMENTATION should be set", clientEnv.containsKey("LOGGING_IMPLEMENTATION"));
+    String loggingImpl = (String) clientEnv.get("LOGGING_IMPLEMENTATION");
+    assertThat(
+        "LOGGING_IMPLEMENTATION should be JUL or SLF4J",
+        "JUL".equals(loggingImpl) || "SLF4J".equals(loggingImpl));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/internal/log/SFLoggerFactoryTest.java
+++ b/src/test/java/net/snowflake/client/internal/log/SFLoggerFactoryTest.java
@@ -1,5 +1,6 @@
 package net.snowflake.client.internal.log;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -10,5 +11,10 @@ public class SFLoggerFactoryTest {
   public void testGetLoggerByNameDefault() {
     SFLogger sflogger = SFLoggerFactory.getLogger("SnowflakeConnectionImpl");
     assertTrue(sflogger instanceof JDK14Logger);
+  }
+
+  @Test
+  public void testGetLoggerImplementationNameDefaultsToJUL() {
+    assertEquals("JUL", SFLoggerFactory.getLoggerImplementationName());
   }
 }


### PR DESCRIPTION
# Overview

Reports the active logging backend (JUL or SLF4J) as a new LOGGING_IMPLEMENTATION field in the CLIENT_ENVIRONMENT section of the login request.

# Why
The Snowflake JDBC driver supports two logging backends:
- JUL (java.util.logging) — the default
- SLF4J — opt-in via -Dnet.snowflake.jdbc.loggerImpl=net.snowflake.client.log.SLF4JLogger

We are considering deprecating the JUL backend in favor of SLF4J, which is the industry standard used by all major Java libraries (AWS SDK, Azure SDK, Google Cloud SDK, etc.). However, removing JUL support could be a breaking change for customers who rely on it.

This telemetry will give us data to make an informed decision about whether we can:
- Remove JUL support
- Change slf4j-api from provided to compile scope, simplifying the dependency experience for customers