### PR TITLE
SNOW-3437358: Fix inverted null check in CredentialManager.updateInputWithTokenAndPublicKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - Fixed auto-config debug log messages (provenance, TOML parsing) not appearing in `client_config_file`-governed log file; messages are now replayed after logger initialization so they reach the FileHandler (snowflakedb/snowflake-jdbc#2632).
     - The AWS S3 client now reuses a per-session shared Netty `SdkEventLoopGroup`, torn down once at session close, eliminating Netty's 2 s `shutdownGracefully` quiet period previously paid on every per-PUT/GET client close (snowflakedb/snowflake-jdbc#2620).
     - Bumped netty to 4.1.135.Final which addresses several vulnerabilities  (snowflakedb/snowflake-jdbc#2655). 
+    - Fixed inverted null check in `CredentialManager.updateInputWithTokenAndPublicKey` that prevented DPoP bundled access tokens loaded from the credential cache from being applied to the login input (snowflakedb/snowflake-jdbc#2650).
 
 - v4.2.0
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)

--- a/src/main/java/net/snowflake/client/internal/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/internal/core/CredentialManager.java
@@ -210,7 +210,7 @@ public class CredentialManager {
 
   private void updateInputWithTokenAndPublicKey(String cred, SFLoginInput loginInput)
       throws SFException {
-    if (isNullOrEmpty(cred)) {
+    if (!isNullOrEmpty(cred)) {
       String[] values = cred.split("\\.");
       if (values.length != 2) {
         throw new SFException(


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
