### PR TITLE
SNOW-3204822 Fix AWS error handling manifested with NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - Add SLF4J bridge from shaded dependencies to `SFLogger` (snowflakedb/snowflake-jdbc#2543)
     - Fixed proxy authentication when connecting to GCP (snowflakedb/snowflake-jdbc#2540)
     - Fixed bug where called-provided schema was ignored in getStreams()
+    - Fixed S3 error handling manifested with `NullPointerException`
 
 - v4.0.1
     - Add /etc/os-release data to Minicore telemetry

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/S3ErrorHandler.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/S3ErrorHandler.java
@@ -62,9 +62,9 @@ public class S3ErrorHandler {
     // we need to refresh our S3 client with the new token
     if (cause instanceof S3Exception) {
       S3Exception e = (S3Exception) cause;
-      if (e.awsErrorDetails()
-          .errorCode()
-          .equalsIgnoreCase(SnowflakeS3Client.EXPIRED_AWS_TOKEN_ERROR_CODE)) {
+      if (e.awsErrorDetails() != null
+          && SnowflakeS3Client.EXPIRED_AWS_TOKEN_ERROR_CODE.equalsIgnoreCase(
+              e.awsErrorDetails().errorCode())) {
         // If session is null we cannot renew the token so throw the ExpiredToken exception
         if (session != null) {
           SnowflakeFileTransferAgent.renewExpiredToken(session, command, s3Client);

--- a/src/test/java/net/snowflake/client/annotations/RunOnGCP.java
+++ b/src/test/java/net/snowflake/client/annotations/RunOnGCP.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @EnabledIfEnvironmentVariable(named = "CLOUD_PROVIDER", matches = "(?i)GCP(?-i)")
 public @interface RunOnGCP {}

--- a/src/test/java/net/snowflake/client/internal/jdbc/AuthenticatedProxyLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/AuthenticatedProxyLatestIT.java
@@ -14,6 +14,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import net.snowflake.client.annotations.RunOnGCP;
 import net.snowflake.client.category.TestTags;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -21,7 +22,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -34,21 +34,12 @@ import org.junit.jupiter.api.Test;
  * proxy code path.
  */
 @Tag(TestTags.OTHERS)
+@RunOnGCP
 public class AuthenticatedProxyLatestIT extends BaseWiremockTest {
 
   private static final String PROXY_USER = "testUser";
   private static final String PROXY_PASSWORD = "testPassword";
   private static final String TEST_DATA_FILE = "orders_100.csv";
-
-  /**
-   * Override the WireMock startup to use {@code --proxy-pass-through true}. The base class uses
-   * {@code false} which blocks unmatched requests. For PUT tests, both Snowflake API calls and
-   * cloud storage (GCS/S3/Azure) uploads must be forwarded, so pass-through mode is required.
-   */
-  @BeforeAll
-  public static void setUpClass() {
-    startWiremockStandAlone(true);
-  }
 
   @AfterEach
   public void tearDown() {

--- a/src/test/java/net/snowflake/client/internal/jdbc/BaseWiremockTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/BaseWiremockTest.java
@@ -84,10 +84,6 @@ public abstract class BaseWiremockTest {
   }
 
   protected static void startWiremockStandAlone() {
-    startWiremockStandAlone(false);
-  }
-
-  protected static void startWiremockStandAlone(boolean proxyPassThrough) {
     // retrying in case of fail in port bindings
     await()
         .alias("wait for wiremock responding")
@@ -97,8 +93,7 @@ public abstract class BaseWiremockTest {
               try {
                 wiremockHttpPort = findFreePort();
                 wiremockHttpsPort = findFreePort();
-                wiremockStandalone =
-                    startWiremockProcess(wiremockHttpPort, wiremockHttpsPort, proxyPassThrough);
+                wiremockStandalone = startWiremockProcess(wiremockHttpPort, wiremockHttpsPort);
                 waitForWiremockOnPort(wiremockHttpPort);
                 return true;
               } catch (Exception e) {
@@ -110,11 +105,6 @@ public abstract class BaseWiremockTest {
 
   protected static Process startWiremockProcess(int wiremockHttpPort, int wiremockHttpsPort)
       throws IOException {
-    return startWiremockProcess(wiremockHttpPort, wiremockHttpsPort, false);
-  }
-
-  protected static Process startWiremockProcess(
-      int wiremockHttpPort, int wiremockHttpsPort, boolean proxyPassThrough) throws IOException {
     String javaExecutable =
         System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
     return new ProcessBuilder(
@@ -125,7 +115,8 @@ public abstract class BaseWiremockTest {
             System.getProperty("user.dir") + File.separator + WIREMOCK_HOME_DIR + File.separator,
             "--enable-browser-proxying", // work as forward proxy
             "--proxy-pass-through",
-            String.valueOf(proxyPassThrough),
+            "true",
+            "--preserve-host-header",
             "--port",
             String.valueOf(wiremockHttpPort),
             "--https-port",


### PR DESCRIPTION
This PR fixes AWS error handling manifested with `NullPointerException`.
This PR also blocks proxy tests on AWS, because AWS requests are signed (sigv4), but Wiremocks slightly modifies the requests. The fix and authenticated proxy overall was tested manually with MITM (which doesn't modify the request).
It also fixes hanging CIs. The previous code started the second instance of wiremock and overwrote the original process handle, so the child process was never closed, blocking the main test process. Now, there is only one wiremock instance, but starts it in proxy passthrough mode.