### PR TITLE
SNOW-2900795: Make file transfer buffer size configurable

### DIFF
--- a/src/main/java/net/snowflake/client/internal/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSessionProperty.java
@@ -100,6 +100,8 @@ public enum SFSessionProperty {
 
   PUT_GET_MAX_RETRIES("putGetMaxRetries", false, Integer.class),
 
+  PUT_GET_MAX_BUFFER_SIZE("putGetMaxBufferSize", false, Integer.class),
+
   RETRY_TIMEOUT("retryTimeout", false, Integer.class),
   ENABLE_DIAGNOSTICS("ENABLE_DIAGNOSTICS", false, Boolean.class),
   DIAGNOSTICS_ALLOWLIST_FILE("DIAGNOSTICS_ALLOWLIST_FILE", false, String.class),

--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgent.java
@@ -57,6 +57,7 @@ import net.snowflake.client.internal.core.ObjectMapperFactory;
 import net.snowflake.client.internal.core.SFBaseSession;
 import net.snowflake.client.internal.core.SFException;
 import net.snowflake.client.internal.core.SFFixedViewResultSet;
+import net.snowflake.client.internal.core.SFSessionProperty;
 import net.snowflake.client.internal.core.SFSession;
 import net.snowflake.client.internal.core.SFStatement;
 import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
@@ -89,9 +90,29 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
 
   private static final ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
 
-  // We will allow buffering of upto 128M data before spilling to disk during
-  // compression and digest computation
+  // Default cap on bytes buffered in memory before spilling to a temp file during
+  // PUT compression. May be overridden per-session via putGetMaxBufferSize.
   static final int MAX_BUFFER_SIZE = 1 << 27;
+
+  /**
+   * Resolve the FileBackedOutputStream buffering threshold for the given session, falling back to
+   * {@link #MAX_BUFFER_SIZE} when the session is missing or the property is unset/non-positive.
+   */
+  static int resolveMaxBufferSize(SFBaseSession session) {
+    if (session == null) {
+      return MAX_BUFFER_SIZE;
+    }
+    Object value =
+        session.getConnectionPropertiesMap().get(SFSessionProperty.PUT_GET_MAX_BUFFER_SIZE);
+    if (value instanceof Integer) {
+      int configured = (Integer) value;
+      if (configured > 0) {
+        return configured;
+      }
+    }
+    return MAX_BUFFER_SIZE;
+  }
+
   public static final String SRC_FILE_NAME_FOR_STREAM = "stream";
 
   private static final String FILE_PROTOCOL = "file://";
@@ -334,7 +355,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
    */
   private static InputStreamWithMetadata compressStreamWithGZIP(
       InputStream inputStream, SFBaseSession session, String queryId) throws SnowflakeSQLException {
-    FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+    FileBackedOutputStream tempStream = new FileBackedOutputStream(resolveMaxBufferSize(session), true);
 
     try {
 
@@ -394,7 +415,7 @@ public class SnowflakeFileTransferAgent extends SFBaseFileTransferAgent {
   private static InputStreamWithMetadata compressStreamWithGZIPNoDigest(
       InputStream inputStream, SFBaseSession session, String queryId) throws SnowflakeSQLException {
     try {
-      FileBackedOutputStream tempStream = new FileBackedOutputStream(MAX_BUFFER_SIZE, true);
+      FileBackedOutputStream tempStream = new FileBackedOutputStream(resolveMaxBufferSize(session), true);
 
       CountingOutputStream countingStream = new CountingOutputStream(tempStream);
 

--- a/src/test/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgentBufferSizeTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/SnowflakeFileTransferAgentBufferSizeTest.java
@@ -1,0 +1,53 @@
+package net.snowflake.client.internal.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.client.internal.core.SFBaseSession;
+import net.snowflake.client.internal.core.SFSessionProperty;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class SnowflakeFileTransferAgentBufferSizeTest {
+
+  @Test
+  public void returnsDefaultWhenSessionIsNull() {
+    assertEquals(
+        SnowflakeFileTransferAgent.MAX_BUFFER_SIZE,
+        SnowflakeFileTransferAgent.resolveMaxBufferSize(null));
+  }
+
+  @Test
+  public void returnsDefaultWhenPropertyAbsent() {
+    SFBaseSession session = Mockito.mock(SFBaseSession.class);
+    Mockito.when(session.getConnectionPropertiesMap())
+        .thenReturn(new HashMap<SFSessionProperty, Object>());
+    assertEquals(
+        SnowflakeFileTransferAgent.MAX_BUFFER_SIZE,
+        SnowflakeFileTransferAgent.resolveMaxBufferSize(session));
+  }
+
+  @Test
+  public void returnsConfiguredValue() {
+    SFBaseSession session = Mockito.mock(SFBaseSession.class);
+    Map<SFSessionProperty, Object> props = new HashMap<>();
+    int configured = 64 * 1024 * 1024;
+    props.put(SFSessionProperty.PUT_GET_MAX_BUFFER_SIZE, configured);
+    Mockito.when(session.getConnectionPropertiesMap()).thenReturn(props);
+    assertEquals(
+        configured, SnowflakeFileTransferAgent.resolveMaxBufferSize(session));
+  }
+
+  @Test
+  public void ignoresNonPositiveValue() {
+    SFBaseSession session = Mockito.mock(SFBaseSession.class);
+    Map<SFSessionProperty, Object> props = new HashMap<>();
+    props.put(SFSessionProperty.PUT_GET_MAX_BUFFER_SIZE, 0);
+    Mockito.when(session.getConnectionPropertiesMap()).thenReturn(props);
+    assertEquals(
+        SnowflakeFileTransferAgent.MAX_BUFFER_SIZE,
+        SnowflakeFileTransferAgent.resolveMaxBufferSize(session));
+  }
+}
+


### PR DESCRIPTION
## Motivation
During PUT/uploadStream, the file transfer agent buffers compressed data in memory up to a fixed 128 MB threshold before spilling to a temp file. Workloads that run many parallel uploadStream jobs with chunks just under that threshold can exhaust the JVM heap. Exposing the threshold as a connection property lets those callers tune it down without changing the default.

## Changes
- Add `putGetMaxBufferSize` connection property (`SFSessionProperty.PUT_GET_MAX_BUFFER_SIZE`).
- Resolve the FileBackedOutputStream threshold from the session in `compressStreamWithGZIP` and `compressStreamWithGZIPNoDigest`, falling back to the existing 128 MB constant.
- Add unit tests for the new resolver.

## Testing
Added `SnowflakeFileTransferAgentBufferSizeTest` covering the null-session, missing-property, configured-value, and non-positive-value cases. Verified locally with `mvn -DskipTests=false test -Dtest=SnowflakeFileTransferAgentBufferSizeTest`.

---
Auto-generated from https://snowflakecomputing.atlassian.net/browse/SNOW-2900795