### PR TITLE
SNOW-3388174: Log 400 response bodies instead of closed-stream IOException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Changelog
 - v4.2.1-SNAPSHOT
     - Fixed `Connection.isValid()` silently swallowing thread interruption: when the underlying heartbeat is interrupted, the connection's interrupt flag is now restored via `Thread.currentThread().interrupt()` so connection pools and Thread shutdown mechanisms can react to the interruption (snowflakedb/snowflake-jdbc#2314).
-    - Fixed non-retryable HTTP 400 response bodies always being logged as `"Failed to read content due to exception: Attempted read from closed stream"`. The response entity is now buffered before `RestRequest#checkForDPoPNonceError` and `SnowflakeUtil#logResponseDetails` consume it so both readers see the body (snowflakedb/snowflake-jdbc#2584).
+    - Fixed non-retryable HTTP 400 response bodies always being logged as `"Failed to read content due to exception: Attempted read from closed stream"`. The response entity is now buffered before `RestRequest#checkForDPoPNonceError` and `SnowflakeUtil#logResponseDetails` consume it so both readers see the body (snowflakedb/snowflake-jdbc#2631).
     - Added defense-in-depth canonical-path validation in the S3, Azure, and GCS download clients to ensure resolved local download paths cannot escape the user's GET target directory via traversal segments, absolute paths, or symlink redirection (snowflakedb/snowflake-jdbc#2623).
     - Fixed path traversal via server-controlled filenames in `SnowflakeFileTransferAgent` GET destination filename derivation; backslash separators are now stripped and traversal/absolute basenames are rejected (snowflakedb/snowflake-jdbc#2622).
     - Further changes regarding auto-configuration (`jdbc:snowflake:auto` style connection config) (snowflakedb/snowflake-jdbc#2625):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Changelog
 - v4.2.1-SNAPSHOT
     - Fixed `Connection.isValid()` silently swallowing thread interruption: when the underlying heartbeat is interrupted, the connection's interrupt flag is now restored via `Thread.currentThread().interrupt()` so connection pools and Thread shutdown mechanisms can react to the interruption (snowflakedb/snowflake-jdbc#2314).
+    - Fixed non-retryable HTTP 400 response bodies always being logged as `"Failed to read content due to exception: Attempted read from closed stream"`. The response entity is now buffered before `RestRequest#checkForDPoPNonceError` and `SnowflakeUtil#logResponseDetails` consume it so both readers see the body (snowflakedb/snowflake-jdbc#2584).
     - Added defense-in-depth canonical-path validation in the S3, Azure, and GCS download clients to ensure resolved local download paths cannot escape the user's GET target directory via traversal segments, absolute paths, or symlink redirection (snowflakedb/snowflake-jdbc#2623).
     - Fixed path traversal via server-controlled filenames in `SnowflakeFileTransferAgent` GET destination filename derivation; backslash separators are now stripped and traversal/absolute basenames are rejected (snowflakedb/snowflake-jdbc#2622).
     - Further changes regarding auto-configuration (`jdbc:snowflake:auto` style connection config) (snowflakedb/snowflake-jdbc#2625):

--- a/src/main/java/net/snowflake/client/internal/jdbc/RestRequest.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/RestRequest.java
@@ -59,6 +59,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 
@@ -1444,6 +1445,16 @@ public class RestRequest {
         if (response == null || response.getStatusLine().getStatusCode() != 200) {
           logger.error(
               "Error executing request: {}", httpExecutingContext.getRequestInfoScrubbed());
+
+          // Buffer the response entity in memory so it can be consumed more than once.
+          // Both checkForDPoPNonceError(..) and SnowflakeUtil.logResponseDetails(..) read
+          // the body; without buffering, the first reader closes the underlying stream
+          // and the second silently fails (see SNOW-3388174 / GitHub issue #2584).
+          if (response != null
+              && response.getEntity() != null
+              && !response.getEntity().isRepeatable()) {
+            response.setEntity(new BufferedHttpEntity(response.getEntity()));
+          }
 
           if (response != null
               && response.getStatusLine().getStatusCode() == 400

--- a/src/test/java/net/snowflake/client/internal/jdbc/RestRequest400BodyLoggingWiremockLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/RestRequest400BodyLoggingWiremockLatestIT.java
@@ -1,0 +1,190 @@
+package net.snowflake.client.internal.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import net.snowflake.client.category.TestTags;
+import net.snowflake.client.internal.jdbc.telemetry.ExecTimeTelemetryData;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that response bodies for non-retryable HTTP 400 responses are logged through {@link
+ * SnowflakeUtil#logResponseDetails(org.apache.http.HttpResponse,
+ * net.snowflake.client.internal.log.SFLogger)} instead of being silently consumed by {@code
+ * RestRequest#checkForDPoPNonceError}.
+ *
+ * <p>See SNOW-3388174 / GitHub issue #2584.
+ */
+@Tag(TestTags.OTHERS)
+public class RestRequest400BodyLoggingWiremockLatestIT extends BaseWiremockTest {
+
+  private static final String LOGGER_NAME = "net.snowflake.client.internal.jdbc.RestRequest";
+
+  /**
+   * Distinctive marker string baked into the stubbed 400 body. The test asserts this exact string
+   * shows up in the captured log records, proving the body was actually read and logged.
+   */
+  private static final String BODY_MARKER = "snow-3388174-marker";
+
+  private static final String BAD_REQUEST_SCENARIO =
+      "{\n"
+          + "    \"mappings\": [\n"
+          + "        {\n"
+          + "            \"request\": {\n"
+          + "                \"method\": \"GET\",\n"
+          + "                \"url\": \"/some-endpoint-returning-400\"\n"
+          + "            },\n"
+          + "            \"response\": {\n"
+          + "                \"status\": 400,\n"
+          + "                \"headers\": { \"Content-Type\": \"application/json\" },\n"
+          + "                \"body\": \"{\\\"error\\\":\\\"invalid_resource\\\",\\\"error_description\\\":\\\""
+          + BODY_MARKER
+          + "\\\"}\"\n"
+          + "            }\n"
+          + "        }\n"
+          + "    ],\n"
+          + "    \"importOptions\": {\n"
+          + "        \"duplicatePolicy\": \"IGNORE\",\n"
+          + "        \"deleteAllNotInImport\": true\n"
+          + "    }\n"
+          + "}";
+
+  private CapturingLogHandler handler;
+  private Logger internalLogger;
+  private Level previousLevel;
+  private boolean previousUseParentHandlers;
+
+  @BeforeEach
+  public void attachLogCapture() {
+    internalLogger = Logger.getLogger(LOGGER_NAME);
+    previousLevel = internalLogger.getLevel();
+    previousUseParentHandlers = internalLogger.getUseParentHandlers();
+
+    internalLogger.setLevel(Level.ALL);
+    internalLogger.setUseParentHandlers(false);
+
+    handler = new CapturingLogHandler();
+    handler.setLevel(Level.ALL);
+    internalLogger.addHandler(handler);
+  }
+
+  @AfterEach
+  public void detachLogCapture() {
+    if (internalLogger != null && handler != null) {
+      internalLogger.removeHandler(handler);
+      internalLogger.setLevel(previousLevel);
+      internalLogger.setUseParentHandlers(previousUseParentHandlers);
+    }
+  }
+
+  @Test
+  public void logs400ResponseBodyInsteadOfClosedStreamError() throws Exception {
+    importMapping(BAD_REQUEST_SCENARIO);
+
+    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().disableAutomaticRetries();
+    try (CloseableHttpClient httpClient = httpClientBuilder.build()) {
+      HttpGet request =
+          new HttpGet(
+              String.format(
+                  "http://%s:%d/some-endpoint-returning-400", WIREMOCK_HOST, wiremockHttpPort));
+
+      // We don't care about the return value - we only care about what got logged while
+      // RestRequest processed the 400 response.
+      try {
+        RestRequest.executeWithRetries(
+            httpClient,
+            request,
+            0,
+            0,
+            0,
+            0,
+            0,
+            new AtomicBoolean(false),
+            false,
+            false,
+            false,
+            false,
+            false,
+            new ExecTimeTelemetryData(),
+            null,
+            null,
+            null,
+            false);
+      } catch (Exception ignored) {
+        // executeWithRetries may surface the 400 as a SnowflakeSQLException; that's fine.
+      }
+    }
+
+    List<String> messages = handler.getFormattedMessages();
+
+    assertTrue(
+        messages.stream().anyMatch(m -> m.contains(BODY_MARKER)),
+        "Expected the 400 response body to be logged (looking for marker '"
+            + BODY_MARKER
+            + "'); captured messages:\n"
+            + String.join("\n----\n", messages));
+
+    assertFalse(
+        messages.stream().anyMatch(m -> m.contains("Attempted read from closed stream")),
+        "Response body must not have been consumed before logResponseDetails(..) could "
+            + "read it. Captured messages:\n"
+            + String.join("\n----\n", messages));
+  }
+
+  /** Minimal {@link Handler} that records every {@link LogRecord} it receives. */
+  private static class CapturingLogHandler extends Handler {
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public synchronized void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+
+    synchronized List<String> getFormattedMessages() {
+      List<String> out = new ArrayList<>(records.size());
+      for (LogRecord r : records) {
+        out.add(formatMessage(r));
+      }
+      return out;
+    }
+
+    /**
+     * Best-effort substitution of SLF4J-style {@code {}} placeholders with the record's parameters,
+     * so the captured message string contains the resolved body content even though the underlying
+     * SFLogger formats lazily.
+     */
+    private static String formatMessage(LogRecord r) {
+      String msg = r.getMessage() == null ? "" : r.getMessage();
+      Object[] params = r.getParameters();
+      if (params != null) {
+        for (Object p : params) {
+          int idx = msg.indexOf("{}");
+          if (idx < 0) {
+            break;
+          }
+          msg = msg.substring(0, idx) + String.valueOf(p) + msg.substring(idx + 2);
+        }
+      }
+      return msg;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `RestRequest#handleNonRetryableHttpCode` now buffers the response entity (via `BufferedHttpEntity`) before either `checkForDPoPNonceError(..)` or `SnowflakeUtil#logResponseDetails(..)` reads it. Previously, on a 400 response `checkForDPoPNonceError` consumed the entity via `EntityUtils.toString(..)`, after which `logResponseDetails` saw a closed stream and logged the cryptic message `"Failed to read content due to exception: Attempted read from closed stream"` instead of the actual body.
- Added `RestRequest400BodyLoggingWiremockLatestIT`: a WireMock-based integration test that stubs a 400 response with a known marker in the body, drives a request through `RestRequest.executeWithRetries`, captures the `RestRequest` logger output via a `java.util.logging.Handler`, and asserts:
  - the marker substring appears in the captured log records (body was logged), and
  - the closed-stream IOException message does NOT appear (the bug regression sentinel).

## Context
Fixes [#2584](https://github.com/snowflakedb/snowflake-jdbc/issues/2584). The reporter pinpointed the exact lines in `RestRequest.handleNonRetryableHttpCode`:

> when the status code is 400 it calls `checkForDPoPNonceError` prior to logging the response details. Hence, `SnowflakeUtil.logResponseDetails` fails because the response body stream was already consumed by `checkForDPoPNonceError`.

Buffering the entity (rather than reordering the calls) is the more robust fix because both readers genuinely need to inspect the body for distinct purposes (DPoP nonce header detection vs. operator-visible diagnostics).

## Verification of the bug-and-fix
The new test was first run with the production fix temporarily reverted - it fails with exactly the symptom from the bug report:
> `Failed to read content due to exception: Attempted read from closed stream.`

With the fix re-applied, the test passes.

## Note on security / log hygiene
This PR doesn't change *what kinds* of data are logged: the driver already logs non-200, non-retryable response bodies at ERROR level for all status codes other than 400 (the 400 case was just broken). A separate concern - that `SnowflakeUtil#logResponseDetails` does not run the body or headers through `SecretDetector` before logging - is pre-existing and out of scope; it would be better tracked in its own SNOW ticket.

## Test plan
- New test: `./mvnw -Dtest=RestRequest400BodyLoggingWiremockLatestIT test` -> 1 run, 0 failed.
- Bug-regression check: temporarily reverted the buffering hunk; the same test correctly fails with `"Attempted read from closed stream"`. Re-applied the fix; test passes again.
- Related WireMock unit tests: `./mvnw -Dtest=RestRequestWiremockLatestIT test` -> 4 run, 0 failed.
- Formatting: `./mvnw com.spotify.fmt:fmt-maven-plugin:format` -> 0 reformatted.
- Style: `./mvnw clean validate -P check-style` -> 0 Checkstyle violations.