### PR TITLE
SNOW-2114317: Improve CRL

### DIFF
--- a/src/main/java/net/snowflake/client/internal/core/crl/CRLCacheConfig.java
+++ b/src/main/java/net/snowflake/client/internal/core/crl/CRLCacheConfig.java
@@ -29,7 +29,7 @@ public class CRLCacheConfig {
 
   public static Duration getCacheValidityTime() {
     String validityTime = SnowflakeUtil.systemGetProperty(CRL_CACHE_VALIDITY_TIME);
-    if (validityTime != null && !validityTime.isEmpty()) {
+    if (!SnowflakeUtil.isNullOrEmpty(validityTime)) {
       try {
         long seconds = Long.parseLong(validityTime);
         if (seconds <= 0) {
@@ -46,7 +46,7 @@ public class CRLCacheConfig {
 
   public static Path getOnDiskCacheDir() {
     String cacheDir = SnowflakeUtil.systemGetProperty(CRL_RESPONSE_CACHE_DIR);
-    if (cacheDir == null || cacheDir.isEmpty()) {
+    if (SnowflakeUtil.isNullOrEmpty(cacheDir)) {
       File defaultCacheDir = FileCacheUtil.getDefaultCacheDir();
       if (defaultCacheDir != null) {
         return Paths.get(defaultCacheDir.getAbsolutePath(), "crls");
@@ -61,7 +61,7 @@ public class CRLCacheConfig {
 
   public static long getCrlDownloadMaxSizeBytes() {
     String value = SnowflakeUtil.systemGetProperty(CRL_DOWNLOAD_MAX_SIZE_BYTES);
-    if (value != null && !value.isEmpty()) {
+    if (!SnowflakeUtil.isNullOrEmpty(value)) {
       try {
         long bytes = Long.parseLong(value);
         if (bytes <= 0) {
@@ -81,7 +81,7 @@ public class CRLCacheConfig {
 
   public static Duration getCrlOnDiskCacheRemovalDelay() {
     String removalDelay = SnowflakeUtil.systemGetProperty(CRL_ON_DISK_CACHE_REMOVAL_DELAY);
-    if (removalDelay != null && !removalDelay.isEmpty()) {
+    if (!SnowflakeUtil.isNullOrEmpty(removalDelay)) {
       try {
         long seconds = Long.parseLong(removalDelay);
         if (seconds <= 0) {

--- a/src/main/java/net/snowflake/client/internal/core/crl/CRLCacheConfig.java
+++ b/src/main/java/net/snowflake/client/internal/core/crl/CRLCacheConfig.java
@@ -16,6 +16,8 @@ public class CRLCacheConfig {
   public static final String CRL_CACHE_VALIDITY_TIME = "CRL_CACHE_VALIDITY_TIME";
   public static final String CRL_RESPONSE_CACHE_DIR = "CRL_RESPONSE_CACHE_DIR";
   public static final String CRL_ON_DISK_CACHE_REMOVAL_DELAY = "CRL_ON_DISK_CACHE_REMOVAL_DELAY";
+  public static final String CRL_DOWNLOAD_MAX_SIZE_BYTES = "CRL_DOWNLOAD_MAX_SIZE_BYTES";
+  private static final long DEFAULT_CRL_DOWNLOAD_MAX_SIZE_BYTES = 20L * 1024 * 1024; // 20 MB
 
   public static boolean getInMemoryCacheEnabled() {
     return SnowflakeUtil.convertSystemPropertyToBooleanValue(ENABLE_CRL_IN_MEMORY_CACHING, true);
@@ -55,6 +57,26 @@ public class CRLCacheConfig {
     } else {
       return Paths.get(cacheDir);
     }
+  }
+
+  public static long getCrlDownloadMaxSizeBytes() {
+    String value = SnowflakeUtil.systemGetProperty(CRL_DOWNLOAD_MAX_SIZE_BYTES);
+    if (value != null && !value.isEmpty()) {
+      try {
+        long bytes = Long.parseLong(value);
+        if (bytes <= 0) {
+          throw new IllegalArgumentException("CRL download max size must be positive");
+        }
+        if (bytes > Integer.MAX_VALUE - 1) {
+          throw new IllegalArgumentException(
+              "CRL download max size must not exceed " + (Integer.MAX_VALUE - 1) + " bytes");
+        }
+        return bytes;
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Invalid CRL download max size: " + value, e);
+      }
+    }
+    return DEFAULT_CRL_DOWNLOAD_MAX_SIZE_BYTES;
   }
 
   public static Duration getCrlOnDiskCacheRemovalDelay() {

--- a/src/main/java/net/snowflake/client/internal/core/crl/CRLFileCache.java
+++ b/src/main/java/net/snowflake/client/internal/core/crl/CRLFileCache.java
@@ -163,7 +163,7 @@ class CRLFileCache implements CRLCache {
         if (Constants.getOS().isPosix()) {
           Files.createDirectories(
               cacheDir,
-              PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+              PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
           logger.debug("Initialized CRL cache directory: {}", cacheDir);
         } else {
           Files.createDirectories(cacheDir);

--- a/src/main/java/net/snowflake/client/internal/core/crl/CRLValidationUtils.java
+++ b/src/main/java/net/snowflake/client/internal/core/crl/CRLValidationUtils.java
@@ -134,6 +134,14 @@ class CRLValidationUtils {
         return false;
       }
 
+      // Check if this CRL only covers specific revocation reasons
+      if (idp.getOnlySomeReasons() != null) {
+        logger.debug(
+            "CRL only covers specific revocation reasons (onlySomeReasons is set) - "
+                + "treating as not authoritative for full revocation checking");
+        return false;
+      }
+
       DistributionPointName dpName = idp.getDistributionPoint();
       if (dpName != null) {
         if (dpName.getType() == DistributionPointName.FULL_NAME) {

--- a/src/main/java/net/snowflake/client/internal/core/crl/CRLValidator.java
+++ b/src/main/java/net/snowflake/client/internal/core/crl/CRLValidator.java
@@ -37,6 +37,7 @@ import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -331,7 +332,18 @@ public class CRLValidator {
       long start = System.currentTimeMillis();
       try (CloseableHttpResponse response = this.httpClient.execute(get)) {
         try (InputStream inputStream = response.getEntity().getContent()) {
-          byte[] crlData = IOUtils.toByteArray(inputStream);
+          long maxSize = CRLCacheConfig.getCrlDownloadMaxSizeBytes();
+          InputStream bounded =
+              BoundedInputStream.builder()
+                  .setInputStream(inputStream)
+                  .setMaxCount(maxSize + 1)
+                  .get();
+          byte[] crlData = IOUtils.toByteArray(bounded);
+          if (crlData.length > maxSize) {
+            logger.warn(
+                "CRL from {} exceeds max download size of {} bytes, aborting", crlUrl, maxSize);
+            return null;
+          }
           revocationTelemetry.setTimeDownloadingCrl(System.currentTimeMillis() - start);
           start = System.currentTimeMillis();
           X509CRL crl = (X509CRL) cf.generateCRL(new ByteArrayInputStream(crlData));

--- a/src/test/java/net/snowflake/client/internal/core/crl/CRLValidationUtilsTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/crl/CRLValidationUtilsTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import net.snowflake.client.category.TestTags;
 import net.snowflake.client.internal.core.crl.CertificateGeneratorUtil.CertificateChain;
 import org.bouncycastle.asn1.x509.IssuingDistributionPoint;
+import org.bouncycastle.asn1.x509.ReasonFlags;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -232,6 +233,19 @@ class CRLValidationUtilsTest {
 
       assertTrue(
           verifyIssuingDistributionPoint(crl, chain.leafCert, "http://snowflake.com/test.crl"));
+    }
+
+    @Test
+    void shouldRejectCRLWithOnlySomeReasons() throws Exception {
+      CertificateChain chain = certGen.createSimpleChain();
+      ReasonFlags reasons = new ReasonFlags(ReasonFlags.keyCompromise);
+      IssuingDistributionPoint idp =
+          new IssuingDistributionPoint(null, false, false, reasons, false, false);
+      X509CRL crl = certGen.createCRLWithIDP(chain.rootCert, idp);
+
+      assertFalse(
+          verifyIssuingDistributionPoint(crl, chain.leafCert, "http://snowflake.com/test.crl"),
+          "Should reject CRL that only covers specific revocation reasons");
     }
   }
 }

--- a/src/test/java/net/snowflake/client/internal/core/crl/CRLValidatorWiremockIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/crl/CRLValidatorWiremockIT.java
@@ -241,10 +241,15 @@ public class CRLValidatorWiremockIT extends BaseWiremockTest {
     String previousValue = System.getProperty(CRLCacheConfig.CRL_DOWNLOAD_MAX_SIZE_BYTES);
     try {
       System.setProperty(CRLCacheConfig.CRL_DOWNLOAD_MAX_SIZE_BYTES, "1024");
-      // Create a CRL response that exceeds the configured max download size (1 KB)
-      byte[] oversizedContent = new byte[2048];
-      Arrays.fill(oversizedContent, (byte) 0xFF);
-      setupCRLMapping("/oversized-ca.crl", oversizedContent, 200);
+      // Generate a valid CRL with many revoked entries so its encoded size exceeds 1 KB
+      for (int i = 0; i < 50; i++) {
+        certGen.generateCRLWithRevokedCertificate(java.math.BigInteger.valueOf(1000 + i));
+      }
+      byte[] largeCrl = certGen.generateValidCRL();
+      assertTrue(
+          largeCrl.length > 1024,
+          "Test precondition: CRL should be larger than 1024 bytes, but was " + largeCrl.length);
+      setupCRLMapping("/oversized-ca.crl", largeCrl, 200);
 
       X509Certificate cert =
           certGen.createCertificateWithCRLDistributionPoints(

--- a/src/test/java/net/snowflake/client/internal/core/crl/CRLValidatorWiremockIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/crl/CRLValidatorWiremockIT.java
@@ -236,6 +236,39 @@ public class CRLValidatorWiremockIT extends BaseWiremockTest {
   }
 
   @Test
+  void shouldFailWhenCrlExceedsMaxSizeLimit() throws Exception {
+    // Override max size to a small value for testing
+    String previousValue = System.getProperty(CRLCacheConfig.CRL_DOWNLOAD_MAX_SIZE_BYTES);
+    try {
+      System.setProperty(CRLCacheConfig.CRL_DOWNLOAD_MAX_SIZE_BYTES, "1024");
+      // Create a CRL response that exceeds the configured max download size (1 KB)
+      byte[] oversizedContent = new byte[2048];
+      Arrays.fill(oversizedContent, (byte) 0xFF);
+      setupCRLMapping("/oversized-ca.crl", oversizedContent, 200);
+
+      X509Certificate cert =
+          certGen.createCertificateWithCRLDistributionPoints(
+              "CN=Oversized CRL Server",
+              Arrays.asList("http://localhost:" + wiremockHttpPort + "/oversized-ca.crl"));
+      X509Certificate[] chain = {cert, certGen.getCACertificate()};
+
+      CRLValidator validator =
+          new CRLValidator(
+              CertRevocationCheckMode.ENABLED, false, httpClient, cacheManager, telemetry);
+
+      assertFalse(
+          validator.validateCertificateChains(Arrays.asList(new X509Certificate[][] {chain})),
+          "Should fail validation when CRL exceeds max download size");
+    } finally {
+      if (previousValue != null) {
+        System.setProperty(CRLCacheConfig.CRL_DOWNLOAD_MAX_SIZE_BYTES, previousValue);
+      } else {
+        System.clearProperty(CRLCacheConfig.CRL_DOWNLOAD_MAX_SIZE_BYTES);
+      }
+    }
+  }
+
+  @Test
   void shouldEmitCrlTelemetry() throws Exception {
     byte[] crlContent = certGen.generateValidCRL();
     String crlUrl = "http://localhost:" + wiremockHttpPort + "/test-ca.crl";


### PR DESCRIPTION
# Overview

Add a configurable maximum CRL download size (default 20 MB) and enforce it during CRL fetch.
Reject CRLs whose IDP extension specifies onlySomeReasons (treat as not authoritative for full revocation checking).
Adjust POSIX CRL cache directory permissions to ensure directories are usable (rwx------) and add tests for the new behaviors.

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
