### PR TITLE
SNOW-2101444: Clamp ARROW memoryLimit to prevent negative value

### DIFF
--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeResultSetSerializableV1.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeResultSetSerializableV1.java
@@ -961,7 +961,8 @@ public class SnowflakeResultSetSerializableV1
     if (queryResultFormat == QueryResultFormat.ARROW
         && Runtime.getRuntime().maxMemory() < LOW_MAX_MEMORY
         && memoryLimit * 2 + maxChunkSize > Runtime.getRuntime().maxMemory()) {
-      memoryLimit = Runtime.getRuntime().maxMemory() / 2 - maxChunkSize;
+      memoryLimit =
+          Math.max(Runtime.getRuntime().maxMemory() / 2 - maxChunkSize, maxChunkSize);
       logger.debug(
           "To avoid OOM for arrow buffer allocation, "
               + "memoryLimit {} should be less than half of the "


### PR DESCRIPTION
## Motivation
With small JVM heaps and ARROW result format, the conservative-memory branch in `SnowflakeResultSetSerializableV1#adjustMemorySettings` computes `maxMemory/2 - maxChunkSize`. When `maxChunkSize` is larger than half of `maxMemory`, the result is negative. That negative bound then propagates into `SnowflakeChunkDownloader`, whose prefetch accounting does not assume a negative limit, and the query hangs until the connection is closed. The existing debug log already surfaces the issue (e.g. `memoryLimit -60,325,888 should be less than half of the maxMemory ...`).

## Changes
- Floor the adjusted ARROW memoryLimit at `maxChunkSize` so it is always positive. The chunk downloader then bumps the limit up to whatever a single chunk actually needs, matching the path it already takes when `neededChunkMemory > memoryLimit`.

## Testing
Verified by inspection that the new expression cannot produce a negative value for any non-negative inputs, and that the downstream code path in `SnowflakeChunkDownloader#startNextDownloaders` already handles the floored value via its `neededChunkMemory > memoryLimit` adjustment. Existing chunk-download and result-set tests exercise the surrounding code path; run with `mvn -DskipTests=false test`.

---
Auto-generated from https://snowflakecomputing.atlassian.net/browse/SNOW-2101444