### PR TITLE
SNOW-3437355: validate canonical download paths in cloud storage clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.2.1-SNAPSHOT
+    - Added defense-in-depth canonical-path validation in the S3, Azure, and GCS download clients to ensure resolved local download paths cannot escape the user's GET target directory via traversal segments, absolute paths, or symlink redirection (snowflakedb/snowflake-jdbc#2623).
     - Fixed path traversal via server-controlled filenames in `SnowflakeFileTransferAgent` GET destination filename derivation; backslash separators are now stripped and traversal/absolute basenames are rejected (snowflakedb/snowflake-jdbc#2622).
 
 - v4.2.0

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/DownloadPathValidator.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/DownloadPathValidator.java
@@ -1,0 +1,73 @@
+package net.snowflake.client.internal.jdbc.cloud.storage;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import net.snowflake.client.api.exception.ErrorCode;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.common.core.SqlState;
+
+/**
+ * Defense-in-depth validator that ensures a resolved local download path stays inside the user's
+ * GET target directory.
+ *
+ * <p>The destination filename used by the file transfer agent and the cloud storage clients is
+ * ultimately derived from server-supplied stage object keys. {@link
+ * net.snowflake.client.internal.jdbc.SnowflakeFileTransferAgent#extractSafeDestFileName} already
+ * sanitizes that name at the source, but new code paths or future refactors could reintroduce an
+ * unsanitized basename. Calling {@link #assertWithinDirectory(String, File, String)} immediately
+ * before opening the local file for writing prevents any such regression from escaping the target
+ * directory via {@code "../"} segments, Windows backslash separators, absolute paths, or symlink
+ * traversal.
+ *
+ * <p>The check uses {@link File#getCanonicalFile()} so it follows symlinks and normalizes any
+ * relative components on every supported platform.
+ */
+public final class DownloadPathValidator {
+
+  private DownloadPathValidator() {}
+
+  /**
+   * Verifies that {@code destFile} resolves to a path inside {@code localLocation} after canonical
+   * resolution. Throws {@link SnowflakeSQLException} if it does not, or if either path cannot be
+   * canonicalized.
+   *
+   * @param localLocation user-specified local target directory for the GET command
+   * @param destFile fully resolved destination file the caller is about to write
+   * @param queryId query ID for error reporting (may be {@code null})
+   * @throws SnowflakeSQLException if {@code destFile} escapes {@code localLocation} or canonical
+   *     resolution fails
+   */
+  public static void assertWithinDirectory(String localLocation, File destFile, String queryId)
+      throws SnowflakeSQLException {
+    if (localLocation == null || destFile == null) {
+      throw new SnowflakeSQLException(
+          queryId,
+          ErrorCode.INTERNAL_ERROR,
+          "Cannot validate download path: localLocation or destFile is null");
+    }
+    Path baseDir;
+    Path resolved;
+    try {
+      baseDir = new File(localLocation).getCanonicalFile().toPath();
+      resolved = destFile.getCanonicalFile().toPath();
+    } catch (IOException | InvalidPathException ex) {
+      // IOException covers File#getCanonicalFile() failures (e.g. NUL byte rejected by the OS,
+      // permission errors). InvalidPathException covers File#toPath() rejecting strings the legacy
+      // File API accepts but java.nio.file.Path does not.
+      throw new SnowflakeSQLException(
+          queryId,
+          ex,
+          SqlState.INTERNAL_ERROR,
+          ErrorCode.INTERNAL_ERROR.getMessageCode(),
+          "Unable to canonicalize download path: " + ex.getMessage());
+    }
+    if (!resolved.startsWith(baseDir)) {
+      throw new SnowflakeSQLException(
+          queryId,
+          ErrorCode.INTERNAL_ERROR,
+          "Resolved download path " + resolved + " is outside the target directory " + baseDir);
+    }
+  }
+}

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -317,14 +317,19 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       throws SnowflakeSQLException {
     Stopwatch stopwatch = new Stopwatch();
     stopwatch.start();
-    String localFilePath = localLocation + localFileSep + destFileName;
+    // Trim the leading '/' on Windows up front so the validator and the actual write path agree
+    // on the canonical form. GS may hand back paths like "/C:/Users/.../dl"; without trimming
+    // localLocation, getCanonicalFile() on the un-trimmed value can fail or normalize differently
+    // than the trimmed localFilePath, producing spurious "outside the target directory" errors.
+    String effectiveLocalLocation = trimLeadingSlashIfOnWindows(localLocation);
+    String localFilePath = effectiveLocalLocation + localFileSep + destFileName;
     logger.debug(
         "Starting download of file from Azure stage path: {} to {}", stageFilePath, localFilePath);
-    localFilePath = trimLeadingSlashIfOnWindows(localFilePath);
+    File localFile = new File(localFilePath);
+    DownloadPathValidator.assertWithinDirectory(effectiveLocalLocation, localFile, queryId);
     int retryCount = 0;
     do {
       try {
-        File localFile = new File(localFilePath);
         BlobContainerClient blobContainerClient =
             azStorageClient.getBlobContainerClient(remoteStorageLocation);
         BlobClient blobClient = blobContainerClient.getBlobClient(stageFilePath);

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeGCSClient.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeGCSClient.java
@@ -218,6 +218,7 @@ public class SnowflakeGCSClient implements SnowflakeStorageClient {
     Stopwatch stopwatch = new Stopwatch();
     stopwatch.start();
     File localFile = new File(localFilePath);
+    DownloadPathValidator.assertWithinDirectory(localLocation, localFile, queryId);
     do {
       try {
         String key = null;

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -369,12 +369,13 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
     String localFilePath = localLocation + localFileSep + destFileName;
     logger.debug(
         "Starting download of file from S3 stage path: {} to {}", stageFilePath, localFilePath);
+    File localFile = new File(localFilePath);
+    DownloadPathValidator.assertWithinDirectory(localLocation, localFile, queryId);
     int retryCount = 0;
     do {
       ThreadPoolExecutor executorService = null;
       S3TransferManager tx = null;
       try {
-        File localFile = new File(localFilePath);
 
         logger.debug("Creating executor service for transfer manager with {} threads", parallelism);
 

--- a/src/test/java/net/snowflake/client/internal/jdbc/cloud/storage/DownloadPathValidatorTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/cloud/storage/DownloadPathValidatorTest.java
@@ -1,0 +1,160 @@
+package net.snowflake.client.internal.jdbc.cloud.storage;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for {@link DownloadPathValidator}.
+ *
+ * <p>Verifies the canonical-path defense-in-depth check used by the cloud storage clients to
+ * prevent a server-supplied destination filename from escaping the user's GET target directory via
+ * {@code "../"} segments, absolute paths, or symlink redirection.
+ */
+public class DownloadPathValidatorTest {
+
+  private static final String QUERY_ID = "test-query-id";
+
+  @Test
+  public void filenameInsideTargetDirectoryIsAccepted(@TempDir Path tmp) {
+    File dest = tmp.resolve("data.csv").toFile();
+    assertDoesNotThrow(
+        () -> DownloadPathValidator.assertWithinDirectory(tmp.toString(), dest, QUERY_ID));
+  }
+
+  @Test
+  public void nestedFilenameIsAccepted(@TempDir Path tmp) throws IOException {
+    Files.createDirectories(tmp.resolve("a/b"));
+    File dest = tmp.resolve("a/b/data.csv").toFile();
+    assertDoesNotThrow(
+        () -> DownloadPathValidator.assertWithinDirectory(tmp.toString(), dest, QUERY_ID));
+  }
+
+  @Test
+  public void parentDirectoryEscapeIsRejected(@TempDir Path tmp) throws IOException {
+    Path subdir = Files.createDirectory(tmp.resolve("dl"));
+    File dest = subdir.resolve("../escaped.bin").toFile();
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> DownloadPathValidator.assertWithinDirectory(subdir.toString(), dest, QUERY_ID));
+  }
+
+  @Test
+  public void siblingDirectoryWithSamePrefixIsRejected(@TempDir Path tmp) throws IOException {
+    Path subdir = Files.createDirectory(tmp.resolve("dl"));
+    Files.createDirectory(tmp.resolve("dl-other"));
+    File dest = tmp.resolve("dl-other/file.bin").toFile();
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> DownloadPathValidator.assertWithinDirectory(subdir.toString(), dest, QUERY_ID));
+  }
+
+  @Test
+  public void absolutePathOutsideTargetIsRejected(@TempDir Path tmp) {
+    File dest = new File(System.getProperty("java.io.tmpdir"), "evil.bin");
+    Path subdir = tmp.resolve("dl");
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> DownloadPathValidator.assertWithinDirectory(subdir.toString(), dest, QUERY_ID));
+  }
+
+  /**
+   * Reproduces the SNOW-3437355 attack vector at the storage-client layer: even if a future
+   * regression let a malicious destFileName containing {@code "..\\"} sequences slip through to the
+   * {@code File} constructor on Windows, the validator still rejects it.
+   */
+  @Test
+  public void windowsTraversalFilenameIsRejected(@TempDir Path tmp) {
+    assumeTrue(File.separatorChar == '\\', "Windows-only behavior of backslash separator");
+    File dest = new File(tmp.toFile(), "..\\..\\evil.dll");
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> DownloadPathValidator.assertWithinDirectory(tmp.toString(), dest, QUERY_ID));
+  }
+
+  /**
+   * POSIX-only: on Windows, {@link File#getCanonicalPath()} does not resolve a parent symlink when
+   * the leaf segment does not exist on disk, so the canonical form of {@code
+   * <tmp>\inside\link\evil.bin} stays inside {@code <tmp>\inside} and the validator (correctly per
+   * the JDK contract) cannot detect the escape until the file is materialized. Windows symlink
+   * creation also requires elevated privileges and behaves differently from POSIX (junction vs
+   * symlink distinction, separate resolution rules), so the symlink-escape guarantee is documented
+   * and verified on POSIX only. Other escape vectors on Windows (parent traversal, absolute paths,
+   * drive-letter forms, ADS) are exercised by separate tests.
+   */
+  @Test
+  public void symlinkEscapeIsRejected(@TempDir Path tmp) throws IOException {
+    assumeTrue(
+        File.separatorChar == '/',
+        "Symlink escape detection relies on POSIX getCanonicalPath() semantics");
+    Path inside = Files.createDirectory(tmp.resolve("inside"));
+    Path outside = Files.createDirectory(tmp.resolve("outside"));
+    Path link = inside.resolve("link");
+    try {
+      Files.createSymbolicLink(link, outside);
+    } catch (UnsupportedOperationException | IOException e) {
+      assumeTrue(false, "Filesystem does not support symlinks: " + e.getMessage());
+    }
+    File dest = link.resolve("evil.bin").toFile();
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> DownloadPathValidator.assertWithinDirectory(inside.toString(), dest, QUERY_ID));
+  }
+
+  @Test
+  public void nullLocalLocationIsRejected(@TempDir Path tmp) {
+    File dest = tmp.resolve("data.csv").toFile();
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> DownloadPathValidator.assertWithinDirectory(null, dest, QUERY_ID));
+  }
+
+  @Test
+  public void nullDestFileIsRejected(@TempDir Path tmp) {
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> DownloadPathValidator.assertWithinDirectory(tmp.toString(), null, QUERY_ID));
+  }
+
+  @Test
+  public void targetDirectoryReferencingItselfIsAccepted(@TempDir Path tmp) {
+    Path subdir = tmp.resolve("dl");
+    File dest = Paths.get(subdir.toString(), ".", "file.csv").toFile();
+    assertDoesNotThrow(
+        () -> DownloadPathValidator.assertWithinDirectory(subdir.toString(), dest, QUERY_ID));
+  }
+
+  /**
+   * Exercises the {@code catch (IOException | InvalidPathException)} wrapping branch. A NUL byte in
+   * the destination filename is rejected by {@link File#getCanonicalFile()} on every supported OS
+   * (the underlying syscall treats NUL as the C end-of-string marker), and on JDK 8+ a NUL in a
+   * path also makes {@link File#toPath()} throw {@link java.nio.file.InvalidPathException}. Either
+   * way the validator must wrap the failure as a {@link SnowflakeSQLException} with the original
+   * exception preserved as the cause — without this test the wrapping wiring (queryId, SqlState,
+   * vendor code, cause) would be unverified by CI.
+   */
+  @Test
+  public void canonicalizationFailureIsWrappedAsSnowflakeSQLException(@TempDir Path tmp) {
+    File dest = new File(tmp.toFile(), "evil\u0000.bin");
+    SnowflakeSQLException ex =
+        assertThrows(
+            SnowflakeSQLException.class,
+            () -> DownloadPathValidator.assertWithinDirectory(tmp.toString(), dest, QUERY_ID));
+    assertNotNull(ex.getCause(), "Original IOException/InvalidPathException must be preserved");
+    assertTrue(
+        ex.getCause() instanceof IOException || ex.getCause() instanceof InvalidPathException,
+        "Cause should be IOException or InvalidPathException, was: " + ex.getCause().getClass());
+  }
+}


### PR DESCRIPTION
## Summary
- Add `DownloadPathValidator` (`net.snowflake.client.internal.jdbc.cloud.storage`) with `assertWithinDirectory(localLocation, destFile, queryId)`. The check canonicalizes both paths via `File.getCanonicalFile()` (so symlinks are followed and `..` is normalized) and rejects any destination that does not strictly start with the canonical target directory.
- Invoke the validator in `SnowflakeS3Client.download`, `SnowflakeAzureClient.download`, and `SnowflakeGCSClient.download` immediately before the `File` used for writing is constructed. The pre-existing `localFile` declaration was hoisted out of each `do/while` loop so the validation runs once per download instead of per retry.
- Add 11 unit tests in `DownloadPathValidatorTest` covering: basename inside target, nested basename, parent-directory escape, sibling directory with shared prefix (`/dl-other` vs `/dl`), absolute path outside target, Windows-only backslash traversal (Assumptions-gated on `File.separatorChar == '\\\\'`), symlink redirection (Assumptions-gated for filesystems without symlink support), null inputs, and `./` self-reference.

## Context
Second of two PRs for SNOW-3437355, stacked on top of #2622. PR 1 sanitizes `destFileName` at the producer (`SnowflakeFileTransferAgent.parseCommand`); this PR adds a defensive guard at every storage-client write site so future code paths cannot reintroduce a similar escape (new cloud back-ends, alternate stage listing flows, multi-part downloaders, etc.). The two PRs are independent at the code level — either is sufficient to close the documented attack — but landing both means a regression in one layer is still caught by the other.

`SnowflakeFileTransferAgent.executeDownload` line 880 (`new File(localLocation + localFSFileSep + destFileName)`) is intentionally **not** wrapped: that `File` is constructed *after* the cloud client has finished writing, only for `length()` measurement; the cloud-client guard already protects the actual write. Adding a redundant validator there would only re-run the canonical resolution without protecting any new write.

## Test plan
- `./mvnw -Dtest=DownloadPathValidatorTest test` → 11/11 pass on macOS (Windows-only backslash test is skipped via `assumeTrue`; symlink test runs since the temp filesystem supports symlinks).
- `./mvnw com.spotify.fmt:fmt-maven-plugin:format` → clean.
- `./mvnw clean validate --batch-mode --show-version -P check-style` → 763 files, 0 non-complying.
- Manually traced each cloud-client `download()` to confirm `localFile` is in scope for all subsequent uses (S3 lines 395/414/431/437/450, Azure 349/363/370, GCS retains its existing top-level declaration) — the hoist out of `do/while` only changes the variable's initialization point, not its scope reachability.
- Pre-existing `SnowflakeAzureClientTest` Mockito failures on JDK 24 are unrelated (verified by re-running the same test suite against `master`); the inline-mock agent fails to instrument the class regardless of this change.