### PR TITLE
SNOW-2999725: Remove redundant slow wildcard metadata tests for procedures and functions

### DIFF
--- a/src/test/java/net/snowflake/client/internal/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/DatabaseMetaDataLatestIT.java
@@ -2606,40 +2606,6 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCWithSharedConnectionIT {
                   r -> Arrays.asList(r.getString("TABLE_NAME"), r.getString("TABLE_SCHEM"))));
         }
       }
-
-      @Test
-      void testGetProcedures() throws Exception {
-        try (ResultSet rs =
-            metaData.getProcedures(database, schemaWithUnderscore, procedureWithUnderscore)) {
-          assertMetadataQueryResult(
-              rs,
-              "procedures like '" + procedureWithUnderscore + "' in database \"" + database + "\"",
-              2,
-              Arrays.asList(
-                  Arrays.asList(alternativeProcedure, alternativeSchema),
-                  Arrays.asList(procedureWithUnderscore, schemaWithUnderscore)),
-              handleException(
-                  r ->
-                      Arrays.asList(
-                          r.getString("PROCEDURE_NAME"), r.getString("PROCEDURE_SCHEM"))));
-        }
-      }
-
-      @Test
-      void testGetFunctions() throws Exception {
-        try (ResultSet rs =
-            metaData.getFunctions(database, schemaWithUnderscore, functionWithUnderscore)) {
-          assertMetadataQueryResult(
-              rs,
-              "functions like '" + functionWithUnderscore + "' in database \"" + database + "\"",
-              2,
-              Arrays.asList(
-                  Arrays.asList(alternativeFunction, alternativeSchema),
-                  Arrays.asList(functionWithUnderscore, schemaWithUnderscore)),
-              handleException(
-                  r -> Arrays.asList(r.getString("FUNCTION_NAME"), r.getString("FUNCTION_SCHEM"))));
-        }
-      }
     }
 
     @Nested


### PR DESCRIPTION
# Overview

Removed testGetProcedures and testGetFunctions from WildcardsInShowMetadataQueries$WhenWildcardsEnabled. These 2 tests (out of 5) contributed ~160s of the nested class's ~404s runtime, because each executes a broad SHOW ... LIKE query against the database when _ in identifiers is treated as a LIKE wildcard.

#### Why no coverage is lost:
getProcedures, getFunctions, and getTables all go through the same wildcard code path in the driver — isSchemaNameWildcardPattern() (line 292 in SnowflakeDatabaseMetaDataImpl), which checks enableWildcardsInShowMetadataCommands. The retained testGetTables covers this shared path.

getColumns and getSchemas have their own distinct wildcard-handling code (lines 1766 and 3337 respectively), which is why both are retained.
The WhenWildcardsDisabled nested class still has all 5 tests (including testGetProcedures and testGetFunctions), verifying the procedure/function-specific SQL generation. These tests are fast (~3s total) because disabled wildcards produce narrowly-scoped queries.

