### PR TITLE
SNOW-2434159 Fix protocol handling logic in SFConnectionConfigParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     - Fixed connections.toml auto-configuration behaviour (snowflakedb/snowflake-jdbc#2591):
       - now defaulting to port 443 instead of 80 when neither port nor protocol is specified
       - config coming from the JDBC connection string are no longer ignored when auto-configuration sourced items also present (when both present, direct connection config takes precedence)
-    - Fixed protocol field in connections.toml being ignored, causing connections to always use HTTPS
+    - Fixed protocol field in connections.toml being ignored, causing connections to always use HTTPS (snowflakedb/snowflake-jdbc#2585)
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).
     - Fix initializing ObjectMapper when DATE_OUTPUT_FORMAT is specified (snowflakedb/snowflake-jdbc#2545).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - v4.1.1-SNAPSHOT
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)
+    - Fixed protocol field in connections.toml being ignored, causing connections to always use HTTPS
+    - Fixed default port being set to 80 instead of 443 when no protocol is specified in connections.toml
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).
     - Fix initializing ObjectMapper when DATE_OUTPUT_FORMAT is specified (snowflakedb/snowflake-jdbc#2545).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     - Fixed connections.toml auto-configuration behaviour (snowflakedb/snowflake-jdbc#2591):
       - now defaulting to port 443 instead of 80 when neither port nor protocol is specified
       - config coming from the JDBC connection string are no longer ignored when auto-configuration sourced items also present (when both present, direct connection config takes precedence)
-
+    - Fixed protocol field in connections.toml being ignored, causing connections to always use HTTPS
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).
     - Fix initializing ObjectMapper when DATE_OUTPUT_FORMAT is specified (snowflakedb/snowflake-jdbc#2545).

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -274,14 +274,11 @@ public class SFConnectionConfigParser {
     logger.debug("Host created using parameters from connection configuration file: {}", host);
     String port = fileConnectionConfiguration.get("port");
     String protocol = fileConnectionConfiguration.get("protocol");
-    if (isNullOrEmpty(port)) {
-      if ("https".equals(protocol)) {
-        port = "443";
-      } else {
-        port = "80";
-      }
+    if ("http".equals(protocol)) {
+      return String.format(
+          "jdbc:snowflake://http://%s:%s", host, isNullOrEmpty(port) ? "80" : port);
     }
-    return String.format("jdbc:snowflake://%s:%s", host, port);
+    return String.format("jdbc:snowflake://%s:%s", host, isNullOrEmpty(port) ? "443" : port);
   }
 
   private static void putPropertyIfNotNull(Properties props, Object key, Object value) {

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -296,14 +296,11 @@ public class SFConnectionConfigParser {
     logger.debug("Host created using parameters from connection configuration file: {}", host);
     String port = fileConnectionConfiguration.get("port");
     String protocol = fileConnectionConfiguration.get("protocol");
-    if (isNullOrEmpty(port)) {
-      if ("http".equalsIgnoreCase(protocol)) {
-        port = "80";
-      } else {
-        port = "443";
-      }
+    if ("http".equalsIgnoreCase(protocol)) {
+      return String.format(
+          "jdbc:snowflake://http://%s:%s", host, isNullOrEmpty(port) ? "80" : port);
     }
-    return String.format("jdbc:snowflake://%s:%s", host, port);
+    return String.format("jdbc:snowflake://%s:%s", host, isNullOrEmpty(port) ? "443" : port);
   }
 
   private static void putPropertyIfNotNull(Properties props, Object key, Object value) {

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -154,6 +154,88 @@ public class SFConnectionConfigParserTest {
   }
 
   @Test
+  public void testProtocolFromTomlIsPreservedInUrl() throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    Map<String, String> extraparams = new HashMap();
+    extraparams.put("host", "snowflake.reg.local");
+    extraparams.put("account", null);
+    extraparams.put("port", "8082");
+    extraparams.put("token", "testToken");
+    extraparams.put("protocol", "http");
+    prepareConnectionConfigurationTomlFile(extraparams);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals("jdbc:snowflake://http://snowflake.reg.local:8082", data.getUrl());
+  }
+
+  @Test
+  public void testHttpsProtocolFromTomlIsPreservedInUrl()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    Map<String, String> extraparams = new HashMap();
+    extraparams.put("host", "snowflake.reg.local");
+    extraparams.put("account", null);
+    extraparams.put("port", "8082");
+    extraparams.put("token", "testToken");
+    extraparams.put("protocol", "https");
+    prepareConnectionConfigurationTomlFile(extraparams);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals("jdbc:snowflake://snowflake.reg.local:8082", data.getUrl());
+  }
+
+  @Test
+  public void testDefaultPortIsSelectedBasedOnProtocol() throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    Map<String, String> extraparams = new HashMap();
+    extraparams.put("host", "snowflake.reg.local");
+    extraparams.put("account", null);
+    extraparams.put("port", null);
+    extraparams.put("token", "testToken");
+    extraparams.put("protocol", "http");
+    prepareConnectionConfigurationTomlFile(extraparams);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals("jdbc:snowflake://http://snowflake.reg.local:80", data.getUrl());
+  }
+
+  @Test
+  public void testDefaultPortIs443WhenNoProtocolSpecified()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    Map<String, String> extraparams = new HashMap();
+    extraparams.put("host", "snowflake.reg.local");
+    extraparams.put("account", null);
+    extraparams.put("port", null);
+    extraparams.put("token", "testToken");
+    prepareConnectionConfigurationTomlFile(extraparams);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals("jdbc:snowflake://snowflake.reg.local:443", data.getUrl());
+  }
+
+  @Test
+  public void testDefaultPortIs443WhenProtocolIsEmptyString()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    Map<String, String> extraparams = new HashMap();
+    extraparams.put("host", "snowflake.reg.local");
+    extraparams.put("account", null);
+    extraparams.put("port", null);
+    extraparams.put("token", "testToken");
+    extraparams.put("protocol", "");
+    prepareConnectionConfigurationTomlFile(extraparams);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals("jdbc:snowflake://snowflake.reg.local:443", data.getUrl());
+  }
+
+  @Test
   public void shouldThrowExceptionIfNoneOfHostAndAccountIsSet() throws IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -43,7 +43,7 @@ public class SFConnectionConfigParserTest {
               SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION));
   private Path tempPath = null;
   private TomlMapper tomlMapper = new TomlMapper();
