### PR TITLE
SNOW-3437355: strip backslash separators when deriving GET destination filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Changelog
 - v4.2.1-SNAPSHOT
+    - Fixed path traversal via server-controlled filenames in `SnowflakeFileTransferAgent` GET destination filename derivation; backslash separators are now stripped and traversal/absolute basenames are rejected (snowflakedb/snowflake-jdbc#2622).
+
 - v4.2.0
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)
     - Fixed NPE in `RestRequest.sendIBHttpErrorEvent` when `SFSession.getTelemetryClient()` returns null because the session URL is not yet set; a `NoOpTelemetryClient` is now returned instead, allowing the original HTTP error to be surfaced to the caller (snowflakedb/snowflake-jdbc#2610)

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
@@ -3099,11 +3099,33 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         FileMetadata fileMetadata = new FileMetadata();
         fileMetadataMap.put(sourceFile, fileMetadata);
         fileMetadata.srcFileName = sourceFile;
-
-        fileMetadata.destFileName =
-            sourceFile.substring(sourceFile.lastIndexOf("/") + 1); // s3 uses / as separator
+        fileMetadata.destFileName = extractSafeDestFileName(sourceFile, queryID);
       }
     }
+  }
+
+  static String extractSafeDestFileName(String sourceFile, String queryId)
+      throws SnowflakeSQLException {
+    if (sourceFile == null) {
+      throw new SnowflakeSQLException(
+          queryId, ErrorCode.INTERNAL_ERROR, "Source file path from server is null");
+    }
+    int lastSeparator = Math.max(sourceFile.lastIndexOf('/'), sourceFile.lastIndexOf('\\'));
+    String name = sourceFile.substring(lastSeparator + 1);
+
+    if (name.isEmpty()
+        || ".".equals(name)
+        || "..".equals(name)
+        || name.indexOf('\0') >= 0
+        || name.indexOf('/') >= 0
+        || name.indexOf('\\') >= 0
+        || name.indexOf(':') >= 0) {
+      throw new SnowflakeSQLException(
+          queryId,
+          ErrorCode.INTERNAL_ERROR,
+          "Invalid destination file name received from server: " + sourceFile);
+    }
+    return name;
   }
 
   /**

--- a/src/test/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgentExtractSafeDestFileNameTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgentExtractSafeDestFileNameTest.java
@@ -1,0 +1,149 @@
+package net.snowflake.client.internal.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for {@link SnowflakeFileTransferAgent#extractSafeDestFileName(String, String)}.
+ *
+ * <p>Covers the SNOW-3437355 regression: server-supplied stage object keys must not be allowed to
+ * escape the user's download directory via Windows backslash path separators or other traversal
+ * forms.
+ */
+public class SnowflakeFileTransferAgentExtractSafeDestFileNameTest {
+
+  private static final String QUERY_ID = "test-query-id";
+
+  @Test
+  public void simpleNameIsReturnedAsIs() throws SnowflakeSQLException {
+    assertEquals(
+        "report.csv", SnowflakeFileTransferAgent.extractSafeDestFileName("report.csv", QUERY_ID));
+  }
+
+  @Test
+  public void forwardSlashPathReturnsBasename() throws SnowflakeSQLException {
+    assertEquals(
+        "report.csv",
+        SnowflakeFileTransferAgent.extractSafeDestFileName("stage/dir/sub/report.csv", QUERY_ID));
+  }
+
+  @Test
+  public void backslashOnlyPathReturnsBasename() throws SnowflakeSQLException {
+    assertEquals(
+        "evil.dll",
+        SnowflakeFileTransferAgent.extractSafeDestFileName("stage\\dir\\evil.dll", QUERY_ID));
+  }
+
+  @Test
+  public void mixedSeparatorsReturnTrailingBasename() throws SnowflakeSQLException {
+    assertEquals(
+        "real.csv",
+        SnowflakeFileTransferAgent.extractSafeDestFileName("stage/dir\\sub/real.csv", QUERY_ID));
+    assertEquals(
+        "real.csv",
+        SnowflakeFileTransferAgent.extractSafeDestFileName("stage\\dir/sub\\real.csv", QUERY_ID));
+  }
+
+  @Test
+  public void windowsTraversalAttackIsNeutralized() throws SnowflakeSQLException {
+    assertEquals(
+        "evil.dll",
+        SnowflakeFileTransferAgent.extractSafeDestFileName(
+            "stage/dir/..\\..\\..\\Windows\\System32\\evil.dll", QUERY_ID));
+  }
+
+  @Test
+  public void singleBackslashTraversalIsNeutralized() throws SnowflakeSQLException {
+    assertEquals(
+        "evil", SnowflakeFileTransferAgent.extractSafeDestFileName("stage/dir/..\\evil", QUERY_ID));
+  }
+
+  @Test
+  public void trailingDotDotIsRejected() {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> SnowflakeFileTransferAgent.extractSafeDestFileName("stage/dir/..", QUERY_ID));
+  }
+
+  @Test
+  public void backslashTrailingDotDotIsRejected() {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> SnowflakeFileTransferAgent.extractSafeDestFileName("stage\\dir\\..", QUERY_ID));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {".", "..", ""})
+  public void dotAndEmptyTokensAreRejected(String input) {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> SnowflakeFileTransferAgent.extractSafeDestFileName(input, QUERY_ID));
+  }
+
+  @Test
+  public void trailingForwardSlashYieldsEmptyAndIsRejected() {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> SnowflakeFileTransferAgent.extractSafeDestFileName("stage/dir/", QUERY_ID));
+  }
+
+  @Test
+  public void trailingBackslashYieldsEmptyAndIsRejected() {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> SnowflakeFileTransferAgent.extractSafeDestFileName("stage\\dir\\", QUERY_ID));
+  }
+
+  @Test
+  public void nulByteIsRejected() {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () ->
+            SnowflakeFileTransferAgent.extractSafeDestFileName(
+                "stage/dir/file\u0000hidden", QUERY_ID));
+  }
+
+  @Test
+  public void nullSourceFileIsRejected() {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> SnowflakeFileTransferAgent.extractSafeDestFileName(null, QUERY_ID));
+  }
+
+  @Test
+  public void leadingDotsInOtherwiseValidNamesAreAllowed() throws SnowflakeSQLException {
+    assertEquals(
+        ".hidden",
+        SnowflakeFileTransferAgent.extractSafeDestFileName("stage/dir/.hidden", QUERY_ID));
+    assertEquals(
+        "..something",
+        SnowflakeFileTransferAgent.extractSafeDestFileName("stage/dir/..something", QUERY_ID));
+  }
+
+  @Test
+  public void noSeparatorAtAllReturnsWholeString() throws SnowflakeSQLException {
+    assertEquals(
+        "lonely.csv", SnowflakeFileTransferAgent.extractSafeDestFileName("lonely.csv", QUERY_ID));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "C:foo",
+        ":foo",
+        "foo:",
+        "passwd:hidden",
+        "stage/dir/C:foo",
+        "stage\\dir\\name:stream"
+      })
+  public void colonInBasenameIsRejected(String input) {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> SnowflakeFileTransferAgent.extractSafeDestFileName(input, QUERY_ID));
+  }
+}


