### PR TITLE
NO-SNOW: Fix StreamLoader vector metadata detection error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.2.1-SNAPSHOT
+    - Fix StreamLoader vector metadata detection to handle empty metadata result sets safely and avoid aborting load jobs on non-critical metadata lookup failures.
     - Fixed `Connection.isValid()` silently swallowing thread interruption: when the underlying heartbeat is interrupted, the connection's interrupt flag is now restored via `Thread.currentThread().interrupt()` so connection pools and Thread shutdown mechanisms can react to the interruption (snowflakedb/snowflake-jdbc#2314).
     - Added defense-in-depth canonical-path validation in the S3, Azure, and GCS download clients to ensure resolved local download paths cannot escape the user's GET target directory via traversal segments, absolute paths, or symlink redirection (snowflakedb/snowflake-jdbc#2623).
     - Fixed path traversal via server-controlled filenames in `SnowflakeFileTransferAgent` GET destination filename derivation; backslash separators are now stripped and traversal/absolute basenames are rejected (snowflakedb/snowflake-jdbc#2622).

--- a/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -3722,9 +3722,27 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
     try {
       resultSet = statement.executeQuery(sql);
     } catch (SnowflakeSQLException e) {
+      if (metadataType == GET_COLUMNS) {
+        logger.warn(
+            "DatabaseMetaData.getColumns received SQL exception and may return empty result: "
+                + "sqlState={}, errorCode={}, queryId={}, message={}, sql={}",
+            e.getSQLState(),
+            e.getErrorCode(),
+            e.getQueryId(),
+            e.getMessage(),
+            sql);
+      }
       if (e.getSQLState().equals(SqlState.NO_DATA)
           || e.getSQLState().equals(SqlState.BASE_TABLE_OR_VIEW_NOT_FOUND)
           || e.getMessage().contains("Operation is not supported in reader account")) {
+        if (metadataType == GET_COLUMNS) {
+          logger.warn(
+              "DatabaseMetaData.getColumns normalized SQL exception to empty result set: "
+                  + "sqlState={}, queryId={}, sql={}",
+              e.getSQLState(),
+              e.getQueryId(),
+              sql);
+        }
         return SnowflakeDatabaseMetaDataResultSet.getEmptyResult(
             metadataType, statement, e.getQueryId());
       }

--- a/src/main/java/net/snowflake/client/internal/loader/StreamLoader.java
+++ b/src/main/java/net/snowflake/client/internal/loader/StreamLoader.java
@@ -57,6 +57,9 @@ public class StreamLoader implements Loader, Runnable {
   /** Default batch row size */
   private static final long DEFAULT_BATCH_ROW_SIZE = -1L;
 
+  private static final String FAIL_ON_MISSING_COLUMN_METADATA_KEY =
+      SYSTEM_PARAMETER_PREFIX + "failOnMissingColumnMetadata";
+
   public static DatabaseMetaData metadata;
 
   private BufferStage _stage = null;
@@ -632,24 +635,47 @@ public class StreamLoader implements Loader, Runnable {
   }
 
   public void setVectorColumns() {
+    _vectorColumnsNameAndSize.clear();
+    if (_columns == null || _columns.isEmpty()) {
+      return;
+    }
+
     try {
       DatabaseMetaData dbmd = _processConn.getMetaData();
       for (String col : _columns) {
         try (ResultSet rs = dbmd.getColumns(_database, _schema, _table, col)) {
-          rs.next();
+          if (!rs.next()) {
+            String message =
+                String.format(
+                    "No metadata row returned for column %s.%s.%s.%s",
+                    _database, _schema, _table, col);
+            logger.warn(message);
+            if (shouldFailOnMissingColumnMetadata()) {
+              throw new Loader.ConnectionError(message);
+            }
+            continue;
+          }
           if (isColumnTypeVector(rs.getString(6))) {
             _vectorColumnsNameAndSize.put(col, rs.getInt(7));
           }
         }
       }
     } catch (SQLException e) {
-      logger.error(e.getMessage(), e);
-      abort(new Loader.ConnectionError(Utils.getCause(e)));
+      logger.warn(
+          "Failed to detect vector columns via metadata query. "
+              + "Vector column type casting will be skipped. Error: {}",
+          e.getMessage());
+      logger.debug("setVectorColumns metadata query failure details", e);
+      _vectorColumnsNameAndSize.clear();
     }
   }
 
   private boolean isColumnTypeVector(String col) {
     return col != null && col.equalsIgnoreCase("vector");
+  }
+
+  private boolean shouldFailOnMissingColumnMetadata() {
+    return Boolean.parseBoolean(systemGetProperty(FAIL_ON_MISSING_COLUMN_METADATA_KEY));
   }
 
   @Override

--- a/src/test/java/net/snowflake/client/internal/loader/FlatfileReadMultithreadIT.java
+++ b/src/test/java/net/snowflake/client/internal/loader/FlatfileReadMultithreadIT.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Test;
 @Tag(TestTags.LOADER)
 public class FlatfileReadMultithreadIT {
   private final int NUM_RECORDS = 100000;
+  private static final String FAIL_ON_MISSING_COLUMN_METADATA_KEY =
+      "net.snowflake.client.loader.failOnMissingColumnMetadata";
 
   private static final String TARGET_STAGE = "STAGE_MULTITHREAD_LOADER";
   private static String TARGET_SCHEMA;
@@ -63,6 +65,9 @@ public class FlatfileReadMultithreadIT {
   @Test
   public void testIssueSimpleDateFormat() throws Throwable {
     final String targetTable = "TABLE_ISSUE_SIMPLEDATEFORMAT";
+    String originalFailOnMissingMetadataValue =
+        System.getProperty(FAIL_ON_MISSING_COLUMN_METADATA_KEY);
+    System.setProperty(FAIL_ON_MISSING_COLUMN_METADATA_KEY, "true");
     try (Connection testConnection = AbstractDriverIT.getConnection();
         Statement statement = testConnection.createStatement()) {
       try {
@@ -100,6 +105,12 @@ public class FlatfileReadMultithreadIT {
       } finally {
         statement.execute(
             String.format("DROP TABLE IF EXISTS %s.%s.%s", TARGET_DB, TARGET_SCHEMA, targetTable));
+        if (originalFailOnMissingMetadataValue == null) {
+          System.clearProperty(FAIL_ON_MISSING_COLUMN_METADATA_KEY);
+        } else {
+          System.setProperty(
+              FAIL_ON_MISSING_COLUMN_METADATA_KEY, originalFailOnMissingMetadataValue);
+        }
       }
     }
   }


### PR DESCRIPTION
# Overview

- Fixed flaky loader startup in StreamLoader by safely handling metadata ResultSet access when getColumns(...) returns no rows.
- Replaced hard failure behavior for vector metadata lookup issues with warning-level handling, so non-critical metadata hiccups do not abort the load.
- Simplified vector metadata detection logic (rs.next() guard, early clear/return paths) and added a changelog entry under upcoming release.