-  private Map<String, String> envVariables = new HashMap();
+  private Map<String, String> envVariables = new HashMap<>();
 
   @BeforeEach
   public void setUp() throws IOException {
@@ -141,7 +141,7 @@ public class SFConnectionConfigParserTest {
       throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    Map<String, String> extraparams = new HashMap();
+    Map<String, String> extraparams = new HashMap<>();
     extraparams.put("host", "snowflake.reg.local");
     extraparams.put("account", null);
     extraparams.put("port", "8082");
@@ -272,10 +272,10 @@ public class SFConnectionConfigParserTest {
   }
 
   @Test
-  public void testProtocolFromTomlIsPreservedInUrl() throws SnowflakeSQLException, IOException {
+  public void testHttpProtocolFromTomlIsEmbeddedInUrl() throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    Map<String, String> extraparams = new HashMap();
+    Map<String, String> extraparams = new HashMap<>();
     extraparams.put("host", "snowflake.reg.local");
     extraparams.put("account", null);
     extraparams.put("port", "8082");
@@ -288,11 +288,11 @@ public class SFConnectionConfigParserTest {
   }
 
   @Test
-  public void testHttpsProtocolFromTomlIsPreservedInUrl()
+  public void testHttpsProtocolFromTomlProducesStandardUrl()
       throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    Map<String, String> extraparams = new HashMap();
+    Map<String, String> extraparams = new HashMap<>();
     extraparams.put("host", "snowflake.reg.local");
     extraparams.put("account", null);
     extraparams.put("port", "8082");
@@ -309,7 +309,7 @@ public class SFConnectionConfigParserTest {
       throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    Map<String, String> extraparams = new HashMap();
+    Map<String, String> extraparams = new HashMap<>();
     extraparams.put("host", "snowflake.reg.local");
     extraparams.put("account", null);
     extraparams.put("port", null);
@@ -325,7 +325,7 @@ public class SFConnectionConfigParserTest {
   public void shouldThrowExceptionIfNoneOfHostAndAccountIsSet() throws IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    Map<String, String> extraparams = new HashMap();
+    Map<String, String> extraparams = new HashMap<>();
     extraparams.put("host", null);
     extraparams.put("account", null);
     prepareConnectionConfigurationTomlFile(extraparams);
@@ -350,19 +350,22 @@ public class SFConnectionConfigParserTest {
     prepareConnectionConfigurationTomlFile(null, true, true);
   }
 
-  private void prepareConnectionConfigurationTomlFile(Map moreParameters) throws IOException {
+  private void prepareConnectionConfigurationTomlFile(Map<String, String> moreParameters)
+      throws IOException {
     prepareConnectionConfigurationTomlFile(moreParameters, true, true);
   }
 
   private void prepareConnectionConfigurationTomlFile(
-      Map moreParameters, boolean onlyUserPermissionConnection, boolean onlyUserPermissionToken)
+      Map<String, String> moreParameters,
+      boolean onlyUserPermissionConnection,
+      boolean onlyUserPermissionToken)
       throws IOException {
     prepareConnectionConfigurationTomlFile(
         moreParameters, onlyUserPermissionConnection, onlyUserPermissionToken, "token_from_file");
   }
 
   private void prepareConnectionConfigurationTomlFile(
-      Map moreParameters,
+      Map<String, String> moreParameters,
       boolean onlyUserPermissionConnection,
       boolean onlyUserPermissionToken,
       String token)
@@ -371,8 +374,8 @@ public class SFConnectionConfigParserTest {
     Path filePath = createFilePathWithPermission(path, onlyUserPermissionConnection);
     File file = filePath.toFile();
 
-    Map configuration = new HashMap();
-    Map configurationParams = new HashMap();
+    Map<String, Object> configuration = new HashMap<>();
+    Map<String, Object> configurationParams = new HashMap<>();
     configurationParams.put("account", "snowaccount.us-west-2.aws");
     configurationParams.put("user", "user1");
     configurationParams.put("port", "443");

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -182,7 +182,8 @@ public class SFConnectionConfigParserTest {
     prepareTomlWithPortAndProtocol(null, "http");
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
-    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:80", data.getUrl());
+    assertEquals(
+        "jdbc:snowflake://http://myorg-myaccount.snowflakecomputing.com:80", data.getUrl());
   }
 
   @Test
@@ -193,7 +194,8 @@ public class SFConnectionConfigParserTest {
     prepareTomlWithPortAndProtocol("8082", "http");
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
-    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
+    assertEquals(
+        "jdbc:snowflake://http://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
   }
 
   @Test
@@ -262,10 +264,61 @@ public class SFConnectionConfigParserTest {
         SFConnectionConfigParser.buildConnectionParameters(
             "jdbc:snowflake:auto?connectionName=default");
     assertNotNull(data);
-    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
+    assertEquals(
+        "jdbc:snowflake://http://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
     assertEquals("user1", data.getParams().get("user"));
     assertEquals("pass1", data.getParams().get("password"));
     assertEquals("MY_WH", data.getParams().get("warehouse"));
+  }
+
+  @Test
+  public void testProtocolFromTomlIsPreservedInUrl() throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    Map<String, String> extraparams = new HashMap();
+    extraparams.put("host", "snowflake.reg.local");
+    extraparams.put("account", null);
+    extraparams.put("port", "8082");
+    extraparams.put("token", "testToken");
+    extraparams.put("protocol", "http");
+    prepareConnectionConfigurationTomlFile(extraparams);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals("jdbc:snowflake://http://snowflake.reg.local:8082", data.getUrl());
+  }
+
+  @Test
+  public void testHttpsProtocolFromTomlIsPreservedInUrl()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    Map<String, String> extraparams = new HashMap();
+    extraparams.put("host", "snowflake.reg.local");
+    extraparams.put("account", null);
+    extraparams.put("port", "8082");
+    extraparams.put("token", "testToken");
+    extraparams.put("protocol", "https");
+    prepareConnectionConfigurationTomlFile(extraparams);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals("jdbc:snowflake://snowflake.reg.local:8082", data.getUrl());
+  }
+
+  @Test
+  public void testDefaultPortIs443WhenProtocolIsEmptyString()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    Map<String, String> extraparams = new HashMap();
+    extraparams.put("host", "snowflake.reg.local");
+    extraparams.put("account", null);
+    extraparams.put("port", null);
+    extraparams.put("token", "testToken");
+    extraparams.put("protocol", "");
+    prepareConnectionConfigurationTomlFile(extraparams);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals("jdbc:snowflake://snowflake.reg.local:443", data.getUrl());
   }
 
   @Test


### PR DESCRIPTION
# Overview

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: SNOW-2434159


2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
     - Not needed. The URL used to create connection is already logged.  
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

The PR fixes two problems:
1. If the protocol is empty, we default the port to 80 which is incorrect because the default protocol is https.
2. We drop the protocol entirely when returning the URL so the protocol is always https.

I have read the CLA Document and I hereby sign the CLA
