### PR TITLE
SNOW-3423458: Escape embedded double quotes in setCatalog/setSchema identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     - The AWS S3 client now reuses a per-session shared Netty `SdkEventLoopGroup`, torn down once at session close, eliminating Netty's 2 s `shutdownGracefully` quiet period previously paid on every per-PUT/GET client close (snowflakedb/snowflake-jdbc#2620).
     - Bumped netty to 4.1.135.Final which addresses several vulnerabilities  (snowflakedb/snowflake-jdbc#2655). 
     - Fixed inverted null check in `CredentialManager.updateInputWithTokenAndPublicKey` that prevented DPoP bundled access tokens loaded from the credential cache from being applied to the login input (snowflakedb/snowflake-jdbc#2650).
+    - Fixed `Connection.setCatalog` and `Connection.setSchema` producing malformed SQL (or switching to an unintended database/schema) when the supplied name contained an embedded `"` character; the name is now escaped per the SQL-standard quoted-identifier rule before being interpolated into the `USE` statement (snowflakedb/snowflake-jdbc#2651).
 
 - v4.2.0
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)

--- a/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -482,7 +482,7 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
     logger.trace("void setCatalog(String catalog)", false);
 
     // switch db by running "use db"
-    this.executeImmediate("use database \"" + catalog + "\"");
+    this.executeImmediate("use database \"" + escapeIdentifier(catalog) + "\"");
   }
 
   @Override
@@ -811,9 +811,14 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
 
     // switch schema by running "use db.schema"
     if (databaseName == null) {
-      this.executeImmediate("use schema \"" + schema + "\"");
+      this.executeImmediate("use schema \"" + escapeIdentifier(schema) + "\"");
     } else {
-      this.executeImmediate("use schema \"" + databaseName + "\".\"" + schema + "\"");
+      this.executeImmediate(
+          "use schema \""
+              + escapeIdentifier(databaseName)
+              + "\".\""
+              + escapeIdentifier(schema)
+              + "\"");
     }
   }
 
@@ -1164,5 +1169,9 @@ public class SnowflakeConnectionImpl implements Connection, SnowflakeConnection 
 
   public void removeClosedStatement(Statement stmt) {
     openStatements.remove(stmt);
+  }
+
+  private static String escapeIdentifier(String name) {
+    return name == null ? null : name.replace("\"", "\"\"");
   }
 }


### PR DESCRIPTION
# Overview

SNOW-XXXXX

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
