### PR TITLE
SNOW-2875919 Add IPv6 support for GCP WIF and AWS platform detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
     - Added support for attaching the SPCS service-identifier token (`SPCS_TOKEN`) to login requests when the driver is running inside an SPCS container (gated on the `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable; token read from `/snowflake/session/spcs_token`) (snowflakedb/snowflake-jdbc#2603)
     - Added libc family and version detection (`LIBC_FAMILY`, `LIBC_VERSION`) to the `CLIENT_ENVIRONMENT` section of the login request on Linux
     - Fixed NPE in `SFTrustManager.validateRevocationStatusMain` when the OCSP cache contains a non-SUCCESSFUL response (e.g. `unauthorized(6)`); the response is now surfaced as an `SFOCSPException` so cache eviction and fail-open run normally (snowflakedb/snowflake-jdbc#2597)
-    - GCP WIF attestation now uses hostname `metadata.google.internal` instead of the IPv4 link-local address, so it works on IPv6-only GCP VMs (snowflakedb/snowflake-jdbc#2586)
+    - Added IPv6 support for cloud metadata services so Workload Identity Federation and platform detection work on IPv6-only instances (snowflakedb/snowflake-jdbc#2586):
+      - GCP WIF attestation now uses hostname `metadata.google.internal` instead of the IPv4 link-local address.
+      - EC2 instance detection falls back to the IPv6 IMDS endpoint (`[fd00:ec2::254]`) when the IPv4 endpoint is unreachable.
     - Added `enableCopyResultSet` connection property (default `false`): when `true`, `Statement.execute()` exposes the COPY INTO per-file metadata result set via `getResultSet()` instead of consuming it internally (snowflakedb/snowflake-jdbc#SNOW-3388627)
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - Added support for attaching the SPCS service-identifier token (`SPCS_TOKEN`) to login requests when the driver is running inside an SPCS container (gated on the `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable; token read from `/snowflake/session/spcs_token`) (snowflakedb/snowflake-jdbc#2603)
     - Added libc family and version detection (`LIBC_FAMILY`, `LIBC_VERSION`) to the `CLIENT_ENVIRONMENT` section of the login request on Linux
     - Fixed NPE in `SFTrustManager.validateRevocationStatusMain` when the OCSP cache contains a non-SUCCESSFUL response (e.g. `unauthorized(6)`); the response is now surfaced as an `SFOCSPException` so cache eviction and fail-open run normally (snowflakedb/snowflake-jdbc#2597)
+    - GCP WIF attestation now uses hostname `metadata.google.internal` instead of the IPv4 link-local address, so it works on IPv6-only GCP VMs (snowflakedb/snowflake-jdbc#2586)
     - Added `enableCopyResultSet` connection property (default `false`): when `true`, `Statement.execute()` exposes the COPY INTO per-file metadata result set via `getResultSet()` instead of consuming it internally (snowflakedb/snowflake-jdbc#SNOW-3388627)
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     - Fixed NPE in `SFTrustManager.validateRevocationStatusMain` when the OCSP cache contains a non-SUCCESSFUL response (e.g. `unauthorized(6)`); the response is now surfaced as an `SFOCSPException` so cache eviction and fail-open run normally (snowflakedb/snowflake-jdbc#2597)
     - Added IPv6 support for cloud metadata services so Workload Identity Federation and platform detection work on IPv6-only instances (snowflakedb/snowflake-jdbc#2586):
       - GCP WIF attestation now uses hostname `metadata.google.internal` instead of the IPv4 link-local address.
-      - EC2 instance detection falls back to the IPv6 IMDS endpoint (`[fd00:ec2::254]`) when the IPv4 endpoint is unreachable.
+      - EC2 instance detection probes the IPv4 and IPv6 IMDS endpoints (`[fd00:ec2::254]`) in parallel so detection succeeds on IPv6-only instances without doubling the detection budget on dual-stack hosts.
     - Added `enableCopyResultSet` connection property (default `false`): when `true`, `Statement.execute()` exposes the COPY INTO per-file metadata result set via `getResultSet()` instead of consuming it internally (snowflakedb/snowflake-jdbc#SNOW-3388627)
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)

--- a/src/main/java/net/snowflake/client/internal/core/auth/wif/AzureIdentityAttestationCreator.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/wif/AzureIdentityAttestationCreator.java
@@ -1,6 +1,6 @@
 package net.snowflake.client.internal.core.auth.wif;
 
-import static net.snowflake.client.internal.core.auth.wif.WorkloadIdentityUtil.DEFAULT_METADATA_SERVICE_BASE_URL;
+import static net.snowflake.client.internal.core.auth.wif.WorkloadIdentityUtil.DEFAULT_AZURE_METADATA_SERVICE_BASE_URL;
 import static net.snowflake.client.internal.core.auth.wif.WorkloadIdentityUtil.SubjectAndIssuer;
 import static net.snowflake.client.internal.core.auth.wif.WorkloadIdentityUtil.extractClaimsWithoutVerifyingSignature;
 
@@ -31,7 +31,7 @@ public class AzureIdentityAttestationCreator implements WorkloadIdentityAttestat
   public AzureIdentityAttestationCreator(
       AzureAttestationService azureAttestationService, SFLoginInput loginInput) {
     this.azureAttestationService = azureAttestationService;
-    this.azureMetadataServiceBaseUrl = DEFAULT_METADATA_SERVICE_BASE_URL;
+    this.azureMetadataServiceBaseUrl = DEFAULT_AZURE_METADATA_SERVICE_BASE_URL;
     this.loginInput = loginInput;
     this.workloadIdentityEntraResource = getEntraResource(loginInput);
   }

--- a/src/main/java/net/snowflake/client/internal/core/auth/wif/GcpIdentityAttestationCreator.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/wif/GcpIdentityAttestationCreator.java
@@ -1,6 +1,6 @@
 package net.snowflake.client.internal.core.auth.wif;
 
-import static net.snowflake.client.internal.core.auth.wif.WorkloadIdentityUtil.DEFAULT_METADATA_SERVICE_BASE_URL;
+import static net.snowflake.client.internal.core.auth.wif.WorkloadIdentityUtil.DEFAULT_GCP_METADATA_SERVICE_BASE_URL;
 import static net.snowflake.client.internal.core.auth.wif.WorkloadIdentityUtil.performIdentityRequest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -39,7 +39,7 @@ public class GcpIdentityAttestationCreator implements WorkloadIdentityAttestatio
 
   public GcpIdentityAttestationCreator(SFLoginInput loginInput) {
     this.loginInput = loginInput;
-    this.gcpMetadataServiceBaseUrl = DEFAULT_METADATA_SERVICE_BASE_URL;
+    this.gcpMetadataServiceBaseUrl = DEFAULT_GCP_METADATA_SERVICE_BASE_URL;
     this.gcpIamCredentialsBaseUrl = DEFAULT_GCP_IAM_CREDENTIALS_URL;
   }
 

--- a/src/main/java/net/snowflake/client/internal/core/auth/wif/WorkloadIdentityUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/wif/WorkloadIdentityUtil.java
@@ -22,8 +22,11 @@ public class WorkloadIdentityUtil {
 
   private static final SFLogger logger = SFLoggerFactory.getLogger(WorkloadIdentityUtil.class);
 
-  // Address commonly used by AWS, Azure & GCP to host instance metadata service
-  public static final String DEFAULT_METADATA_SERVICE_BASE_URL = "http://169.254.169.254";
+  // GCP metadata service uses a hostname that resolves to both IPv4 and IPv6 via DNS
+  public static final String DEFAULT_GCP_METADATA_SERVICE_BASE_URL =
+      "http://metadata.google.internal";
+  // Azure instance metadata service (IPv4 only; Azure does not expose an IPv6 IMDS endpoint)
+  public static final String DEFAULT_AZURE_METADATA_SERVICE_BASE_URL = "http://169.254.169.254";
 
   public static final String SNOWFLAKE_AUDIENCE_HEADER_NAME = "X-Snowflake-Audience";
   public static final String SNOWFLAKE_AUDIENCE = "snowflakecomputing.com";

--- a/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
+++ b/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
@@ -49,6 +49,8 @@ public class PlatformDetector {
 
   // Default cloud metadata service URLs
   private static final String DEFAULT_METADATA_SERVICE_BASE_URL = "http://169.254.169.254";
+  // IPv6 fallback for EC2 IMDS on IPv6-only instances (IPv4 unreachable)
+  private static final String DEFAULT_AWS_METADATA_IPV6_BASE_URL = "http://[fd00:ec2::254]";
   private static final String DEFAULT_GCP_METADATA_BASE_URL = "http://metadata.google.internal";
 
   // Metadata service headers and values
@@ -80,6 +82,7 @@ public class PlatformDetector {
 
   // Instance fields for configurable URLs and environment provider (for testing)
   private final String awsMetadataBaseUrl;
+  private final String awsMetadataIpv6BaseUrl;
   private final String azureMetadataBaseUrl;
   private final String gcpMetadataBaseUrl;
   private final EnvironmentProvider environmentProvider;
@@ -87,6 +90,7 @@ public class PlatformDetector {
   // Default constructor for production use
   public PlatformDetector() {
     this.awsMetadataBaseUrl = DEFAULT_METADATA_SERVICE_BASE_URL;
+    this.awsMetadataIpv6BaseUrl = DEFAULT_AWS_METADATA_IPV6_BASE_URL;
     this.azureMetadataBaseUrl = DEFAULT_METADATA_SERVICE_BASE_URL;
     this.gcpMetadataBaseUrl = DEFAULT_GCP_METADATA_BASE_URL;
     this.environmentProvider = new SnowflakeEnvironmentProvider();
@@ -95,10 +99,12 @@ public class PlatformDetector {
   /** Constructor for testing purposes - allows overriding both URLs and environment provider */
   PlatformDetector(
       String awsMetadataBaseUrl,
+      String awsMetadataIpv6BaseUrl,
       String azureMetadataBaseUrl,
       String gcpMetadataBaseUrl,
       EnvironmentProvider environmentProvider) {
     this.awsMetadataBaseUrl = awsMetadataBaseUrl;
+    this.awsMetadataIpv6BaseUrl = awsMetadataIpv6BaseUrl;
     this.azureMetadataBaseUrl = azureMetadataBaseUrl;
     this.gcpMetadataBaseUrl = gcpMetadataBaseUrl;
     this.environmentProvider = environmentProvider;
@@ -297,22 +303,32 @@ public class PlatformDetector {
   }
 
   private DetectionState isEc2Instance(int timeoutMs) {
+    // Try IPv4 first. On IPv6-only EC2 instances the IPv4 link-local address is
+    // unreachable; fall through to the IPv6 IMDS endpoint so detection still works.
+    DetectionState ipv4Result = probeEc2Instance(awsMetadataBaseUrl, timeoutMs);
+    if (ipv4Result == DetectionState.DETECTED || ipv4Result == DetectionState.TIMEOUT) {
+      return ipv4Result;
+    }
+    return probeEc2Instance(awsMetadataIpv6BaseUrl, timeoutMs);
+  }
+
+  private DetectionState probeEc2Instance(String baseUrl, int timeoutMs) {
     try {
       // First try to get IMDSv2 token
       String token = null;
       try {
         String tokenResponse =
             executeHttpPut(
-                getAwsMetadataTokenEndpoint(),
+                baseUrl + AWS_TOKEN_ENDPOINT_PATH,
                 Collections.singletonMap(
                     AWS_METADATA_TOKEN_TTL_HEADER, AWS_METADATA_TOKEN_TTL_VALUE),
                 timeoutMs);
         if (tokenResponse != null && !tokenResponse.trim().isEmpty()) {
           token = tokenResponse.trim();
-          logger.debug("Successfully obtained IMDSv2 token");
+          logger.debug("Successfully obtained IMDSv2 token from {}", baseUrl);
         }
       } catch (Exception e) {
-        logger.debug("Failed to get IMDSv2 token, will try IMDSv1: {}", e.getMessage());
+        logger.debug("Failed to get IMDSv2 token from {}, will try IMDSv1: {}", baseUrl, e.getMessage());
       }
 
       // Try to get instance identity document
@@ -321,13 +337,14 @@ public class PlatformDetector {
         headers.put(AWS_METADATA_TOKEN_HEADER, token);
       }
 
-      String response = executeHttpGet(getAwsMetadataIdentityEndpoint(), headers, timeoutMs);
+      String response =
+          executeHttpGet(baseUrl + AWS_INSTANCE_IDENTITY_ENDPOINT_PATH, headers, timeoutMs);
       if (response != null && !response.trim().isEmpty()) {
-        logger.debug("Successfully detected EC2 instance via metadata service");
+        logger.debug("Successfully detected EC2 instance via metadata service at {}", baseUrl);
         return DetectionState.DETECTED;
       }
     } catch (Exception e) {
-      logger.debug("EC2 instance detection failed: {}", e.getMessage());
+      logger.debug("EC2 instance detection failed at {}: {}", baseUrl, e.getMessage());
       if (isTimeoutException(e)) {
         return DetectionState.TIMEOUT;
       }
@@ -474,14 +491,6 @@ public class PlatformDetector {
     logger.debug(
         "All environment variables are present: {}", java.util.Arrays.toString(variableNames));
     return true;
-  }
-
-  private String getAwsMetadataTokenEndpoint() {
-    return awsMetadataBaseUrl + AWS_TOKEN_ENDPOINT_PATH;
-  }
-
-  private String getAwsMetadataIdentityEndpoint() {
-    return awsMetadataBaseUrl + AWS_INSTANCE_IDENTITY_ENDPOINT_PATH;
   }
 
   private String getAzureMetadataInstanceEndpoint() {

--- a/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
+++ b/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
@@ -303,24 +303,43 @@ public class PlatformDetector {
   }
 
   private DetectionState isEc2Instance(int timeoutMs) {
-    // Try IPv4 first. On IPv6-only EC2 instances the IPv4 link-local address is
-    // unreachable (no route, connection refused, or timeout), so fall through to
-    // the IPv6 IMDS endpoint. The outer detectPlatforms() executor enforces the
-    // overall detection budget via future.get(timeout), so a second probe here
-    // cannot exceed that budget.
-    DetectionState ipv4Result = probeEc2Instance(awsMetadataBaseUrl, timeoutMs);
-    if (ipv4Result == DetectionState.DETECTED) {
-      return ipv4Result;
+    // Probe IPv4 and IPv6 IMDS endpoints in parallel so detection stays within the
+    // per-task budget on IPv6-only EC2 instances (where the IPv4 link-local address
+    // is unreachable) and without doubling the time on dual-stack hosts.
+    ExecutorService ec2Executor = Executors.newFixedThreadPool(2);
+    try {
+      CompletableFuture<DetectionState> ipv4Future =
+          CompletableFuture.supplyAsync(
+              () -> probeEc2Instance(awsMetadataBaseUrl, timeoutMs), ec2Executor);
+      CompletableFuture<DetectionState> ipv6Future =
+          CompletableFuture.supplyAsync(
+              () -> probeEc2Instance(awsMetadataIpv6BaseUrl, timeoutMs), ec2Executor);
+
+      DetectionState ipv4Result = joinProbe(ipv4Future, timeoutMs);
+      DetectionState ipv6Result = joinProbe(ipv6Future, timeoutMs);
+
+      if (ipv4Result == DetectionState.DETECTED || ipv6Result == DetectionState.DETECTED) {
+        return DetectionState.DETECTED;
+      }
+      if (ipv4Result == DetectionState.TIMEOUT || ipv6Result == DetectionState.TIMEOUT) {
+        return DetectionState.TIMEOUT;
+      }
+      return DetectionState.NOT_DETECTED;
+    } finally {
+      ec2Executor.shutdownNow();
     }
-    DetectionState ipv6Result = probeEc2Instance(awsMetadataIpv6BaseUrl, timeoutMs);
-    if (ipv6Result == DetectionState.DETECTED) {
-      return ipv6Result;
-    }
-    // Neither detected — surface a timeout if either attempt timed out, otherwise NOT_DETECTED.
-    if (ipv4Result == DetectionState.TIMEOUT || ipv6Result == DetectionState.TIMEOUT) {
+  }
+
+  private static DetectionState joinProbe(CompletableFuture<DetectionState> future, int timeoutMs) {
+    try {
+      return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      future.cancel(true);
       return DetectionState.TIMEOUT;
+    } catch (Exception e) {
+      future.cancel(true);
+      return DetectionState.NOT_DETECTED;
     }
-    return DetectionState.NOT_DETECTED;
   }
 
   private DetectionState probeEc2Instance(String baseUrl, int timeoutMs) {

--- a/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
+++ b/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
@@ -304,12 +304,23 @@ public class PlatformDetector {
 
   private DetectionState isEc2Instance(int timeoutMs) {
     // Try IPv4 first. On IPv6-only EC2 instances the IPv4 link-local address is
-    // unreachable; fall through to the IPv6 IMDS endpoint so detection still works.
+    // unreachable (no route, connection refused, or timeout), so fall through to
+    // the IPv6 IMDS endpoint. The outer detectPlatforms() executor enforces the
+    // overall detection budget via future.get(timeout), so a second probe here
+    // cannot exceed that budget.
     DetectionState ipv4Result = probeEc2Instance(awsMetadataBaseUrl, timeoutMs);
-    if (ipv4Result == DetectionState.DETECTED || ipv4Result == DetectionState.TIMEOUT) {
+    if (ipv4Result == DetectionState.DETECTED) {
       return ipv4Result;
     }
-    return probeEc2Instance(awsMetadataIpv6BaseUrl, timeoutMs);
+    DetectionState ipv6Result = probeEc2Instance(awsMetadataIpv6BaseUrl, timeoutMs);
+    if (ipv6Result == DetectionState.DETECTED) {
+      return ipv6Result;
+    }
+    // Neither detected — surface a timeout if either attempt timed out, otherwise NOT_DETECTED.
+    if (ipv4Result == DetectionState.TIMEOUT || ipv6Result == DetectionState.TIMEOUT) {
+      return DetectionState.TIMEOUT;
+    }
+    return DetectionState.NOT_DETECTED;
   }
 
   private DetectionState probeEc2Instance(String baseUrl, int timeoutMs) {

--- a/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
+++ b/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
@@ -302,42 +302,94 @@ public class PlatformDetector {
     return PlatformDetectionUtil.performPlatformDetectionRequest(request, timeoutMs);
   }
 
+  // Shared daemon executor for EC2 IMDS probes. Cached pool: threads live briefly
+  // during platform detection, daemon so they never block JVM shutdown, named for
+  // log/thread-dump visibility.
+  private static final ExecutorService EC2_PROBE_EXECUTOR =
+      Executors.newCachedThreadPool(
+          r -> {
+            Thread t = new Thread(r, "snowflake-jdbc-ec2-imds-probe");
+            t.setDaemon(true);
+            return t;
+          });
+
   private DetectionState isEc2Instance(int timeoutMs) {
-    // Probe IPv4 and IPv6 IMDS endpoints in parallel so detection stays within the
-    // per-task budget on IPv6-only EC2 instances (where the IPv4 link-local address
-    // is unreachable) and without doubling the time on dual-stack hosts.
-    ExecutorService ec2Executor = Executors.newFixedThreadPool(2);
+    // Probe IPv4 and IPv6 IMDS endpoints concurrently and return as soon as either
+    // succeeds. On dual-stack hosts the IPv4 probe wins quickly; on IPv6-only EC2
+    // instances (where the IPv4 link-local address is unreachable) the IPv6 probe
+    // succeeds. We never wait longer than timeoutMs total.
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+
+    CompletableFuture<DetectionState> ipv4Future =
+        CompletableFuture.supplyAsync(
+            () -> probeEc2Instance(awsMetadataBaseUrl, timeoutMs), EC2_PROBE_EXECUTOR);
+    CompletableFuture<DetectionState> ipv6Future =
+        CompletableFuture.supplyAsync(
+            () -> probeEc2Instance(awsMetadataIpv6BaseUrl, timeoutMs), EC2_PROBE_EXECUTOR);
+
     try {
-      CompletableFuture<DetectionState> ipv4Future =
-          CompletableFuture.supplyAsync(
-              () -> probeEc2Instance(awsMetadataBaseUrl, timeoutMs), ec2Executor);
-      CompletableFuture<DetectionState> ipv6Future =
-          CompletableFuture.supplyAsync(
-              () -> probeEc2Instance(awsMetadataIpv6BaseUrl, timeoutMs), ec2Executor);
-
-      DetectionState ipv4Result = joinProbe(ipv4Future, timeoutMs);
-      DetectionState ipv6Result = joinProbe(ipv6Future, timeoutMs);
-
-      if (ipv4Result == DetectionState.DETECTED || ipv6Result == DetectionState.DETECTED) {
+      DetectionState firstResult =
+          awaitFirstDetectionOrDeadline(ipv4Future, ipv6Future, deadlineNanos);
+      if (firstResult == DetectionState.DETECTED) {
         return DetectionState.DETECTED;
       }
-      if (ipv4Result == DetectionState.TIMEOUT || ipv6Result == DetectionState.TIMEOUT) {
+      // First probe did not detect; wait for the other within the remaining budget.
+      DetectionState secondResult = awaitRemaining(ipv4Future, ipv6Future, deadlineNanos);
+      if (secondResult == DetectionState.DETECTED) {
+        return DetectionState.DETECTED;
+      }
+      if (firstResult == DetectionState.TIMEOUT || secondResult == DetectionState.TIMEOUT) {
         return DetectionState.TIMEOUT;
       }
       return DetectionState.NOT_DETECTED;
     } finally {
-      ec2Executor.shutdownNow();
+      ipv4Future.cancel(true);
+      ipv6Future.cancel(true);
     }
   }
 
-  private static DetectionState joinProbe(CompletableFuture<DetectionState> future, int timeoutMs) {
+  private static DetectionState awaitFirstDetectionOrDeadline(
+      CompletableFuture<DetectionState> a,
+      CompletableFuture<DetectionState> b,
+      long deadlineNanos) {
+    while (true) {
+      long remainingNanos = deadlineNanos - System.nanoTime();
+      if (remainingNanos <= 0) {
+        return DetectionState.TIMEOUT;
+      }
+      try {
+        DetectionState result =
+            (DetectionState)
+                CompletableFuture.anyOf(a, b).get(remainingNanos, TimeUnit.NANOSECONDS);
+        if (result == DetectionState.DETECTED) {
+          return result;
+        }
+        // One probe finished without detecting; return its state so the caller can
+        // wait on the other.
+        return result;
+      } catch (TimeoutException e) {
+        return DetectionState.TIMEOUT;
+      } catch (Exception e) {
+        // A probe threw; treat as NOT_DETECTED and let the caller consider the other.
+        return DetectionState.NOT_DETECTED;
+      }
+    }
+  }
+
+  private static DetectionState awaitRemaining(
+      CompletableFuture<DetectionState> a,
+      CompletableFuture<DetectionState> b,
+      long deadlineNanos) {
+    CompletableFuture<DetectionState> pending = a.isDone() ? b : a;
+    long remainingNanos = deadlineNanos - System.nanoTime();
+    if (remainingNanos <= 0) {
+      return DetectionState.TIMEOUT;
+    }
     try {
-      return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+      return pending.get(remainingNanos, TimeUnit.NANOSECONDS);
     } catch (TimeoutException e) {
-      future.cancel(true);
       return DetectionState.TIMEOUT;
     } catch (Exception e) {
-      future.cancel(true);
       return DetectionState.NOT_DETECTED;
     }
   }

--- a/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
+++ b/src/main/java/net/snowflake/client/internal/util/PlatformDetector.java
@@ -328,7 +328,8 @@ public class PlatformDetector {
           logger.debug("Successfully obtained IMDSv2 token from {}", baseUrl);
         }
       } catch (Exception e) {
-        logger.debug("Failed to get IMDSv2 token from {}, will try IMDSv1: {}", baseUrl, e.getMessage());
+        logger.debug(
+            "Failed to get IMDSv2 token from {}, will try IMDSv1: {}", baseUrl, e.getMessage());
       }
 
       // Try to get instance identity document

--- a/src/test/java/net/snowflake/client/internal/util/PlatformDetectorLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/util/PlatformDetectorLatestIT.java
@@ -45,7 +45,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("LAMBDA_TASK_ROOT")).thenReturn("/var/task");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -67,7 +68,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
         .thenReturn("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test;");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -88,7 +90,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("K_CONFIGURATION")).thenReturn("my-config");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -108,7 +111,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("CLOUD_RUN_EXECUTION")).thenReturn("my-execution");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -127,7 +131,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("GITHUB_ACTIONS")).thenReturn("true");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -147,7 +152,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -165,7 +171,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -186,19 +193,14 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
 
     PlatformDetector detector =
         new PlatformDetector(
-            "http://192.0.2.1",
-            getBaseUrl(),
-            getBaseUrl(),
-            getBaseUrl(),
-            mockEnvironmentProvider);
+            "http://192.0.2.1", getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
 
     // Assert
     assertTrue(
-        platforms.contains("is_ec2_instance"),
-        "Should detect EC2 instance via IPv6 IMDS fallback");
+        platforms.contains("is_ec2_instance"), "Should detect EC2 instance via IPv6 IMDS fallback");
   }
 
   @Test
@@ -209,7 +211,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -227,7 +230,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -247,7 +251,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -265,7 +270,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -286,7 +292,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("IDENTITY_HEADER")).thenReturn("test-header-value");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Use timeout > 0 to trigger async execution
     List<String> platforms = detector.detectPlatforms(1000, mockAwsAttestationService);
@@ -314,7 +321,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
         .thenReturn("arn:aws:iam::123456789012:user/testuser");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(200, mockAwsAttestationService);
@@ -351,7 +359,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
         .thenReturn("arn:aws:sts::123456789012:assumed-role/test-role/session");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Use small timeout to enable HTTP calls but ensure static mocks work in async context
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -371,7 +380,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
   public void testTimeoutScenariosNoNetwork() {
     // Arrange - No mappings to simulate timeout
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Short timeout to force timeouts
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -388,7 +398,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Use 200ms timeout, but server takes 5 seconds
     long startTime = System.currentTimeMillis();
@@ -424,7 +435,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Use 2000ms timeout, server takes 1 second
     List<String> platforms = detector.detectPlatforms(2000, mockAwsAttestationService);
@@ -438,7 +450,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
   @DisplayName("Should demonstrate env-only vs env + unreachable http endpoints time difference")
   public void testEnvVsEnvAndUnreachableEndpointsPerformance() {
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Test 1: Fast timeout with no network (should be very fast)
     long startTime1 = System.currentTimeMillis();
@@ -480,7 +493,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("LAMBDA_TASK_ROOT")).thenReturn("/var/task");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(
+            getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     long startTime1 = System.currentTimeMillis();
     List<String> platforms1 =

--- a/src/test/java/net/snowflake/client/internal/util/PlatformDetectorLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/util/PlatformDetectorLatestIT.java
@@ -186,14 +186,19 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
   @DisplayName("Should fall back to IPv6 IMDS endpoint when IPv4 is unreachable")
   public void testDetectEc2InstanceIpv6Fallback() throws IOException {
     // Arrange: IMDSv2 mapping served by wiremock, used as the IPv6 base URL. The IPv4 base URL
-    // points at an unroutable TEST-NET-1 address (RFC 5737) that fails fast, so detection must
-    // fall back to the IPv6 endpoint.
+    // points at a loopback port with no listener so the connect fails fast with
+    // "connection refused" (mimicking "no route" behaviour on an IPv6-only EC2 instance),
+    // forcing detection to fall back to the IPv6 endpoint.
     String mappingContent = loadMappingFile("platform-detection/ec2_successful_imdsv2");
     importMapping(mappingContent);
 
     PlatformDetector detector =
         new PlatformDetector(
-            "http://192.0.2.1", getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+            "http://127.0.0.1:1",
+            getBaseUrl(),
+            getBaseUrl(),
+            getBaseUrl(),
+            mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);

--- a/src/test/java/net/snowflake/client/internal/util/PlatformDetectorLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/util/PlatformDetectorLatestIT.java
@@ -183,12 +183,12 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
   }
 
   @Test
-  @DisplayName("Should fall back to IPv6 IMDS endpoint when IPv4 is unreachable")
-  public void testDetectEc2InstanceIpv6Fallback() throws IOException {
+  @DisplayName("Should detect EC2 via the IPv6 probe when the IPv4 endpoint is unreachable")
+  public void testDetectEc2InstanceIpv6Probe() throws IOException {
     // Arrange: IMDSv2 mapping served by wiremock, used as the IPv6 base URL. The IPv4 base URL
-    // points at a loopback port with no listener so the connect fails fast with
-    // "connection refused" (mimicking "no route" behaviour on an IPv6-only EC2 instance),
-    // forcing detection to fall back to the IPv6 endpoint.
+    // points at a loopback port with no listener so its probe errors out while the IPv6 probe
+    // (racing in parallel) resolves wiremock and succeeds — mirroring what happens on an
+    // IPv6-only EC2 instance where the IPv4 link-local address is unreachable.
     String mappingContent = loadMappingFile("platform-detection/ec2_successful_imdsv2");
     importMapping(mappingContent);
 
@@ -205,7 +205,8 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
 
     // Assert
     assertTrue(
-        platforms.contains("is_ec2_instance"), "Should detect EC2 instance via IPv6 IMDS fallback");
+        platforms.contains("is_ec2_instance"),
+        "Should detect EC2 instance via the parallel IPv6 IMDS probe");
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/internal/util/PlatformDetectorLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/util/PlatformDetectorLatestIT.java
@@ -45,7 +45,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("LAMBDA_TASK_ROOT")).thenReturn("/var/task");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -67,7 +67,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
         .thenReturn("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test;");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -88,7 +88,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("K_CONFIGURATION")).thenReturn("my-config");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -108,7 +108,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("CLOUD_RUN_EXECUTION")).thenReturn("my-execution");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -127,7 +127,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("GITHUB_ACTIONS")).thenReturn("true");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -147,7 +147,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -165,7 +165,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -176,6 +176,32 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
   }
 
   @Test
+  @DisplayName("Should fall back to IPv6 IMDS endpoint when IPv4 is unreachable")
+  public void testDetectEc2InstanceIpv6Fallback() throws IOException {
+    // Arrange: IMDSv2 mapping served by wiremock, used as the IPv6 base URL. The IPv4 base URL
+    // points at an unroutable TEST-NET-1 address (RFC 5737) that fails fast, so detection must
+    // fall back to the IPv6 endpoint.
+    String mappingContent = loadMappingFile("platform-detection/ec2_successful_imdsv2");
+    importMapping(mappingContent);
+
+    PlatformDetector detector =
+        new PlatformDetector(
+            "http://192.0.2.1",
+            getBaseUrl(),
+            getBaseUrl(),
+            getBaseUrl(),
+            mockEnvironmentProvider);
+
+    // Act
+    List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
+
+    // Assert
+    assertTrue(
+        platforms.contains("is_ec2_instance"),
+        "Should detect EC2 instance via IPv6 IMDS fallback");
+  }
+
+  @Test
   @DisplayName("Should detect Azure VM using wiremock")
   public void testDetectAzureVm() throws IOException {
     // Arrange
@@ -183,7 +209,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -201,7 +227,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -221,7 +247,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -239,7 +265,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -260,7 +286,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("IDENTITY_HEADER")).thenReturn("test-header-value");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Use timeout > 0 to trigger async execution
     List<String> platforms = detector.detectPlatforms(1000, mockAwsAttestationService);
@@ -288,7 +314,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
         .thenReturn("arn:aws:iam::123456789012:user/testuser");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act
     List<String> platforms = detector.detectPlatforms(200, mockAwsAttestationService);
@@ -325,7 +351,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
         .thenReturn("arn:aws:sts::123456789012:assumed-role/test-role/session");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Use small timeout to enable HTTP calls but ensure static mocks work in async context
     List<String> platforms = detector.detectPlatforms(500, mockAwsAttestationService);
@@ -345,7 +371,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
   public void testTimeoutScenariosNoNetwork() {
     // Arrange - No mappings to simulate timeout
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Short timeout to force timeouts
     List<String> platforms = detector.detectPlatforms(0, mockAwsAttestationService);
@@ -362,7 +388,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Use 200ms timeout, but server takes 5 seconds
     long startTime = System.currentTimeMillis();
@@ -398,7 +424,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     importMapping(mappingContent);
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Act - Use 2000ms timeout, server takes 1 second
     List<String> platforms = detector.detectPlatforms(2000, mockAwsAttestationService);
@@ -412,7 +438,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
   @DisplayName("Should demonstrate env-only vs env + unreachable http endpoints time difference")
   public void testEnvVsEnvAndUnreachableEndpointsPerformance() {
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     // Test 1: Fast timeout with no network (should be very fast)
     long startTime1 = System.currentTimeMillis();
@@ -454,7 +480,7 @@ public class PlatformDetectorLatestIT extends BaseWiremockTest {
     when(mockEnvironmentProvider.getEnv("LAMBDA_TASK_ROOT")).thenReturn("/var/task");
 
     PlatformDetector detector =
-        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
+        new PlatformDetector(getBaseUrl(), getBaseUrl(), getBaseUrl(), getBaseUrl(), mockEnvironmentProvider);
 
     long startTime1 = System.currentTimeMillis();
     List<String> platforms1 =

--- a/src/test/java/net/snowflake/client/wif/WIFLatestIT.java
+++ b/src/test/java/net/snowflake/client/wif/WIFLatestIT.java
@@ -85,7 +85,7 @@ public class WIFLatestIT {
   private String getGCPAccessToken() {
     try {
       String command =
-          "curl -H \"Metadata-Flavor: Google\" \"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com\"";
+          "curl -H \"Metadata-Flavor: Google\" \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com\"";
       ProcessBuilder processBuilder = new ProcessBuilder("bash", "-c", command);
       Process process = processBuilder.start();
 


### PR DESCRIPTION
## Summary
Adds IPv6 support for cloud metadata services so WIF attestation and platform detection work on IPv6-only instances.

- **WIF (`WorkloadIdentityUtil`)**: split `DEFAULT_METADATA_SERVICE_BASE_URL` into `DEFAULT_GCP_METADATA_SERVICE_BASE_URL` (`metadata.google.internal`) and `DEFAULT_AZURE_METADATA_SERVICE_BASE_URL` (`169.254.169.254`). `GcpIdentityAttestationCreator` now uses the GCP hostname, which resolves to both IPv4 and IPv6 via DNS.
- **Platform detection (`PlatformDetector.isEc2Instance`)**: attempts the IPv4 IMDS endpoint first and falls back to `[fd00:ec2::254]` (IPv6) when the IPv4 endpoint is unreachable. Timeouts are not fallen through, to preserve the 200ms detection budget.
- Added `testDetectEc2InstanceIpv6Fallback` to exercise the fallback path.

## Per-CSP coverage

| CSP | Path | Change |
|---|---|---|
| GCP | WIF attestation | Use `metadata.google.internal` (dual-stack DNS) |
| GCP | Platform detection | Already used the hostname — no change |
| AWS | Platform detection | IPv4 → IPv6 fallback to `[fd00:ec2::254]` |
| AWS | WIF attestation | No change needed — the AWS SDK respects `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE=IPv6` |
| Azure | All paths | No change — Azure IMDS has no documented IPv6 endpoint |

## Why fallback rather than the AWS SDK `Ec2MetadataClient`?
The SDK approach would be cleaner in isolation, but Universal Driver is the long-term home for this code. A minimal fallback keeps the change small and avoids adding a new dependency that will be replaced soon.

## Test plan
- [ ] Existing WIF unit tests pass (they inject test URLs directly)
- [ ] `PlatformDetectorLatestIT#testDetectEc2InstanceIpv6Fallback` — new
- [ ] Full test suite — no regressions
- [ ] On GCP IPv6-only VM: WIF integration test with GCP provider
- [ ] On AWS IPv6-only instance: confirm `is_ec2_instance` appears in platform detection output

🤖 Generated with [Claude Code](https://claude.com/claude-code)