### PR TITLE
NO-SNOW: Fix prepareNewVersion.sh

### DIFF
--- a/prepareNewVersion.sh
+++ b/prepareNewVersion.sh
@@ -6,16 +6,10 @@ if [[ -z "$1" ]]; then
 fi
 
 version=$1
-
-# prepare release with maven
-./mvnw -f parent-pom.xml versions:set -DnewVersion=$version -DgenerateBackupPoms=false
-
-# update version in Driver code
 version_without_snapshot=${version%-*}
-file_with_version=src/main/java/net/snowflake/client/internal/driver/DriverVersion.java
-tmp_file_with_version=${file_with_version}.tmp
-sed -E "s/( implementVersion = )(.+)(;)/\1\"${version_without_snapshot}\"\3/" src/main/java/net/snowflake/client/internal/driver/DriverVersion.java > $tmp_file_with_version
-mv $tmp_file_with_version $file_with_version
+
+# prepare release with maven (version.properties is populated by Maven resource filtering)
+./mvnw -f parent-pom.xml versions:set -DnewVersion=$version -DgenerateBackupPoms=false
 
 if [[ "$version" == *-SNAPSHOT ]]; then
 sed -i '' '3a\


### PR DESCRIPTION
# Overview

The prepareNewVersion.sh script was updated to reflect the new versioning approach introduced by readAndNormalizeVersion() in DriverVersion.java. Previously, the driver version was hardcoded as a string literal in the Java source, and the script used sed to patch that value during release. Now, the version is read at runtime from version.properties, which is populated automatically by Maven resource filtering from the POM version. The -SNAPSHOT suffix stripping also moved from the shell script into the Java method. As a result, the sed command and its supporting variables (file_with_version, tmp_file_with_version) were removed from the script, since the Maven versions:set command alone is sufficient to propagate the version through the entire build.