### PR TITLE
SNOW-3580924: Don't send scope parameter when scope is empty/blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.2.1-SNAPSHOT
+    - Fixed OAuth token requests sending `scope=session:role:null` when no scope is configured (or scope is empty/blank); the `scope` parameter is now omitted entirely in those cases (snowflakedb/snowflake-jdbc#2646).
     - Fixed Okta native SSO federated login sending malformed JSON to `/api/v1/authn` (HTTP 400 from Okta) when the username or password contained JSON-special characters such as double quotes or backslashes; the request body is now serialized with Jackson instead of string concatenation.
     - Added one in-band telemetry record per successful login describing which connection-identifier fields the user supplied (`account_provided`, `account_with_region`, `account_org_provided`, `region_provided`, `host_provided`). No hostname or account value is included. This is gated by the existing server-side `CLIENT_TELEMETRY_ENABLED` parameter and can additionally be disabled locally by setting `SF_TELEMETRY_DISABLE_CONNECTION_SHAPE=true`. The telemetry collection is time-boxed and will be removed in a future release.
     - Fixed `Connection.isValid()` silently swallowing thread interruption: when the underlying heartbeat is interrupted, the connection's interrupt flag is now restored via `Thread.currentThread().interrupt()` so connection pools and Thread shutdown mechanisms can react to the interruption (snowflakedb/snowflake-jdbc#2314).

--- a/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthAccessTokenForRefreshTokenProvider.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthAccessTokenForRefreshTokenProvider.java
@@ -68,8 +68,8 @@ public class OAuthAccessTokenForRefreshTokenProvider implements AccessTokenProvi
         new ClientSecretBasic(
             new ClientID(loginInput.getOauthLoginInput().getClientId()),
             new Secret(loginInput.getOauthLoginInput().getClientSecret()));
-    Scope scope =
-        new Scope(OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole()));
+    String scopeString = OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole());
+    Scope scope = scopeString != null ? new Scope(scopeString) : null;
     RefreshToken refreshToken = new RefreshToken(loginInput.getOauthRefreshToken());
     TokenRequest tokenRequest =
         new TokenRequest(

--- a/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthAuthorizationCodeAccessTokenProvider.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthAuthorizationCodeAccessTokenProvider.java
@@ -181,10 +181,11 @@ public class OAuthAuthorizationCodeAccessTokenProvider implements AccessTokenPro
       throws SFException {
     SFOauthLoginInput oauthLoginInput = loginInput.getOauthLoginInput();
     ClientID clientID = new ClientID(oauthLoginInput.getClientId());
-    String scope = OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole());
+    String scopeString = OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole());
+    Scope scope = scopeString != null ? new Scope(scopeString) : null;
     AuthorizationRequest.Builder builder =
         new AuthorizationRequest.Builder(new ResponseType(ResponseType.Value.CODE), clientID)
-            .scope(new Scope(scope))
+            .scope(scope)
             .state(state)
             .redirectionURI(redirectUri)
             .codeChallenge(pkceVerifier, CodeChallengeMethod.S256)
@@ -211,8 +212,8 @@ public class OAuthAuthorizationCodeAccessTokenProvider implements AccessTokenPro
         new ClientSecretBasic(
             new ClientID(loginInput.getOauthLoginInput().getClientId()),
             new Secret(loginInput.getOauthLoginInput().getClientSecret()));
