### PR TITLE
SNOW-3277710: Fix Netty native library conflict in thin JAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Upcoming release
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).
     - Fix initializing ObjectMapper when DATE_OUTPUT_FORMAT is specified (snowflakedb/snowflake-jdbc#2545).
+    - Fix Netty native library conflict in thin JAR (snowflakedb/snowflake-jdbc#2559)
 
 - v4.0.2
     - Fix expired session token renewal when polling results (snowflakedb/snowflake-jdbc#2489)   

--- a/pom.xml
+++ b/pom.xml
@@ -670,7 +670,8 @@
                       <include>net.snowflake:snowflake-common</include>
                       <include>org.apache.arrow:*</include>
                       <include>org.apache.tika:tika-core</include>
-                      <include>io.netty:*</include>
+                      <include>io.netty:netty-common</include>
+                      <include>io.netty:netty-buffer</include>
                     </includes>
                   </artifactSet>
                   <relocations>


### PR DESCRIPTION
# Overview

The thin JAR's shade config included `io.netty:*`, which bundled native `.so/.jnilib` files from transport modules (epoll, kqueue, dns-macos) that Arrow doesn't need. These unshaded native libraries conflict with consumer-provided Netty on the classpath.

Narrowed the artifact set to only `io.netty:netty-common` and `io.netty:netty-buffer` — the two modules Arrow actually depends on. These contain no native binaries.

Fixes: classpath conflict when consumers bring their own netty-transport-native-epoll alongside snowflake-jdbc-thin.


