### PR TITLE
NO-SNOW: Change slf4j-api scope to default compile value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - Fixed fat jar with S3 iteration, the problem of not finding class `software.amazon.awssdk.transfer.s3.internal.ApplyUserAgentInterceptor` (snowflakedb/snowflake-jdbc#2519).
     - Removed Conscrypt from shading to prevent `failed to find class org/conscrypt/CryptoUpcalls` native error (snowflakedb/snowflake-jdbc#2519).
     - Add logging implementation to CLIENT_ENVIRONMENT telemetry
+    - Change slf4j-api scope from provided to compile
 
 - v4.0.1
     - Add /etc/os-release data to Minicore telemetry

--- a/fat-jar-test-app/pom.xml
+++ b/fat-jar-test-app/pom.xml
@@ -26,7 +26,7 @@
                     <executable>java</executable>
                     <arguments>
                         <argument>-cp</argument>
-                        <argument>${project.build.outputDirectory}:${snowflake.jdbc.jar}:${settings.localRepository}/org/slf4j/slf4j-api/2.0.4/slf4j-api-2.0.4.jar${additional.classpath}</argument>
+                        <argument>${project.build.outputDirectory}:${snowflake.jdbc.jar}${additional.classpath}</argument>
                         <argument>${exec.mainClass}</argument>
                     </arguments>
                 </configuration>
@@ -35,11 +35,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.4</version>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -468,7 +468,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <!-- used by apache arrow -->


### PR DESCRIPTION
## Change slf4j-api scope from provided to compile

### Summary

- Change `slf4j-api` dependency scope from `provided` to `compile` (the default) in `parent-pom.xml`
- Remove the now-unnecessary explicit `slf4j-api` dependency and classpath wiring from `fat-jar-test-app`

### Motivation

The `provided` scope forced consumers to manually supply `slf4j-api` on the classpath, which is non-standard. Every major Java library that uses SLF4J (AWS SDK v2, Azure SDK, Google Cloud SDK, Logback, HikariCP) declares it with `compile` scope. The verbose dependency tree confirmed that all transitive occurrences of `slf4j-api` originate as `compile` and were being overridden to `provided` by our `dependencyManagement`.

For fat jar users, this was especially painful — the fat jar requires `slf4j-api` at runtime (shaded cloud SDK classes reference `org.slf4j.LoggerFactory`), but the `provided` scope excluded it from the fat jar, causing `NoClassDefFoundError: org/slf4j/LoggerFactory` unless the user manually added it to their classpath.

### What changes

- **`parent-pom.xml`**: Removed `<scope>provided</scope>` from the `slf4j-api` entry in `dependencyManagement`
- **`fat-jar-test-app/pom.xml`**: Removed the `slf4j-api` dependency and its classpath reference from the exec plugin, since `slf4j-api` is now bundled in the fat jar

### Impact

- **Fat jar**: `slf4j-api` is now bundled — the fat jar is self-contained and no longer requires users to supply `slf4j-api` separately
- **Thin jar**: No practical change — `slf4j-api` was already reaching consumers transitively through AWS SDK, Azure SDK, and Google Cloud SDK
- **SLF4J "No providers" warning**: Unchanged — this warning already appeared when users supplied `slf4j-api` without a binding; the behavior is identical

### Verified

- Built the fat jar **without** the scope change, removed `slf4j-api` from the test app, confirmed `NoClassDefFoundError: org/slf4j/LoggerFactory`
- Built the fat jar **with** the scope change, confirmed the test app compiles and connects to Snowflake without supplying `slf4j-api` externally