### PR TITLE
NO-SNOW: Remove ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN from LobSizeLatestIT

### DIFF
--- a/src/test/java/net/snowflake/client/internal/jdbc/LobSizeLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/LobSizeLatestIT.java
@@ -202,9 +202,6 @@ public class LobSizeLatestIT extends BaseJDBCTest {
         Statement stmt = con.createStatement()) {
       createTable(lobSize, stmt);
       setResultFormat(stmt, resultFormat);
-      if (lobSize > originLobSize) { // for increased LOB size (16MB < lobSize < 128MB)
-        stmt.execute("alter session set ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN = true");
-      }
       // Test PUT
       String sqlPut = "PUT 'file://" + filePathEscaped + "' @%" + tableName;
 


### PR DESCRIPTION
### TL;DR

Removed the session parameter override for `ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN` in the LOB size integration test, because tests started failing with `SQL compilation error: invalid parameter 'ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN`

### What changed?

The conditional statement that executed `alter session set ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN = true` for LOB sizes exceeding the original limit (16MB–128MB) has been removed from the `testPutAndGet` test method.

### How to test?

Run the `LobSizeLatestIT` integration tests across the various LOB size and result format combinations to confirm that large LOB PUT/GET operations succeed without requiring the session parameter to be explicitly set.

### Why make this change?

The `ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN` session parameter has been removed from Snowflake (server release 10.15). Since early-access accounts have started rolling forward to 10.15, JDBC CI began failing. 