### PR TITLE
SNOW-3411310: fix auto-connection issues: default port and connection string vs. toml-sourced items conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - v4.1.1-SNAPSHOT
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)
+    - Fixed connections.toml auto-configuration defaulting to port 80 instead of 443 when neither port nor protocol is specified (snowflakedb/snowflake-jdbc#XXXX)
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).
     - Fix initializing ObjectMapper when DATE_OUTPUT_FORMAT is specified (snowflakedb/snowflake-jdbc#2545).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - v4.1.1-SNAPSHOT
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)
-    - Fixed connections.toml auto-configuration behaviour (snowflakedb/snowflake-jdbc#XXXX) :
+    - Fixed connections.toml auto-configuration behaviour (snowflakedb/snowflake-jdbc#2591) :
       - now defaulting to port 443 instead of 80 when neither port nor protocol is specified
       - config coming from the JDBC connection string are no longer ignored when auto-configuration sourced items also present (when both present, direct connection config takes precedence)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 - v4.1.1-SNAPSHOT
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)
-    - Fixed connections.toml auto-configuration defaulting to port 80 instead of 443 when neither port nor protocol is specified (snowflakedb/snowflake-jdbc#XXXX)
+    - Fixed connections.toml auto-configuration behaviour (snowflakedb/snowflake-jdbc#XXXX) :
+      - now defaulting to port 443 instead of 80 when neither port nor protocol is specified
+      - config coming from the JDBC connection string are no longer ignored when auto-configuration sourced items also present (when both present, direct connection config takes precedence)
+
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).
     - Fix initializing ObjectMapper when DATE_OUTPUT_FORMAT is specified (snowflakedb/snowflake-jdbc#2545).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - v4.1.1-SNAPSHOT
     - Migrated CI test images from CentOS 7 (EOL) to Rocky Linux 8
     - Fixed NPE "The URI scheme of endpointOverride must not be null" happening during file transfer (e.g. PUT) in some use-cases (snowflakedb/snowflake-jdbc#2572)
-    - Fixed connections.toml auto-configuration behaviour (snowflakedb/snowflake-jdbc#2591) :
+    - Fixed connections.toml auto-configuration behaviour (snowflakedb/snowflake-jdbc#2591):
       - now defaulting to port 443 instead of 80 when neither port nor protocol is specified
       - config coming from the JDBC connection string are no longer ignored when auto-configuration sourced items also present (when both present, direct connection config takes precedence)
 

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -151,11 +151,9 @@ public class SFConnectionConfigParser {
       String tomlValue = fileConfig.get(key);
       if (tomlValue != null && !tomlValue.equals(urlValue)) {
         logger.debug(
-            "For config item '{}' the value from connections.toml ('{}') and the connection"
-                + " string ('{}') differ; the connection string value will be applied.",
-            key,
-            tomlValue,
-            urlValue);
+            "For config item '{}' the values from connections.toml and the connection string"
+                + " differ; the connection string value will be applied.",
+            key);
       }
       fileConfig.put(key, urlValue);
     }

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -144,12 +144,12 @@ public class SFConnectionConfigParser {
       Map<String, String> fileConfig, Map<String, String> urlParameters) {
     for (Map.Entry<String, String> entry : urlParameters.entrySet()) {
       String key = entry.getKey();
-      if ("connectionName".equals(key)) {
+      if ("connectionName".equalsIgnoreCase(key)) {
         continue;
       }
       String urlValue = entry.getValue();
       String tomlValue = fileConfig.get(key);
-      if (tomlValue != null && !tomlValue.equals(urlValue)) {
+      if (tomlValue != null && !tomlValue.equalsIgnoreCase(urlValue)) {
         logger.debug(
             "For config item '{}' the values from connections.toml and the connection string"
                 + " differ; the connection string value will be applied.",

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -275,10 +275,10 @@ public class SFConnectionConfigParser {
     String port = fileConnectionConfiguration.get("port");
     String protocol = fileConnectionConfiguration.get("protocol");
     if (isNullOrEmpty(port)) {
-      if ("https".equals(protocol)) {
-        port = "443";
-      } else {
+      if ("http".equals(protocol)) {
         port = "80";
+      } else {
+        port = "443";
       }
     }
     return String.format("jdbc:snowflake://%s:%s", host, port);

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -59,6 +59,9 @@ public class SFConnectionConfigParser {
         loadDefaultConnectionConfiguration(defaultConnectionName);
 
     if (fileConnectionConfiguration != null && !fileConnectionConfiguration.isEmpty()) {
+      Map<String, String> urlParameters = parseAutoConfigJdbcUrlParameters(connectionUrl);
+      mergeUrlParametersIntoConfiguration(fileConnectionConfiguration, urlParameters);
+
       Properties connectionProperties = new Properties();
       connectionProperties.putAll(fileConnectionConfiguration);
 
@@ -135,6 +138,27 @@ public class SFConnectionConfigParser {
     }
 
     return paramMap;
+  }
+
+  private static void mergeUrlParametersIntoConfiguration(
+      Map<String, String> fileConfig, Map<String, String> urlParameters) {
+    for (Map.Entry<String, String> entry : urlParameters.entrySet()) {
+      String key = entry.getKey();
+      if ("connectionName".equals(key)) {
+        continue;
+      }
+      String urlValue = entry.getValue();
+      String tomlValue = fileConfig.get(key);
+      if (tomlValue != null && !tomlValue.equals(urlValue)) {
+        logger.debug(
+            "For config item '{}' the value from connections.toml ('{}') and the connection"
+                + " string ('{}') differ; the connection string value will be applied.",
+            key,
+            tomlValue,
+            urlValue);
+      }
+      fileConfig.put(key, urlValue);
+    }
   }
 
   private static Map<String, String> loadDefaultConnectionConfiguration(

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -49,7 +49,8 @@ public class SFConnectionConfigParser {
 
   public static ConnectionParameters buildConnectionParameters(String connectionUrl)
       throws SnowflakeSQLException {
-    String defaultConnectionName = getConnectionNameFromUrl(connectionUrl);
+    Map<String, String> urlParameters = parseAutoConfigJdbcUrlParameters(connectionUrl);
+    String defaultConnectionName = urlParameters.get("connectionName");
     if (isBlank(defaultConnectionName)) {
       defaultConnectionName =
           Optional.ofNullable(systemGetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY)).orElse(DEFAULT);
@@ -59,7 +60,6 @@ public class SFConnectionConfigParser {
         loadDefaultConnectionConfiguration(defaultConnectionName);
 
     if (fileConnectionConfiguration != null && !fileConnectionConfiguration.isEmpty()) {
-      Map<String, String> urlParameters = parseAutoConfigJdbcUrlParameters(connectionUrl);
       mergeUrlParametersIntoConfiguration(fileConnectionConfiguration, urlParameters);
 
       Properties connectionProperties = new Properties();
@@ -297,7 +297,7 @@ public class SFConnectionConfigParser {
     String port = fileConnectionConfiguration.get("port");
     String protocol = fileConnectionConfiguration.get("protocol");
     if (isNullOrEmpty(port)) {
-      if ("http".equals(protocol)) {
+      if ("http".equalsIgnoreCase(protocol)) {
         port = "80";
       } else {
         port = "443";

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -162,7 +162,7 @@ public class SFConnectionConfigParserTest {
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
     assertEquals(
-        "jdbc:snowflake://snowaccount.us-west-2.aws.snowflakecomputing.com:443", data.getUrl());
+        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
   }
 
   @Test
@@ -174,7 +174,7 @@ public class SFConnectionConfigParserTest {
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
     assertEquals(
-        "jdbc:snowflake://snowaccount.us-west-2.aws.snowflakecomputing.com:443", data.getUrl());
+        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
   }
 
   @Test
@@ -186,7 +186,7 @@ public class SFConnectionConfigParserTest {
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
     assertEquals(
-        "jdbc:snowflake://snowaccount.us-west-2.aws.snowflakecomputing.com:80", data.getUrl());
+        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:80", data.getUrl());
   }
 
   @Test
@@ -198,7 +198,69 @@ public class SFConnectionConfigParserTest {
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
     assertEquals(
-        "jdbc:snowflake://snowaccount.us-west-2.aws.snowflakecomputing.com:8082", data.getUrl());
+        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
+  }
+
+  @Test
+  public void testUrlParametersAreMergedIntoTomlConfiguration()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, null);
+    ConnectionParameters data =
+        SFConnectionConfigParser.buildConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&tracing=ALL&disablePlatformDetection=true");
+    assertNotNull(data);
+    assertEquals(
+        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
+    assertEquals("ALL", data.getParams().get("tracing"));
+    assertEquals("true", data.getParams().get("disablePlatformDetection"));
+    assertEquals("user1", data.getParams().get("user"));
+    assertEquals("pass1", data.getParams().get("password"));
+  }
+
+  @Test
+  public void testUrlParameterOverridesTomlValueForSameKey()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol("8082", "http");
+    ConnectionParameters data =
+        SFConnectionConfigParser.buildConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&port=443&protocol=https");
+    assertNotNull(data);
+    assertEquals(
+        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
+    assertEquals("https", data.getParams().get("protocol"));
+  }
+
+  @Test
+  public void testUrlParameterOverridesTomlUser()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, null);
+    ConnectionParameters data =
+        SFConnectionConfigParser.buildConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&user=overridden_user");
+    assertNotNull(data);
+    assertEquals("overridden_user", data.getParams().get("user"));
+  }
+
+  @Test
+  public void testUrlParametersWithNoExtraParamsKeepsTomlValues()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol("8082", "http");
+    ConnectionParameters data =
+        SFConnectionConfigParser.buildConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default");
+    assertNotNull(data);
+    assertEquals(
+        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
+    assertEquals("user1", data.getParams().get("user"));
+    assertEquals("pass1", data.getParams().get("password"));
   }
 
   @Test
@@ -288,7 +350,7 @@ public class SFConnectionConfigParserTest {
     File file = filePath.toFile();
 
     Map<String, Object> configurationParams = new HashMap<>();
-    configurationParams.put("account", "snowaccount.us-west-2.aws");
+    configurationParams.put("account", "myorg-myaccount");
     configurationParams.put("user", "user1");
     configurationParams.put("password", "pass1");
     if (port != null) {

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -245,10 +245,7 @@ public class SFConnectionConfigParserTest {
             Arrays.asList(
                 "account", "user", "password", "warehouse", "port", "protocol", "tracing"));
     Set<String> actualKeys = data.getParams().stringPropertyNames();
-    for (String key : expectedKeys) {
-      long count = actualKeys.stream().filter(k -> k.equals(key)).count();
-      assertEquals(1, count, "Key '" + key + "' should appear exactly once");
-    }
+    assertEquals(expectedKeys, actualKeys);
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -154,6 +154,54 @@ public class SFConnectionConfigParserTest {
   }
 
   @Test
+  public void testDefaultPortIs443WhenNeitherPortNorProtocolIsSet()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, null);
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals(
+        "jdbc:snowflake://snowaccount.us-west-2.aws.snowflakecomputing.com:443", data.getUrl());
+  }
+
+  @Test
+  public void testDefaultPortIs443WhenProtocolIsHttps()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, "https");
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals(
+        "jdbc:snowflake://snowaccount.us-west-2.aws.snowflakecomputing.com:443", data.getUrl());
+  }
+
+  @Test
+  public void testDefaultPortIs80WhenProtocolIsHttp()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, "http");
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals(
+        "jdbc:snowflake://snowaccount.us-west-2.aws.snowflakecomputing.com:80", data.getUrl());
+  }
+
+  @Test
+  public void testExplicitPortIsPreservedRegardlessOfProtocol()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol("8082", "http");
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals(
+        "jdbc:snowflake://snowaccount.us-west-2.aws.snowflakecomputing.com:8082", data.getUrl());
+  }
+
+  @Test
   public void shouldThrowExceptionIfNoneOfHostAndAccountIsSet() throws IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
@@ -232,6 +280,27 @@ public class SFConnectionConfigParserTest {
               onlyUserPermissionToken);
       Files.write(emptyTokenFilePath, "".getBytes());
     }
+  }
+
+  private void prepareTomlWithPortAndProtocol(String port, String protocol) throws IOException {
+    Path path = Paths.get(tempPath.toString(), "connections.toml");
+    Path filePath = createFilePathWithPermission(path, true);
+    File file = filePath.toFile();
+
+    Map<String, Object> configurationParams = new HashMap<>();
+    configurationParams.put("account", "snowaccount.us-west-2.aws");
+    configurationParams.put("user", "user1");
+    configurationParams.put("password", "pass1");
+    if (port != null) {
+      configurationParams.put("port", port);
+    }
+    if (protocol != null) {
+      configurationParams.put("protocol", protocol);
+    }
+
+    Map<String, Object> configuration = new HashMap<>();
+    configuration.put("default", configurationParams);
+    tomlMapper.writeValue(file, configuration);
   }
 
   private Path createFilePathWithPermission(Path path, boolean onlyUserPermission)

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -217,6 +218,7 @@ public class SFConnectionConfigParserTest {
     assertEquals("true", data.getParams().get("disablePlatformDetection"));
     assertEquals("user1", data.getParams().get("user"));
     assertEquals("pass1", data.getParams().get("password"));
+    assertEquals("MY_WH", data.getParams().get("warehouse"));
   }
 
   @Test
@@ -227,11 +229,26 @@ public class SFConnectionConfigParserTest {
     prepareTomlWithPortAndProtocol("8082", "http");
     ConnectionParameters data =
         SFConnectionConfigParser.buildConnectionParameters(
-            "jdbc:snowflake:auto?connectionName=default&port=443&protocol=https");
+            "jdbc:snowflake:auto?connectionName=default&port=443&protocol=https&warehouse=OTHER_WH&tracing=ALL");
     assertNotNull(data);
     assertEquals(
         "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
+    assertEquals("443", data.getParams().get("port"));
     assertEquals("https", data.getParams().get("protocol"));
+    assertEquals("OTHER_WH", data.getParams().get("warehouse"));
+    assertEquals("ALL", data.getParams().get("tracing"));
+    assertEquals("user1", data.getParams().get("user"));
+    assertEquals("pass1", data.getParams().get("password"));
+    assertEquals("myorg-myaccount", data.getParams().get("account"));
+    Set<String> expectedKeys =
+        new HashSet<>(
+            Arrays.asList(
+                "account", "user", "password", "warehouse", "port", "protocol", "tracing"));
+    Set<String> actualKeys = data.getParams().stringPropertyNames();
+    for (String key : expectedKeys) {
+      long count = actualKeys.stream().filter(k -> k.equals(key)).count();
+      assertEquals(1, count, "Key '" + key + "' should appear exactly once");
+    }
   }
 
   @Test
@@ -261,6 +278,7 @@ public class SFConnectionConfigParserTest {
         "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
     assertEquals("user1", data.getParams().get("user"));
     assertEquals("pass1", data.getParams().get("password"));
+    assertEquals("MY_WH", data.getParams().get("warehouse"));
   }
 
   @Test
@@ -353,6 +371,7 @@ public class SFConnectionConfigParserTest {
     configurationParams.put("account", "myorg-myaccount");
     configurationParams.put("user", "user1");
     configurationParams.put("password", "pass1");
+    configurationParams.put("warehouse", "MY_WH");
     if (port != null) {
       configurationParams.put("port", port);
     }

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -162,32 +162,27 @@ public class SFConnectionConfigParserTest {
     prepareTomlWithPortAndProtocol(null, null);
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
-    assertEquals(
-        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
+    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
   }
 
   @Test
-  public void testDefaultPortIs443WhenProtocolIsHttps()
-      throws SnowflakeSQLException, IOException {
+  public void testDefaultPortIs443WhenProtocolIsHttps() throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
     prepareTomlWithPortAndProtocol(null, "https");
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
-    assertEquals(
-        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
+    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
   }
 
   @Test
-  public void testDefaultPortIs80WhenProtocolIsHttp()
-      throws SnowflakeSQLException, IOException {
+  public void testDefaultPortIs80WhenProtocolIsHttp() throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
     prepareTomlWithPortAndProtocol(null, "http");
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
-    assertEquals(
-        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:80", data.getUrl());
+    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:80", data.getUrl());
   }
 
   @Test
@@ -198,8 +193,7 @@ public class SFConnectionConfigParserTest {
     prepareTomlWithPortAndProtocol("8082", "http");
     ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
     assertNotNull(data);
-    assertEquals(
-        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
+    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
   }
 
   @Test
@@ -212,8 +206,7 @@ public class SFConnectionConfigParserTest {
         SFConnectionConfigParser.buildConnectionParameters(
             "jdbc:snowflake:auto?connectionName=default&tracing=ALL&disablePlatformDetection=true");
     assertNotNull(data);
-    assertEquals(
-        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
+    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
     assertEquals("ALL", data.getParams().get("tracing"));
     assertEquals("true", data.getParams().get("disablePlatformDetection"));
     assertEquals("user1", data.getParams().get("user"));
@@ -231,8 +224,7 @@ public class SFConnectionConfigParserTest {
         SFConnectionConfigParser.buildConnectionParameters(
             "jdbc:snowflake:auto?connectionName=default&port=443&protocol=https&warehouse=OTHER_WH&tracing=ALL");
     assertNotNull(data);
-    assertEquals(
-        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
+    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
     assertEquals("443", data.getParams().get("port"));
     assertEquals("https", data.getParams().get("protocol"));
     assertEquals("OTHER_WH", data.getParams().get("warehouse"));
@@ -249,8 +241,7 @@ public class SFConnectionConfigParserTest {
   }
 
   @Test
-  public void testUrlParameterOverridesTomlUser()
-      throws SnowflakeSQLException, IOException {
+  public void testUrlParameterOverridesTomlUser() throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
     prepareTomlWithPortAndProtocol(null, null);
@@ -271,8 +262,7 @@ public class SFConnectionConfigParserTest {
         SFConnectionConfigParser.buildConnectionParameters(
             "jdbc:snowflake:auto?connectionName=default");
     assertNotNull(data);
-    assertEquals(
-        "jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
+    assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
     assertEquals("user1", data.getParams().get("user"));
     assertEquals("pass1", data.getParams().get("password"));
     assertEquals("MY_WH", data.getParams().get("warehouse"));


### PR DESCRIPTION
# Overview

This is for issues:
* #2589
* #2590 

Due to the wrong logic of selecting port 80 for connection when protocol is not specified, we seem to be ending up with `myorg-myaccount.snowflakecomputing.com:80` when connection config is sourced from `connections.toml` auto-config , `jdbc:snowflake:auto?connectionName=sample` 

Besides that, when `connections.toml` is present and auto-config is used, then only the config keys coming from the toml file seem to take effect in the connection string, and those which were explicitly specified there, do not. 

This PR aims to provide a fix for both issues:
* make port 443 and https the default for connections, if port is not specified
* when config keys come from both the toml file _and_ the manually configured connection string, merge them to allow all of them to take effect
  * when a given key is in conflict (comes both from toml _and_ explicit connection string), prefer the connection string sourced one - connections.toml is generic and shared across Snowflake drivers, but a directly specified connection string is only present in the JDBC driver thus more specific

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements
