### PR TITLE
SNOW-3463039: fix NPE in TelemetryClient operations when session is null for some reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.1.1-SNAPSHOT
+    - Fixed NPE in `RestRequest.sendIBHttpErrorEvent` when `SFSession.getTelemetryClient()` returns null because the session URL is not yet set; a `NoOpTelemetryClient` is now returned instead, allowing the original HTTP error to be surfaced to the caller (snowflakedb/snowflake-jdbc#XXXX)
     - Added support for attaching the SPCS service-identifier token (`SPCS_TOKEN`) to login requests when the driver is running inside an SPCS container (gated on the `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable; token read from `/snowflake/session/spcs_token`) (snowflakedb/snowflake-jdbc#2603)
     - Added libc family and version detection (`LIBC_FAMILY`, `LIBC_VERSION`) to the `CLIENT_ENVIRONMENT` section of the login request on Linux
     - Fixed NPE in `SFTrustManager.validateRevocationStatusMain` when the OCSP cache contains a non-SUCCESSFUL response (e.g. `unauthorized(6)`); the response is now surfaced as an `SFOCSPException` so cache eviction and fail-open run normally (snowflakedb/snowflake-jdbc#2597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.1.1-SNAPSHOT
-    - Fixed NPE in `RestRequest.sendIBHttpErrorEvent` when `SFSession.getTelemetryClient()` returns null because the session URL is not yet set; a `NoOpTelemetryClient` is now returned instead, allowing the original HTTP error to be surfaced to the caller (snowflakedb/snowflake-jdbc#XXXX)
+    - Fixed NPE in `RestRequest.sendIBHttpErrorEvent` when `SFSession.getTelemetryClient()` returns null because the session URL is not yet set; a `NoOpTelemetryClient` is now returned instead, allowing the original HTTP error to be surfaced to the caller (snowflakedb/snowflake-jdbc#2610)
     - Added support for attaching the SPCS service-identifier token (`SPCS_TOKEN`) to login requests when the driver is running inside an SPCS container (gated on the `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable; token read from `/snowflake/session/spcs_token`) (snowflakedb/snowflake-jdbc#2603)
     - Added libc family and version detection (`LIBC_FAMILY`, `LIBC_VERSION`) to the `CLIENT_ENVIRONMENT` section of the login request on Linux
     - Fixed NPE in `SFTrustManager.validateRevocationStatusMain` when the OCSP cache contains a non-SUCCESSFUL response (e.g. `unauthorized(6)`); the response is now surfaced as an `SFOCSPException` so cache eviction and fail-open run normally (snowflakedb/snowflake-jdbc#2597)

--- a/src/main/java/net/snowflake/client/internal/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSession.java
@@ -43,6 +43,7 @@ import net.snowflake.client.internal.jdbc.SnowflakeUtil;
 import net.snowflake.client.internal.jdbc.diagnostic.DiagnosticContext;
 import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker;
 import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
+import net.snowflake.client.internal.jdbc.telemetry.NoOpTelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
@@ -1320,8 +1321,9 @@ public class SFSession extends SFBaseSession {
     // properties have been set, else the client won't properly resolve the URL.
     if (telemetryClient == null) {
       if (getUrl() == null) {
-        logger.error("Telemetry client created before session properties set.", false);
-        return null;
+        logger.debug(
+            "Telemetry client requested before session properties set; returning no-op client");
+        return new NoOpTelemetryClient();
       }
       telemetryClient = TelemetryClient.createTelemetry(this);
 

--- a/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.jdbc;
 import static net.snowflake.client.AssumptionUtils.assumeRunningOnLinuxMac;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,6 +49,7 @@ import net.snowflake.client.internal.core.SFTrustManager;
 import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
 import net.snowflake.client.internal.jdbc.telemetry.ExecTimeTelemetryData;
 import net.snowflake.client.internal.jdbc.telemetry.InternalApiTelemetryTracker.InternalCallMarker;
+import net.snowflake.client.internal.jdbc.telemetry.NoOpTelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryData;
@@ -964,6 +966,55 @@ public class RestRequestTest {
     assertFalse(
         RestRequest.isExceptionInGroup(new RuntimeException("test"), RestRequest.sslExceptions),
         "RuntimeException should not be in SSL exceptions group");
+  }
+
+  /**
+   * Regression test: when getTelemetryClient() returns a NoOpTelemetryClient (e.g. because the
+   * session URL is not yet set), sendIBHttpErrorEvent must complete without throwing an NPE.
+   * Previously, getTelemetryClient() returned null in this case, causing a NullPointerException
+   * when addLogToBatch() was called on the null reference.
+   */
+  @Test
+  public void testSendIBHttpErrorEventWithNoOpTelemetryClientDoesNotThrow() throws Exception {
+    HttpRequestBase request =
+        new HttpGet(
+            "https://testaccount.snowflakecomputing.com"
+                + "/v1/streamlit/testapp/_stcore/upload_file/12345");
+    StatusLine statusLine =
+        new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 500, "Internal Server Error");
+    CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+    when(mockResponse.getStatusLine()).thenReturn(statusLine);
+
+    SFBaseSession mockSession = mock(SFBaseSession.class);
+    when(mockSession.getTelemetryClient(any(InternalCallMarker.class)))
+        .thenReturn(new NoOpTelemetryClient());
+
+    HttpExecutingContext mockContext = mock(HttpExecutingContext.class);
+    when(mockContext.getSfSession()).thenReturn(mockSession);
+
+    try (MockedStatic<TelemetryUtil> mockedTelemetryUtil =
+        Mockito.mockStatic(TelemetryUtil.class)) {
+      ObjectNode mockIbValue = mock(ObjectNode.class);
+      TelemetryData mockTelemetryData = mock(TelemetryData.class);
+
+      mockedTelemetryUtil
+          .when(
+              () -> TelemetryUtil.createIBValue(any(), any(), anyInt(), any(), anyString(), any()))
+          .thenReturn(mockIbValue);
+      mockedTelemetryUtil
+          .when(() -> TelemetryUtil.buildJobData(any(ObjectNode.class)))
+          .thenReturn(mockTelemetryData);
+
+      java.lang.reflect.Method method =
+          RestRequest.class.getDeclaredMethod(
+              "sendIBHttpErrorEvent",
+              HttpRequestBase.class,
+              CloseableHttpResponse.class,
+              HttpExecutingContext.class);
+      method.setAccessible(true);
+
+      assertDoesNotThrow(() -> method.invoke(null, request, mockResponse, mockContext));
+    }
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
@@ -969,10 +969,10 @@ public class RestRequestTest {
   }
 
   /**
-   * SNOW-3463039 - Regression test: when getTelemetryClient() returns a NoOpTelemetryClient (e.g. because the
-   * session URL is not yet set), sendIBHttpErrorEvent must complete without throwing an NPE.
-   * Previously, getTelemetryClient() returned null in this case, causing a NullPointerException
-   * when addLogToBatch() was called on the null reference.
+   * SNOW-3463039 - Regression test: when getTelemetryClient() returns a NoOpTelemetryClient (e.g.
+   * because the session URL is not yet set), sendIBHttpErrorEvent must complete without throwing an
+   * NPE. Previously, getTelemetryClient() returned null in this case, causing a
+   * NullPointerException when addLogToBatch() was called on the null reference.
    */
   @Test
   public void testSendIBHttpErrorEventWithNoOpTelemetryClientDoesNotThrow() throws Exception {

--- a/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
@@ -969,7 +969,7 @@ public class RestRequestTest {
   }
 
   /**
-   * Regression test: when getTelemetryClient() returns a NoOpTelemetryClient (e.g. because the
+   * SNOW-3463039 - Regression test: when getTelemetryClient() returns a NoOpTelemetryClient (e.g. because the
    * session URL is not yet set), sendIBHttpErrorEvent must complete without throwing an NPE.
    * Previously, getTelemetryClient() returned null in this case, causing a NullPointerException
    * when addLogToBatch() was called on the null reference.


### PR DESCRIPTION
## Problem
This is coming from a Streamlit use-case but likely not limited to it, see the internal jira. 

Original issue was that when Streamlit tried to upload a file, it failed due to some unknown reason with HTTP500, which event -the failure- by default we want to send with Telemetry with `addLogToBatch`. 
During construction of the Telemetry Client, the moment it was constructed, the SERVER_URL from the Snowflake Session was null, thus the [TelemetryClient itself comes back as null](https://github.com/snowflakedb/snowflake-jdbc/blob/v3.27.1/src/main/java/net/snowflake/client/core/SFSession.java#L1302-L1309) from the creation , thus the `addLogsToBatch` is called on a null object, leading to two issues.

1. the NPE itself
```
java.lang.NullPointerException: Cannot invoke "net.snowflake.client.jdbc.telemetry.Telemetry.addLogToBatch(net.snowflake.client.jdbc.telemetry.TelemetryData)" because the return value of "net.snowflake.client.core.SFBaseSession.getTelemetryClient()" is null
  at net.snowflake.client.jdbc.RestRequest.sendIBHttpErrorEvent(RestRequest.java:1527)
  at net.snowflake.client.jdbc.RestRequest.executeWithRetries(RestRequest.java:1063)
  at net.snowflake.client.core.HttpUtil.executeRequestInternalWithContext(HttpUtil.java:1431)
  at net.snowflake.client.core.HttpUtil.exe... 
```

2. what is even worse, that this NPE coming from a (supposedly silent, background..) operation, now overwrites the original, useful error which happened during the file upload, and instead of 'here's what originally happened' we now log 'telemetry could not be sent due to NPE' which is entirely not useful.

The issue ( `getTelemetryClient()` returns `null` when `getUrl()` is `null` ) also violates the [contract documented on SFBaseSession](https://github.com/snowflakedb/snowflake-jdbc/blob/v4.1.0/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java#L1312-L1318): "If session doesn't support TC, should return a NoOpTelemetryClient")
```java
  /**
   * @return Returns the telemetry client, if supported, by this session. If not, should return a
   *     NoOpTelemetryClient.
   */
  public Telemetry getTelemetryClient() {
    return getTelemetryClient(null);
  }
```

and can cause NPE in at least 5 unguarded callers, including `addLogToBatch`.

## Fix
Fix is to honor the documented contract ;) 

Originally when TelemetryClient was created in 2018, the `NoOpTelemetryClient` did not exist yet, it was only added in 2019. So probably made sense to use the 'return null and an error' approach. But now we can convently use `NoOpTelemetryClient` in occassions where there is no session and protect all callers.

Speaking about the original use-case from Streamlit vs. HTTP500 on upload; this fix now also allows the original issue to be surfaced and handled , by the inband telemetry event send completing silently (the `NoOpTelemetryClient.addLogToBatch()` does nothing), and then the original exception from the HTTP500 is thrown to the caller as intended.

Also downgraded the loglevel to debug, because there's no action we expect from the operations when the session doesn't support the TelemetryClient, but of course this can be changed.

A unit test was also added. 