### PR TITLE
NO-SNOW: Remove SNOW-** and NO-SNOW-** from the push trigger

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,8 +4,6 @@ on:
     push:
         branches:
             - master
-            - SNOW-**
-            - NO-SNOW-**
         tags:
             - v*
     pull_request:


### PR DESCRIPTION
# Overview

When a branch matching SNOW-** or NO-SNOW-** has an open PR, every push fires both the push and pull_request events. Because the concurrency groups differ (github.ref vs PR number), both runs execute in parallel — resulting in ~300 duplicate jobs instead of ~120.

The push trigger is unnecessary for feature branches: the pull_request trigger with synchronize already covers new commits pushed to open PRs. The full test matrix is still available via the FULL-TEST-MATRIX label on PRs, and master retains the push trigger for post-merge validation.

This change cuts CI jobs per push from ~300 to ~120 for branches matching SNOW-* / NO-SNOW-*.
