### PR TITLE
SNOW-3420102: drop stage object on prober cleanup

### DIFF
--- a/prober/Dockerfile
+++ b/prober/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     done && \
     \
     for jdbc_version in $(echo "${MATRIX_VERSION}" | jq -r '.[][]' | sort -u); do \
-      DRIVER_URL="https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/${jdbc_version}/snowflake-jdbc-${jdbc_version}.jar" && \
+      DRIVER_URL="https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/development-maven-virtual/net/snowflake/snowflake-jdbc/${jdbc_version}/snowflake-jdbc-${jdbc_version}.jar" && \
       curl -fSL -o "${DRIVERS_DIR}/snowflake-jdbc-${jdbc_version}.jar.tmp" "${DRIVER_URL}" && \
       mv "${DRIVERS_DIR}/snowflake-jdbc-${jdbc_version}.jar.tmp" "${DRIVERS_DIR}/snowflake-jdbc-${jdbc_version}.jar"; \
     done

--- a/prober/Jenkinsfile.groovy
+++ b/prober/Jenkinsfile.groovy
@@ -36,7 +36,7 @@ pipeline {
                 dir('k8sc-jenkins_scripts') {
                     git branch: 'master',
                             credentialsId: 'jenkins-snowflake-github-app-3',
-                            url: 'https://github.com/snowflakedb/k8sc-jenkins_scripts.git'
+                            url: 'https://github.com/snowflake-eng/k8sc-jenkins_scripts.git'
                 }
             }
         }

--- a/prober/src/main/java/com/snowflake/client/jdbc/prober/Prober.java
+++ b/prober/src/main/java/com/snowflake/client/jdbc/prober/Prober.java
@@ -212,7 +212,8 @@ public class Prober {
   private static void cleanupResources(Statement statement, String metricName) {
     try {
       try (ResultSet rs1 = statement.executeQuery("REMOVE @" + stageName);
-           ResultSet rs2 = statement.executeQuery("DROP TABLE IF EXISTS " + tableName)) {
+           ResultSet rs2 = statement.executeQuery("DROP TABLE IF EXISTS " + tableName);
+           ResultSet rs3 = statement.executeQuery("DROP STAGE IF EXISTS " + stageName)) {
       }
       logMetric(metricName, Status.SUCCESS);
     } catch (SQLException e) {

--- a/prober/src/main/java/com/snowflake/client/jdbc/prober/Prober.java
+++ b/prober/src/main/java/com/snowflake/client/jdbc/prober/Prober.java
@@ -1,6 +1,6 @@
 package com.snowflake.client.jdbc.prober;
 
-import net.snowflake.client.api.connection.SnowflakeConnection;
+import net.snowflake.client.jdbc.SnowflakeConnection;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
# Overview

[SNOW-3420102](https://snowflakecomputing.atlassian.net/browse/SNOW-3420102)

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.


[SNOW-3420102]: https://snowflakecomputing.atlassian.net/browse/SNOW-3420102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