### PR TITLE
SNOW-3419325 Fix file owner check for container user.name and guard cache delete paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
       - now defaulting to port 443 instead of 80 when neither port nor protocol is specified
       - config coming from the JDBC connection string are no longer ignored when auto-configuration sourced items also present (when both present, direct connection config takes precedence)
     - Fixed protocol field in connections.toml being ignored, causing connections to always use HTTPS (snowflakedb/snowflake-jdbc#2585)
+    - Fixed SecurityException on credential cache file ownership check in containers where JVM returns '?' for user.name (snowflakedb/snowflake-jdbc#2600).
+    - Fixed credential cache delete operations ignoring clientStoreTemporaryCredential=false setting (snowflakedb/snowflake-jdbc#2600).
+
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).
     - Fix initializing ObjectMapper when DATE_OUTPUT_FORMAT is specified (snowflakedb/snowflake-jdbc#2545).

--- a/src/main/java/net/snowflake/client/internal/core/FileUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/FileUtil.java
@@ -18,6 +18,15 @@ import net.snowflake.client.internal.log.SFLoggerFactory;
 
 public class FileUtil {
   private static final SFLogger logger = SFLoggerFactory.getLogger(FileUtil.class);
+
+  /**
+   * Placeholder value returned by the JVM for {@code user.name} when the current OS user has no
+   * matching entry in the system user database (e.g. a container started with {@code runAsUser} and
+   * no {@code /etc/passwd} entry). Treated as "unknown user" — file owner validation is skipped in
+   * this case.
+   */
+  static final String UNKNOWN_USER_NAME_MARKER = "?";
+
   private static final Collection<PosixFilePermission> WRITE_BY_OTHERS =
       Arrays.asList(PosixFilePermission.GROUP_WRITE, PosixFilePermission.OTHERS_WRITE);
   private static final Collection<PosixFilePermission> READ_BY_OTHERS =
@@ -163,9 +172,9 @@ public class FileUtil {
     try {
       String fileOwnerName = getFileOwnerName(filePath);
       String currentUser = systemGetProperty("user.name");
-      if (currentUser == null) {
-        logger.debug(
-            "Cannot determine user (possibly due to security manager restrictions), skipping file owner validation");
+      if (currentUser == null || UNKNOWN_USER_NAME_MARKER.equals(currentUser)) {
+        logger.warn(
+            "Cannot determine user (possibly due to security manager restrictions or missing passwd entry in container), skipping file owner validation");
         return;
       }
       if (!currentUser.equalsIgnoreCase(fileOwnerName)) {

--- a/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
@@ -476,7 +476,9 @@ public class SessionUtil {
       logger.debug(
           "Refreshing OAuth access token failed. Removing OAuth refresh token from cache and restarting OAuth flow...",
           e);
-      CredentialManager.deleteOAuthRefreshTokenCacheEntry(loginInput);
+      if (asBoolean(loginInput.getSessionParameters().get(CLIENT_STORE_TEMPORARY_CREDENTIAL))) {
+        CredentialManager.deleteOAuthRefreshTokenCacheEntry(loginInput);
+      }
       loginInput.restoreOriginalAuthenticator();
       fetchOAuthAccessTokenAndUpdateInput(loginInput);
     }
@@ -896,7 +898,9 @@ public class SessionUtil {
         if (errorCode == Constants.ID_TOKEN_INVALID_LOGIN_REQUEST_GS_CODE) {
           // clean id_token first
           loginInput.setIdToken(null);
-          deleteIdTokenCache(loginInput.getHostFromServerUrl(), loginInput.getUserName());
+          if (asBoolean(loginInput.getSessionParameters().get(CLIENT_STORE_TEMPORARY_CREDENTIAL))) {
+            deleteIdTokenCache(loginInput.getHostFromServerUrl(), loginInput.getUserName());
+          }
 
           logger.debug(
               "ID Token Expired / Not Applicable. Reauthenticating with ID Token cleared...: {}",
@@ -920,7 +924,8 @@ public class SessionUtil {
           }
         }
 
-        if (authenticatorType == AuthenticatorType.USERNAME_PASSWORD_MFA) {
+        if (authenticatorType == AuthenticatorType.USERNAME_PASSWORD_MFA
+            && asBoolean(loginInput.getSessionParameters().get(CLIENT_REQUEST_MFA_TOKEN))) {
           deleteMfaTokenCache(loginInput.getHostFromServerUrl(), loginInput.getUserName());
         }
 
@@ -1262,8 +1267,10 @@ public class SessionUtil {
   private static void clearAccessTokenCache(SFLoginInput loginInput) throws SFException {
     loginInput.setOauthAccessToken(null);
     loginInput.setDPoPPublicKey(null);
-    CredentialManager.deleteOAuthAccessTokenCacheEntry(loginInput);
-    CredentialManager.deleteDPoPBundledAccessTokenCacheEntry(loginInput);
+    if (asBoolean(loginInput.getSessionParameters().get(CLIENT_STORE_TEMPORARY_CREDENTIAL))) {
+      CredentialManager.deleteOAuthAccessTokenCacheEntry(loginInput);
+      CredentialManager.deleteDPoPBundledAccessTokenCacheEntry(loginInput);
+    }
   }
 
   private static void setServiceNameHeader(SFLoginInput loginInput, HttpPost postRequest) {

--- a/src/test/java/net/snowflake/client/internal/core/FileCacheManagerTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/FileCacheManagerTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import net.snowflake.client.annotations.RunOnLinuxOrMac;
 import net.snowflake.client.category.TestTags;
 import net.snowflake.client.internal.jdbc.BaseJDBCTest;
+import net.snowflake.client.internal.jdbc.SnowflakeUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -181,6 +182,19 @@ class FileCacheManagerTest extends BaseJDBCTest {
       SecurityException ex =
           assertThrows(SecurityException.class, () -> fileCacheManager.readCacheFile());
       assertTrue(ex.getMessage().contains("The file owner is different than current user"));
+    }
+  }
+
+  @Test
+  @RunOnLinuxOrMac
+  public void notThrowWhenUserNameIsQuestionMarkInContainerEnvironment() {
+    try (MockedStatic<FileUtil> fileUtilMock =
+            Mockito.mockStatic(FileUtil.class, Mockito.CALLS_REAL_METHODS);
+        MockedStatic<SnowflakeUtil> snowflakeUtilMock =
+            Mockito.mockStatic(SnowflakeUtil.class, Mockito.CALLS_REAL_METHODS)) {
+      fileUtilMock.when(() -> FileUtil.getFileOwnerName(isA(Path.class))).thenReturn("root");
+      snowflakeUtilMock.when(() -> SnowflakeUtil.systemGetProperty("user.name")).thenReturn("?");
+      assertDoesNotThrow(() -> fileCacheManager.readCacheFile());
     }
   }
 

--- a/src/test/java/net/snowflake/client/internal/core/OAuthTokenCacheLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/OAuthTokenCacheLatestIT.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import net.snowflake.client.api.auth.AuthenticatorType;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.category.TestTags;
@@ -259,6 +260,30 @@ public class OAuthTokenCacheLatestIT extends BaseWiremockTest {
     }
   }
 
+  @Test
+  public void shouldNotDeleteCachedTokensWhenCachingIsDisabled()
+      throws SFException, SnowflakeSQLException {
+    importMappingFromResources(REFRESHING_EXPIRED_ACCESS_TOKEN_SCENARIO_MAPPINGS);
+    try (MockedStatic<CredentialManager> credentialManagerMockedStatic =
+        mockStatic(CredentialManager.class)) {
+      SFLoginInput loginInput = createLoginInputStubWithCachingDisabled();
+      loginInput.setOauthAccessToken("expired-access-token-123");
+      loginInput.setOauthRefreshToken("some-refresh-token-123");
+      SFLoginOutput loginOutput = SessionUtil.openSession(loginInput, new HashMap<>(), "INFO");
+
+      credentialManagerMockedStatic.verify(
+          () -> CredentialManager.deleteOAuthAccessTokenCacheEntry(loginInput), never());
+      credentialManagerMockedStatic.verify(
+          () -> CredentialManager.deleteDPoPBundledAccessTokenCacheEntry(loginInput), never());
+      credentialManagerMockedStatic.verify(
+          () -> CredentialManager.writeOAuthAccessToken(any(SFLoginInput.class)), never());
+      credentialManagerMockedStatic.verify(
+          () -> CredentialManager.writeOAuthRefreshToken(any(SFLoginInput.class)), never());
+
+      assertEquals("new-refreshed-access-token-123", loginOutput.getOauthAccessToken());
+    }
+  }
+
   private SFLoginInput createLoginInputStub() {
     SFLoginInput input = new SFLoginInput();
     input.setAuthenticator(AuthenticatorType.OAUTH_AUTHORIZATION_CODE.name());
@@ -289,6 +314,35 @@ public class OAuthTokenCacheLatestIT extends BaseWiremockTest {
   private SFLoginInput createLoginInputStubWithDPoPEnabled() {
     SFLoginInput input = createLoginInputStub();
     input.setDPoPEnabled(true);
+    return input;
+  }
+
+  private SFLoginInput createLoginInputStubWithCachingDisabled() {
+    SFLoginInput input = new SFLoginInput();
+    input.setAuthenticator(AuthenticatorType.OAUTH_AUTHORIZATION_CODE.name());
+    input.setOriginalAuthenticator(AuthenticatorType.OAUTH_AUTHORIZATION_CODE.name());
+    input.setServerUrl(String.format("http://%s:%d/", WIREMOCK_HOST, wiremockHttpPort));
+    input.setUserName("MOCK_USERNAME");
+    input.setAccountName("MOCK_ACCOUNT_NAME");
+    input.setAppId("MOCK_APP_ID");
+    input.setAppVersion("MOCK_APP_VERSION");
+    input.setOCSPMode(OCSPMode.FAIL_OPEN);
+    input.setHttpClientSettingsKey(new HttpClientSettingsKey(OCSPMode.FAIL_OPEN));
+    input.setBrowserResponseTimeout(Duration.ofSeconds(5));
+    input.setBrowserHandler(
+        new OAuthAuthorizationCodeFlowLatestIT.WiremockProxyRequestBrowserHandler());
+    input.setLoginTimeout(1000);
+    Map<String, Object> sessionParams = new HashMap<>();
+    sessionParams.put("CLIENT_STORE_TEMPORARY_CREDENTIAL", false);
+    input.setSessionParameters(sessionParams);
+    input.setOauthLoginInput(
+        new SFOauthLoginInput(
+            "123",
+            "123",
+            null,
+            String.format("http://%s:%d/oauth/authorize", WIREMOCK_HOST, wiremockHttpPort),
+            String.format("http://%s:%d/oauth/token-request", WIREMOCK_HOST, wiremockHttpPort),
+            "session:role:ANALYST"));
     return input;
   }
 


### PR DESCRIPTION
### TL;DR

Fixed two credential cache bugs: a `SecurityException` in containerized environments and cache deletion operations ignoring the `clientStoreTemporaryCredential=false` setting.

### What changed?

- When `user.name` returns `'?'` (which can happen in containers without a `/etc/passwd` entry for the running user), the file ownership check now skips validation instead of throwing a `SecurityException`.
- Cache deletion calls for ID tokens, MFA tokens, and OAuth access tokens are now gated behind their respective session parameter checks (`CLIENT_STORE_TEMPORARY_CREDENTIAL` and `CLIENT_REQUEST_MFA_TOKEN`), so credentials are not deleted from the cache when caching is explicitly disabled.

### How to test?

- Run `FileCacheManagerTest#notThrowWhenUserNameIsQuestionMarkInContainerEnvironment` to verify no exception is thrown when `user.name` is `'?'`.
- Run `OAuthTokenCacheLatestIT#shouldNotDeleteCachedTokensWhenCachingIsDisabled` to verify that `CredentialManager` delete and write methods are never called when `CLIENT_STORE_TEMPORARY_CREDENTIAL=false`.

### Why make this change?

In containerized environments where the JVM cannot resolve the current user's name from `/etc/passwd`, `System.getProperty("user.name")` returns `'?'`, causing an unexpected `SecurityException` during credential cache file ownership validation. Additionally, cache deletion logic was not respecting the `clientStoreTemporaryCredential=false` configuration, causing unintended cache modifications even when credential caching was explicitly disabled. Fixes [snowflakedb/snowflake-jdbc#2600](https://github.com/snowflakedb/snowflake-jdbc/issues/2600).