### PR TITLE
SNOW-2277485: Preserve thread interrupt flag in Connection.isValid()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Changelog
 
 - v4.2.1-SNAPSHOT
+    - Fixed `Connection.isValid()` silently swallowing thread interruption: when the underlying heartbeat is interrupted, the connection's interrupt flag is now restored via `Thread.currentThread().interrupt()` so connection pools and Thread shutdown mechanisms can react to the interruption (snowflakedb/snowflake-jdbc#2314).
     - Added defense-in-depth canonical-path validation in the S3, Azure, and GCS download clients to ensure resolved local download paths cannot escape the user's GET target directory via traversal segments, absolute paths, or symlink redirection (snowflakedb/snowflake-jdbc#2623).
     - Fixed path traversal via server-controlled filenames in `SnowflakeFileTransferAgent` GET destination filename derivation; backslash separators are now stripped and traversal/absolute basenames are rejected (snowflakedb/snowflake-jdbc#2622).
 <<<<<<< SNOW-3478870-dont-throw-when-adding-session-to-shutdown-heartbeatregistry

--- a/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -713,6 +713,14 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
     } else {
       try {
         sfSession.callHeartBeat(timeout);
+      } catch (InterruptedException ex) {
+        // The heartbeat call was interrupted (either directly, or because the
+        // executor running it observed the interrupt). Restore the interrupt
+        // flag so callers - notably connection pools and Thread shutdown
+        // mechanisms - can still react to the interruption rather than
+        // silently losing it.
+        Thread.currentThread().interrupt();
+        return false;
       } catch (SFException | Exception ex) {
         return false;
       }

--- a/src/test/java/net/snowflake/client/internal/jdbc/SnowflakeConnectionImplIsValidTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/SnowflakeConnectionImplIsValidTest.java
@@ -1,0 +1,75 @@
+package net.snowflake.client.internal.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import net.snowflake.client.internal.core.SFBaseSession;
+import net.snowflake.client.internal.core.SFException;
+import net.snowflake.client.internal.jdbc.MockConnectionTest.MockSnowflakeConnectionImpl;
+import net.snowflake.client.internal.jdbc.MockConnectionTest.MockSnowflakeSFSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeConnectionImplIsValidTest {
+
+  @AfterEach
+  public void clearInterruptFlag() {
+    Thread.interrupted();
+  }
+
+  @Test
+  public void isValidPreservesInterruptFlagWhenHeartbeatIsInterrupted() throws SQLException {
+    try (SnowflakeConnectionImpl connection =
+        new SnowflakeConnectionImpl(new InterruptingHandler())) {
+      assertFalse(Thread.currentThread().isInterrupted());
+
+      boolean valid = connection.isValid(0);
+
+      assertFalse(valid, "isValid should return false when the heartbeat is interrupted");
+      assertTrue(
+          Thread.currentThread().isInterrupted(),
+          "isValid must restore the thread's interrupt flag after catching InterruptedException");
+    }
+  }
+
+  @Test
+  public void isValidDoesNotClearPreExistingInterruptOnSuccess() throws SQLException {
+    try (SnowflakeConnectionImpl connection =
+        new SnowflakeConnectionImpl(new MockSnowflakeConnectionImpl())) {
+      Thread.currentThread().interrupt();
+      boolean valid = connection.isValid(0);
+
+      assertTrue(valid, "isValid should return true when the heartbeat succeeds");
+      assertTrue(
+          Thread.currentThread().isInterrupted(),
+          "isValid must not clear a pre-existing interrupt flag when the heartbeat succeeds");
+    }
+  }
+
+  private static class InterruptingHandler extends MockSnowflakeConnectionImpl {
+    private final InterruptingSession session = new InterruptingSession(this);
+
+    @Override
+    public SFBaseSession getSFSession() {
+      return session;
+    }
+  }
+
+  private static class InterruptingSession extends MockSnowflakeSFSession {
+    InterruptingSession(SFConnectionHandler handler) {
+      super(handler);
+    }
+
+    @Override
+    public void callHeartBeat(int timeout) throws SFException, SQLException {
+      sneakyThrow(new InterruptedException("simulated heartbeat interruption"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> void sneakyThrow(Throwable t) throws E {
+      throw (E) t;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `SnowflakeConnectionImpl#isValid(int)` previously caught all exceptions (including `InterruptedException` propagated from `SFSession#callHeartBeat` / the heartbeat executor's `Future.get`) and silently returned `false`, leaving the thread's interrupt flag cleared.
- Added a dedicated `catch (InterruptedException ...)` branch that calls `Thread.currentThread().interrupt()` before returning `false`, so connection pools and Thread shutdown mechanisms can still observe the interruption.
- Added `SnowflakeConnectionImplIsValidTest` with two unit tests:
  - the interrupt flag is restored when the heartbeat throws `InterruptedException`,
  - a pre-existing interrupt flag is not cleared on the success path.

## Context
Fixes [#2314](https://github.com/snowflakedb/snowflake-jdbc/issues/2314). Matches options 1 and 3 of the resolutions suggested by the reporter (re-interrupt + return quickly while preserving the flag). Option 2 (throwing a new exception) was deliberately not chosen because `Connection#isValid` is contractually a yes/no probe and changing its return semantics would affect every pool (HikariCP, DBCP, c3p0) that calls it.

This is the standard fix for SonarLint rule `java:S2142` ("InterruptedException should not be ignored").

## Test plan
- New unit tests: `./mvnw -Dtest=SnowflakeConnectionImplIsValidTest test` -> 2 run, 0 failed.
- Related existing tests: `./mvnw -Dtest='MockConnectionTest,SnowflakeConnectionImplTest' test` -> 5 run, 0 failed (the new test reuses `MockSnowflakeConnectionImpl`/`MockSnowflakeSFSession` as a fixture).
- Formatting: `./mvnw com.spotify.fmt:fmt-maven-plugin:format` -> 0 reformatted.
- Style: `./mvnw clean validate -P check-style` -> 0 Checkstyle violations.