### PR TITLE
SNOW-2900795: Make MAX_BUFFER_SIZE in SnowflakeFileTranferAgent Configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 #### For all official JDBC Release Notes please refer to https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc
 
 # Changelog
+
 - v4.2.1-SNAPSHOT
     - Added defense-in-depth canonical-path validation in the S3, Azure, and GCS download clients to ensure resolved local download paths cannot escape the user's GET target directory via traversal segments, absolute paths, or symlink redirection (snowflakedb/snowflake-jdbc#2623).
     - Fixed path traversal via server-controlled filenames in `SnowflakeFileTransferAgent` GET destination filename derivation; backslash separators are now stripped and traversal/absolute basenames are rejected (snowflakedb/snowflake-jdbc#2622).
+<<<<<<< SNOW-3478870-dont-throw-when-adding-session-to-shutdown-heartbeatregistry
+    - Fixed IllegalStateException when creating new Snowflake connections during JVM shutdown (SIGTERM); HeartbeatRegistry now skips heartbeat registration gracefully instead of throwing (snowflakedb/snowflake-jdbc#2617).
+=======
     - Further changes regarding auto-configuration (`jdbc:snowflake:auto` style connection config) (snowflakedb/snowflake-jdbc#2625):
       - Fixed bug leading to `'Connection property specified more than once: DB'` error, when both `connections.toml` (`database`) and JDBC URL (`db`) defined database 
       - Enhancement: now parameters passed as `Properties()` are also considered when building connection. For conflicting items defined in multiple places, priority is: Properties > JDBC URL > `connections.toml`
       - Enhancement (supportability): added provenance tracking for config keys and log them once per connection on debug level
+>>>>>>> master
 
 - v4.2.0
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)

--- a/src/main/java/net/snowflake/client/api/connection/UploadStreamConfig.java
+++ b/src/main/java/net/snowflake/client/api/connection/UploadStreamConfig.java
@@ -15,6 +15,7 @@ package net.snowflake.client.api.connection;
  *   UploadStreamConfig config = UploadStreamConfig.builder()
  *       .setDestPrefix("data/2024")
  *       .setCompressData(true)
+ *       .setFileBackedBufferThreshold(1024 * 1024 * 1024) // 1 GiB
  *       .build();
  *
  *   connection.uploadStream("@my_stage", "uploaded_data.csv", dataStream, config);
@@ -26,6 +27,7 @@ package net.snowflake.client.api.connection;
 public class UploadStreamConfig {
   private final String destPrefix;
   private final boolean compressData;
+  private final int fileBackedBufferThreshold;
 
   /**
    * Private constructor. Use {@link Builder} to create instances.
@@ -35,6 +37,7 @@ public class UploadStreamConfig {
   private UploadStreamConfig(Builder builder) {
     this.destPrefix = builder.destPrefix;
     this.compressData = builder.compressData;
+    this.fileBackedBufferThreshold = builder.fileBackedBufferThreshold;
   }
 
   /**
@@ -53,6 +56,16 @@ public class UploadStreamConfig {
    */
   public boolean isCompressData() {
     return compressData;
+  }
+
+  /**
+   * Gets the threshold in bytes at which the internal buffer switches from heap memory to a temp
+   * file on disk during compression and digest computation.
+   *
+   * @return the threshold in bytes (always positive; default is 128 MiB)
+   */
+  public int getFileBackedBufferThreshold() {
+    return fileBackedBufferThreshold;
   }
 
   /**
@@ -76,12 +89,14 @@ public class UploadStreamConfig {
    * UploadStreamConfig config = UploadStreamConfig.builder()
    *     .setDestPrefix("data/2024")
    *     .setCompressData(true)
+   *     .setFileBackedBufferThreshold(1024 * 1024 * 1024) // 1 GiB
    *     .build();
    * }</pre>
    */
   public static class Builder {
     private String destPrefix;
     private boolean compressData = true;
+    private int fileBackedBufferThreshold = 1 << 27; // 128 MiB
 
     /** Private constructor. Use {@link UploadStreamConfig#builder()} instead. */
     private Builder() {}
@@ -127,6 +142,29 @@ public class UploadStreamConfig {
     }
 
     /**
+     * Sets the threshold in bytes at which the internal buffer switches from heap memory to a temp
+     * file on disk during compression and digest computation.
+     *
+     * <p>Below this threshold, stream data is held entirely in JVM heap memory. Above it, the data
+     * spills to a temporary file on local disk, which reduces heap pressure at the cost of disk
+     * I/O.
+     *
+     * <p>The default is 128 MiB ({@code 1 << 27}). Lower values reduce heap usage at the cost of
+     * disk I/O; higher values keep more data in memory and avoid temp file creation.
+     *
+     * @param fileBackedBufferThreshold the threshold in bytes; must be positive
+     * @return this builder instance
+     * @throws IllegalArgumentException if the value is not positive
+     */
+    public Builder setFileBackedBufferThreshold(int fileBackedBufferThreshold) {
+      if (fileBackedBufferThreshold <= 0) {
+        throw new IllegalArgumentException("fileBackedBufferThreshold must be positive");
+      }
+      this.fileBackedBufferThreshold = fileBackedBufferThreshold;
+      return this;
+    }
+
+    /**
      * Builds the {@link UploadStreamConfig} instance.
      *
      * @return a new {@link UploadStreamConfig} instance
@@ -144,6 +182,8 @@ public class UploadStreamConfig {
         + '\''
         + ", compressData="
         + compressData
+        + ", fileBackedBufferThreshold="
+        + fileBackedBufferThreshold
         + '}';
   }
 }

--- a/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -891,7 +891,12 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
       throw new IllegalArgumentException("UploadStreamConfig cannot be null");
     }
     uploadStreamInternal(
-        stageName, config.getDestPrefix(), inputStream, destFileName, config.isCompressData());
+        stageName,
+        config.getDestPrefix(),
+        inputStream,
+        destFileName,
+        config.isCompressData(),
+        config.getFileBackedBufferThreshold());
   }
 
   /**
@@ -912,7 +917,7 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
   public void compressAndUploadStream(
       String stageName, String destPrefix, InputStream inputStream, String destFileName)
       throws SQLException {
-    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, true);
+    uploadStreamInternal(stageName, destPrefix, inputStream, destFileName, true, null);
   }
 
   /**
@@ -930,6 +935,9 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
    * @param inputStream input stream from which the data will be uploaded
    * @param destFileName destination file name to use
    * @param compressData whether compression is requested fore uploading data
+   * @param fileBackedBufferThreshold threshold (in bytes) at which the internal buffer used for
+   *     compression and digest computation switches from heap memory to a temp file on disk; pass
+   *     {@code null} to use the driver default
    * @throws SQLException raises if any error occurs
    */
   private void uploadStreamInternal(
@@ -937,7 +945,8 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
       String destPrefix,
       InputStream inputStream,
       String destFileName,
-      boolean compressData)
+      boolean compressData,
+      Integer fileBackedBufferThreshold)
       throws SQLException {
     logger.debug(
         "Upload data from stream: stageName={}" + ", destPrefix={}, destFileName={}",
@@ -991,6 +1000,9 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
     transferAgent.setSourceStream(inputStream);
     transferAgent.setDestFileNameForStreamSource(destFileName);
     transferAgent.setCompressSourceFromStream(compressData);
+    if (fileBackedBufferThreshold != null) {
+      transferAgent.setFileBackedBufferThreshold(fileBackedBufferThreshold);
+    }
     transferAgent.execute();
 
     stmt.close();

--- a/src/main/java/net/snowflake/client/internal/core/HeartbeatRegistry.java
+++ b/src/main/java/net/snowflake/client/internal/core/HeartbeatRegistry.java
@@ -135,7 +135,10 @@ public class HeartbeatRegistry {
           "Heartbeat frequency must be positive: " + heartbeatFrequencyInSecs);
     }
     if (isShutdown) {
-      throw new IllegalStateException("Cannot add session to shutdown HeartbeatRegistry");
+      logger.info(
+          "HeartbeatRegistry is shut down (JVM exiting); skipping heartbeat registration for session."
+              + " Session will function normally but won't be refreshed.");
+      return;
     }
 
     // Calculate required interval: min of requested frequency and 1/4 of token validity
@@ -154,7 +157,10 @@ public class HeartbeatRegistry {
     // Synchronize thread creation to prevent race conditions with limit check
     synchronized (this) {
       if (isShutdown) {
-        throw new IllegalStateException("Cannot add session to shutdown HeartbeatRegistry");
+        logger.info(
+            "HeartbeatRegistry is shut down (JVM exiting); skipping heartbeat registration for session."
+                + " Session will function normally but won't be refreshed.");
+        return;
       }
       // Check thread count limit
       if (threads.size() >= MAX_HEARTBEAT_THREADS && !threads.containsKey(requiredInterval)) {

--- a/src/main/java/net/snowflake/client/internal/jdbc/SFBaseFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SFBaseFileTransferAgent.java
@@ -164,6 +164,8 @@ public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
   protected boolean showEncryptionParameter;
   protected List<Object> statusRows = new ArrayList<>();
   protected CommandType commandType = CommandType.UPLOAD;
+  protected int fileBackedBufferThreshold =
+      SnowflakeFileTransferAgent.DEFAULT_FILE_BACKED_BUFFER_THRESHOLD;
   private int currentRowIndex;
 
   /**
@@ -254,6 +256,20 @@ public abstract class SFBaseFileTransferAgent implements SnowflakeFixedView {
    */
   public void setCompressSourceFromStream(boolean compressSourceFromStream) {
     this.compressSourceFromStream = compressSourceFromStream;
+  }
+
+  /**
+   * Sets the threshold in bytes at which the internal buffer switches from heap memory to a temp
+   * file on disk during compression and digest computation.
+   *
+   * @param fileBackedBufferThreshold the threshold in bytes; must be positive
+   * @throws IllegalArgumentException if the value is not positive
+   */
+  public void setFileBackedBufferThreshold(int fileBackedBufferThreshold) {
+    if (fileBackedBufferThreshold <= 0) {
+      throw new IllegalArgumentException("fileBackedBufferThreshold must be positive");
+    }
+    this.fileBackedBufferThreshold = fileBackedBufferThreshold;
   }
 
   /**

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
@@ -89,9 +89,9 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
   private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
 
-  // We will allow buffering of upto 128M data before spilling to disk during
-  // compression and digest computation
-  static final int MAX_BUFFER_SIZE = 1 << 27;
+  // Default threshold (128 MiB) for FileBackedOutputStream: data is held in heap memory below this
+  // size and spills to a temp file on disk once exceeded.
+  static final int DEFAULT_FILE_BACKED_BUFFER_THRESHOLD = 1 << 27;
   public static final String SRC_FILE_NAME_FOR_STREAM = "stream";
 
   private static final String FILE_PROTOCOL = "file://";
@@ -328,13 +328,17 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    * Compress an input stream with GZIP and return the result size, digest and compressed stream.
    *
    * @param inputStream data input
-   * @param session the session
+   * @param session the session (may be {@code null})
+   * @param queryId last executed query id (for forwarding in possible exceptions)
+   * @param fileBackedBufferThreshold bytes held in heap before the backing {@link
+   *     FileBackedOutputStream} spills to a temp file on disk; must be positive
    * @return result size, digest and compressed stream
    * @throws SnowflakeSQLException if encountered exception when compressing
    */
   private static InputStreamWithMetadata compressStreamWithGZIP(
-      InputStream inputStream, SFBaseSession session, String queryId) throws SnowflakeSQLException {
-    FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+      InputStream inputStream, SFBaseSession session, String queryId, int fileBackedBufferThreshold)
+      throws SnowflakeSQLException {
+    FileBackedOutputStream tempStream = new FileBackedOutputStream(fileBackedBufferThreshold, true);
 
     try {
 
@@ -386,15 +390,21 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    * Compress an input stream with GZIP and return the result size, digest and compressed stream.
    *
    * @param inputStream The input stream to compress
+   * @param session the session (may be {@code null})
+   * @param queryId last executed query id (for forwarding in possible exceptions)
+   * @param fileBackedBufferThreshold bytes held in heap before the backing {@link
+   *     FileBackedOutputStream} spills to a temp file on disk; must be positive
    * @return the compressed stream
    * @throws SnowflakeSQLException Will be thrown if there is a problem with compression
    * @deprecated Can be removed when all accounts are encrypted
    */
   @Deprecated
   private static InputStreamWithMetadata compressStreamWithGZIPNoDigest(
-      InputStream inputStream, SFBaseSession session, String queryId) throws SnowflakeSQLException {
+      InputStream inputStream, SFBaseSession session, String queryId, int fileBackedBufferThreshold)
+      throws SnowflakeSQLException {
     try {
-      FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+      FileBackedOutputStream tempStream =
+          new FileBackedOutputStream(fileBackedBufferThreshold, true);
 
       CountingOutputStream countingStream = new CountingOutputStream(tempStream);
 
@@ -431,11 +441,13 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     }
   }
 
-  private static InputStreamWithMetadata computeDigest(InputStream is, boolean resetStream)
+  private static InputStreamWithMetadata computeDigest(
+      InputStream is, boolean resetStream, int fileBackedBufferThreshold)
       throws NoSuchAlgorithmException, IOException {
     MessageDigest md = MessageDigest.getInstance("SHA-256");
     if (resetStream) {
-      FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+      FileBackedOutputStream tempStream =
+          new FileBackedOutputStream(fileBackedBufferThreshold, true);
 
       CountingOutputStream countingOutputStream = new CountingOutputStream(tempStream);
 
@@ -541,6 +553,36 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
       final File srcFile,
       final RemoteStoreFileEncryptionMaterial encMat,
       final String queryId) {
+    return getUploadFileCallable(
+        stage,
+        srcFilePath,
+        metadata,
+        client,
+        session,
+        command,
+        inputStream,
+        sourceFromStream,
+        parallel,
+        srcFile,
+        encMat,
+        queryId,
+        DEFAULT_FILE_BACKED_BUFFER_THRESHOLD);
+  }
+
+  private static Callable<Void> getUploadFileCallable(
+      final StageInfo stage,
+      final String srcFilePath,
+      final FileMetadata metadata,
+      final SnowflakeStorageClient client,
+      final SFSession session,
+      final String command,
+      final InputStream inputStream,
+      final boolean sourceFromStream,
+      final int parallel,
+      final File srcFile,
+      final RemoteStoreFileEncryptionMaterial encMat,
+      final String queryId,
+      final int fileBackedBufferThreshold) {
     return new Callable<Void>() {
       public Void call() throws Exception {
 
@@ -600,8 +642,10 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           if (metadata.requireCompress) {
             InputStreamWithMetadata compressedSizeAndStream =
                 (encMat == null
-                    ? compressStreamWithGZIPNoDigest(uploadStream, session, queryId)
-                    : compressStreamWithGZIP(uploadStream, session, queryId));
+                    ? compressStreamWithGZIPNoDigest(
+                        uploadStream, session, queryId, fileBackedBufferThreshold)
+                    : compressStreamWithGZIP(
+                        uploadStream, session, queryId, fileBackedBufferThreshold));
 
             fileBackedOutputStream = compressedSizeAndStream.fileBackedOutputStream;
 
@@ -618,7 +662,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
             // If it's not local_fs, we store our digest in the metadata
             // In local_fs, we don't need digest, and if we turn it on, we will consume whole
             // uploadStream, which local_fs uses.
-            InputStreamWithMetadata result = computeDigest(uploadStream, sourceFromStream);
+            InputStreamWithMetadata result =
+                computeDigest(uploadStream, sourceFromStream, fileBackedBufferThreshold);
             digest = result.digest;
             fileBackedOutputStream = result.fileBackedOutputStream;
             uploadSize = result.size;
@@ -1691,7 +1736,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
                     parallel,
                     null,
                     encMat,
-                    queryID));
+                    queryID,
+                    fileBackedBufferThreshold));
       } else if (commandType == CommandType.DOWNLOAD) {
         throw new SnowflakeSQLLoggedException(
             queryID, session, ErrorCode.INTERNAL_ERROR.getMessageCode(), SqlState.INTERNAL_ERROR);
@@ -2313,6 +2359,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
     Properties proxyProperties = config.getProxyProperties();
     String streamingIngestClientName = config.getStreamingIngestClientName();
     String streamingIngestClientKey = config.getStreamingIngestClientKey();
+    int fileBackedBufferThreshold = config.getFileBackedBufferThreshold();
 
     // Create HttpClient key
     HttpClientSettingsKey key =
@@ -2343,8 +2390,13 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
       if (requireCompress) {
         InputStreamWithMetadata compressedSizeAndStream =
             (encMat == null
-                ? compressStreamWithGZIPNoDigest(uploadStream, /* session= */ null, null)
-                : compressStreamWithGZIP(uploadStream, /* session= */ null, encMat.getQueryId()));
+                ? compressStreamWithGZIPNoDigest(
+                    uploadStream, /* session= */ null, null, fileBackedBufferThreshold)
+                : compressStreamWithGZIP(
+                    uploadStream,
+                    /* session= */ null,
+                    encMat.getQueryId(),
+                    fileBackedBufferThreshold));
 
         fileBackedOutputStream = compressedSizeAndStream.fileBackedOutputStream;
 
@@ -2361,7 +2413,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
         // If it's not local_fs, we store our digest in the metadata
         // In local_fs, we don't need digest, and if we turn it on,
         // we will consume whole uploadStream, which local_fs uses.
-        InputStreamWithMetadata result = computeDigest(uploadStream, true);
+        InputStreamWithMetadata result =
+            computeDigest(uploadStream, true, fileBackedBufferThreshold);
         digest = result.digest;
         fileBackedOutputStream = result.fileBackedOutputStream;
         uploadSize = result.size;
@@ -2779,13 +2832,16 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           if (fileMetadataMap.get(mappedSrcFile).requireCompress) {
             logger.debug("Compressing stream for digest check");
 
-            InputStreamWithMetadata res = compressStreamWithGZIP(localFileStream, session, queryID);
+            InputStreamWithMetadata res =
+                compressStreamWithGZIP(
+                    localFileStream, session, queryID, fileBackedBufferThreshold);
             fileBackedOutputStreams.add(res.fileBackedOutputStream);
 
             localFileStream = res.fileBackedOutputStream.asByteSource().openStream();
           }
 
-          InputStreamWithMetadata res = computeDigest(localFileStream, false);
+          InputStreamWithMetadata res =
+              computeDigest(localFileStream, false, fileBackedBufferThreshold);
           localFileHashText = res.digest;
           fileBackedOutputStreams.add(res.fileBackedOutputStream);
         } catch (IOException | NoSuchAlgorithmException ex) {
@@ -2815,7 +2871,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           // calculate digest for stage file
           stageFileStream = new FileInputStream(stageFilePath);
 
-          InputStreamWithMetadata res = computeDigest(stageFileStream, false);
+          InputStreamWithMetadata res =
+              computeDigest(stageFileStream, false, fileBackedBufferThreshold);
           stageFileHashText = res.digest;
           fileBackedOutputStream = res.fileBackedOutputStream;
 
@@ -2963,7 +3020,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           if (fileMetadataMap.get(mappedSrcFile).requireCompress) {
             logger.debug("Compressing stream for digest check");
 
-            InputStreamWithMetadata res = compressStreamWithGZIP(fileStream, session, queryID);
+            InputStreamWithMetadata res =
+                compressStreamWithGZIP(fileStream, session, queryID, fileBackedBufferThreshold);
 
             fileStream = res.fileBackedOutputStream.asByteSource().openStream();
             fileBackedOutputStreams.add(res.fileBackedOutputStream);
@@ -2977,7 +3035,8 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
           // Otherwise (remote file is encrypted, but has no sfc-digest),
           // no comparison is performed
           if (objDigest != null) {
-            InputStreamWithMetadata res = computeDigest(fileStream, false);
+            InputStreamWithMetadata res =
+                computeDigest(fileStream, false, fileBackedBufferThreshold);
             hashText = res.digest;
             fileBackedOutputStreams.add(res.fileBackedOutputStream);
 

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferConfig.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferConfig.java
@@ -23,6 +23,7 @@ public class SnowflakeFileTransferConfig {
   private String streamingIngestClientName;
   private String streamingIngestClientKey;
   private boolean silentException;
+  private int fileBackedBufferThreshold;
 
   public SnowflakeFileTransferConfig(Builder builder) {
     this.metadata = builder.metadata;
@@ -39,6 +40,7 @@ public class SnowflakeFileTransferConfig {
     this.streamingIngestClientKey = builder.streamingIngestClientKey;
     this.streamingIngestClientName = builder.streamingIngestClientName;
     this.silentException = builder.silentException;
+    this.fileBackedBufferThreshold = builder.fileBackedBufferThreshold;
   }
 
   public SnowflakeFileTransferMetadata getSnowflakeFileTransferMetadata() {
@@ -97,6 +99,16 @@ public class SnowflakeFileTransferConfig {
     return silentException;
   }
 
+  /**
+   * Gets the threshold in bytes at which the internal buffer switches from heap memory to a temp
+   * file on disk during compression and digest computation.
+   *
+   * @return the threshold in bytes (always positive)
+   */
+  public int getFileBackedBufferThreshold() {
+    return fileBackedBufferThreshold;
+  }
+
   // Builder class
   public static class Builder {
     private SnowflakeFileTransferMetadata metadata = null;
@@ -113,6 +125,8 @@ public class SnowflakeFileTransferConfig {
     private String streamingIngestClientName;
     private String streamingIngestClientKey;
     private boolean silentException = false;
+    private int fileBackedBufferThreshold =
+        SnowflakeFileTransferAgent.DEFAULT_FILE_BACKED_BUFFER_THRESHOLD;
 
     public static Builder newInstance() {
       return new Builder();
@@ -224,6 +238,28 @@ public class SnowflakeFileTransferConfig {
      */
     public Builder setSilentException(boolean silentException) {
       this.silentException = silentException;
+      return this;
+    }
+
+    /**
+     * Sets the threshold in bytes at which the internal buffer switches from heap memory to a temp
+     * file on disk during compression and digest computation.
+     *
+     * <p>Below this threshold, stream data is held entirely in JVM heap memory. Above it, the data
+     * spills to a temporary file on local disk, which reduces heap pressure at the cost of disk
+     * I/O.
+     *
+     * <p>The default is 128 MiB ({@code 1 << 27}).
+     *
+     * @param fileBackedBufferThreshold the threshold in bytes; must be positive
+     * @return this builder
+     * @throws IllegalArgumentException if the value is not positive
+     */
+    public Builder setFileBackedBufferThreshold(int fileBackedBufferThreshold) {
+      if (fileBackedBufferThreshold <= 0) {
+        throw new IllegalArgumentException("fileBackedBufferThreshold must be positive");
+      }
+      this.fileBackedBufferThreshold = fileBackedBufferThreshold;
       return this;
     }
   }

--- a/src/test/java/net/snowflake/client/api/connection/UploadStreamConfigTest.java
+++ b/src/test/java/net/snowflake/client/api/connection/UploadStreamConfigTest.java
@@ -1,0 +1,53 @@
+package net.snowflake.client.api.connection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class UploadStreamConfigTest {
+
+  @Test
+  public void defaultConfigHas128MiBBufferThreshold() {
+    UploadStreamConfig config = UploadStreamConfig.builder().build();
+    assertEquals(1 << 27, config.getFileBackedBufferThreshold());
+  }
+
+  @Test
+  public void customBufferThresholdIsPreserved() {
+    int threshold = 1024 * 1024; // 1 MiB
+    UploadStreamConfig config =
+        UploadStreamConfig.builder().setFileBackedBufferThreshold(threshold).build();
+    assertEquals(threshold, config.getFileBackedBufferThreshold());
+  }
+
+  @Test
+  public void zeroBufferThresholdThrowsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> UploadStreamConfig.builder().setFileBackedBufferThreshold(0));
+  }
+
+  @Test
+  public void negativeBufferThresholdThrowsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> UploadStreamConfig.builder().setFileBackedBufferThreshold(-1));
+  }
+
+  @Test
+  public void toStringIncludesBufferThreshold() {
+    UploadStreamConfig config =
+        UploadStreamConfig.builder().setFileBackedBufferThreshold(512).build();
+    assertTrue(config.toString().contains("fileBackedBufferThreshold=512"));
+  }
+
+  @Test
+  public void builderDefaultsAreNotAffectedByBufferThreshold() {
+    UploadStreamConfig config =
+        UploadStreamConfig.builder().setFileBackedBufferThreshold(4096).build();
+    assertTrue(config.isCompressData(), "compressData should still default to true");
+    assertEquals(null, config.getDestPrefix(), "destPrefix should still default to null");
+  }
+}

--- a/src/test/java/net/snowflake/client/internal/core/HeartbeatRegistryTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/HeartbeatRegistryTest.java
@@ -247,6 +247,19 @@ public class HeartbeatRegistryTest {
   }
 
   @Test
+  public void testAddSession_AfterShutdown_SkipsHeartbeatInsteadOfThrowing() {
+    registry.addSession(mockSession1, 60, 10);
+    assertEquals(1, registry.getActiveThreadCount());
+
+    registry.shutdown();
+    assertEquals(0, registry.getActiveThreadCount());
+
+    assertDoesNotThrow(() -> registry.addSession(mockSession2, 60, 10));
+    assertEquals(0, registry.getActiveThreadCount());
+    assertEquals(0, registry.getSessionCountForInterval(10));
+  }
+
+  @Test
   public void testShutdown_CleansUpAllThreads() {
     registry.addSession(mockSession1, 60, 10);
     registry.addSession(mockSession2, 14400, 3600);

--- a/src/test/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferConfigTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferConfigTest.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.jdbc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -38,6 +39,36 @@ public class SnowflakeFileTransferConfigTest {
 
     assertObligatoryParameters(config);
     assertTrue(config.isSilentException());
+  }
+
+  @Test
+  public void defaultConfigHas128MiBBufferThreshold() {
+    SnowflakeFileTransferConfig config = createObligatoryConfigPartInBuilder().build();
+    assertEquals(
+        SnowflakeFileTransferAgent.DEFAULT_FILE_BACKED_BUFFER_THRESHOLD,
+        config.getFileBackedBufferThreshold());
+  }
+
+  @Test
+  public void customBufferThresholdIsPreserved() {
+    int threshold = 1024 * 1024; // 1 MiB
+    SnowflakeFileTransferConfig config =
+        createObligatoryConfigPartInBuilder().setFileBackedBufferThreshold(threshold).build();
+    assertEquals(threshold, config.getFileBackedBufferThreshold());
+  }
+
+  @Test
+  public void zeroBufferThresholdThrowsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createObligatoryConfigPartInBuilder().setFileBackedBufferThreshold(0));
+  }
+
+  @Test
+  public void negativeBufferThresholdThrowsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createObligatoryConfigPartInBuilder().setFileBackedBufferThreshold(-1));
   }
 
   private static SnowflakeFileTransferConfig.Builder createObligatoryConfigPartInBuilder() {


### PR DESCRIPTION
# Overview

SNOW-2900795: Github Issue #2443

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #2443


2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [x] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

This change improves memory management during data uploads by allowing users to configure the buffer threshold, enhancing performance and stability.

- Added a new property `fileBackedBufferThreshold` to `UploadStreamConfig` to control the threshold in bytes at which the internal buffer switches from heap memory to a temporary file on disk during compression and digest computation.
- Updated the builder pattern to include methods for setting and getting the buffer threshold, with validation for positive values.
- Modified `SnowflakeConnectionImpl` and `SFBaseFileTransferAgent` to utilize the new buffer threshold in upload operations.
- Introduced unit tests for `UploadStreamConfig` and `SnowflakeFileTransferConfig` to validate default and custom buffer threshold behavior, including edge cases for invalid values.
- Updated relevant documentation and comments to reflect the new functionality.