### PR DESCRIPTION
## Summary
- `SnowflakeFileTransferAgent.parseCommand` previously derived the local destination filename for downloads via `sourceFile.substring(sourceFile.lastIndexOf("/") + 1)`. On Windows the JVM also treats `\` as a path separator, so a server response containing a stage key like `stage/dir/..\..\..\evil.dll` produced a `destFileName` that `new File(localLocation, destFileName)` resolved **outside** the user's GET target directory — enabling arbitrary file write under a compromised-backend / MITM threat model.
- Replace the unsafe chop with a new package-private helper `extractSafeDestFileName(sourceFile, queryId)` that:
  - chops at the last `/` **or** `\` (whichever is later), and
  - rejects empty / `.` / `..` / NUL-containing / absolute names with `ErrorCode.INTERNAL_ERROR`.
- Add 15 unit tests in `SnowflakeFileTransferAgentExtractSafeDestFileNameTest` covering the happy paths, the SNOW-3437355 attack vector being neutralized to a harmless basename, mixed separators, dotfiles that must remain valid (`.hidden`, `..something`), trailing-separator rejection, NUL injection, and the absolute-path edge case.

## Context
First of two PRs for SNOW-3437355. This PR closes the documented vulnerability at the source — the producer of `destFileName` — keeping the diff small and self-contained for security review and easy backport. A follow-up PR will add canonical-path validation at every download write site (`SnowflakeFileTransferAgent.executeDownload`, `SnowflakeS3Client.download`, `SnowflakeAzureClient.download`, `SnowflakeGCSClient.download`) as defense in depth so future code paths cannot reintroduce a similar escape.

Linux/macOS clients were not vulnerable to the original issue (`\` is a literal filename character there); the fix is still applied uniformly because the helper is OS-agnostic and the rejection rules (`isEmpty`/`.`/`..`/NUL/absolute) are valid invariants on every platform.

## Test plan
- `./mvnw -Dtest=SnowflakeFileTransferAgentExtractSafeDestFileNameTest test` → 15/15 pass.
- `./mvnw com.spotify.fmt:fmt-maven-plugin:format` → clean (touched files reformatted).
- `./mvnw clean validate --batch-mode --show-version -P check-style` → 761 files processed, 0 non-complying.
- Manually traced the SNOW-3437355 attack input `"stage/dir/..\..\..\Windows\System32\evil.dll"` through the new helper: returns `"evil.dll"`, which `new File(localLocation, "evil.dll")` resolves inside the GET target directory.
- No legitimate stage key shape (POSIX `/`-separated, no `..`/`.`/NUL/absolute as a basename) is rejected by the new guard.