### PR TITLE
SNOW-3350278: Honor SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION for connections.toml and credential cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.1.1-SNAPSHOT
+    - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)
     - Fixed NPE in `RestRequest.sendIBHttpErrorEvent` when `SFSession.getTelemetryClient()` returns null because the session URL is not yet set; a `NoOpTelemetryClient` is now returned instead, allowing the original HTTP error to be surfaced to the caller (snowflakedb/snowflake-jdbc#2610)
     - Added support for attaching the SPCS service-identifier token (`SPCS_TOKEN`) to login requests when the driver is running inside an SPCS container (gated on the `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable; token read from `/snowflake/session/spcs_token`) (snowflakedb/snowflake-jdbc#2603)
     - Added libc family and version detection (`LIBC_FAMILY`, `LIBC_VERSION`) to the `CLIENT_ENVIRONMENT` section of the login request on Linux

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -197,7 +197,14 @@ public class SFConnectionConfigParser {
       throws SnowflakeSQLException {
     try {
       File file = new File(configFilePath.toUri());
-      verifyFilePermissionSecure(configFilePath);
+      boolean shouldSkipTokenFilePermissionsVerification =
+          convertSystemGetEnvToBooleanValue(SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION, false);
+      if (!shouldSkipTokenFilePermissionsVerification) {
+        verifyFilePermissionSecure(configFilePath);
+      } else {
+        logger.debug(
+            "Skip connection configuration file permissions verification for {}", configFilePath);
+      }
       return mapper.readValue(file, Map.class);
     } catch (IOException ex) {
       throw new SnowflakeSQLException(ex, "Problem during reading a configuration file.");

--- a/src/main/java/net/snowflake/client/internal/core/SecureStorageLinuxManager.java
+++ b/src/main/java/net/snowflake/client/internal/core/SecureStorageLinuxManager.java
@@ -1,6 +1,8 @@
 package net.snowflake.client.internal.core;
 
+import static net.snowflake.client.internal.config.SFConnectionConfigParser.SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION;
 import static net.snowflake.client.internal.core.StmtUtil.mapper;
+import static net.snowflake.client.internal.jdbc.SnowflakeUtil.convertSystemGetEnvToBooleanValue;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isNullOrEmpty;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -27,11 +29,19 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
   private final FileCacheManager fileCacheManager;
 
   private SecureStorageLinuxManager() {
+    boolean shouldSkipTokenFilePermissionsVerification =
+        convertSystemGetEnvToBooleanValue(SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION, false);
+    if (shouldSkipTokenFilePermissionsVerification) {
+      logger.debug(
+          "Skip credential cache file permissions verification because {} is enabled",
+          SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION);
+    }
     fileCacheManager =
         new FileCacheManagerBuilder()
             .setCacheDirectorySystemProperty(CACHE_DIR_PROP)
             .setCacheDirectoryEnvironmentVariable(CACHE_DIR_ENV)
             .setBaseCacheFileName(CACHE_FILE_NAME)
+            .setOnlyOwnerPermissions(!shouldSkipTokenFilePermissionsVerification)
             .setCacheFileLockExpirationInSeconds(CACHE_FILE_LOCK_EXPIRATION_IN_SECONDS)
             .build();
   }

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -137,6 +137,22 @@ public class SFConnectionConfigParserTest {
   }
 
   @Test
+  public void testNoThrowErrorWhenWrongPermissionsForConnectionConfigButSkippingFlagIsEnabled()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    SnowflakeUtil.systemSetEnv(SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION, "true");
+    File tokenFile = new File(Paths.get(tempPath.toString(), "token").toUri());
+    prepareConnectionConfigurationTomlFile(
+        Collections.singletonMap("token_file_path", tokenFile.toString()), false, false);
+    assumeRunningOnLinuxMac();
+
+    ConnectionParameters data = SFConnectionConfigParser.buildConnectionParameters("");
+    assertNotNull(data);
+    assertEquals(tokenFile.toString(), data.getParams().get("token_file_path"));
+  }
+
+  @Test
   public void testLoadSFConnectionConfigWithHostConfigured()
       throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());


### PR DESCRIPTION
## Summary
- Extend the existing `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` env var so it also bypasses permission verification on the `connections.toml` config file (previously only the OAuth token file referenced by `token_file_path` was bypassable).
- Honor the same env var in `SecureStorageLinuxManager` for the JSON credential cache (`credential_cache_v1.json`). Previously `onlyOwnerPermissions=true` was hardcoded, so SPCS environments could not bypass strict ownership/permission checks. When the flag is set, the manager now wires `setOnlyOwnerPermissions(false)` into `FileCacheManagerBuilder`, which causes `DefaultFileCacheManager` to skip ownership / wider-than-user-only permission errors and avoid creating the cache dir/file with strict 600/700 modes.
- Behavior is unchanged when the flag is unset or `false` (the default). All existing strict checks remain in force.

## Context
Implements the JDBC slice (SNOW-3350278) of epic [SNOW-1794102](https://snowflakecomputing.atlassian.net/browse/SNOW-1794102) — _"Introduce SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION to allow driver work in SPCS environment"_. The epic aligns the bypass flag across drivers so that SPCS workloads (which cannot guarantee strict 0600/0700 ownership on mounted credential and config files) can still authenticate via TOML config + token cache. ODBC/libsfc already implement this flag with the same name; this PR brings JDBC to parity for both the TOML config file and the credential cache JSON file.

The existing `SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE` (which only suppresses the read-permission warning on `connections.toml`) is left in place for backward compatibility.

## Test plan
- Added `testNoThrowErrorWhenWrongPermissionsForConnectionConfigButSkippingFlagIsEnabled` to `SFConnectionConfigParserTest`, which writes a `connections.toml` with group/other-readable permissions (`rwxrw----`), sets `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION=true`, and asserts the driver successfully loads the configuration. The pre-existing `testThrowErrorWhenWrongPermissionsForConnectionConfigurationFile` continues to validate that bad permissions still error out without the flag.
- The pre-existing `testNoThrowErrorWhenWrongPermissionsForTokenFileButSkippingFlagIsEnabled` continues to cover the OAuth token-file bypass path.
- `SecureStorageManagerTest` (including `testLinuxManager`) continues to pass, verifying the credential cache wiring is unaffected when the flag is unset.

Commands run from repo root:

```
./mvnw -Dtest=SFConnectionConfigParserTest test       # PASS
./mvnw -Dtest=SecureStorageManagerTest test           # PASS
./mvnw com.spotify.fmt:fmt-maven-plugin:format        # 0 files reformatted
./mvnw clean validate -P check-style                  # 0 violations
```

[SNOW-1794102]: https://snowflakecomputing.atlassian.net/browse/SNOW-1794102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