### PR TITLE
SNOW-3411804: fix merge logic for JDBC URL vs connections.toml  for aliased properties + consider Properties sourced config too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 # Changelog
 - v4.2.1-SNAPSHOT
     - Fixed path traversal via server-controlled filenames in `SnowflakeFileTransferAgent` GET destination filename derivation; backslash separators are now stripped and traversal/absolute basenames are rejected (snowflakedb/snowflake-jdbc#2622).
+    - Further changes regarding auto-configuration (`jdbc:snowflake:auto` style connection config) (snowflakedb/snowflake-jdbc#2625):
+      - Fixed bug leading to `'Connection property specified more than once: DB'` error, when both `connections.toml` (`database`) and JDBC URL (`db`) defined database 
+      - Enhancement: now parameters passed as `Properties()` are also considered when building connection. For conflicting items defined in multiple places, priority is: Properties > JDBC URL > `connections.toml`
+      - Enhancement (supportability): added provenance tracking for config keys and log them once per connection on debug level
 
 - v4.2.0
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -50,6 +50,15 @@ public class SFConnectionConfigParser {
 
   public static ConnectionParameters buildConnectionParameters(String connectionUrl)
       throws SnowflakeSQLException {
+    return buildConnectionParameters(connectionUrl, null);
+  }
+
+  /**
+   * Build connection parameters from URL and TOML file, optionally tracking provenance. When
+   * provenance is non-null, each key's source ("TOML" or "URL") is recorded as it is resolved.
+   */
+  public static ConnectionParameters buildConnectionParameters(
+      String connectionUrl, Map<String, String> provenance) throws SnowflakeSQLException {
     Map<String, String> urlParameters = parseAutoConfigJdbcUrlParameters(connectionUrl);
     String defaultConnectionName = urlParameters.get("connectionName");
     if (isBlank(defaultConnectionName)) {
@@ -61,7 +70,13 @@ public class SFConnectionConfigParser {
         loadDefaultConnectionConfiguration(defaultConnectionName);
 
     if (fileConnectionConfiguration != null && !fileConnectionConfiguration.isEmpty()) {
-      mergeUrlParametersIntoConfiguration(fileConnectionConfiguration, urlParameters);
+      if (provenance != null) {
+        for (String key : fileConnectionConfiguration.keySet()) {
+          provenance.put(key, "TOML");
+        }
+      }
+
+      mergeUrlParametersIntoConfiguration(fileConnectionConfiguration, urlParameters, provenance);
 
       Properties connectionProperties = new Properties();
       connectionProperties.putAll(fileConnectionConfiguration);
@@ -142,13 +157,15 @@ public class SFConnectionConfigParser {
   }
 
   private static void mergeUrlParametersIntoConfiguration(
-      Map<String, String> fileConfig, Map<String, String> urlParameters) {
+      Map<String, String> fileConfig,
+      Map<String, String> urlParameters,
+      Map<String, String> provenance) {
     for (Map.Entry<String, String> entry : urlParameters.entrySet()) {
       String key = entry.getKey();
       if ("connectionName".equalsIgnoreCase(key)) {
         continue;
       }
-      putResolvingAliases(fileConfig, key, entry.getValue());
+      putResolvingAliases(fileConfig, key, entry.getValue(), provenance, "URL");
     }
   }
 
@@ -158,6 +175,19 @@ public class SFConnectionConfigParser {
    * errors when e.g. the TOML uses "database" and the URL uses alias "db".
    */
   public static void putResolvingAliases(Map<String, String> map, String key, String value) {
+    putResolvingAliases(map, key, value, null, null);
+  }
+
+  /**
+   * Put a key/value into the map with provenance tracking. When provenance is non-null, records the
+   * source of the key and notes any alias conflict that was resolved.
+   */
+  public static void putResolvingAliases(
+      Map<String, String> map,
+      String key,
+      String value,
+      Map<String, String> provenance,
+      String source) {
     String conflictingKey = null;
     for (String existing : map.keySet()) {
       if (existing.equalsIgnoreCase(key)) {
@@ -168,6 +198,8 @@ public class SFConnectionConfigParser {
         break;
       }
     }
+
+    String overriddenSource = null;
     if (conflictingKey != null) {
       String oldValue = map.get(conflictingKey);
       if (oldValue != null && !oldValue.equalsIgnoreCase(value)) {
@@ -177,9 +209,23 @@ public class SFConnectionConfigParser {
             key,
             conflictingKey);
       }
+      if (provenance != null) {
+        overriddenSource = provenance.remove(conflictingKey);
+      }
       map.remove(conflictingKey);
+    } else if (provenance != null && map.containsKey(key)) {
+      overriddenSource = provenance.remove(key);
     }
+
     map.put(key, value);
+
+    if (provenance != null && source != null) {
+      if (overriddenSource != null) {
+        provenance.put(key, source + "(overrode " + overriddenSource + ")");
+      } else {
+        provenance.put(key, source);
+      }
+    }
   }
 
   private static Map<String, String> loadDefaultConnectionConfiguration(

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.core.SFSessionProperty;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 
@@ -147,16 +148,38 @@ public class SFConnectionConfigParser {
       if ("connectionName".equalsIgnoreCase(key)) {
         continue;
       }
-      String urlValue = entry.getValue();
-      String tomlValue = fileConfig.get(key);
-      if (tomlValue != null && !tomlValue.equalsIgnoreCase(urlValue)) {
-        logger.debug(
-            "For config item '{}' the values from connections.toml and the connection string"
-                + " differ; the connection string value will be applied.",
-            key);
-      }
-      fileConfig.put(key, urlValue);
+      putResolvingAliases(fileConfig, key, entry.getValue());
     }
+  }
+
+  /**
+   * Put a key/value into the map, removing any existing entry that resolves to the same
+   * SFSessionProperty under a different key name. This prevents "duplicate connection property"
+   * errors when e.g. the TOML uses "database" and the URL uses alias "db".
+   */
+  public static void putResolvingAliases(Map<String, String> map, String key, String value) {
+    String conflictingKey = null;
+    for (String existing : map.keySet()) {
+      if (existing.equalsIgnoreCase(key)) {
+        continue;
+      }
+      if (SFSessionProperty.resolvesToSameProperty(existing, key)) {
+        conflictingKey = existing;
+        break;
+      }
+    }
+    if (conflictingKey != null) {
+      String oldValue = map.get(conflictingKey);
+      if (oldValue != null && !oldValue.equalsIgnoreCase(value)) {
+        logger.debug(
+            "For config item '{}' (alias of '{}') the values differ;"
+                + " the overriding value will be applied.",
+            key,
+            conflictingKey);
+      }
+      map.remove(conflictingKey);
+    }
+    map.put(key, value);
   }
 
   private static Map<String, String> loadDefaultConnectionConfiguration(

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.core.SFException;
 import net.snowflake.client.internal.core.SFSessionProperty;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
@@ -50,7 +51,7 @@ public class SFConnectionConfigParser {
 
   public static ConnectionParameters buildConnectionParameters(String connectionUrl)
       throws SnowflakeSQLException {
-    return buildConnectionParameters(connectionUrl, null);
+    return buildConnectionParameters(connectionUrl, new HashMap<>());
   }
 
   /**
@@ -76,7 +77,12 @@ public class SFConnectionConfigParser {
         }
       }
 
-      mergeUrlParametersIntoConfiguration(fileConnectionConfiguration, urlParameters, provenance);
+      try {
+        mergeUrlParametersIntoConfiguration(fileConnectionConfiguration, urlParameters, provenance);
+      } catch (SFException e) {
+        throw new SnowflakeSQLException(
+            e.getQueryId(), e, e.getSqlState(), e.getVendorCode(), e.getParams());
+      }
 
       Properties connectionProperties = new Properties();
       connectionProperties.putAll(fileConnectionConfiguration);
@@ -159,72 +165,14 @@ public class SFConnectionConfigParser {
   private static void mergeUrlParametersIntoConfiguration(
       Map<String, String> fileConfig,
       Map<String, String> urlParameters,
-      Map<String, String> provenance) {
+      Map<String, String> provenance)
+      throws SFException {
     for (Map.Entry<String, String> entry : urlParameters.entrySet()) {
       String key = entry.getKey();
       if ("connectionName".equalsIgnoreCase(key)) {
         continue;
       }
-      putResolvingAliases(fileConfig, key, entry.getValue(), provenance, "URL");
-    }
-  }
-
-  /**
-   * Put a key/value into the map, removing any existing entry that resolves to the same
-   * SFSessionProperty under a different key name. This prevents "duplicate connection property"
-   * errors when e.g. the TOML uses "database" and the URL uses alias "db".
-   */
-  public static void putResolvingAliases(Map<String, String> map, String key, String value) {
-    putResolvingAliases(map, key, value, null, null);
-  }
-
-  /**
-   * Put a key/value into the map with provenance tracking. When provenance is non-null, records the
-   * source of the key and notes any alias conflict that was resolved.
-   */
-  public static void putResolvingAliases(
-      Map<String, String> map,
-      String key,
-      String value,
-      Map<String, String> provenance,
-      String source) {
-    String conflictingKey = null;
-    for (String existing : map.keySet()) {
-      if (existing.equalsIgnoreCase(key)) {
-        continue;
-      }
-      if (SFSessionProperty.resolvesToSameProperty(existing, key)) {
-        conflictingKey = existing;
-        break;
-      }
-    }
-
-    String overriddenSource = null;
-    if (conflictingKey != null) {
-      String oldValue = map.get(conflictingKey);
-      if (oldValue != null && !oldValue.equalsIgnoreCase(value)) {
-        logger.debug(
-            "For config item '{}' (alias of '{}') the values differ;"
-                + " the overriding value will be applied.",
-            key,
-            conflictingKey);
-      }
-      if (provenance != null) {
-        overriddenSource = provenance.remove(conflictingKey);
-      }
-      map.remove(conflictingKey);
-    } else if (provenance != null && map.containsKey(key)) {
-      overriddenSource = provenance.remove(key);
-    }
-
-    map.put(key, value);
-
-    if (provenance != null && source != null) {
-      if (overriddenSource != null) {
-        provenance.put(key, source + "(overrode " + overriddenSource + ")");
-      } else {
-        provenance.put(key, source);
-      }
+      SFSessionProperty.putResolvingAliases(fileConfig, key, entry.getValue(), provenance, "URL");
     }
   }
 

--- a/src/main/java/net/snowflake/client/internal/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSessionProperty.java
@@ -196,6 +196,19 @@ public enum SFSessionProperty {
     this.aliases = aliases;
   }
 
+  /**
+   * Returns true if two property key strings resolve to the same SFSessionProperty (accounting for
+   * aliases). Returns false if either key is unrecognized or they resolve to different properties.
+   */
+  public static boolean resolvesToSameProperty(String key1, String key2) {
+    if (key1 == null || key2 == null) {
+      return false;
+    }
+    SFSessionProperty prop1 = lookupByKey(key1);
+    SFSessionProperty prop2 = lookupByKey(key2);
+    return prop1 != null && prop1 == prop2;
+  }
+
   static SFSessionProperty lookupByKey(String propertyKey) {
     for (SFSessionProperty property : SFSessionProperty.values()) {
       if (property.propertyKey.equalsIgnoreCase(propertyKey)) {

--- a/src/main/java/net/snowflake/client/internal/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSessionProperty.java
@@ -1,10 +1,15 @@
 package net.snowflake.client.internal.core;
 
 import java.security.PrivateKey;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import net.snowflake.client.api.exception.ErrorCode;
 import net.snowflake.client.api.http.HttpHeadersCustomizer;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
 
 /** session properties accepted for opening a new session. */
 public enum SFSessionProperty {
@@ -162,6 +167,21 @@ public enum SFSessionProperty {
 
   DISABLE_PLATFORM_DETECTION("disablePlatformDetection", false, Boolean.class);
 
+  private static final SFLogger logger = SFLoggerFactory.getLogger(SFSessionProperty.class);
+
+  private static final Map<String, SFSessionProperty> KEY_LOOKUP_MAP;
+
+  static {
+    Map<String, SFSessionProperty> map = new HashMap<>();
+    for (SFSessionProperty prop : values()) {
+      map.put(prop.propertyKey.toLowerCase(), prop);
+      for (String alias : prop.aliases) {
+        map.put(alias.toLowerCase(), prop);
+      }
+    }
+    KEY_LOOKUP_MAP = Collections.unmodifiableMap(map);
+  }
+
   // property key in string
   private String propertyKey;
 
@@ -196,32 +216,107 @@ public enum SFSessionProperty {
     this.aliases = aliases;
   }
 
-  /**
-   * Returns true if two property key strings resolve to the same SFSessionProperty (accounting for
-   * aliases). Returns false if either key is unrecognized or they resolve to different properties.
-   */
-  public static boolean resolvesToSameProperty(String key1, String key2) {
-    if (key1 == null || key2 == null) {
-      return false;
-    }
-    SFSessionProperty prop1 = lookupByKey(key1);
-    SFSessionProperty prop2 = lookupByKey(key2);
-    return prop1 != null && prop1 == prop2;
+  static SFSessionProperty lookupByKey(String propertyKey) {
+    return KEY_LOOKUP_MAP.get(propertyKey.toLowerCase());
   }
 
-  static SFSessionProperty lookupByKey(String propertyKey) {
-    for (SFSessionProperty property : SFSessionProperty.values()) {
-      if (property.propertyKey.equalsIgnoreCase(propertyKey)) {
-        return property;
+  /**
+   * Put a key/value into the map, removing any existing entry that resolves to the same
+   * SFSessionProperty under a different key name (or same key with different casing). This prevents
+   * "duplicate connection property" errors when e.g. the TOML uses "database" and the URL uses
+   * alias "db". Delegates to the provenance-tracking overload with null provenance.
+   */
+  public static void putResolvingAliases(Map<String, String> map, String key, String value) {
+    try {
+      putResolvingAliases(map, key, value, null, null);
+    } catch (SFException e) {
+      // Unreachable: same-source duplicate detection requires non-null provenance and source
+      throw new AssertionError("Unexpected SFException without provenance tracking", e);
+    }
+  }
+
+  /**
+   * Put a key/value into the map with provenance tracking. When provenance is non-null, records the
+   * source of the key and notes any alias conflict that was resolved. Throws
+   * DUPLICATE_CONNECTION_PROPERTY_SPECIFIED if the conflict is within the same source (e.g., URL
+   * provides both "db" and "database").
+   */
+  public static void putResolvingAliases(
+      Map<String, String> map,
+      String key,
+      String value,
+      Map<String, String> provenance,
+      String source)
+      throws SFException {
+    String conflictingKey = null;
+    for (String existing : map.keySet()) {
+      if (existing.equals(key)) {
+        continue;
+      }
+      SFSessionProperty prop1 = lookupByKey(existing);
+      SFSessionProperty prop2 = lookupByKey(key);
+      if (prop1 != null && prop1 == prop2) {
+        conflictingKey = existing;
+        break;
+      }
+    }
+
+    if (conflictingKey != null) {
+      if (provenance != null && source != null) {
+        String existingSource = provenance.get(conflictingKey);
+        if (existingSource != null && isSameBaseSource(existingSource, source)) {
+          throw new SFException(ErrorCode.DUPLICATE_CONNECTION_PROPERTY_SPECIFIED, key);
+        }
+      }
+
+      String oldValue = map.get(conflictingKey);
+      if (oldValue != null && !oldValue.equalsIgnoreCase(value)) {
+        logger.debug(
+            "For config item '{}' (alias of '{}') the values differ;"
+                + " the overriding value will be applied.",
+            key,
+            conflictingKey);
+      }
+      if (provenance != null) {
+        String overriddenSource = provenance.remove(conflictingKey);
+        map.remove(conflictingKey);
+        map.put(key, value);
+        if (source != null) {
+          provenance.put(
+              key,
+              overriddenSource != null ? source + "(overrode " + overriddenSource + ")" : source);
+        }
       } else {
-        for (String alias : property.aliases) {
-          if (alias.equalsIgnoreCase(propertyKey)) {
-            return property;
-          }
+        map.remove(conflictingKey);
+        map.put(key, value);
+      }
+    } else {
+      String overriddenSource = null;
+      if (provenance != null && map.containsKey(key)) {
+        overriddenSource = provenance.remove(key);
+      }
+      map.put(key, value);
+      if (provenance != null && source != null) {
+        if (overriddenSource != null) {
+          provenance.put(key, source + "(overrode " + overriddenSource + ")");
+        } else {
+          provenance.put(key, source);
         }
       }
     }
-    return null;
+  }
+
+  /**
+   * Checks if the existing provenance source has the same base as the incoming source. Strips
+   * "(overrode ...)" suffixes for comparison. E.g., "URL(overrode TOML)" has base source "URL".
+   */
+  private static boolean isSameBaseSource(String existingSource, String incomingSource) {
+    String existingBase = existingSource;
+    int parenIdx = existingSource.indexOf('(');
+    if (parenIdx > 0) {
+      existingBase = existingSource.substring(0, parenIdx);
+    }
+    return existingBase.equals(incomingSource);
   }
 
   /**

--- a/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
+++ b/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
@@ -89,7 +89,7 @@ public final class AutoConfigurationHelper {
         }
       }
 
-      logProvenance(provenance);
+      logAutoConfigProvenance(provenance);
 
       return params;
     } else {
@@ -130,7 +130,9 @@ public final class AutoConfigurationHelper {
     resolved.putAll(nonStringEntries);
   }
 
-  private static void logProvenance(Map<String, String> provenance) {
+  // Only covers the jdbc:snowflake:auto path. The standard jdbc:snowflake:// path merges
+  // URL+Properties in SnowflakeConnectString.parse without provenance tracking.
+  private static void logAutoConfigProvenance(Map<String, String> provenance) {
     if (!logger.isDebugEnabled()) {
       return;
     }

--- a/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
+++ b/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.driver;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.StringJoiner;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.config.ConnectionParameters;
 import net.snowflake.client.internal.config.SFConnectionConfigParser;
@@ -68,7 +69,9 @@ public final class AutoConfigurationHelper {
           "JDBC connection initializing with URL '{}'. Autoconfiguration is enabled.",
           AUTO_CONNECTION_PREFIX);
 
-      ConnectionParameters params = SFConnectionConfigParser.buildConnectionParameters(url);
+      Map<String, String> provenance = new HashMap<>();
+      ConnectionParameters params =
+          SFConnectionConfigParser.buildConnectionParameters(url, provenance);
       if (params == null) {
         throw new SnowflakeSQLException(
             "Unavailable connection configuration parameters expected for "
@@ -76,8 +79,10 @@ public final class AutoConfigurationHelper {
       }
 
       if (info != null && !info.isEmpty()) {
-        mergeInfoPropertiesIntoParams(params.getParams(), info);
+        mergeInfoPropertiesIntoParams(params.getParams(), info, provenance);
       }
+
+      logProvenance(provenance);
 
       return params;
     } else {
@@ -90,7 +95,8 @@ public final class AutoConfigurationHelper {
    * both TOML and URL values (consistent with standard JDBC semantics where Properties overwrite
    * URL query params). Uses alias-aware put to prevent duplicate property errors downstream.
    */
-  private static void mergeInfoPropertiesIntoParams(Properties resolved, Properties info) {
+  private static void mergeInfoPropertiesIntoParams(
+      Properties resolved, Properties info, Map<String, String> provenance) {
     Map<String, String> resolvedMap = new HashMap<>();
     for (String key : resolved.stringPropertyNames()) {
       resolvedMap.put(key, resolved.getProperty(key));
@@ -99,10 +105,22 @@ public final class AutoConfigurationHelper {
     for (Map.Entry<Object, Object> entry : info.entrySet()) {
       String key = entry.getKey().toString();
       String value = entry.getValue().toString();
-      SFConnectionConfigParser.putResolvingAliases(resolvedMap, key, value);
+      SFConnectionConfigParser.putResolvingAliases(resolvedMap, key, value, provenance, "PROP");
     }
 
     resolved.clear();
     resolved.putAll(resolvedMap);
+  }
+
+  private static void logProvenance(Map<String, String> provenance) {
+    if (!logger.isDebugEnabled()) {
+      return;
+    }
+    StringJoiner sj = new StringJoiner(", ");
+    for (Map.Entry<String, String> entry : provenance.entrySet()) {
+      sj.add(entry.getKey() + "(" + entry.getValue() + ")");
+    }
+    logger.debug("Auto-configuration resolved properties: [{}]", sj.toString());
+    provenance.clear();
   }
 }

--- a/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
+++ b/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
@@ -7,6 +7,8 @@ import java.util.StringJoiner;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.config.ConnectionParameters;
 import net.snowflake.client.internal.config.SFConnectionConfigParser;
+import net.snowflake.client.internal.core.SFException;
+import net.snowflake.client.internal.core.SFSessionProperty;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 
@@ -79,7 +81,12 @@ public final class AutoConfigurationHelper {
       }
 
       if (info != null && !info.isEmpty()) {
-        mergeInfoPropertiesIntoParams(params.getParams(), info, provenance);
+        try {
+          mergeInfoPropertiesIntoParams(params.getParams(), info, provenance);
+        } catch (SFException e) {
+          throw new SnowflakeSQLException(
+              e.getQueryId(), e, e.getSqlState(), e.getVendorCode(), e.getParams());
+        }
       }
 
       logProvenance(provenance);
@@ -94,22 +101,33 @@ public final class AutoConfigurationHelper {
    * Merge user-provided Properties into the resolved connection parameters. Properties override
    * both TOML and URL values (consistent with standard JDBC semantics where Properties overwrite
    * URL query params). Uses alias-aware put to prevent duplicate property errors downstream.
+   * Non-String values (e.g. PrivateKey, HttpHeadersCustomizer) are preserved directly in the final
+   * Properties without alias resolution since they can only come from the Properties object.
    */
   private static void mergeInfoPropertiesIntoParams(
-      Properties resolved, Properties info, Map<String, String> provenance) {
+      Properties resolved, Properties info, Map<String, String> provenance) throws SFException {
     Map<String, String> resolvedMap = new HashMap<>();
     for (String key : resolved.stringPropertyNames()) {
       resolvedMap.put(key, resolved.getProperty(key));
     }
 
+    Map<String, Object> nonStringEntries = new HashMap<>();
     for (Map.Entry<Object, Object> entry : info.entrySet()) {
       String key = entry.getKey().toString();
-      String value = entry.getValue().toString();
-      SFConnectionConfigParser.putResolvingAliases(resolvedMap, key, value, provenance, "PROP");
+      Object value = entry.getValue();
+      if (value instanceof String) {
+        SFSessionProperty.putResolvingAliases(resolvedMap, key, (String) value, provenance, "PROP");
+      } else {
+        nonStringEntries.put(key, value);
+        if (provenance != null) {
+          provenance.put(key, "PROP");
+        }
+      }
     }
 
     resolved.clear();
     resolved.putAll(resolvedMap);
+    resolved.putAll(nonStringEntries);
   }
 
   private static void logProvenance(Map<String, String> provenance) {

--- a/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
+++ b/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
@@ -1,5 +1,7 @@
 package net.snowflake.client.internal.driver;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.config.ConnectionParameters;
@@ -72,9 +74,35 @@ public final class AutoConfigurationHelper {
             "Unavailable connection configuration parameters expected for "
                 + "auto configuration using file");
       }
+
+      if (info != null && !info.isEmpty()) {
+        mergeInfoPropertiesIntoParams(params.getParams(), info);
+      }
+
       return params;
     } else {
       return new ConnectionParameters(url, info);
     }
+  }
+
+  /**
+   * Merge user-provided Properties into the resolved connection parameters. Properties override
+   * both TOML and URL values (consistent with standard JDBC semantics where Properties overwrite
+   * URL query params). Uses alias-aware put to prevent duplicate property errors downstream.
+   */
+  private static void mergeInfoPropertiesIntoParams(Properties resolved, Properties info) {
+    Map<String, String> resolvedMap = new HashMap<>();
+    for (String key : resolved.stringPropertyNames()) {
+      resolvedMap.put(key, resolved.getProperty(key));
+    }
+
+    for (Map.Entry<Object, Object> entry : info.entrySet()) {
+      String key = entry.getKey().toString();
+      String value = entry.getValue().toString();
+      SFConnectionConfigParser.putResolvingAliases(resolvedMap, key, value);
+    }
+
+    resolved.clear();
+    resolved.putAll(resolvedMap);
   }
 }

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -6,9 +6,11 @@ import static net.snowflake.client.internal.config.SFConnectionConfigParser.SNOW
 import static net.snowflake.client.internal.config.SFConnectionConfigParser.SNOWFLAKE_HOME_KEY;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.isWindows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.dataformat.toml.TomlMapper;
 import java.io.File;
@@ -26,8 +28,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.driver.AutoConfigurationHelper;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -227,9 +231,9 @@ public class SFConnectionConfigParserTest {
     assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
     assertEquals("ALL", data.getParams().get("tracing"));
     assertEquals("true", data.getParams().get("disablePlatformDetection"));
-    assertEquals("user1", data.getParams().get("user"));
-    assertEquals("pass1", data.getParams().get("password"));
-    assertEquals("MY_WH", data.getParams().get("warehouse"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+    assertEquals("TOML_PASS", data.getParams().get("password"));
+    assertEquals("TOML_WH", data.getParams().get("warehouse"));
   }
 
   @Test
@@ -240,15 +244,15 @@ public class SFConnectionConfigParserTest {
     prepareTomlWithPortAndProtocol("8082", "http");
     ConnectionParameters data =
         SFConnectionConfigParser.buildConnectionParameters(
-            "jdbc:snowflake:auto?connectionName=default&port=443&protocol=https&warehouse=OTHER_WH&tracing=ALL");
+            "jdbc:snowflake:auto?connectionName=default&port=443&protocol=https&warehouse=URL_WH&tracing=ALL");
     assertNotNull(data);
     assertEquals("jdbc:snowflake://myorg-myaccount.snowflakecomputing.com:443", data.getUrl());
     assertEquals("443", data.getParams().get("port"));
     assertEquals("https", data.getParams().get("protocol"));
-    assertEquals("OTHER_WH", data.getParams().get("warehouse"));
+    assertEquals("URL_WH", data.getParams().get("warehouse"));
     assertEquals("ALL", data.getParams().get("tracing"));
-    assertEquals("user1", data.getParams().get("user"));
-    assertEquals("pass1", data.getParams().get("password"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+    assertEquals("TOML_PASS", data.getParams().get("password"));
     assertEquals("myorg-myaccount", data.getParams().get("account"));
     Set<String> expectedKeys =
         new HashSet<>(
@@ -265,9 +269,9 @@ public class SFConnectionConfigParserTest {
     prepareTomlWithPortAndProtocol(null, null);
     ConnectionParameters data =
         SFConnectionConfigParser.buildConnectionParameters(
-            "jdbc:snowflake:auto?connectionName=default&user=overridden_user");
+            "jdbc:snowflake:auto?connectionName=default&user=URL_USER");
     assertNotNull(data);
-    assertEquals("overridden_user", data.getParams().get("user"));
+    assertEquals("URL_USER", data.getParams().get("user"));
   }
 
   @Test
@@ -282,9 +286,9 @@ public class SFConnectionConfigParserTest {
     assertNotNull(data);
     assertEquals(
         "jdbc:snowflake://http://myorg-myaccount.snowflakecomputing.com:8082", data.getUrl());
-    assertEquals("user1", data.getParams().get("user"));
-    assertEquals("pass1", data.getParams().get("password"));
-    assertEquals("MY_WH", data.getParams().get("warehouse"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+    assertEquals("TOML_PASS", data.getParams().get("password"));
+    assertEquals("TOML_WH", data.getParams().get("warehouse"));
   }
 
   @Test
@@ -362,6 +366,214 @@ public class SFConnectionConfigParserTest {
         SnowflakeSQLException.class, () -> SFConnectionConfigParser.buildConnectionParameters(""));
   }
 
+  @Test
+  public void testUrlDbAliasDoesNotConflictWithTomlDatabase()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabase("TOML_DB");
+
+    ConnectionParameters data =
+        SFConnectionConfigParser.buildConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&db=URL_DB&tracing=WARNING");
+    assertNotNull(data);
+    assertEquals("URL_DB", data.getParams().get("db"));
+    assertNull(data.getParams().get("database"));
+    assertEquals("WARNING", data.getParams().get("tracing"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+  }
+
+  @Test
+  public void testUrlDbAliasOverridesTomlDatabaseWithOtherConflicts()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabaseAndExtras("TOML_DB", "TOML_WH", "TOML_ROLE");
+
+    ConnectionParameters data =
+        SFConnectionConfigParser.buildConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&db=URL_DB&warehouse=URL_WH&tracing=ALL");
+    assertNotNull(data);
+    assertEquals("URL_DB", data.getParams().get("db"));
+    assertNull(data.getParams().get("database"));
+    assertEquals("URL_WH", data.getParams().get("warehouse"));
+    assertEquals("ALL", data.getParams().get("tracing"));
+    assertEquals("TOML_ROLE", data.getParams().get("role"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+  }
+
+  @Test
+  public void testNonSFSessionPropertyFromTomlIsPreservedAfterMerge()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithCustomSessionParam("TOML_DB", "10");
+
+    ConnectionParameters data =
+        SFConnectionConfigParser.buildConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&db=URL_DB");
+    assertNotNull(data);
+    assertEquals("URL_DB", data.getParams().get("db"));
+    assertNull(data.getParams().get("database"));
+    assertEquals("10", data.getParams().get("CLIENT_RESULT_CHUNK_SIZE"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+  }
+
+  @Test
+  public void testPropertiesAndUrlNoConflict() throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, null);
+
+    Properties info = new Properties();
+    info.setProperty("schema", "PROP_SCHEMA");
+    info.setProperty("role", "PROP_ROLE");
+
+    ConnectionParameters data =
+        AutoConfigurationHelper.resolveConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&db=URL_DB&tracing=WARNING", info);
+    assertNotNull(data);
+    assertEquals("URL_DB", data.getParams().get("db"));
+    assertEquals("WARNING", data.getParams().get("tracing"));
+    assertEquals("PROP_SCHEMA", data.getParams().get("schema"));
+    assertEquals("PROP_ROLE", data.getParams().get("role"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+    assertEquals("TOML_PASS", data.getParams().get("password"));
+    assertEquals("TOML_WH", data.getParams().get("warehouse"));
+  }
+
+  @Test
+  public void testPropertiesUrlAndTomlNoConflict() throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabase("TOML_DB");
+
+    Properties info = new Properties();
+    info.setProperty("schema", "PROP_SCHEMA");
+
+    ConnectionParameters data =
+        AutoConfigurationHelper.resolveConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&tracing=WARNING", info);
+    assertNotNull(data);
+    assertEquals("TOML_DB", data.getParams().get("database"));
+    assertEquals("WARNING", data.getParams().get("tracing"));
+    assertEquals("PROP_SCHEMA", data.getParams().get("schema"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+  }
+
+  @Test
+  public void testPropertiesOverridesUrlAndTomlOnConflict()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabaseAndExtras("TOML_DB", "TOML_WH", "TOML_ROLE");
+
+    Properties info = new Properties();
+    info.setProperty("warehouse", "PROP_WH");
+    info.setProperty("schema", "PROP_SCHEMA");
+
+    ConnectionParameters data =
+        AutoConfigurationHelper.resolveConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&warehouse=URL_WH&tracing=ALL", info);
+    assertNotNull(data);
+    assertEquals("PROP_WH", data.getParams().get("warehouse"));
+    assertEquals("PROP_SCHEMA", data.getParams().get("schema"));
+    assertEquals("ALL", data.getParams().get("tracing"));
+    assertEquals("TOML_ROLE", data.getParams().get("role"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+  }
+
+  @Test
+  public void testPropertiesDbOverridesUrlDbAndTomlDatabase()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabaseAndExtras("TOML_DB", "TOML_WH", "TOML_ROLE");
+
+    Properties info = new Properties();
+    info.setProperty("db", "PROP_DB");
+    info.setProperty("schema", "PROP_SCHEMA");
+    info.setProperty("queryTimeout", "30");
+
+    ConnectionParameters data =
+        AutoConfigurationHelper.resolveConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default"
+                + "&db=URL_DB&tracing=WARNING&loginTimeout=120",
+            info);
+    assertNotNull(data);
+    // Properties win for db (alias conflict resolved: TOML's "database" removed by URL's "db",
+    // then Properties' "db" overwrites URL's "db")
+    assertEquals("PROP_DB", data.getParams().get("db"));
+    assertNull(data.getParams().get("database"));
+    // Properties' own values
+    assertEquals("PROP_SCHEMA", data.getParams().get("schema"));
+    assertEquals("30", data.getParams().get("queryTimeout"));
+    // URL values not overridden by Properties
+    assertEquals("WARNING", data.getParams().get("tracing"));
+    assertEquals("120", data.getParams().get("loginTimeout"));
+    // TOML values not overridden
+    assertEquals("TOML_WH", data.getParams().get("warehouse"));
+    assertEquals("TOML_ROLE", data.getParams().get("role"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
+    // Verify no duplicate keys that could cause "property specified more than once"
+    Set<String> keys = data.getParams().stringPropertyNames();
+    assertFalse(keys.contains("database"));
+    assertTrue(keys.contains("db"));
+  }
+
+  private void prepareTomlWithDatabase(String databaseValue) throws IOException {
+    Path path = Paths.get(tempPath.toString(), "connections.toml");
+    Path filePath = createFilePathWithPermission(path, true);
+    File file = filePath.toFile();
+
+    Map<String, Object> configurationParams = new HashMap<>();
+    configurationParams.put("account", "myorg-myaccount");
+    configurationParams.put("user", "TOML_USER");
+    configurationParams.put("password", "TOML_PASS");
+    configurationParams.put("database", databaseValue);
+
+    Map<String, Object> configuration = new HashMap<>();
+    configuration.put("default", configurationParams);
+    tomlMapper.writeValue(file, configuration);
+  }
+
+  private void prepareTomlWithDatabaseAndExtras(
+      String databaseValue, String warehouseValue, String roleValue) throws IOException {
+    Path path = Paths.get(tempPath.toString(), "connections.toml");
+    Path filePath = createFilePathWithPermission(path, true);
+    File file = filePath.toFile();
+
+    Map<String, Object> configurationParams = new HashMap<>();
+    configurationParams.put("account", "myorg-myaccount");
+    configurationParams.put("user", "TOML_USER");
+    configurationParams.put("password", "TOML_PASS");
+    configurationParams.put("database", databaseValue);
+    configurationParams.put("warehouse", warehouseValue);
+    configurationParams.put("role", roleValue);
+
+    Map<String, Object> configuration = new HashMap<>();
+    configuration.put("default", configurationParams);
+    tomlMapper.writeValue(file, configuration);
+  }
+
+  private void prepareTomlWithCustomSessionParam(String databaseValue, String clientResultChunkSize)
+      throws IOException {
+    Path path = Paths.get(tempPath.toString(), "connections.toml");
+    Path filePath = createFilePathWithPermission(path, true);
+    File file = filePath.toFile();
+
+    Map<String, Object> configurationParams = new HashMap<>();
+    configurationParams.put("account", "myorg-myaccount");
+    configurationParams.put("user", "TOML_USER");
+    configurationParams.put("password", "TOML_PASS");
+    configurationParams.put("database", databaseValue);
+    configurationParams.put("CLIENT_RESULT_CHUNK_SIZE", clientResultChunkSize);
+
+    Map<String, Object> configuration = new HashMap<>();
+    configuration.put("default", configurationParams);
+    tomlMapper.writeValue(file, configuration);
+  }
+
   private void prepareConnectionConfigurationTomlFile() throws IOException {
     prepareConnectionConfigurationTomlFile(null, true, true);
   }
@@ -428,9 +640,9 @@ public class SFConnectionConfigParserTest {
 
     Map<String, Object> configurationParams = new HashMap<>();
     configurationParams.put("account", "myorg-myaccount");
-    configurationParams.put("user", "user1");
-    configurationParams.put("password", "pass1");
-    configurationParams.put("warehouse", "MY_WH");
+    configurationParams.put("user", "TOML_USER");
+    configurationParams.put("password", "TOML_PASS");
+    configurationParams.put("warehouse", "TOML_WH");
     if (port != null) {
       configurationParams.put("port", port);
     }

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -674,7 +674,10 @@ public class SFConnectionConfigParserTest {
   private void prepareTomlWithCustomSessionParam(String databaseValue, String clientResultChunkSize)
       throws IOException {
     prepareTomlWithDatabase(
-        databaseValue, null, null, Collections.singletonMap("CLIENT_RESULT_CHUNK_SIZE", clientResultChunkSize));
+        databaseValue,
+        null,
+        null,
+        Collections.singletonMap("CLIENT_RESULT_CHUNK_SIZE", clientResultChunkSize));
   }
 
   private void prepareConnectionConfigurationTomlFile() throws IOException {

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -394,7 +394,7 @@ public class SFConnectionConfigParserTest {
       throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    prepareTomlWithDatabaseAndExtras("TOML_DB", "TOML_WH", "TOML_ROLE");
+    prepareTomlWithDatabase("TOML_DB", "TOML_WH", "TOML_ROLE");
 
     ConnectionParameters data =
         SFConnectionConfigParser.buildConnectionParameters(
@@ -477,7 +477,7 @@ public class SFConnectionConfigParserTest {
       throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    prepareTomlWithDatabaseAndExtras("TOML_DB", "TOML_WH", "TOML_ROLE");
+    prepareTomlWithDatabase("TOML_DB", "TOML_WH", "TOML_ROLE");
 
     Properties info = new Properties();
     info.setProperty("warehouse", "PROP_WH");
@@ -501,7 +501,7 @@ public class SFConnectionConfigParserTest {
       throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    prepareTomlWithDatabaseAndExtras("TOML_DB", "TOML_WH", "TOML_ROLE");
+    prepareTomlWithDatabase("TOML_DB", "TOML_WH", "TOML_ROLE");
 
     Properties info = new Properties();
     info.setProperty("db", "PROP_DB");
@@ -576,6 +576,20 @@ public class SFConnectionConfigParserTest {
                 "jdbc:snowflake:auto?connectionName=default&database=URL_DB_A&DATABASE=URL_DB_B"));
   }
 
+  // URL with alias "DB" (uppercase) and "database" (lowercase) in same source must throw
+  @Test
+  public void testUrlUppercaseAliasAndLowercasePropertyDuplicateThrows() throws IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, null);
+
+    assertThrows(
+        SnowflakeSQLException.class,
+        () ->
+            SFConnectionConfigParser.buildConnectionParameters(
+                "jdbc:snowflake:auto?connectionName=default&DB=URL_DB_A&database=URL_DB_B"));
+  }
+
   // Cross-source case-insensitive override: TOML "database" overridden by URL "DATABASE"
   @Test
   public void testCrossSourceCaseInsensitiveOverride() throws SnowflakeSQLException, IOException {
@@ -588,6 +602,7 @@ public class SFConnectionConfigParserTest {
             "jdbc:snowflake:auto?connectionName=default&DATABASE=URL_DB_A");
     assertNotNull(data);
     assertEquals("URL_DB_A", data.getParams().get("DATABASE"));
+    // TOML's "database" key must be removed when URL's "DATABASE" overrides it
     assertNull(data.getParams().get("database"));
   }
 
@@ -618,41 +633,19 @@ public class SFConnectionConfigParserTest {
   }
 
   private void prepareTomlWithDatabase(String databaseValue) throws IOException {
-    Path path = Paths.get(tempPath.toString(), "connections.toml");
-    Path filePath = createFilePathWithPermission(path, true);
-    File file = filePath.toFile();
-
-    Map<String, Object> configurationParams = new HashMap<>();
-    configurationParams.put("account", "myorg-myaccount");
-    configurationParams.put("user", "TOML_USER");
-    configurationParams.put("password", "TOML_PASS");
-    configurationParams.put("database", databaseValue);
-
-    Map<String, Object> configuration = new HashMap<>();
-    configuration.put("default", configurationParams);
-    tomlMapper.writeValue(file, configuration);
+    prepareTomlWithDatabase(databaseValue, null, null, null);
   }
 
-  private void prepareTomlWithDatabaseAndExtras(
+  private void prepareTomlWithDatabase(
       String databaseValue, String warehouseValue, String roleValue) throws IOException {
-    Path path = Paths.get(tempPath.toString(), "connections.toml");
-    Path filePath = createFilePathWithPermission(path, true);
-    File file = filePath.toFile();
-
-    Map<String, Object> configurationParams = new HashMap<>();
-    configurationParams.put("account", "myorg-myaccount");
-    configurationParams.put("user", "TOML_USER");
-    configurationParams.put("password", "TOML_PASS");
-    configurationParams.put("database", databaseValue);
-    configurationParams.put("warehouse", warehouseValue);
-    configurationParams.put("role", roleValue);
-
-    Map<String, Object> configuration = new HashMap<>();
-    configuration.put("default", configurationParams);
-    tomlMapper.writeValue(file, configuration);
+    prepareTomlWithDatabase(databaseValue, warehouseValue, roleValue, null);
   }
 
-  private void prepareTomlWithCustomSessionParam(String databaseValue, String clientResultChunkSize)
+  private void prepareTomlWithDatabase(
+      String databaseValue,
+      String warehouseValue,
+      String roleValue,
+      Map<String, String> extraParams)
       throws IOException {
     Path path = Paths.get(tempPath.toString(), "connections.toml");
     Path filePath = createFilePathWithPermission(path, true);
@@ -663,11 +656,25 @@ public class SFConnectionConfigParserTest {
     configurationParams.put("user", "TOML_USER");
     configurationParams.put("password", "TOML_PASS");
     configurationParams.put("database", databaseValue);
-    configurationParams.put("CLIENT_RESULT_CHUNK_SIZE", clientResultChunkSize);
+    if (warehouseValue != null) {
+      configurationParams.put("warehouse", warehouseValue);
+    }
+    if (roleValue != null) {
+      configurationParams.put("role", roleValue);
+    }
+    if (extraParams != null) {
+      configurationParams.putAll(extraParams);
+    }
 
     Map<String, Object> configuration = new HashMap<>();
     configuration.put("default", configurationParams);
     tomlMapper.writeValue(file, configuration);
+  }
+
+  private void prepareTomlWithCustomSessionParam(String databaseValue, String clientResultChunkSize)
+      throws IOException {
+    prepareTomlWithDatabase(
+        databaseValue, null, null, Collections.singletonMap("CLIENT_RESULT_CHUNK_SIZE", clientResultChunkSize));
   }
 
   private void prepareConnectionConfigurationTomlFile() throws IOException {

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -366,6 +366,7 @@ public class SFConnectionConfigParserTest {
         SnowflakeSQLException.class, () -> SFConnectionConfigParser.buildConnectionParameters(""));
   }
 
+  // URL "db" and TOML "database" resolve to same property; URL wins, no duplicate error
   @Test
   public void testUrlDbAliasDoesNotConflictWithTomlDatabase()
       throws SnowflakeSQLException, IOException {
@@ -383,6 +384,8 @@ public class SFConnectionConfigParserTest {
     assertEquals("TOML_USER", data.getParams().get("user"));
   }
 
+  // URL "db" + other overrides vs TOML "database" + extras; URL wins on conflicts, TOML retained
+  // otherwise
   @Test
   public void testUrlDbAliasOverridesTomlDatabaseWithOtherConflicts()
       throws SnowflakeSQLException, IOException {
@@ -402,6 +405,8 @@ public class SFConnectionConfigParserTest {
     assertEquals("TOML_USER", data.getParams().get("user"));
   }
 
+  // TOML has a non-SFSessionProperty key (CLIENT_RESULT_CHUNK_SIZE); it survives the alias-aware
+  // merge
   @Test
   public void testNonSFSessionPropertyFromTomlIsPreservedAfterMerge()
       throws SnowflakeSQLException, IOException {
@@ -419,6 +424,7 @@ public class SFConnectionConfigParserTest {
     assertEquals("TOML_USER", data.getParams().get("user"));
   }
 
+  // Properties + URL + TOML with no overlapping keys; all values correctly merged
   @Test
   public void testPropertiesAndUrlNoConflict() throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
@@ -442,6 +448,7 @@ public class SFConnectionConfigParserTest {
     assertEquals("TOML_WH", data.getParams().get("warehouse"));
   }
 
+  // Properties + URL + TOML all use distinct keys; TOML "database" preserved when no alias conflict
   @Test
   public void testPropertiesUrlAndTomlNoConflict() throws SnowflakeSQLException, IOException {
     SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
@@ -461,6 +468,7 @@ public class SFConnectionConfigParserTest {
     assertEquals("TOML_USER", data.getParams().get("user"));
   }
 
+  // Properties "warehouse" overrides both URL and TOML; non-conflicting TOML/URL values preserved
   @Test
   public void testPropertiesOverridesUrlAndTomlOnConflict()
       throws SnowflakeSQLException, IOException {
@@ -483,6 +491,8 @@ public class SFConnectionConfigParserTest {
     assertEquals("TOML_USER", data.getParams().get("user"));
   }
 
+  // Three-way alias conflict: TOML "database", URL "db", Properties "db"; Properties wins, no
+  // duplicate
   @Test
   public void testPropertiesDbOverridesUrlDbAndTomlDatabase()
       throws SnowflakeSQLException, IOException {

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,6 +22,8 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -529,6 +532,89 @@ public class SFConnectionConfigParserTest {
     Set<String> keys = data.getParams().stringPropertyNames();
     assertFalse(keys.contains("database"));
     assertTrue(keys.contains("db"));
+  }
+
+  // URL with both "db" and "database" (same-source alias duplicates) must throw
+  @Test
+  public void testUrlSameSourceAliasDuplicateThrows() throws IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, null);
+
+    assertThrows(
+        SnowflakeSQLException.class,
+        () ->
+            SFConnectionConfigParser.buildConnectionParameters(
+                "jdbc:snowflake:auto?connectionName=default&db=URL_DB_A&database=URL_DB_B"));
+  }
+
+  // URL alias duplicates still throw even when TOML also has the same property
+  @Test
+  public void testUrlSameSourceAliasDuplicateThrowsEvenWithTomlPresent() throws IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabase("TOML_DB_X");
+
+    assertThrows(
+        SnowflakeSQLException.class,
+        () ->
+            SFConnectionConfigParser.buildConnectionParameters(
+                "jdbc:snowflake:auto?connectionName=default&db=URL_DB_A&database=URL_DB_B"));
+  }
+
+  // URL with case-variant duplicates ("database" and "DATABASE") must throw
+  @Test
+  public void testUrlCaseVariantDuplicateThrows() throws IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithPortAndProtocol(null, null);
+
+    assertThrows(
+        SnowflakeSQLException.class,
+        () ->
+            SFConnectionConfigParser.buildConnectionParameters(
+                "jdbc:snowflake:auto?connectionName=default&database=URL_DB_A&DATABASE=URL_DB_B"));
+  }
+
+  // Cross-source case-insensitive override: TOML "database" overridden by URL "DATABASE"
+  @Test
+  public void testCrossSourceCaseInsensitiveOverride() throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabase("TOML_DB_X");
+
+    ConnectionParameters data =
+        SFConnectionConfigParser.buildConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&DATABASE=URL_DB_A");
+    assertNotNull(data);
+    assertEquals("URL_DB_A", data.getParams().get("DATABASE"));
+    assertNull(data.getParams().get("database"));
+  }
+
+  // Non-String PrivateKey in Properties is preserved through the three-way merge
+  @Test
+  public void testNonStringPrivateKeyPreservedInThreeWayMerge() throws Exception {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabase("TOML_DB_X");
+
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(2048);
+    PrivateKey mockKey = keyGen.generateKeyPair().getPrivate();
+
+    Properties info = new Properties();
+    info.put("privateKey", mockKey);
+    info.setProperty("db", "PROP_DB_A");
+
+    ConnectionParameters data =
+        AutoConfigurationHelper.resolveConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&tracing=WARNING", info);
+    assertNotNull(data);
+    assertSame(mockKey, data.getParams().get("privateKey"));
+    assertEquals("PROP_DB_A", data.getParams().get("db"));
+    assertNull(data.getParams().get("database"));
+    assertEquals("WARNING", data.getParams().get("tracing"));
+    assertEquals("TOML_USER", data.getParams().get("user"));
   }
 
   private void prepareTomlWithDatabase(String databaseValue) throws IOException {

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -576,20 +576,6 @@ public class SFConnectionConfigParserTest {
                 "jdbc:snowflake:auto?connectionName=default&database=URL_DB_A&DATABASE=URL_DB_B"));
   }
 
-  // URL with alias "DB" (uppercase) and "database" (lowercase) in same source must throw
-  @Test
-  public void testUrlUppercaseAliasAndLowercasePropertyDuplicateThrows() throws IOException {
-    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
-    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
-    prepareTomlWithPortAndProtocol(null, null);
-
-    assertThrows(
-        SnowflakeSQLException.class,
-        () ->
-            SFConnectionConfigParser.buildConnectionParameters(
-                "jdbc:snowflake:auto?connectionName=default&DB=URL_DB_A&database=URL_DB_B"));
-  }
-
   // Cross-source case-insensitive override: TOML "database" overridden by URL "DATABASE"
   @Test
   public void testCrossSourceCaseInsensitiveOverride() throws SnowflakeSQLException, IOException {


### PR DESCRIPTION

# Overview

PR #2591 fixed the long-standing issue where the JDBC URL-sourced configuration properties were ignored when using auto-connection (`jdbc:snowflake:auto` style URL) and `connections.toml`, but with the database config which is called `database` in the TOML and usually `db` in the JDBC URL, when both is configured, an error is thrown: `Connection property specified more than once: DB`

This PR aims to:

1. fix merge logic for JDBC URL vs connections.toml where the config properties are aliases for each other (currently only: database / db)
2. Properties-sourced config properties were never considered for building the connection config when auto-connection, fixed
3. [Supportability] since the config properties can come from three places now (TOML < JDBC URL < Properties) this can lead to not-so-trivial to troubleshoot situations when the same key is configured in multiple places; which takes precedence. Preserve their provenance and log it once per connection, which key was sourced (and, possibly, overridden) from where.
  * (TODO1) during manual testing it was discovered that none of the loglines (already existing ones, thus not related to this change) referencing the auto-config, are actually making it into the `client_config_file` governed logfile, as they are emitted sooner than the logging was initialized. This also needs to be addressed. 
  
Further bugs found during testing this change, which are not in scope for this PR: 
  * (TODO2) also pre-existing bug, even in v4.1.0 and before: no alias deduplication (`db` vs. `database`) and config merging (PROP > URL) exist in the non-auto-config path (`jdbc:snowflake:https://blabla.snowflakecomputing.com/?db=URL_DB_A` vs `jdbc:snowflake:auto`). It's a bug but a pre-existing one and needs to be fixed separately. 
  * (TODO3) also pre-existing condition in v4.1.0 and before: when duplicate used in JDBC URL, the HashMap in `SnowflakeConnectString.parse` simply overwrites the first entry without throwing 'duplicate detected' error. Examples:
    * `?warehouse=smalla&warehouse=bigb` (exact same key) --> session opened with warehouse `bigb`, second overrides the first , no 'duplicate detected'
    * `?warehouse=smalla&WAREHOUSE=BIGB` (case variant from same key) --> session opened with warehous `BIGB`, second overrides the first, no 'duplicate detected'
  
Added automated tests to cover the various situations where items are sourced from TOML and/or URL and/or Properties.

Also manually tested with live Snowflake account and a locally built jar that connection is possible with `database` defined in the TOML and `db` in the JDBC URL.

