### PR TITLE
SNOW-3450553: externally managed EventLoopGroup to eliminate netty hardcoded quiet period of 2s for shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - Fixed SecurityException on credential cache file ownership check in containers where JVM returns '?' for user.name (snowflakedb/snowflake-jdbc#2600).
     - Fixed credential cache delete operations ignoring clientStoreTemporaryCredential=false setting (snowflakedb/snowflake-jdbc#2600).
     - Fixed S3 transfer thread pool leak during repeated PUT/GET operations causing possible OOM (snowflakedb/snowflake-jdbc#2602).
+    - Fixed ~2-second per-operation overhead in S3 PUT/GET caused by Netty EventLoopGroup hardcoded graceful shutdown quiet period (snowflakedb/snowflake-jdbc#2609).
     - Bumped BouncyCastle to 1.84 to address CVE-2026-0636, CVE-2026-5588, and CVE-2026-5598 (snowflakedb/snowflake-jdbc#2593).
     - Added `workloadIdentityAwsExternalId` connection property to support AWS STS external ID in Workload Identity Federation role-chaining flows 
 

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>netty-common</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -37,6 +37,11 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-fips</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -37,16 +37,6 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-fips</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport</artifactId>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,16 +29,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
@@ -1161,9 +1166,7 @@
                          but SLF4JLogger must reference the user's real org.slf4j for SLF4J opt-in.
                          SLF4JJCLWrapper is left shaded since it also implements the shaded
                          org.apache.commons.logging.Log interface. -->
-                    <copy file="${project.build.outputDirectory}/net/snowflake/client/internal/log/SLF4JLogger.class"
-                          todir="${project.build.directory}/relocate/net/snowflake/client/internal/log"
-                          overwrite="true"/>
+                    <copy file="${project.build.outputDirectory}/net/snowflake/client/internal/log/SLF4JLogger.class" overwrite="true" todir="${project.build.directory}/relocate/net/snowflake/client/internal/log"/>
                     <zip basedir="${project.build.directory}/relocate" destfile="${project.build.directory}/${project.build.finalName}.jar"/>
                     <delete dir="${project.build.directory}/relocate/META-INF/versions/9/${relocationBase}"/>
                     <delete dir="${project.build.directory}/relocate/META-INF/versions/11/${relocationBase}"/>

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -328,7 +328,8 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     amazonClient.close();
     if (sdkEventLoopGroup != null) {
       try {
-        sdkEventLoopGroup.eventLoopGroup()
+        sdkEventLoopGroup
+            .eventLoopGroup()
             .shutdownGracefully(0, 2, TimeUnit.SECONDS)
             .get(3, TimeUnit.SECONDS);
       } catch (Exception e) {

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -341,7 +341,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
                 .getClass()
                 .getMethod("shutdownGracefully", long.class, long.class, TimeUnit.class)
                 .invoke(eventLoopGroup, 0L, 2L, TimeUnit.SECONDS);
-        future.getClass().getMethod("get", long.class, TimeUnit.class).invoke(future, 3L, TimeUnit.SECONDS);
+        future
+            .getClass()
+            .getMethod("get", long.class, TimeUnit.class)
+            .invoke(future, 3L, TimeUnit.SECONDS);
       } catch (Exception e) {
         logger.warn("Failed to shut down S3 Netty EventLoopGroup cleanly", e);
       }

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -327,11 +327,21 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     logger.debug("Shutting down the Snowflake S3 client");
     amazonClient.close();
     if (sdkEventLoopGroup != null) {
+      // Reflection is used here intentionally to avoid a compile-time dependency on
+      // io.netty.channel.EventLoopGroup. The thin-jar build shades io.netty.* (relocating it to
+      // net.snowflake.client.jdbc.internal.io.netty.*) but does NOT shade software.amazon.awssdk.*.
+      // A direct call to sdkEventLoopGroup.eventLoopGroup() would embed the shaded return type in
+      // our bytecode, causing NoSuchMethodError at runtime when the un-shaded SdkEventLoopGroup
+      // returns the original io.netty type.
       try {
-        sdkEventLoopGroup
-            .eventLoopGroup()
-            .shutdownGracefully(0, 2, TimeUnit.SECONDS)
-            .get(3, TimeUnit.SECONDS);
+        Object eventLoopGroup =
+            sdkEventLoopGroup.getClass().getMethod("eventLoopGroup").invoke(sdkEventLoopGroup);
+        Object future =
+            eventLoopGroup
+                .getClass()
+                .getMethod("shutdownGracefully", long.class, long.class, TimeUnit.class)
+                .invoke(eventLoopGroup, 0L, 2L, TimeUnit.SECONDS);
+        future.getClass().getMethod("get", long.class, TimeUnit.class).invoke(future, 3L, TimeUnit.SECONDS);
       } catch (Exception e) {
         logger.warn("Failed to shut down S3 Netty EventLoopGroup cleanly", e);
       }

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -56,6 +56,7 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -87,6 +88,19 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
 
   // expired AWS token error code
   protected static final String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
+
+  // Externally-managed Netty EventLoopGroup for the S3 async HTTP client.
+  // The AWS SDK's default NettyNioAsyncHttpClient uses shutdownGracefully(2, 15, SECONDS) on its
+  // EventLoopGroup, where the 2-second "quiet period" causes a mandatory ~2-second blocking wait
+  // on every close() — even when all I/O is complete and no tasks are pending. Since the JDBC
+  // driver creates and destroys an S3 client per PUT/GET operation, this adds ~2 seconds of pure
+  // overhead per transfer (confirmed via log analysis: zero log events in the 2s gap, upload
+  // already confirmed with HTTP 200 before shutdown is called).
+  // By providing an externally-managed EventLoopGroup via SdkEventLoopGroup, the SDK will NOT
+  // shut it down when the S3 client is closed. We then shut it down ourselves with
+  // shutdownGracefully(0, 2, SECONDS) — zero quiet period (immediate if idle) with a 2-second
+  // safety timeout for any edge case.
+  private SdkEventLoopGroup sdkEventLoopGroup = null;
 
   private int encryptionKeySize = 0; // used for PUTs
   private S3AsyncClient amazonClient = null;
@@ -201,8 +215,10 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     // Explicitly force to use virtual address style
     clientBuilder.forcePathStyle(false);
 
+    sdkEventLoopGroup = SdkEventLoopGroup.builder().build();
     clientBuilder.httpClientBuilder(
         NettyNioAsyncHttpClient.builder()
+            .eventLoopGroup(sdkEventLoopGroup)
             .maxConcurrency(clientConfig.getMaxConnections())
             .connectionAcquisitionTimeout(Duration.ofSeconds(60))
             .proxyConfiguration(proxyConfiguration)
@@ -310,6 +326,15 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
   public void shutdown() {
     logger.debug("Shutting down the Snowflake S3 client");
     amazonClient.close();
+    if (sdkEventLoopGroup != null) {
+      try {
+        sdkEventLoopGroup.eventLoopGroup()
+            .shutdownGracefully(0, 2, TimeUnit.SECONDS)
+            .get(3, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        logger.warn("Failed to shut down S3 Netty EventLoopGroup cleanly", e);
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
## Summary

Eliminate ~2-second per-operation performance overhead in S3 PUT/GET operations caused by Netty EventLoopGroup's hardcoded graceful shutdown quiet period.

## Problem

Since JDBC 4.x migrated from AWS SDK v1 (Apache HttpClient) to AWS SDK v2 (Netty NIO async client), sequential PUT operations are ~2x slower for small files compared to v3.28.0.

**Root cause**: The JDBC driver creates and destroys an `S3AsyncClient` per PUT/GET operation. This is by design — each file transfer operation receives fresh, short-lived scoped credentials from the server that are specific to that transfer's target location, so the S3 client cannot be trivially reused across operations. When `S3AsyncClient.close()` is called, the underlying `NettyNioAsyncHttpClient` shuts down its `EventLoopGroup` with a hardcoded `shutdownGracefully(2, 15, TimeUnit.SECONDS)` — imposing a mandatory **2-second quiet period** that blocks even when all I/O is complete and no tasks are pending.

**Evidence (from verbose log analysis)**:
- Between "Uploaded file" (HTTP 200 confirmed) and "Setting result set", there are **zero** log events for exactly ~2,080ms — a pure blocking wait
- Bytecode inspection of `NettyNioAsyncHttpClient.closeEventLoopUninterruptibly()` confirms: `EventLoopGroup.shutdownGracefully(2L, 15L, TimeUnit.SECONDS)`
- This behavior is identical in v4.1.0 and v4.1.1 (not a regression from the thread leak fix)

## Benchmark: Before (5 MB file, 10 iterations, same account/network)

| Driver | P50 | Throughput |
|--------|-----|-----------|
| v3.28.0 (baseline) | 2,269 ms | 2.2 MB/s |
| v4.1.0 | 3,910 ms | 1.3 MB/s |
| v4.1.1 (thread leak fix) | 3,716 ms | 1.3 MB/s |

## Fix

Provide an externally-managed `SdkEventLoopGroup` to the Netty HTTP client builder. When the `EventLoopGroup` is externally managed, `S3AsyncClient.close()` does **not** shut it down. We then shut it down ourselves with `shutdownGracefully(0, 2, SECONDS)` — zero quiet period (terminates immediately when idle) with a 2-second safety timeout.

The shutdown uses **reflection** to call `sdkEventLoopGroup.eventLoopGroup().shutdownGracefully(...)`. This is intentional: the thin-jar build profile shades `io.netty.*` (relocating it to `net.snowflake.client.jdbc.internal.io.netty.*`) but does NOT shade `software.amazon.awssdk.*`. A direct call would embed the shaded `io.netty` return type in our bytecode, causing `NoSuchMethodError` at runtime when the un-shaded `SdkEventLoopGroup.eventLoopGroup()` returns the original `io.netty.channel.EventLoopGroup`. Reflection avoids this cross-shade-boundary type mismatch entirely.

Changes:
1. `SnowflakeS3Client.java`: Create `SdkEventLoopGroup.builder().build()` and pass via `.eventLoopGroup()` to the HTTP client builder. In `shutdown()`, use reflection to call `shutdownGracefully(0, 2, SECONDS)` on the underlying EventLoopGroup.
2. No new dependencies added — only AWS SDK types (`SdkEventLoopGroup`, `NettyNioAsyncHttpClient.Builder`) are referenced at compile time.

## Benchmark: After (5 MB file, 5 iterations)

| Driver | P50 | Avg | Throughput | vs v3.28.0 |
|--------|-----|-----|-----------|-----------|
| v3.28.0 (baseline) | 2,269 ms | 2,245 ms | 2.2 MB/s | — |
| v4.1.0 (before) | 3,910 ms | 3,970 ms | 1.3 MB/s | +72% slower |
| **v4.1.1 + this fix** | **1,800 ms** | **1,810 ms** | **2.8 MB/s** | **Parity (slightly faster)** |

## Benchmark: 100 MB file, 5 iterations

| Driver | P50 | Avg | Throughput | vs v3.28.0 |
|--------|-----|-----|-----------|-----------|
| v3.28.0 (baseline) | 10,814 ms | 11,005 ms | 9.1 MB/s | — |
| v4.1.0 (before) | 16,617 ms | 16,591 ms | 6.0 MB/s | +54% slower |
| **v4.1.1 + this fix** | **14,277 ms** | **14,279 ms** | **7.0 MB/s** | +32% slower |

For large files (100 MB), the fix provides a ~14% improvement. The remaining gap vs v3.28.0 is from multipart upload pipeline overhead inherent to AWS SDK v2.

## Build verification

- Fat jar (`self-contained-jar`): compiles and runs correctly
- Thin jar (`-Dthin-jar`): compiles correctly, no `NoSuchMethodError` (reflection avoids shade boundary issue)
- FIPS module: compiles correctly
- `dependency:analyze`: no "used undeclared" warnings (no new dependencies)

## Tests executed manually

- [ ] Run existing PUT/GET integration tests (thread leak tests pass)
- [ ] Verify no thread leak regression (EventLoopGroup properly terminates after shutdown)
- [ ] Performance test: 5 MB sequential PUTs confirm parity with v3.28.0
- [ ] Performance test: 100 MB PUTs confirm no regression vs v4.1.0
- [ ] Thin-jar integration tests pass (no `NoSuchMethodError`)
- [ ] FIPS module compiles
