### PR TITLE
SNOW-2999725: Split DatabaseMetaDataLatestIT into its own CI shard to reduce TestCategoryOthers shard time

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,6 +120,7 @@ jobs:
                 category: [{suites: 'ResultSetTestSuite', name: 'TestCategoryResultSet'},
                            {suites: 'StatementTestSuite,LoaderTestSuite', name: 'TestCategoryStatement,TestCategoryLoader'},
                            {suites: 'OthersTestSuite', name: 'TestCategoryOthers'},
+                           {suites: 'DatabaseMetaDataTestSuite', name: 'TestCategoryDatabaseMetaData'},
                            {suites: 'ArrowTestSuite,ConnectionTestSuite,CoreTestSuite,DiagnosticTestSuite', name: 'TestCategoryArrow,TestCategoryConnection,TestCategoryCore,TestCategoryDiagnostic'},
                            {suites: 'FipsTestSuite', name: "TestCategoryFips"}]
                 additionalMavenProfile: ['']
@@ -175,6 +176,7 @@ jobs:
                 category: [{suites: 'ResultSetTestSuite', name: 'TestCategoryResultSet'},
                            {suites: 'StatementTestSuite,LoaderTestSuite', name: 'TestCategoryStatement,TestCategoryLoader'},
                            {suites: 'OthersTestSuite', name: 'TestCategoryOthers'},
+                           {suites: 'DatabaseMetaDataTestSuite', name: 'TestCategoryDatabaseMetaData'},
                            {suites: 'ArrowTestSuite,ConnectionTestSuite,CoreTestSuite,DiagnosticTestSuite', name: 'TestCategoryArrow,TestCategoryConnection,TestCategoryCore,TestCategoryDiagnostic'},
                            {suites: 'FipsTestSuite', name: "TestCategoryFips"}]
                 additionalMavenProfile: ['']
@@ -229,6 +231,7 @@ jobs:
                 category: [{suites: 'ResultSetTestSuite', name: 'TestCategoryResultSet'},
                            {suites: 'StatementTestSuite,LoaderTestSuite', name: 'TestCategoryStatement,TestCategoryLoader'},
                            {suites: 'OthersTestSuite', name: 'TestCategoryOthers'},
+                           {suites: 'DatabaseMetaDataTestSuite', name: 'TestCategoryDatabaseMetaData'},
                            {suites: 'ArrowTestSuite,ConnectionTestSuite,CoreTestSuite,DiagnosticTestSuite', name: 'TestCategoryArrow,TestCategoryConnection,TestCategoryCore,TestCategoryDiagnostic'},
                            {suites: 'FipsTestSuite', name: "TestCategoryFips"}]
                 additionalMavenProfile: ['']
@@ -292,6 +295,7 @@ jobs:
                 category: [{suites: 'ResultSetTestSuite', name: 'TestCategoryResultSet'},
                            {suites: 'StatementTestSuite,LoaderTestSuite', name: 'TestCategoryStatement,TestCategoryLoader'},
                            {suites: 'OthersTestSuite', name: 'TestCategoryOthers'},
+                           {suites: 'DatabaseMetaDataTestSuite', name: 'TestCategoryDatabaseMetaData'},
                            {suites: 'ArrowTestSuite,ConnectionTestSuite,CoreTestSuite,DiagnosticTestSuite', name: 'TestCategoryArrow,TestCategoryConnection,TestCategoryCore,TestCategoryDiagnostic'},
                            {suites: 'FipsTestSuite', name: "TestCategoryFips"}]
         steps:

--- a/src/test/java/net/snowflake/client/category/TestTags.java
+++ b/src/test/java/net/snowflake/client/category/TestTags.java
@@ -8,6 +8,7 @@ public class TestTags {
   public static final String CORE = "core";
   public static final String DIAGNOSTIC = "diagnostic";
   public static final String LOADER = "loader";
+  public static final String DATABASE_META_DATA = "databaseMetaData";
   public static final String OTHERS = "others";
   public static final String RESULT_SET = "resultSet";
   public static final String STATEMENT = "statement";

--- a/src/test/java/net/snowflake/client/internal/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/DatabaseMetaDataLatestIT.java
@@ -65,7 +65,7 @@ import org.junit.jupiter.api.TestInstance;
  * tests still is not applicable. If it is applicable, move tests to DatabaseMetaDataIT so that both
  * the latest and oldest supported driver run the tests.
  */
-@Tag(TestTags.OTHERS)
+@Tag(TestTags.DATABASE_META_DATA)
 public class DatabaseMetaDataLatestIT extends BaseJDBCWithSharedConnectionIT {
   private static final String TEST_PROC =
       "create or replace procedure testproc(param1 float, param2 string)\n"

--- a/src/test/java/net/snowflake/client/suites/DatabaseMetaDataTestSuite.java
+++ b/src/test/java/net/snowflake/client/suites/DatabaseMetaDataTestSuite.java
@@ -1,0 +1,8 @@
+package net.snowflake.client.suites;
+
+import net.snowflake.client.category.TestTags;
+import org.junit.platform.suite.api.IncludeTags;
+
+@BaseTestSuite
+@IncludeTags(TestTags.DATABASE_META_DATA)
+public class DatabaseMetaDataTestSuite {}

--- a/src/test/java/net/snowflake/client/suites/UnitOldDriverTestSuite.java
+++ b/src/test/java/net/snowflake/client/suites/UnitOldDriverTestSuite.java
@@ -8,6 +8,7 @@ import org.junit.platform.suite.api.ExcludeTags;
   TestTags.ARROW,
   TestTags.DIAGNOSTIC,
   TestTags.CONNECTION,
+  TestTags.DATABASE_META_DATA,
   TestTags.LOADER,
   TestTags.OTHERS,
   TestTags.RESULT_SET,

--- a/src/test/java/net/snowflake/client/suites/UnitTestSuite.java
+++ b/src/test/java/net/snowflake/client/suites/UnitTestSuite.java
@@ -11,6 +11,7 @@ import org.junit.platform.suite.api.ExcludeTags;
   TestTags.ARROW,
   TestTags.DIAGNOSTIC,
   TestTags.CONNECTION,
+  TestTags.DATABASE_META_DATA,
   TestTags.LOADER,
   TestTags.OTHERS,
   TestTags.RESULT_SET,


### PR DESCRIPTION
# Overview

DatabaseMetaDataLatestIT was the single heaviest test class in the OthersTestSuite, taking ~55-63 min out of a ~96-112 min total. It runs slowly because each test method executes multiple SHOW/DESC commands against the Snowflake backend, accumulating hundreds of round-trips.
This change isolates it into a new TestCategoryDatabaseMetaData shard so it runs in parallel with the remaining OthersTestSuite (~40 min), cutting the wall time roughly in half.

Changes:
- Added DATABASE_META_DATA tag to TestTags.java
- Created DatabaseMetaDataTestSuite.java
- Re-tagged DatabaseMetaDataLatestIT from others to databaseMetaData
- Added DatabaseMetaDataTestSuite as a new category in the CI matrix (all 4 test jobs)