-    Scope scope =
-        new Scope(OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole()));
+    String scopeString = OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole());
+    Scope scope = scopeString != null ? new Scope(scopeString) : null;
     TokenRequest.Builder tokenRequestBuilder =
         new TokenRequest.Builder(
                 OAuthUtil.getTokenRequestUrl(

--- a/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthClientCredentialsAccessTokenProvider.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthClientCredentialsAccessTokenProvider.java
@@ -69,8 +69,8 @@ public class OAuthClientCredentialsAccessTokenProvider implements AccessTokenPro
         new ClientSecretBasic(
             new ClientID(loginInput.getOauthLoginInput().getClientId()),
             new Secret(loginInput.getOauthLoginInput().getClientSecret()));
-    Scope scope =
-        new Scope(OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole()));
+    String scopeString = OAuthUtil.getScope(loginInput.getOauthLoginInput(), loginInput.getRole());
+    Scope scope = scopeString != null ? new Scope(scopeString) : null;
     TokenRequest tokenRequest =
         new TokenRequest(
             tokenRequestUrl, clientAuthentication, new ClientCredentialsGrant(), scope);

--- a/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthUtil.java
@@ -62,9 +62,14 @@ class OAuthUtil {
   }
 
   static String getScope(SFOauthLoginInput oauthLoginInput, String role) {
-    return (!isNullOrEmpty(oauthLoginInput.getScope()))
-        ? oauthLoginInput.getScope()
-        : DEFAULT_SESSION_ROLE_SCOPE_PREFIX + role;
+    String scope = oauthLoginInput.getScope();
+    if (scope != null) {
+      return scope.trim().isEmpty() ? null : scope;
+    }
+    if (isNullOrEmpty(role) || role.trim().isEmpty()) {
+      return null;
+    }
+    return DEFAULT_SESSION_ROLE_SCOPE_PREFIX + role;
   }
 
   static URI buildRedirectUri(SFOauthLoginInput oauthLoginInput) throws IOException {

--- a/src/test/java/net/snowflake/client/internal/core/OAuthClientCredentialsFlowLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/OAuthClientCredentialsFlowLatestIT.java
@@ -23,6 +23,8 @@ public class OAuthClientCredentialsFlowLatestIT extends BaseWiremockTest {
       SCENARIOS_BASE_DIR + "/dpop_nonce_error_flow.json";
   private static final String TOKEN_REQUEST_ERROR_SCENARIO_MAPPING =
       SCENARIOS_BASE_DIR + "/token_request_error.json";
+  private static final String SUCCESSFUL_FLOW_NO_SCOPE_SCENARIO_MAPPINGS =
+      SCENARIOS_BASE_DIR + "/successful_flow_no_scope.json";
 
   @Test
   public void successfulFlowScenario() throws SFException {
@@ -72,6 +74,18 @@ public class OAuthClientCredentialsFlowLatestIT extends BaseWiremockTest {
             .contains("JDBC driver encountered communication error. Message: HTTP status=400"));
   }
 
+  @Test
+  public void successfulFlowScenarioWithoutScope() throws SFException {
+    importMappingFromResources(SUCCESSFUL_FLOW_NO_SCOPE_SCENARIO_MAPPINGS);
+    SFLoginInput loginInput = createLoginInputStubWithEmptyScope();
+    AccessTokenProvider provider = new OAuthClientCredentialsAccessTokenProvider();
+    TokenResponseDTO tokenResponse = provider.getAccessToken(loginInput);
+    String accessToken = tokenResponse.getAccessToken();
+
+    Assertions.assertFalse(SnowflakeUtil.isNullOrEmpty(accessToken));
+    Assertions.assertEquals("access-token-no-scope", accessToken);
+  }
+
   private SFLoginInput createLoginInputStub() {
     SFLoginInput loginInputStub = new SFLoginInput();
     loginInputStub.setServerUrl(String.format("http://%s:%d/", WIREMOCK_HOST, wiremockHttpPort));
@@ -92,6 +106,23 @@ public class OAuthClientCredentialsFlowLatestIT extends BaseWiremockTest {
   private SFLoginInput createLoginInputStubWithDPoPEnabled() {
     SFLoginInput loginInputStub = createLoginInputStub();
     loginInputStub.setDPoPEnabled(true);
+    return loginInputStub;
+  }
+
+  private SFLoginInput createLoginInputStubWithEmptyScope() {
+    SFLoginInput loginInputStub = new SFLoginInput();
+    loginInputStub.setServerUrl(String.format("http://%s:%d/", WIREMOCK_HOST, wiremockHttpPort));
+    loginInputStub.setOauthLoginInput(
+        new SFOauthLoginInput(
+            "123",
+            "123",
+            null,
+            null,
+            String.format("http://%s:%d/oauth/token-request", WIREMOCK_HOST, wiremockHttpPort),
+            ""));
+    loginInputStub.setSocketTimeout(Duration.ofMinutes(5));
+    loginInputStub.setHttpClientSettingsKey(new HttpClientSettingsKey(OCSPMode.FAIL_OPEN));
+
     return loginInputStub;
   }
 }

--- a/src/test/java/net/snowflake/client/internal/core/auth/oauth/OAuthUtilTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/auth/oauth/OAuthUtilTest.java
@@ -78,6 +78,41 @@ public class OAuthUtilTest {
   }
 
   @Test
+  public void shouldReturnNullScopeWhenScopeIsEmpty() {
+    SFOauthLoginInput loginInput = createLoginInputStub(null, null, "", null);
+    String scope = OAuthUtil.getScope(loginInput, ROLE_FROM_LOGIN_INPUT);
+    Assertions.assertNull(scope);
+  }
+
+  @Test
+  public void shouldReturnNullScopeWhenScopeIsBlank() {
+    SFOauthLoginInput loginInput = createLoginInputStub(null, null, " ", null);
+    String scope = OAuthUtil.getScope(loginInput, ROLE_FROM_LOGIN_INPUT);
+    Assertions.assertNull(scope);
+  }
+
+  @Test
+  public void shouldReturnNullScopeWhenNoScopeAndRoleIsNull() {
+    SFOauthLoginInput loginInput = createLoginInputStub(null, null, null, null);
+    String scope = OAuthUtil.getScope(loginInput, null);
+    Assertions.assertNull(scope);
+  }
+
+  @Test
+  public void shouldReturnNullScopeWhenNoScopeAndRoleIsEmpty() {
+    SFOauthLoginInput loginInput = createLoginInputStub(null, null, null, null);
+    String scope = OAuthUtil.getScope(loginInput, "");
+    Assertions.assertNull(scope);
+  }
+
+  @Test
+  public void shouldReturnNullScopeWhenNoScopeAndRoleIsBlank() {
+    SFOauthLoginInput loginInput = createLoginInputStub(null, null, null, null);
+    String scope = OAuthUtil.getScope(loginInput, "  ");
+    Assertions.assertNull(scope);
+  }
+
+  @Test
   public void shouldCreateDefaultRedirectUri() throws IOException {
     SFOauthLoginInput loginInput = createLoginInputStub(null, null, null, null);
     URI redirectUri = OAuthUtil.buildRedirectUri(loginInput);

--- a/src/test/resources/wiremock/mappings/oauth/client_credentials/successful_flow_no_scope.json
+++ b/src/test/resources/wiremock/mappings/oauth/client_credentials/successful_flow_no_scope.json
@@ -1,0 +1,34 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "Successful OAuth client credentials flow without scope",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "Acquired access token",
+      "request": {
+        "urlPathPattern": "/oauth/token-request.*",
+        "method": "POST",
+        "headers": {
+          "Authorization": {
+            "contains": "Basic"
+          },
+          "Content-Type": {
+            "contains": "application/x-www-form-urlencoded; charset=UTF-8"
+          }
+        },
+        "bodyPatterns": [
+          {
+            "equalTo": "grant_type=client_credentials"
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "access_token": "access-token-no-scope",
+          "token_type": "Bearer",
+          "expires_in": 600
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Overview

When no scope is configured (or set to "" / " "), getScope() was falling through to "session:role:" + role, which produced session:role:null when role was also unset, which is invalid and reject by our token endpoint, which does not expect scope.

Now getScope() returns null in those cases, and callers pass null as the Scope to Nimbus SDK - which omits the scope parameter from the token request entirely.

Changes:
 - OAuthUtil.getScope(): return null for blank/empty scope input, and when no scope is set and role is null/empty
 - Updated all three callers to handle null scope (client credentials, refresh token, authorization code flows)
 - Added unit tests for empty/blank/null scope cases
 - Added wiremock IT verifying a successful client credentials flow without scope

Extra Info:
With Snowflake JDBC not sending a scope appears impossible. With snowflake-connector-python this works.

Issue: SNOW-3580924

## Pre-review self checklist
- [X] PR branch is updated with all the changes from `master` branch
- [X] The code is correctly formatted (run `mvn -P check-style validate`)
- [X] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [X] The pull request name is prefixed with `SNOW-XXXX: `
- [X] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #2646 


2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [X] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with 

3. Please describe how your code solves the related issue.
As written above, now empty scope is interpreted correctly as 'do not send scope' instead of the invalid: session:role:null