### PR TITLE
SNOW-3478870: do not throw on attempt to add new session to HeartbeatRegistry after JVM shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.1.1-SNAPSHOT
+    - Fixed IllegalStateException when creating new Snowflake connections during JVM shutdown (SIGTERM); HeartbeatRegistry now skips heartbeat registration gracefully instead of throwing (snowflakedb/snowflake-jdbc#XXXX)
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)
     - Fixed NPE in `RestRequest.sendIBHttpErrorEvent` when `SFSession.getTelemetryClient()` returns null because the session URL is not yet set; a `NoOpTelemetryClient` is now returned instead, allowing the original HTTP error to be surfaced to the caller (snowflakedb/snowflake-jdbc#2610)
     - Added support for attaching the SPCS service-identifier token (`SPCS_TOKEN`) to login requests when the driver is running inside an SPCS container (gated on the `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable; token read from `/snowflake/session/spcs_token`) (snowflakedb/snowflake-jdbc#2603)

--- a/src/main/java/net/snowflake/client/internal/core/HeartbeatRegistry.java
+++ b/src/main/java/net/snowflake/client/internal/core/HeartbeatRegistry.java
@@ -135,7 +135,10 @@ public class HeartbeatRegistry {
           "Heartbeat frequency must be positive: " + heartbeatFrequencyInSecs);
     }
     if (isShutdown) {
-      throw new IllegalStateException("Cannot add session to shutdown HeartbeatRegistry");
+      logger.info(
+          "HeartbeatRegistry is shut down (JVM exiting); skipping heartbeat registration for session."
+              + " Session will function normally but won't be refreshed.");
+      return;
     }
 
     // Calculate required interval: min of requested frequency and 1/4 of token validity
@@ -154,7 +157,10 @@ public class HeartbeatRegistry {
     // Synchronize thread creation to prevent race conditions with limit check
     synchronized (this) {
       if (isShutdown) {
-        throw new IllegalStateException("Cannot add session to shutdown HeartbeatRegistry");
+        logger.info(
+            "HeartbeatRegistry is shut down (JVM exiting); skipping heartbeat registration for session."
+                + " Session will function normally but won't be refreshed.");
+        return;
       }
       // Check thread count limit
       if (threads.size() >= MAX_HEARTBEAT_THREADS && !threads.containsKey(requiredInterval)) {

--- a/src/test/java/net/snowflake/client/internal/core/HeartbeatRegistryTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/HeartbeatRegistryTest.java
@@ -247,6 +247,19 @@ public class HeartbeatRegistryTest {
   }
 
   @Test
+  public void testAddSession_AfterShutdown_SkipsHeartbeatInsteadOfThrowing() {
+    registry.addSession(mockSession1, 60, 10);
+    assertEquals(1, registry.getActiveThreadCount());
+
+    registry.shutdown();
+    assertEquals(0, registry.getActiveThreadCount());
+
+    assertDoesNotThrow(() -> registry.addSession(mockSession2, 60, 10));
+    assertEquals(0, registry.getActiveThreadCount());
+    assertEquals(0, registry.getSessionCountForInterval(10));
+  }
+
+  @Test
   public void testShutdown_CleansUpAllThreads() {
     registry.addSession(mockSession1, 60, 10);
     registry.addSession(mockSession2, 14400, 3600);


### PR DESCRIPTION
# Overview

To fix an issue where heartbeats were not working correctly with mixed heartbeat intervals (e.g. one session 1 hour, other session 15 minutes), HeartbeatRegistry was introduced with #2566 . 

It works perfectly but also prevents new sessions from being spawned after the JVM has been shut down, which is a logical approach. However now an edge case was reported where certain applications would still need to spawn new Snowflake sessions after they received graceful shutdown (SIGTERM), to finish up their work inside Snowflake. 

The current behaviour of throwing [IllegalStateException](https://github.com/snowflakedb/snowflake-jdbc/blob/v4.1.0/src/main/java/net/snowflake/client/internal/core/HeartbeatRegistry.java#L137-L139) upon attempt to launch a new Snowflake session (with an enabled session heartbeat) _after_ SIGTERM, apparently prevents such applications to perform their work and need considerable working around the current driver behaviour.

This fix aims to rectify this situation. Instead of throwing, the driver now
* logs an INFO line message 
* still allows the new Snowflake Session to be spawned - without the heartbeat enabled, thus won't be refreshed and its master token expires per the current settings (default: 4 hours)
* which should be still posing no impact since the application is anyways being shut down, thus the new Session should not be needed for very long time

Also added new unit test which confirms session can be still launched after SIGTERM/shutdown - without heartbeat enabled.
