### PR TITLE
NO-SNOW: dependency bump: netty 4.1.132.Final -> 4.1.133.Final, grpc-java 1.80.0 -> 1.81.0, animal-sniffer-annotations 1.26 -> 1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
     - Fixed S3 transfer thread pool leak during repeated PUT/GET operations causing possible OOM (snowflakedb/snowflake-jdbc#2602).
     - Bumped BouncyCastle to 1.84 to address CVE-2026-0636, CVE-2026-5588, and CVE-2026-5598 (snowflakedb/snowflake-jdbc#2593).
     - Added `workloadIdentityAwsExternalId` connection property to support AWS STS external ID in Workload Identity Federation role-chaining flows (snowflakedb/snowflake-jdbc#2565).
-    - Bumped grpc-java to 1.81.1 now that they also upgraded to netty 4.1.132.Final as the second part of PR 2561 (snowflakedb/snowflake-jdbc#XXXX).
+    - Bumped grpc-java to 1.81.1 now that they also upgraded to netty 4.1.132.Final as the second part of PR 2561 (snowflakedb/snowflake-jdbc#2611).
 
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
     - Fixed credential cache delete operations ignoring clientStoreTemporaryCredential=false setting (snowflakedb/snowflake-jdbc#2600).
     - Fixed S3 transfer thread pool leak during repeated PUT/GET operations causing possible OOM (snowflakedb/snowflake-jdbc#2602).
     - Bumped BouncyCastle to 1.84 to address CVE-2026-0636, CVE-2026-5588, and CVE-2026-5598 (snowflakedb/snowflake-jdbc#2593).
-    - Added `workloadIdentityAwsExternalId` connection property to support AWS STS external ID in Workload Identity Federation role-chaining flows 
+    - Added `workloadIdentityAwsExternalId` connection property to support AWS STS external ID in Workload Identity Federation role-chaining flows (snowflakedb/snowflake-jdbc#2565).
+    - Bumped grpc-java to 1.81.1 now that they also upgraded to netty 4.1.132.Final as the second part of PR 2561 (snowflakedb/snowflake-jdbc#XXXX).
 
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
     - Fixed S3 transfer thread pool leak during repeated PUT/GET operations causing possible OOM (snowflakedb/snowflake-jdbc#2602).
     - Bumped BouncyCastle to 1.84 to address CVE-2026-0636, CVE-2026-5588, and CVE-2026-5598 (snowflakedb/snowflake-jdbc#2593).
     - Added `workloadIdentityAwsExternalId` connection property to support AWS STS external ID in Workload Identity Federation role-chaining flows (snowflakedb/snowflake-jdbc#2565).
-    - Bumped grpc-java to 1.81.1 now that they also upgraded to netty 4.1.132.Final as the second part of PR 2561 (snowflakedb/snowflake-jdbc#2611).
+    - Bumped grpc-java to 1.81.1 now that they also upgraded to netty 4.1.132.Final as the second part of PR 2561, and also netty itself to 4.1.133.Final to address several CVE (snowflakedb/snowflake-jdbc#2611).
 
 - v4.1.0
     - Added warning about using plain HTTP OAuth endpoints (snowflakedb/snowflake-jdbc#2556).

--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -21,7 +21,7 @@
     <junit.version>5.11.1</junit.version>
     <surefire.version>3.5.1</surefire.version>
     <mockito.version>3.5.6</mockito.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -14,7 +14,7 @@
   </modules>
 
   <properties>
-    <animal.sniffer.annotations.version>1.26</animal.sniffer.annotations.version>
+    <animal.sniffer.annotations.version>1.27</animal.sniffer.annotations.version>
     <apache.commons.compress.version>1.28.0</apache.commons.compress.version>
     <apache.commons.lang3.version>3.18.0</apache.commons.lang3.version>
     <apache.commons.text.version>1.10.0</apache.commons.text.version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -56,7 +56,7 @@
     <google.j2objc-annotations.version>3.0.0</google.j2objc-annotations.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
     <google.protobuf.java.version>4.28.2</google.protobuf.java.version>
-    <grpc.version>1.80.0</grpc.version>
+    <grpc.version>1.81.0</grpc.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hikaricp.version>2.4.3</hikaricp.version>
     <jackson.version>2.18.4.1</jackson.version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -71,7 +71,7 @@
     <logback.version>1.3.6</logback.version>
     <mockito.version>4.11.0</mockito.version>
     <nimbusds.oauth2.version>11.30.1</nimbusds.oauth2.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <nimbusds.version>10.6</nimbusds.version>
     <opencensus.version>0.31.1</opencensus.version>
     <plexus.container.version>1.0-alpha-9-stable-1</plexus.container.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -54,7 +54,7 @@
     <google.http.client.version>1.45.0</google.http.client.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
     <google.protobuf.java.version>4.28.2</google.protobuf.java.version>
-    <grpc.version>1.80.0</grpc.version>
+    <grpc.version>1.81.0</grpc.version>
     <jackson.version>2.18.4.1</jackson.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <animal.sniffer.annotations.version>1.26</animal.sniffer.annotations.version>
+    <animal.sniffer.annotations.version>1.27</animal.sniffer.annotations.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <awssdk.version>2.37.5</awssdk.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -61,7 +61,7 @@
     <json.smart.version>2.5.2</json.smart.version>
     <jsoup.version>1.15.3</jsoup.version>
     <metrics.version>2.2.0</metrics.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <nimbusds.version>10.6</nimbusds.version>
     <nimbusds.oauth2.version>11.30.1</nimbusds.oauth2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
# Overview

Bumped grpc-java to 1.81.1 now that they also upgraded to netty 4.1.132.Final as the second part of PR #2561
(also its dependency `animal-sniffer-annotations` needed a bump to 1.27)


also since the creation of this PR a new netty version (4.1.133.Final) is available, to address vulnerabilities:

CVE-2026-42586 (netty-codec-redis)
CVE-2026-42578 (netty-handler-proxy)
CVE-2026-42587 (netty-codec-http, netty-codec-http2)
CVE-2026-41417 (netty-codec-http)
CVE-2026-42581 (netty-codec-http)
CVE-2026-42580 (netty-codec-http)
CVE-2026-42585 (netty-codec-http)
CVE-2026-42579 (netty-codec-dns)
CVE-2026-42582 (netty-codec-http3)
CVE-2026-42583 (netty-codec, netty-codec-compression)
CVE-2026-42584 (netty-codec-http)
CVE-2026-XXXXX (netty-codec-mqtt)

(and several other bugfixes too) so bumping netty too. 