### PR TITLE
SNOW-3388627: Add enableCopyResultSet connection property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.1.1-SNAPSHOT
+    - Added `enableCopyResultSet` connection property (default `false`): when `true`, `Statement.execute()` exposes the COPY INTO per-file metadata result set via `getResultSet()` instead of consuming it internally (snowflakedb/snowflake-jdbc#SNOW-3388627)
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)
 - v4.1.0

--- a/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -28,6 +28,7 @@ import net.snowflake.client.internal.core.SFBaseResultSet;
 import net.snowflake.client.internal.core.SFBaseStatement;
 import net.snowflake.client.internal.core.SFException;
 import net.snowflake.client.internal.core.SFStatement;
+import net.snowflake.client.internal.core.SFStatementType;
 import net.snowflake.client.internal.core.StmtUtil;
 import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
 import net.snowflake.client.internal.jdbc.QueryIdValidator;
@@ -388,7 +389,12 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
       // statement execute, so we only treat update counts as update counts
       // if CLIENT_SFSQL is not set, or if a statement
       // is multi-statement
-      if (!sfResultSet.getStatementType().isGenerateResultSet()
+      boolean copyResultSetEnabled =
+          sfResultSet.getStatementType() == SFStatementType.COPY
+              && connection.getSFBaseSession(internalCallMarker()).isEnableCopyResultSet();
+
+      if (!copyResultSetEnabled
+          && !sfResultSet.getStatementType().isGenerateResultSet()
           && (!connection.getSFBaseSession(internalCallMarker()).isSfSQLMode()
               || sfBaseStatement.hasChildren())) {
         updateCount = ResultUtil.calculateUpdateCount(sfResultSet);

--- a/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java
@@ -138,6 +138,7 @@ public abstract class SFBaseSession {
 
   // Connection string setting
   private boolean enablePutGet = true;
+  private boolean enableCopyResultSet = false;
 
   // Enables the use of pattern searches for certain DatabaseMetaData methods
   // which do not by definition allow the use of patterns, but
@@ -1131,6 +1132,14 @@ public abstract class SFBaseSession {
 
   public boolean setEnablePutGet(boolean enablePutGet) {
     return this.enablePutGet = enablePutGet;
+  }
+
+  public boolean isEnableCopyResultSet() {
+    return enableCopyResultSet;
+  }
+
+  public boolean setEnableCopyResultSet(boolean enableCopyResultSet) {
+    return this.enableCopyResultSet = enableCopyResultSet;
   }
 
   public boolean getEnablePatternSearch() {

--- a/src/main/java/net/snowflake/client/internal/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSession.java
@@ -453,6 +453,12 @@ public class SFSession extends SFBaseSession {
           }
           break;
 
+        case ENABLE_COPY_RESULT_SET:
+          if (propertyValue != null) {
+            setEnableCopyResultSet(getBooleanValue(propertyValue));
+          }
+          break;
+
         case RETRY_TIMEOUT:
           if (propertyValue != null) {
             int timeoutValue = (Integer) propertyValue;

--- a/src/main/java/net/snowflake/client/internal/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSessionProperty.java
@@ -89,6 +89,7 @@ public enum SFSessionProperty {
   MAX_HTTP_RETRIES("maxHttpRetries", false, Integer.class),
 
   ENABLE_PUT_GET("enablePutGet", false, Boolean.class),
+  ENABLE_COPY_RESULT_SET("enableCopyResultSet", false, Boolean.class),
   DISABLE_CONSOLE_LOGIN("disableConsoleLogin", false, Boolean.class),
 
   PUT_GET_MAX_RETRIES("putGetMaxRetries", false, Integer.class),

--- a/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplCopyResultSetTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplCopyResultSetTest.java
@@ -10,8 +10,8 @@ import static org.mockito.Mockito.when;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import net.snowflake.client.internal.api.implementation.resultset.SnowflakeBaseResultSet;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import net.snowflake.client.internal.api.implementation.resultset.SnowflakeBaseResultSet;
 import net.snowflake.client.internal.core.SFBaseResultSet;
 import net.snowflake.client.internal.core.SFBaseSession;
 import net.snowflake.client.internal.core.SFBaseStatement;
@@ -53,14 +53,16 @@ class SnowflakeStatementImplCopyResultSetTest {
     when(mockSFResultSet.isClosed()).thenReturn(false);
     when(mockSFResultSet.next()).thenReturn(false);
 
-    when(mockHandler.createResultSet(any(SFBaseResultSet.class), any())).thenReturn(mockJdbcResultSet);
+    when(mockHandler.createResultSet(any(SFBaseResultSet.class), any()))
+        .thenReturn(mockJdbcResultSet);
     when(mockJdbcResultSet.isClosed()).thenReturn(false);
 
-    statement = new SnowflakeStatementImpl(
-        mockConnection,
-        ResultSet.TYPE_FORWARD_ONLY,
-        ResultSet.CONCUR_READ_ONLY,
-        ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    statement =
+        new SnowflakeStatementImpl(
+            mockConnection,
+            ResultSet.TYPE_FORWARD_ONLY,
+            ResultSet.CONCUR_READ_ONLY,
+            ResultSet.CLOSE_CURSORS_AT_COMMIT);
   }
 
   @Test
@@ -72,7 +74,8 @@ class SnowflakeStatementImplCopyResultSetTest {
     boolean result = statement.execute("COPY INTO ...");
 
     assertFalse(result, "execute() should return false for COPY when flag is disabled");
-    assertNull(statement.getResultSet(), "getResultSet() should be null when execute() returns false");
+    assertNull(
+        statement.getResultSet(), "getResultSet() should be null when execute() returns false");
   }
 
   @Test
@@ -83,7 +86,8 @@ class SnowflakeStatementImplCopyResultSetTest {
     boolean result = statement.execute("COPY INTO ...");
 
     assertTrue(result, "execute() should return true for COPY when flag is enabled");
-    assertNotNull(statement.getResultSet(), "getResultSet() should be non-null when execute() returns true");
+    assertNotNull(
+        statement.getResultSet(), "getResultSet() should be non-null when execute() returns true");
   }
 
   @Test
@@ -94,6 +98,7 @@ class SnowflakeStatementImplCopyResultSetTest {
 
     boolean result = statement.execute("INSERT INTO t VALUES (1)");
 
-    assertFalse(result, "execute() should return false for INSERT regardless of enableCopyResultSet flag");
+    assertFalse(
+        result, "execute() should return false for INSERT regardless of enableCopyResultSet flag");
   }
 }

--- a/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplCopyResultSetTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplCopyResultSetTest.java
@@ -1,0 +1,99 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import net.snowflake.client.internal.api.implementation.resultset.SnowflakeBaseResultSet;
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import net.snowflake.client.internal.core.SFBaseResultSet;
+import net.snowflake.client.internal.core.SFBaseSession;
+import net.snowflake.client.internal.core.SFBaseStatement;
+import net.snowflake.client.internal.core.SFException;
+import net.snowflake.client.internal.core.SFStatementType;
+import net.snowflake.client.internal.jdbc.SFConnectionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SnowflakeStatementImplCopyResultSetTest {
+
+  private SnowflakeConnectionImpl mockConnection;
+  private SFConnectionHandler mockHandler;
+  private SFBaseStatement mockSFStatement;
+  private SFBaseResultSet mockSFResultSet;
+  private SFBaseSession mockSession;
+  private SnowflakeBaseResultSet mockJdbcResultSet;
+  private SnowflakeStatementImpl statement;
+
+  @BeforeEach
+  void setUp() throws SQLException, SFException {
+    mockConnection = mock(SnowflakeConnectionImpl.class);
+    mockHandler = mock(SFConnectionHandler.class);
+    mockSFStatement = mock(SFBaseStatement.class);
+    mockSFResultSet = mock(SFBaseResultSet.class);
+    mockSession = mock(SFBaseSession.class);
+    mockJdbcResultSet = mock(SnowflakeBaseResultSet.class);
+
+    when(mockConnection.getHandler(any())).thenReturn(mockHandler);
+    when(mockHandler.getSFStatement()).thenReturn(mockSFStatement);
+    when(mockConnection.getSFBaseSession(any())).thenReturn(mockSession);
+    when(mockConnection.getSessionID()).thenReturn("test-session-id");
+    when(mockConnection.isClosed()).thenReturn(false);
+
+    when(mockSFStatement.execute(any(), any(), any(), any())).thenReturn(mockSFResultSet);
+    when(mockSFStatement.hasChildren()).thenReturn(false);
+
+    when(mockSFResultSet.getQueryId()).thenReturn("query-id");
+    when(mockSFResultSet.isClosed()).thenReturn(false);
+    when(mockSFResultSet.next()).thenReturn(false);
+
+    when(mockHandler.createResultSet(any(SFBaseResultSet.class), any())).thenReturn(mockJdbcResultSet);
+    when(mockJdbcResultSet.isClosed()).thenReturn(false);
+
+    statement = new SnowflakeStatementImpl(
+        mockConnection,
+        ResultSet.TYPE_FORWARD_ONLY,
+        ResultSet.CONCUR_READ_ONLY,
+        ResultSet.CLOSE_CURSORS_AT_COMMIT);
+  }
+
+  @Test
+  void copyWithFlagDisabled_executeReturnsFalseAndResultSetIsNull() throws SQLException {
+    when(mockSFResultSet.getStatementType()).thenReturn(SFStatementType.COPY);
+    when(mockSession.isEnableCopyResultSet()).thenReturn(false);
+    when(mockSession.isSfSQLMode()).thenReturn(false);
+
+    boolean result = statement.execute("COPY INTO ...");
+
+    assertFalse(result, "execute() should return false for COPY when flag is disabled");
+    assertNull(statement.getResultSet(), "getResultSet() should be null when execute() returns false");
+  }
+
+  @Test
+  void copyWithFlagEnabled_executeReturnsTrueAndResultSetIsNonNull() throws SQLException {
+    when(mockSFResultSet.getStatementType()).thenReturn(SFStatementType.COPY);
+    when(mockSession.isEnableCopyResultSet()).thenReturn(true);
+
+    boolean result = statement.execute("COPY INTO ...");
+
+    assertTrue(result, "execute() should return true for COPY when flag is enabled");
+    assertNotNull(statement.getResultSet(), "getResultSet() should be non-null when execute() returns true");
+  }
+
+  @Test
+  void insertWithFlagEnabled_executeReturnsFalse() throws SQLException {
+    when(mockSFResultSet.getStatementType()).thenReturn(SFStatementType.INSERT);
+    when(mockSession.isEnableCopyResultSet()).thenReturn(true);
+    when(mockSession.isSfSQLMode()).thenReturn(false);
+
+    boolean result = statement.execute("INSERT INTO t VALUES (1)");
+
+    assertFalse(result, "execute() should return false for INSERT regardless of enableCopyResultSet flag");
+  }
+}

--- a/src/test/java/net/snowflake/client/internal/core/SFSessionPropertyTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SFSessionPropertyTest.java
@@ -3,8 +3,16 @@ package net.snowflake.client.internal.core;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
 import net.snowflake.client.api.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
 
@@ -81,5 +89,45 @@ public class SFSessionPropertyTest {
         SFSessionProperty.checkPropertyValue(SFSessionProperty.PUT_GET_MAX_RETRIES, expectedVal);
 
     assertThat("Integer value should match", (int) value == expectedVal);
+  }
+
+  @Test
+  public void testEnableCopyResultSetPropertyRegistered() {
+    SFSessionProperty prop = SFSessionProperty.lookupByKey("enableCopyResultSet");
+    assertNotNull(prop);
+    assertEquals(SFSessionProperty.ENABLE_COPY_RESULT_SET, prop);
+    assertEquals(Boolean.class, prop.getValueType());
+  }
+
+  @Test
+  void testEnableCopyResultSetDefaultFalse() {
+    SFBaseSession session = mock(SFBaseSession.class, CALLS_REAL_METHODS);
+    assertFalse(session.isEnableCopyResultSet(), "default must be false for backwards compatibility");
+  }
+
+  @Test
+  void testEnableCopyResultSetCanBeSetTrue() {
+    SFBaseSession session = mock(SFBaseSession.class, CALLS_REAL_METHODS);
+    session.setEnableCopyResultSet(true);
+    assertTrue(session.isEnableCopyResultSet());
+  }
+
+  @Test
+  void testEnableCopyResultSetCanBeReset() {
+    SFBaseSession session = mock(SFBaseSession.class, CALLS_REAL_METHODS);
+    session.setEnableCopyResultSet(true);
+    session.setEnableCopyResultSet(false);
+    assertFalse(session.isEnableCopyResultSet(), "flag must be resettable to false");
+  }
+
+  @Test
+  void testAddSFSessionPropertyWiresEnableCopyResultSet() throws SFException, ReflectiveOperationException {
+    SFSession session = mock(SFSession.class, CALLS_REAL_METHODS);
+    Field mapField = SFBaseSession.class.getDeclaredField("connectionPropertiesMap");
+    mapField.setAccessible(true);
+    mapField.set(session, new HashMap<>());
+    session.addSFSessionProperty(
+        SFSessionProperty.ENABLE_COPY_RESULT_SET.getPropertyKey(), Boolean.TRUE);
+    assertTrue(session.isEnableCopyResultSet());
   }
 }

--- a/src/test/java/net/snowflake/client/internal/core/SFSessionPropertyTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SFSessionPropertyTest.java
@@ -102,7 +102,8 @@ public class SFSessionPropertyTest {
   @Test
   void testEnableCopyResultSetDefaultFalse() {
     SFBaseSession session = mock(SFBaseSession.class, CALLS_REAL_METHODS);
-    assertFalse(session.isEnableCopyResultSet(), "default must be false for backwards compatibility");
+    assertFalse(
+        session.isEnableCopyResultSet(), "default must be false for backwards compatibility");
   }
 
   @Test
@@ -121,7 +122,8 @@ public class SFSessionPropertyTest {
   }
 
   @Test
-  void testAddSFSessionPropertyWiresEnableCopyResultSet() throws SFException, ReflectiveOperationException {
+  void testAddSFSessionPropertyWiresEnableCopyResultSet()
+      throws SFException, ReflectiveOperationException {
     SFSession session = mock(SFSession.class, CALLS_REAL_METHODS);
     Field mapField = SFBaseSession.class.getDeclaredField("connectionPropertiesMap");
     mapField.setAccessible(true);

--- a/src/test/java/net/snowflake/client/internal/core/SFStatementTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SFStatementTest.java
@@ -119,4 +119,5 @@ class SFStatementTest {
     assertEquals(originalErrorCode, thrown.getErrorCode());
     assertEquals("qid-123", thrown.getQueryId());
   }
+
 }

--- a/src/test/java/net/snowflake/client/internal/core/SFStatementTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SFStatementTest.java
@@ -119,5 +119,4 @@ class SFStatementTest {
     assertEquals(originalErrorCode, thrown.getErrorCode());
     assertEquals("qid-123", thrown.getQueryId());
   }
-
 }


### PR DESCRIPTION
# Overview

SNOW-3388627

Add a boolean connection property `enableCopyResultSet` (default `false`) that,
when set to `true`, causes `Statement.execute()` to expose the COPY INTO per-file
metadata result set via `getResultSet()` instead of consuming it internally as
an update count.

Related to #140 (same root cause — COPY result set consumed internally since 3.8.x)

## Background

Since commit `68df8617` (2017), `SFStatementType.COPY` has had `generateResultSet=false`.
This causes `executeInternal()` to sum `rows_loaded` into the update count and null out
the result set — making the per-file COPY metadata (file, status, rows_parsed,
rows_loaded, errors_seen, first_error, etc.) inaccessible over JDBC.

Callers such as Apache NiFi's `ExecuteSQLRecord` processor use `Statement.execute()`
and check `getResultSet()` to consume query results. With the current behaviour these
callers receive `execute()=false` / null `ResultSet` for every COPY INTO, regardless
of how many files were loaded.

## Changes

| File | Change |
|------|--------|
| `SFSessionProperty.java` | Add `ENABLE_COPY_RESULT_SET` enum entry |
| `SFBaseSession.java` | Add `enableCopyResultSet` field + getter/setter |
| `SFSession.java` | Wire `ENABLE_COPY_RESULT_SET` in `addSFSessionProperty` switch |
| `SnowflakeStatementImpl.java` | Guard: bypass DML path for COPY when flag is enabled |
| `CHANGELOG.md` | Document the new property under `v4.1.1-SNAPSHOT` |

## Behaviour

With `enableCopyResultSet=true` set on the connection URL or properties:

- `Statement.execute()` returns `true` for COPY INTO statements
- `Statement.getResultSet()` returns the standard COPY metadata result set
- `Statement.getUpdateCount()` returns `-1` (JDBC spec: no update count when result set present)
- `Statement.executeUpdate()` behaviour is **unchanged** — still returns rows_loaded sum
- All other statement types (INSERT, UPDATE, DELETE, etc.) are **unaffected**

Backwards compatible: default is `false`, existing callers see no change.

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (`mvn -P check-style validate` — 0 violations, Java 17)
- [x] New public API is not unnecessarily exposed — follows `enablePutGet` precedent; no `@SnowflakeJdbcInternalApi` added as the property is intentionally user-facing
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors checklist

1. **GitHub issue:** #140 (same root cause — NullPointerException in DataStage when COPY result set was consumed internally)

2. Pre-review checklist:
   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [x] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (the new `enableCopyResultSet` getter/setter on `SFBaseSession` is intentionally user-accessible via the connection property mechanism)

3. **How this solves the issue:**

   The guard in `SnowflakeStatementImpl.executeInternal()` now checks both
   `sfResultSet.getStatementType() == SFStatementType.COPY` and
   `connection.getSFBaseSession().isEnableCopyResultSet()` before deciding whether
   to consume the result set as an update count. When the flag is `true`, the COPY
   statement falls through to the result-set path, so callers receive a live
   `ResultSet` containing one row per loaded file.

   Unit tests added:
   - `SFSessionPropertyTest` — 5 tests: property registration, default value, set/reset, wiring through `addSFSessionProperty`
   - `SnowflakeStatementImplCopyResultSetTest` — 3 behavioural tests: COPY with flag off (backwards compat), COPY with flag on (main feature), INSERT with flag on (no collateral)

   Integration tests against a live Snowflake account are pending; all 19 unit tests pass locally under Java 17/21.
