### PR TITLE
SNOW-3411804: proper logging for auto-config related messages with Easy Logging and the config key provenance added in 2625

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
       - Enhancement: now parameters passed as `Properties()` are also considered when building connection. For conflicting items defined in multiple places, priority is: Properties > JDBC URL > `connections.toml`
       - Enhancement (supportability): added provenance tracking for config keys and log them once per connection on debug level
     - Fixed IllegalStateException when creating new Snowflake connections during JVM shutdown (SIGTERM); HeartbeatRegistry now skips heartbeat registration gracefully instead of throwing (snowflakedb/snowflake-jdbc#2617).
-    - Fixed auto-config debug log messages (provenance, TOML parsing) not appearing in `client_config_file`-governed log file; messages are now replayed after logger initialization so they reach the FileHandler (snowflakedb/snowflake-jdbc#XXXX).
+    - Fixed auto-config debug log messages (provenance, TOML parsing) not appearing in `client_config_file`-governed log file; messages are now replayed after logger initialization so they reach the FileHandler (snowflakedb/snowflake-jdbc#2632).
 
 - v4.2.0
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
       - Enhancement: now parameters passed as `Properties()` are also considered when building connection. For conflicting items defined in multiple places, priority is: Properties > JDBC URL > `connections.toml`
       - Enhancement (supportability): added provenance tracking for config keys and log them once per connection on debug level
     - Fixed IllegalStateException when creating new Snowflake connections during JVM shutdown (SIGTERM); HeartbeatRegistry now skips heartbeat registration gracefully instead of throwing (snowflakedb/snowflake-jdbc#2617).
+    - Fixed auto-config debug log messages (provenance, TOML parsing) not appearing in `client_config_file`-governed log file; messages are now replayed after logger initialization so they reach the FileHandler (snowflakedb/snowflake-jdbc#XXXX).
 
 - v4.2.0
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)

--- a/src/main/java/net/snowflake/client/internal/config/ConnectionParameters.java
+++ b/src/main/java/net/snowflake/client/internal/config/ConnectionParameters.java
@@ -1,10 +1,13 @@
 package net.snowflake.client.internal.config;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 public class ConnectionParameters {
   private final String url;
   private final Properties params;
+  private final List<String> deferredLogMessages = new ArrayList<>();
 
   public ConnectionParameters(String uri, Properties params) {
     this.url = uri;
@@ -17,5 +20,13 @@ public class ConnectionParameters {
 
   public Properties getParams() {
     return params;
+  }
+
+  public void addDeferredLogMessage(String message) {
+    deferredLogMessages.add(message);
+  }
+
+  public List<String> getDeferredLogMessages() {
+    return deferredLogMessages;
   }
 }

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -51,24 +51,37 @@ public class SFConnectionConfigParser {
 
   public static ConnectionParameters buildConnectionParameters(String connectionUrl)
       throws SnowflakeSQLException {
-    return buildConnectionParameters(connectionUrl, new HashMap<>());
+    return buildConnectionParameters(connectionUrl, new HashMap<>(), null);
+  }
+
+  public static ConnectionParameters buildConnectionParameters(
+      String connectionUrl, Map<String, String> provenance) throws SnowflakeSQLException {
+    return buildConnectionParameters(connectionUrl, provenance, null);
   }
 
   /**
    * Build connection parameters from URL and TOML file, optionally tracking provenance. When
-   * provenance is non-null, each key's source ("TOML" or "URL") is recorded as it is resolved.
+   * provenance is non-null, each key's source ("TOML" or "URL") is recorded as it is resolved. When
+   * deferredMessages is non-null, debug log messages are also buffered for later replay.
    */
   public static ConnectionParameters buildConnectionParameters(
-      String connectionUrl, Map<String, String> provenance) throws SnowflakeSQLException {
+      String connectionUrl, Map<String, String> provenance, List<String> deferredMessages)
+      throws SnowflakeSQLException {
     Map<String, String> urlParameters = parseAutoConfigJdbcUrlParameters(connectionUrl);
     String defaultConnectionName = urlParameters.get("connectionName");
     if (isBlank(defaultConnectionName)) {
       defaultConnectionName =
           Optional.ofNullable(systemGetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY)).orElse(DEFAULT);
     }
-    logger.debug("Attempting to load the configuration {} from toml file.", defaultConnectionName);
+    String attemptMsg =
+        String.format(
+            "Attempting to load the configuration %s from toml file.", defaultConnectionName);
+    logger.debug(attemptMsg);
+    if (deferredMessages != null) {
+      deferredMessages.add(attemptMsg);
+    }
     Map<String, String> fileConnectionConfiguration =
-        loadDefaultConnectionConfiguration(defaultConnectionName);
+        loadDefaultConnectionConfiguration(defaultConnectionName, deferredMessages);
 
     if (fileConnectionConfiguration != null && !fileConnectionConfiguration.isEmpty()) {
       if (provenance != null) {
@@ -88,7 +101,12 @@ public class SFConnectionConfigParser {
       connectionProperties.putAll(fileConnectionConfiguration);
 
       String url = createUrl(fileConnectionConfiguration);
-      logger.debug("Url created using parameters from connection configuration file: {}", url);
+      String urlMsg =
+          String.format("Url created using parameters from connection configuration file: %s", url);
+      logger.debug(urlMsg);
+      if (deferredMessages != null) {
+        deferredMessages.add(urlMsg);
+      }
 
       if ("oauth".equals(fileConnectionConfiguration.get("authenticator"))
           && fileConnectionConfiguration.get("token") == null) {
@@ -177,7 +195,7 @@ public class SFConnectionConfigParser {
   }
 
   private static Map<String, String> loadDefaultConnectionConfiguration(
-      String defaultConnectionName) throws SnowflakeSQLException {
+      String defaultConnectionName, List<String> deferredMessages) throws SnowflakeSQLException {
     String configDirectory = systemGetEnv(SNOWFLAKE_HOME_KEY);
     if (configDirectory == null) {
       String homeDir = systemGetProperty("user.home");
@@ -190,18 +208,33 @@ public class SFConnectionConfigParser {
     Path configFilePath = Paths.get(configDirectory, "connections.toml");
 
     if (Files.exists(configFilePath)) {
-      logger.debug(
-          "Reading connection parameters from file {} using key: {}",
-          configFilePath,
-          defaultConnectionName);
+      String readMsg =
+          String.format(
+              "Reading connection parameters from file %s using key: %s",
+              configFilePath, defaultConnectionName);
+      logger.debug(readMsg);
+      if (deferredMessages != null) {
+        deferredMessages.add(readMsg);
+      }
       Map<String, Map> parametersMap = readParametersMap(configFilePath);
       Map<String, String> defaultConnectionParametersMap = parametersMap.get(defaultConnectionName);
       if (defaultConnectionParametersMap == null) {
-        logger.debug("The Connection {} not found in connections.toml.", defaultConnectionName);
+        String notFoundMsg =
+            String.format(
+                "The Connection %s not found in connections.toml.", defaultConnectionName);
+        logger.debug(notFoundMsg);
+        if (deferredMessages != null) {
+          deferredMessages.add(notFoundMsg);
+        }
         throw new SnowflakeSQLException(
             "The Connection " + defaultConnectionName + " not found in connections.toml file.");
       } else {
-        logger.debug("The Connection {} found in connections.toml.", defaultConnectionName);
+        String foundMsg =
+            String.format("The Connection %s found in connections.toml.", defaultConnectionName);
+        logger.debug(foundMsg);
+        if (deferredMessages != null) {
+          deferredMessages.add(foundMsg);
+        }
       }
       return defaultConnectionParametersMap;
     } else {

--- a/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
+++ b/src/main/java/net/snowflake/client/internal/config/SFConnectionConfigParser.java
@@ -54,11 +54,6 @@ public class SFConnectionConfigParser {
     return buildConnectionParameters(connectionUrl, new HashMap<>(), null);
   }
 
-  public static ConnectionParameters buildConnectionParameters(
-      String connectionUrl, Map<String, String> provenance) throws SnowflakeSQLException {
-    return buildConnectionParameters(connectionUrl, provenance, null);
-  }
-
   /**
    * Build connection parameters from URL and TOML file, optionally tracking provenance. When
    * provenance is non-null, each key's source ("TOML" or "URL") is recorded as it is resolved. When

--- a/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
+++ b/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
@@ -1,9 +1,12 @@
 package net.snowflake.client.internal.driver;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.StringJoiner;
+import java.util.TreeMap;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.config.ConnectionParameters;
 import net.snowflake.client.internal.config.SFConnectionConfigParser;
@@ -63,17 +66,30 @@ public final class AutoConfigurationHelper {
    * @return ConnectionParameters with resolved configuration
    * @throws SnowflakeSQLException if auto-configuration is requested but fails
    */
+  /**
+   * Internal key used to carry deferred log messages on the Properties object. The value is a
+   * List&lt;String&gt; (not a String), so it won't interfere with session property parsing.
+   * ConnectionParameters is discarded by ConnectionFactory before reaching
+   * DefaultSFConnectionHandler, so we stash the messages on Properties which does flow through.
+   */
+  public static final String DEFERRED_LOG_MESSAGES_KEY = "_snowflake.internal.deferredLogMessages";
+
   public static ConnectionParameters resolveConnectionParameters(String url, Properties info)
       throws SnowflakeSQLException {
 
     if (isAutoConfigurationUrl(url)) {
-      logger.debug(
-          "JDBC connection initializing with URL '{}'. Autoconfiguration is enabled.",
-          AUTO_CONNECTION_PREFIX);
+      List<String> deferredMessages = new ArrayList<>();
+
+      String initMsg =
+          String.format(
+              "JDBC connection initializing with URL '%s'. Autoconfiguration is enabled.",
+              AUTO_CONNECTION_PREFIX);
+      logger.debug(initMsg);
+      deferredMessages.add(initMsg);
 
       Map<String, String> provenance = new HashMap<>();
       ConnectionParameters params =
-          SFConnectionConfigParser.buildConnectionParameters(url, provenance);
+          SFConnectionConfigParser.buildConnectionParameters(url, provenance, deferredMessages);
       if (params == null) {
         throw new SnowflakeSQLException(
             "Unavailable connection configuration parameters expected for "
@@ -89,7 +105,9 @@ public final class AutoConfigurationHelper {
         }
       }
 
-      logAutoConfigProvenance(provenance);
+      logAutoConfigProvenance(provenance, deferredMessages);
+
+      params.getParams().put(DEFERRED_LOG_MESSAGES_KEY, deferredMessages);
 
       return params;
     } else {
@@ -132,15 +150,18 @@ public final class AutoConfigurationHelper {
 
   // Only covers the jdbc:snowflake:auto path. The standard jdbc:snowflake:// path merges
   // URL+Properties in SnowflakeConnectString.parse without provenance tracking.
-  private static void logAutoConfigProvenance(Map<String, String> provenance) {
-    if (!logger.isDebugEnabled()) {
-      return;
-    }
+  private static void logAutoConfigProvenance(
+      Map<String, String> provenance, List<String> deferredMessages) {
     StringJoiner sj = new StringJoiner(", ");
-    for (Map.Entry<String, String> entry : provenance.entrySet()) {
+    for (Map.Entry<String, String> entry : new TreeMap<>(provenance).entrySet()) {
       sj.add(entry.getKey() + "(" + entry.getValue() + ")");
     }
-    logger.debug("Auto-configuration resolved properties: [{}]", sj.toString());
+    String provenanceMsg =
+        String.format("Auto-configuration resolved properties: [%s]", sj.toString());
+    logger.debug(provenanceMsg);
+    if (deferredMessages != null) {
+      deferredMessages.add(provenanceMsg);
+    }
     provenance.clear();
   }
 }

--- a/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
+++ b/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
@@ -67,10 +67,10 @@ public final class AutoConfigurationHelper {
    * @throws SnowflakeSQLException if auto-configuration is requested but fails
    */
   /**
-   * Internal key used to carry deferred log messages on the Properties object. The value is a
-   * {@code List<String>} (not a String), so it won't interfere with session property parsing.
-   * ConnectionParameters is discarded by ConnectionFactory before reaching
-   * DefaultSFConnectionHandler, so we stash the messages on Properties which does flow through.
+   * Internal key used by ConnectionFactory to carry deferred log messages on the Properties object.
+   * The value is a {@code List<String>} (not a String), so it won't interfere with session property
+   * parsing. ConnectionParameters is discarded before reaching DefaultSFConnectionHandler, so
+   * ConnectionFactory transfers the messages onto Properties which does flow through.
    */
   public static final String DEFERRED_LOG_MESSAGES_KEY = "_snowflake.internal.deferredLogMessages";
 
@@ -107,7 +107,9 @@ public final class AutoConfigurationHelper {
 
       logAutoConfigProvenance(provenance, deferredMessages);
 
-      params.getParams().put(DEFERRED_LOG_MESSAGES_KEY, deferredMessages);
+      for (String msg : deferredMessages) {
+        params.addDeferredLogMessage(msg);
+      }
 
       return params;
     } else {

--- a/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
+++ b/src/main/java/net/snowflake/client/internal/driver/AutoConfigurationHelper.java
@@ -68,7 +68,7 @@ public final class AutoConfigurationHelper {
    */
   /**
    * Internal key used to carry deferred log messages on the Properties object. The value is a
-   * List&lt;String&gt; (not a String), so it won't interfere with session property parsing.
+   * {@code List<String>} (not a String), so it won't interfere with session property parsing.
    * ConnectionParameters is discarded by ConnectionFactory before reaching
    * DefaultSFConnectionHandler, so we stash the messages on Properties which does flow through.
    */

--- a/src/main/java/net/snowflake/client/internal/driver/ConnectionFactory.java
+++ b/src/main/java/net/snowflake/client/internal/driver/ConnectionFactory.java
@@ -2,6 +2,7 @@ package net.snowflake.client.internal.driver;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Properties;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
@@ -57,6 +58,13 @@ public final class ConnectionFactory {
 
     if (!connectString.isValid()) {
       throw new SnowflakeSQLException("Connection string is invalid. Unable to parse.");
+    }
+
+    // Transfer deferred log messages from ConnectionParameters to Properties so they survive
+    // into DefaultSFConnectionHandler.initialize() for replay after initLogger().
+    List<String> deferred = params.getDeferredLogMessages();
+    if (deferred != null && !deferred.isEmpty()) {
+      params.getParams().put(AutoConfigurationHelper.DEFERRED_LOG_MESSAGES_KEY, deferred);
     }
 
     // Create and return the connection implementation

--- a/src/main/java/net/snowflake/client/internal/jdbc/DefaultSFConnectionHandler.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/DefaultSFConnectionHandler.java
@@ -38,6 +38,7 @@ import net.snowflake.client.internal.core.SFException;
 import net.snowflake.client.internal.core.SFSession;
 import net.snowflake.client.internal.core.SFSessionProperty;
 import net.snowflake.client.internal.core.SFStatement;
+import net.snowflake.client.internal.driver.AutoConfigurationHelper;
 import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.internal.jdbc.util.DriverUtil;
@@ -143,6 +144,7 @@ public class DefaultSFConnectionHandler implements SFConnectionHandler {
       initSessionProperties(conStr, appID, appVersion);
       setClientConfig();
       initLogger();
+      replayDeferredLogMessages(properties);
       initHttpHeaderCustomizers(properties);
       logger.debug("Trying to establish session, JDBC driver: {}", DriverUtil.getJdbcJarname());
       if (!skipOpen) {
@@ -227,6 +229,26 @@ public class DefaultSFConnectionHandler implements SFConnectionHandler {
         logger.debug(
             "Instantiating JDK14Logger with level: {}, output path: {}", logLevel, logPattern);
       }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void replayDeferredLogMessages(Properties properties) {
+    if (properties == null) {
+      return;
+    }
+    Object deferredObj = properties.remove(AutoConfigurationHelper.DEFERRED_LOG_MESSAGES_KEY);
+    if (!(deferredObj instanceof List)) {
+      return;
+    }
+    // Only replay under JDK14Logger: under SLF4J/external JUL, the immediate log calls already
+    // reached the correct destination, so replaying would produce duplicates.
+    if (!(logger instanceof JDK14Logger)) {
+      return;
+    }
+    List<String> deferredMessages = (List<String>) deferredObj;
+    for (String msg : deferredMessages) {
+      logger.debug(msg);
     }
   }
 

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -635,9 +635,7 @@ public class SFConnectionConfigParserTest {
             "jdbc:snowflake:auto?connectionName=default&db=URL_DB&tracing=WARNING", info);
     assertNotNull(data);
 
-    @SuppressWarnings("unchecked")
-    List<String> deferred =
-        (List<String>) data.getParams().get(AutoConfigurationHelper.DEFERRED_LOG_MESSAGES_KEY);
+    List<String> deferred = data.getDeferredLogMessages();
     assertNotNull(deferred);
     assertFalse(deferred.isEmpty());
 

--- a/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
+++ b/src/test/java/net/snowflake/client/internal/config/SFConnectionConfigParserTest.java
@@ -618,6 +618,71 @@ public class SFConnectionConfigParserTest {
     assertEquals("TOML_USER", data.getParams().get("user"));
   }
 
+  // Verifies deferred log messages are populated and provenance is sorted alphabetically
+  @Test
+  public void testDeferredLogMessagesAndSortedProvenance()
+      throws SnowflakeSQLException, IOException {
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_HOME_KEY, tempPath.toString());
+    SnowflakeUtil.systemSetEnv(SNOWFLAKE_DEFAULT_CONNECTION_NAME_KEY, "default");
+    prepareTomlWithDatabase("TOML_DB", "TOML_WH", "TOML_ROLE");
+
+    Properties info = new Properties();
+    info.setProperty("warehouse", "PROP_WH");
+    info.setProperty("schema", "PROP_SCHEMA");
+
+    ConnectionParameters data =
+        AutoConfigurationHelper.resolveConnectionParameters(
+            "jdbc:snowflake:auto?connectionName=default&db=URL_DB&tracing=WARNING", info);
+    assertNotNull(data);
+
+    @SuppressWarnings("unchecked")
+    List<String> deferred =
+        (List<String>) data.getParams().get(AutoConfigurationHelper.DEFERRED_LOG_MESSAGES_KEY);
+    assertNotNull(deferred);
+    assertFalse(deferred.isEmpty());
+
+    assertTrue(deferred.stream().anyMatch(m -> m.contains("Attempting to load the configuration")));
+    assertTrue(
+        deferred.stream().anyMatch(m -> m.contains("Reading connection parameters from file")));
+    assertTrue(deferred.stream().anyMatch(m -> m.contains("found in connections.toml")));
+    assertTrue(
+        deferred.stream()
+            .anyMatch(m -> m.contains("Url created using parameters from connection")));
+    assertTrue(deferred.stream().anyMatch(m -> m.contains("Autoconfiguration is enabled")));
+
+    String provenanceLine =
+        deferred.stream()
+            .filter(m -> m.contains("Auto-configuration resolved properties"))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(provenanceLine);
+
+    // Provenance must be sorted alphabetically by key
+    int accountIdx = provenanceLine.indexOf("account(");
+    int dbIdx = provenanceLine.indexOf("db(");
+    int passwordIdx = provenanceLine.indexOf("password(");
+    int roleIdx = provenanceLine.indexOf("role(");
+    int schemaIdx = provenanceLine.indexOf("schema(");
+    int tracingIdx = provenanceLine.indexOf("tracing(");
+    int userIdx = provenanceLine.indexOf("user(");
+    int warehouseIdx = provenanceLine.indexOf("warehouse(");
+    assertTrue(accountIdx < dbIdx);
+    assertTrue(dbIdx < passwordIdx);
+    assertTrue(passwordIdx < roleIdx);
+    assertTrue(roleIdx < schemaIdx);
+    assertTrue(schemaIdx < tracingIdx);
+    assertTrue(tracingIdx < userIdx);
+    assertTrue(userIdx < warehouseIdx);
+
+    // Verify provenance content
+    assertTrue(provenanceLine.contains("db(URL(overrode TOML))"));
+    assertTrue(provenanceLine.contains("warehouse(PROP(overrode TOML))"));
+    assertTrue(provenanceLine.contains("schema(PROP)"));
+    assertTrue(provenanceLine.contains("tracing(URL)"));
+    assertTrue(provenanceLine.contains("role(TOML)"));
+    assertTrue(provenanceLine.contains("account(TOML)"));
+  }
+
   private void prepareTomlWithDatabase(String databaseValue) throws IOException {
     prepareTomlWithDatabase(databaseValue, null, null, null);
   }

--- a/src/test/java/net/snowflake/client/internal/jdbc/DefaultSFConnectionHandlerTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/DefaultSFConnectionHandlerTest.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.jdbc;
 import static net.snowflake.client.api.http.HttpHeadersCustomizer.HTTP_HEADER_CUSTOMIZERS_PROPERTY_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Properties;
 import net.snowflake.client.api.http.HttpHeadersCustomizer;
 import net.snowflake.client.internal.core.SFSession;
+import net.snowflake.client.internal.driver.AutoConfigurationHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -113,5 +115,23 @@ class DefaultSFConnectionHandlerTest {
 
     verify(mockSession).setHttpHeadersCustomizers(listCaptor.capture());
     assertTrue(listCaptor.getValue().isEmpty());
+  }
+
+  // Verifies deferred log messages are removed from Properties after replay
+  @Test
+  void testReplayDeferredLogMessagesRemovesKeyFromProperties() throws SQLException {
+    List<String> msgs = Arrays.asList("msg1", "msg2");
+    properties.put(AutoConfigurationHelper.DEFERRED_LOG_MESSAGES_KEY, msgs);
+
+    connectionHandler.initialize(connectString, "", "", properties);
+
+    assertNull(properties.get(AutoConfigurationHelper.DEFERRED_LOG_MESSAGES_KEY));
+  }
+
+  // Verifies no error when Properties has no deferred messages
+  @Test
+  void testReplayDeferredLogMessagesNoop() throws SQLException {
+    connectionHandler.initialize(connectString, "", "", properties);
+    assertNull(properties.get(AutoConfigurationHelper.DEFERRED_LOG_MESSAGES_KEY));
   }
 }


### PR DESCRIPTION
## Summary

Auto-config debug log messages (provenance tracking, TOML parsing, URL construction) are now preserved in the `client_config_file`-governed log file. Previously, these messages fired before `initLogger()` created the JUL `FileHandler` and were silently dropped.

The fix uses a log-and-replay approach: messages are logged immediately (works for SLF4J / external JUL users) and also buffered in a list. After `initLogger()` initializes the `FileHandler`, the buffered messages are replayed into the logger -- but only under `JDK14Logger` to avoid duplicates when SLF4J or an external JUL config is in use.

Additionally, provenance entries are now sorted alphabetically for deterministic, human-readable output.

## Context

This is a follow-up to PR #2625, which fixed the "Connection property specified more than once: DB" regression and the ignored Properties object in the `jdbc:snowflake:auto` path. That PR introduced provenance tracking to log the source (TOML, URL, PROP) of each resolved connection property. However, those provenance log messages (along with other auto-config debug messages from `SFConnectionConfigParser`) were only visible on the console under SLF4J -- they never reached the `client_config_file` log file because the `FileHandler` is created later in the connection lifecycle.

## Changes

- `ConnectionParameters.java` -- Added `deferredLogMessages` list with `addDeferredLogMessage()` and `getDeferredLogMessages()` to carry buffered messages from `resolveConnectionParameters` through to `DefaultSFConnectionHandler`
- `SFConnectionConfigParser.java` -- Debug messages are appended to the deferred list (when provided) alongside the immediate `logger.debug()` calls. Removed unused 2-argument `buildConnectionParameters(String, Map)` overload
- `AutoConfigurationHelper.java` -- Populates deferred messages via `params.addDeferredLogMessage()`, sorts provenance alphabetically via `TreeMap`. Defines `DEFERRED_LOG_MESSAGES_KEY` constant (used by `ConnectionFactory` and `DefaultSFConnectionHandler`)
- `ConnectionFactory.java` -- Transfers deferred messages from `ConnectionParameters` onto the `Properties` object (under `DEFERRED_LOG_MESSAGES_KEY`) before constructing the connection, bridging the gap since `ConnectionParameters` is discarded mid-flow
- `DefaultSFConnectionHandler.java` -- Added `replayDeferredLogMessages()` after `initLogger()`, guarded by `instanceof JDK14Logger` to prevent duplicates under SLF4J
- `SFConnectionConfigParserTest.java` -- New test `testDeferredLogMessagesAndSortedProvenance`
- `DefaultSFConnectionHandlerTest.java` -- New tests `testReplayDeferredLogMessagesRemovesKeyFromProperties` and `testReplayDeferredLogMessagesNoop`

## Known limitations

- `SFClientConfigParser` messages (e.g., "Found config file path") also fire before `initLogger()` and are not captured by this deferred mechanism. Kept out of scope for now.
- Provenance tracking only covers the `jdbc:snowflake:auto` path. The standard `jdbc:snowflake://` path merges URL+Properties in `SnowflakeConnectString.parse` without provenance.

## Test Plan

### Unit tests

- `testDeferredLogMessagesAndSortedProvenance`: Sets up TOML (database, warehouse, role) + URL (db override, tracing) + Properties (warehouse override, schema). Verifies:
  - All expected debug messages are present in the deferred list
  - Provenance line is sorted alphabetically
  - Provenance content is correct (e.g., `db(URL(overrode TOML))`, `warehouse(PROP(overrode TOML))`)
- `testReplayDeferredLogMessagesRemovesKeyFromProperties`: Verifies that the internal `DEFERRED_LOG_MESSAGES_KEY` is removed from `Properties` after replay
- `testReplayDeferredLogMessagesNoop`: Confirms no error when `Properties` has no deferred messages key
- Full `SFConnectionConfigParserTest` and `DefaultSFConnectionHandlerTest` suites pass

### Manual end-to-end test (before/after)

**Setup** (tested on a real live production test Snowflake account):
- `connections.toml` with `database = "toml_db"`, `warehouse = "toml_wh"`, `role = "ACCOUNTADMIN"`
- JDBC URL: `jdbc:snowflake:auto?client_config_file=.../sf_client_config.json&db=url_db&warehouse=url_wh`
- Properties: `warehouse=prop_wh`, `AUTOCOMMIT=false`
- `sf_client_config.json` configured with `log_level: "DEBUG"` pointing to a local directory

**Before fix (baseline jar):**
- Log file starts at `initLogger:216` -- nothing before it is captured
- "Attempting to load the configuration" -- MISSING from file log
- "Auto-configuration resolved properties" -- MISSING from file log
- "Trying to establish session" -- PRESENT (fires after `initLogger`)

**After fix (rebuilt jar):**
- All messages now appear via replay:
  - `replayDeferredLogMessages - JDBC connection initializing with URL jdbc:snowflake:auto. Autoconfiguration is enabled.`
  - `replayDeferredLogMessages - Attempting to load the configuration default from toml file.`
  - `replayDeferredLogMessages - Reading connection parameters from file .../connections.toml using key: default`
  - `replayDeferredLogMessages - The Connection default found in connections.toml.`
  - `replayDeferredLogMessages - Url created using parameters from connection configuration file: jdbc:snowflake://<account>.snowflakecomputing.com:443`
  - `replayDeferredLogMessages - Auto-configuration resolved properties: [AUTOCOMMIT(PROP), account(TOML), client_config_file(URL), db(URL(overrode TOML)), password(TOML), port(TOML), protocol(TOML), role(TOML), user(TOML), warehouse(PROP(overrode URL(overrode TOML)))]`
- Three-way merge validated: `current_database() = URL_DB` (PASS), `current_warehouse() = PROP_WH` (PASS)
- `AUTOCOMMIT: false` confirmed in session parameters from debug logs
- Provenance entries confirmed sorted alphabetically
- No console duplication observed (JDK14Logger default ConsoleHandler stays at INFO level)