### PR TITLE
NO-SNOW: Fix OAuth invalid-token IT against new server error format

### DIFF
--- a/src/test/java/net/snowflake/client/authentication/AuthTestHelper.java
+++ b/src/test/java/net/snowflake/client/authentication/AuthTestHelper.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.core.SessionUtil;
+import org.hamcrest.Matcher;
 
 public class AuthTestHelper {
 
@@ -44,6 +45,10 @@ public class AuthTestHelper {
 
   public void verifyExceptionIsThrown(String message) {
     assertThat("Expected exception not thrown", this.exception.getMessage(), is(message));
+  }
+
+  public void verifyExceptionIsThrown(Matcher<String> messageMatcher) {
+    assertThat("Expected exception not thrown", this.exception.getMessage(), messageMatcher);
   }
 
   public void verifyExceptionIsNotThrown() {

--- a/src/test/java/net/snowflake/client/authentication/OauthLatestIT.java
+++ b/src/test/java/net/snowflake/client/authentication/OauthLatestIT.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.authentication;
 
 import static net.snowflake.client.authentication.AuthConnectionParameters.getOauthConnectionParameters;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -41,7 +42,7 @@ public class OauthLatestIT {
   @Test
   void shouldThrowErrorForInvalidToken() {
     authTestHelper.connectAndExecuteSimpleQuery(getOauthConnectionParameters("invalidToken"), null);
-    authTestHelper.verifyExceptionIsThrown("Invalid OAuth access token. ");
+    authTestHelper.verifyExceptionIsThrown(containsString("Invalid OAuth access token"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `OauthLatestIT.shouldThrowErrorForInvalidToken` was failing because the server now appends a request ID in brackets to the error message (e.g. `Invalid OAuth access token. [83807702746770]`), breaking the exact-match Hamcrest `is(...)` assertion in `AuthTestHelper.verifyExceptionIsThrown`.
- Add a `Matcher<String>` overload to `verifyExceptionIsThrown` so callers can pass any Hamcrest matcher (`containsString`, `startsWith`, `matchesPattern`, etc.). The existing `String` overload keeps its exact-match semantics so the other 18 auth IT call sites are untouched.
- Update only the failing test to assert with `containsString("Invalid OAuth access token")` — we don't care about the trailing request ID or any future additions to the message.
- Mirrors the equivalent change in snowflake-connector-nodejs#1407.

## Test plan
- [ ] `OauthLatestIT.shouldThrowErrorForInvalidToken` passes against the current server (with bracketed request ID).
- [ ] All other auth ITs using the `String` overload continue to assert exact-equals — no behavioral change for them (`OauthOktaClientCredentialsLatestIT`, `OauthOktaAuthorizationCodeLatestIT`, `OauthSnowflakeAuthorizationCodeLatestIT`, `OauthSnowflakeAuthorizationCodeWildcardsLatestIT`, `PATLatestIT`, `ExternalBrowserLatestIT`, `OktaAuthLatestIT`, `OauthLatestIT.shouldThrowErrorForMismatchedOauthUsername`).