### PR TITLE
SNOW-3411970: AWS WIF outbound JWT token via STS GetWebIdentityToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     - Bumped netty to 4.1.135.Final which addresses several vulnerabilities  (snowflakedb/snowflake-jdbc#2655). 
     - Fixed inverted null check in `CredentialManager.updateInputWithTokenAndPublicKey` that prevented DPoP bundled access tokens loaded from the credential cache from being applied to the login input (snowflakedb/snowflake-jdbc#2650).
     - Fixed `Connection.setCatalog` and `Connection.setSchema` producing malformed SQL (or switching to an unintended database/schema) when the supplied name contained an embedded `"` character; the name is now escaped per the SQL-standard quoted-identifier rule before being interpolated into the `USE` statement (snowflakedb/snowflake-jdbc#2651).
+    - Switched AWS Workload Identity Federation attestation from a SigV4-presigned `GetCallerIdentity` request to STS `GetWebIdentityToken`, returning a signed JWT directly. (snowflakedb/snowflake-jdbc#2653)
 
 - v4.2.0
     - Extended the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to also bypass permission verification on the `connections.toml` config file and on the credential cache file (`credential_cache_v1.json`), unblocking driver use in SPCS environments where strict 0600/0700 ownership cannot be guaranteed (snowflakedb/snowflake-jdbc#2614)

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -666,29 +666,11 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>identity-spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>http-auth-aws</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>software.amazon.awssdk.crt</groupId>
-          <artifactId>aws-crt</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>http-auth-spi</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/net/snowflake/client/internal/core/auth/wif/AwsAttestationService.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/wif/AwsAttestationService.java
@@ -14,11 +14,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
-import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
-import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -26,17 +21,14 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
+import software.amazon.awssdk.services.sts.model.GetWebIdentityTokenRequest;
+import software.amazon.awssdk.services.sts.model.GetWebIdentityTokenResponse;
 
 public class AwsAttestationService {
   public static final SFLogger logger = SFLoggerFactory.getLogger(AwsAttestationService.class);
   public static final int TIMEOUT_MS = 10_000;
+  private static final String SIGNING_ALGORITHM_ES384 = "ES384";
   private static Region region;
-
-  private final AwsV4HttpSigner aws4Signer;
-
-  public AwsAttestationService() {
-    aws4Signer = AwsV4HttpSigner.create();
-  }
 
   void initializeSignerRegion() {
     logger.debug("Getting AWS region from environment variable");
@@ -61,35 +53,6 @@ public class AwsAttestationService {
 
   Region getAWSRegion() {
     return region;
-  }
-
-  SdkHttpRequest signRequestWithSigV4(
-      SdkHttpRequest signableRequest, AwsCredentials awsCredentials) {
-    AwsCredentialsIdentity credentialsIdentity;
-    if (awsCredentials instanceof AwsSessionCredentials) {
-      AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) awsCredentials;
-
-      // Create AwsSessionCredentialsIdentity that properly includes the session token
-      credentialsIdentity =
-          AwsSessionCredentialsIdentity.create(
-              sessionCredentials.accessKeyId(),
-              sessionCredentials.secretAccessKey(),
-              sessionCredentials.sessionToken());
-    } else {
-      // For basic credentials, use AwsCredentialsIdentity
-      credentialsIdentity =
-          AwsCredentialsIdentity.create(
-              awsCredentials.accessKeyId(), awsCredentials.secretAccessKey());
-    }
-
-    SignRequest<AwsCredentialsIdentity> signRequest =
-        SignRequest.builder(credentialsIdentity)
-            .request(signableRequest)
-            .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "sts")
-            .putProperty(AwsV4HttpSigner.REGION_NAME, getAWSRegion().toString())
-            .build();
-
-    return aws4Signer.sign(signRequest).request();
   }
 
   AwsCredentials assumeRole(AwsCredentials currentCredentials, String roleArn, String externalId)
@@ -174,7 +137,31 @@ public class AwsAttestationService {
     }
   }
 
-  private StsClient createStsClient(AwsCredentials credentials, int timeoutMs) {
+  String getWebIdentityToken(AwsCredentials credentials) throws SFException {
+    try (StsClient stsClient = createStsClient(credentials, TIMEOUT_MS)) {
+      GetWebIdentityTokenRequest request =
+          GetWebIdentityTokenRequest.builder()
+              .audience(WorkloadIdentityUtil.SNOWFLAKE_AUDIENCE)
+              .signingAlgorithm(SIGNING_ALGORITHM_ES384)
+              .build();
+      GetWebIdentityTokenResponse response = stsClient.getWebIdentityToken(request);
+      String jwt = response.webIdentityToken();
+      if (jwt == null || jwt.isEmpty()) {
+        throw new SFException(
+            ErrorCode.WORKLOAD_IDENTITY_FLOW_ERROR,
+            "AWS STS GetWebIdentityToken returned an empty token");
+      }
+      return jwt;
+    } catch (Exception e) {
+      logger.debug("AWS STS GetWebIdentityToken call failed", e);
+      throw new SFException(
+          e,
+          ErrorCode.WORKLOAD_IDENTITY_FLOW_ERROR,
+          "Failed to call AWS STS GetWebIdentityToken: " + e.getMessage());
+    }
+  }
+
+  StsClient createStsClient(AwsCredentials credentials, int timeoutMs) {
     return StsClient.builder()
         .credentialsProvider(StaticCredentialsProvider.create(credentials))
         .overrideConfiguration(config -> config.apiCallTimeout(Duration.ofMillis(timeoutMs)))

--- a/src/main/java/net/snowflake/client/internal/core/auth/wif/AwsIdentityAttestationCreator.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/wif/AwsIdentityAttestationCreator.java
@@ -1,28 +1,17 @@
 package net.snowflake.client.internal.core.auth.wif;
 
-import java.io.ByteArrayInputStream;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collections;
-import net.minidev.json.JSONObject;
 import net.snowflake.client.api.exception.ErrorCode;
 import net.snowflake.client.internal.core.SFException;
 import net.snowflake.client.internal.core.SFLoginInput;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.regions.Region;
 
 public class AwsIdentityAttestationCreator implements WorkloadIdentityAttestationCreator {
 
   private static final SFLogger logger =
       SFLoggerFactory.getLogger(AwsIdentityAttestationCreator.class);
-  public static final String API_VERSION = "2011-06-15";
-  public static final String GET_CALLER_IDENTITY_ACTION = "GetCallerIdentity";
 
   private final AwsAttestationService attestationService;
   private final SFLoginInput loginInput;
@@ -50,58 +39,9 @@ public class AwsIdentityAttestationCreator implements WorkloadIdentityAttestatio
       throw new SFException(
           ErrorCode.WORKLOAD_IDENTITY_FLOW_ERROR, "No AWS credentials were found");
     }
-    Region region = attestationService.getAWSRegion();
-    if (region == null) {
-      throw new SFException(ErrorCode.WORKLOAD_IDENTITY_FLOW_ERROR, "No AWS region was found");
-    }
 
-    String stsHostname = getStsHostname(region.id());
-    SdkHttpRequest request = createStsRequest(stsHostname);
-    SdkHttpRequest signedRequest = attestationService.signRequestWithSigV4(request, awsCredentials);
-
-    String credential = createBase64EncodedRequestCredential(signedRequest);
+    String jwt = attestationService.getWebIdentityToken(awsCredentials);
     return new WorkloadIdentityAttestation(
-        WorkloadIdentityProviderType.AWS, credential, Collections.emptyMap());
-  }
-
-  private String getStsHostname(String region) {
-    String domain = region.startsWith("cn-") ? "amazonaws.com.cn" : "amazonaws.com";
-    return String.format("sts.%s.%s", region, domain);
-  }
-
-  private SdkHttpRequest createStsRequest(String hostname) {
-    String url =
-        String.format(
-            "https://%s?Action=%s&Version=%s", hostname, GET_CALLER_IDENTITY_ACTION, API_VERSION);
-
-    SdkHttpFullRequest.Builder requestBuilder =
-        SdkHttpFullRequest.builder()
-            .method(SdkHttpMethod.POST)
-            .uri(URI.create(url))
-            .putHeader("Host", hostname)
-            .putHeader(
-                WorkloadIdentityUtil.SNOWFLAKE_AUDIENCE_HEADER_NAME,
-                WorkloadIdentityUtil.SNOWFLAKE_AUDIENCE)
-            .contentStreamProvider(
-                () -> new ByteArrayInputStream(new byte[0])); // needed to properly sign the request
-
-    return requestBuilder.build();
-  }
-
-  private String createBase64EncodedRequestCredential(SdkHttpRequest request) {
-    JSONObject assertionJson = new JSONObject();
-    JSONObject headers = new JSONObject();
-
-    // AWS SDK 2 headers are Map<String, List<String>>, but backend expects Map<String, String>
-    request.headers().entrySet().stream()
-        .filter(entry -> entry.getValue() != null && !entry.getValue().isEmpty())
-        .forEach(entry -> headers.put(entry.getKey(), entry.getValue().get(0)));
-
-    assertionJson.put("url", request.getUri().toString());
-    assertionJson.put("method", request.method().toString());
-    assertionJson.put("headers", headers);
-
-    String assertionJsonString = assertionJson.toString();
-    return Base64.getEncoder().encodeToString(assertionJsonString.getBytes(StandardCharsets.UTF_8));
+        WorkloadIdentityProviderType.AWS, jwt, Collections.emptyMap());
   }
 }

--- a/src/main/java/net/snowflake/client/internal/core/auth/wif/AwsIdentityAttestationCreator.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/wif/AwsIdentityAttestationCreator.java
@@ -39,6 +39,9 @@ public class AwsIdentityAttestationCreator implements WorkloadIdentityAttestatio
       throw new SFException(
           ErrorCode.WORKLOAD_IDENTITY_FLOW_ERROR, "No AWS credentials were found");
     }
+    if (attestationService.getAWSRegion() == null) {
+      throw new SFException(ErrorCode.WORKLOAD_IDENTITY_FLOW_ERROR, "No AWS region was found");
+    }
 
     String jwt = attestationService.getWebIdentityToken(awsCredentials);
     return new WorkloadIdentityAttestation(

--- a/src/test/java/net/snowflake/client/internal/core/auth/wif/AwsAttestationServiceTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/auth/wif/AwsAttestationServiceTest.java
@@ -1,0 +1,64 @@
+package net.snowflake.client.internal.core.auth.wif;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+
+import net.snowflake.client.internal.core.SFException;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetWebIdentityTokenRequest;
+import software.amazon.awssdk.services.sts.model.GetWebIdentityTokenResponse;
+
+public class AwsAttestationServiceTest {
+
+  private static final AwsSessionCredentials CREDENTIALS =
+      AwsSessionCredentials.create("akid", "secret", "session-token");
+
+  @Test
+  public void shouldReturnJwtFromGetWebIdentityToken() throws SFException {
+    AwsAttestationService spy = Mockito.spy(new AwsAttestationService());
+    Mockito.doReturn(Region.US_EAST_1).when(spy).getAWSRegion();
+
+    StsClient stsClient = mock(StsClient.class);
+    Mockito.when(stsClient.getWebIdentityToken(any(GetWebIdentityTokenRequest.class)))
+        .thenReturn(GetWebIdentityTokenResponse.builder().webIdentityToken("jwt-value").build());
+    Mockito.doReturn(stsClient).when(spy).createStsClient(any(), anyInt());
+
+    String jwt = spy.getWebIdentityToken(CREDENTIALS);
+
+    assertEquals("jwt-value", jwt);
+
+    ArgumentCaptor<GetWebIdentityTokenRequest> requestCaptor =
+        ArgumentCaptor.forClass(GetWebIdentityTokenRequest.class);
+    Mockito.verify(stsClient).getWebIdentityToken(requestCaptor.capture());
+    GetWebIdentityTokenRequest request = requestCaptor.getValue();
+    assertTrue(request.audience().contains(WorkloadIdentityUtil.SNOWFLAKE_AUDIENCE));
+    assertEquals("ES384", request.signingAlgorithm());
+  }
+
+  @Test
+  public void shouldPreserveCauseWhenStsCallFails() {
+    AwsAttestationService spy = Mockito.spy(new AwsAttestationService());
+    Mockito.doReturn(Region.US_EAST_1).when(spy).getAWSRegion();
+
+    StsClient stsClient = mock(StsClient.class);
+    RuntimeException original = new RuntimeException("sts boom");
+    Mockito.when(stsClient.getWebIdentityToken(any(GetWebIdentityTokenRequest.class)))
+        .thenThrow(original);
+    Mockito.doReturn(stsClient).when(spy).createStsClient(any(), anyInt());
+
+    SFException thrown =
+        assertThrows(SFException.class, () -> spy.getWebIdentityToken(CREDENTIALS));
+    // SFException's local override of getCause() returns null in this codebase, so verify
+    // the original failure surfaces in the user-facing message instead.
+    assertTrue(thrown.getMessage().contains("sts boom"), thrown::getMessage);
+  }
+}

--- a/src/test/java/net/snowflake/client/internal/core/auth/wif/AwsIdentityAttestationCreatorTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/auth/wif/AwsIdentityAttestationCreatorTest.java
@@ -11,6 +11,7 @@ import net.snowflake.client.internal.core.SFLoginInput;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.regions.Region;
 
 public class AwsIdentityAttestationCreatorTest {
 
@@ -26,11 +27,24 @@ public class AwsIdentityAttestationCreatorTest {
   }
 
   @Test
+  public void shouldThrowExceptionWhenNoRegion() {
+    AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
+    Mockito.when(attestationServiceMock.getAWSCredentials())
+        .thenReturn(AwsSessionCredentials.create("abc", "abc", "aws-session-token"));
+    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(null);
+
+    AwsIdentityAttestationCreator attestationCreator =
+        new AwsIdentityAttestationCreator(attestationServiceMock, new SFLoginInput());
+    assertThrows(SFException.class, attestationCreator::createAttestation);
+  }
+
+  @Test
   public void shouldPropagateExceptionFromGetWebIdentityToken() throws SFException {
     AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
     AwsSessionCredentials credentials =
         AwsSessionCredentials.create("abc", "abc", "aws-session-token");
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(credentials);
+    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(credentials)))
         .thenThrow(
             new SFException(
@@ -47,6 +61,7 @@ public class AwsIdentityAttestationCreatorTest {
     AwsSessionCredentials credentials =
         AwsSessionCredentials.create("abc", "abc", "aws-session-token");
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(credentials);
+    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(credentials)))
         .thenReturn(FAKE_JWT);
 
@@ -68,6 +83,7 @@ public class AwsIdentityAttestationCreatorTest {
     AwsSessionCredentials credentials =
         AwsSessionCredentials.create("abc", "abc", "aws-session-token");
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(credentials);
+    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(credentials)))
         .thenReturn(FAKE_JWT);
 
@@ -108,6 +124,7 @@ public class AwsIdentityAttestationCreatorTest {
         AwsSessionCredentials.create("assumed-key", "assumed-secret", "assumed-token");
 
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
+    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
     Mockito.when(
             attestationServiceMock.assumeRole(
@@ -142,6 +159,7 @@ public class AwsIdentityAttestationCreatorTest {
         AwsSessionCredentials.create("assumed-key", "assumed-secret", "assumed-token");
 
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
+    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
     Mockito.when(
             attestationServiceMock.assumeRole(
@@ -176,6 +194,7 @@ public class AwsIdentityAttestationCreatorTest {
         AwsSessionCredentials.create("assumed-key", "assumed-secret", "assumed-token");
 
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
+    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
     Mockito.when(
             attestationServiceMock.assumeRole(
@@ -212,6 +231,7 @@ public class AwsIdentityAttestationCreatorTest {
         AwsSessionCredentials.create("final-key", "final-secret", "final-token");
 
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
+    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
     // First hop: no external ID
     Mockito.when(

--- a/src/test/java/net/snowflake/client/internal/core/auth/wif/AwsIdentityAttestationCreatorTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/auth/wif/AwsIdentityAttestationCreatorTest.java
@@ -3,44 +3,38 @@ package net.snowflake.client.internal.core.auth.wif;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.net.URI;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
 import net.snowflake.client.internal.core.SFException;
 import net.snowflake.client.internal.core.SFLoginInput;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.regions.Region;
 
 public class AwsIdentityAttestationCreatorTest {
+
+  private static final String FAKE_JWT = "fake.jwt.token-for-testing-only";
 
   @Test
   public void shouldThrowExceptionWhenNoCredentialsFound() {
     AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(null);
-    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     AwsIdentityAttestationCreator attestationCreator =
         new AwsIdentityAttestationCreator(attestationServiceMock, new SFLoginInput());
     assertThrows(SFException.class, attestationCreator::createAttestation);
   }
 
   @Test
-  public void shouldThrowExceptionWhenNoRegion() {
+  public void shouldPropagateExceptionFromGetWebIdentityToken() throws SFException {
     AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
-    Mockito.when(attestationServiceMock.getAWSCredentials())
-        .thenReturn(AwsBasicCredentials.create("abc", "abc"));
-    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(null);
+    AwsSessionCredentials credentials =
+        AwsSessionCredentials.create("abc", "abc", "aws-session-token");
+    Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(credentials);
+    Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(credentials)))
+        .thenThrow(
+            new SFException(
+                net.snowflake.client.api.exception.ErrorCode.WORKLOAD_IDENTITY_FLOW_ERROR, "boom"));
 
     AwsIdentityAttestationCreator attestationCreator =
         new AwsIdentityAttestationCreator(attestationServiceMock, new SFLoginInput());
@@ -48,81 +42,52 @@ public class AwsIdentityAttestationCreatorTest {
   }
 
   @Test
-  public void shouldReturnProperAttestationWithStandardRegion()
-      throws JsonProcessingException, SFException {
-    shouldReturnProperAttestationWithSignedRequestCredential(
-        Region.US_EAST_1, "sts.us-east-1.amazonaws.com");
-  }
-
-  @Test
-  public void shouldReturnProperAttestationWithCnRegion()
-      throws JsonProcessingException, SFException {
-    shouldReturnProperAttestationWithSignedRequestCredential(
-        Region.CN_NORTHWEST_1, "sts.cn-northwest-1.amazonaws.com.cn");
-  }
-
-  private void shouldReturnProperAttestationWithSignedRequestCredential(
-      Region region, String expectedStsUrl) throws JsonProcessingException, SFException {
-    AwsAttestationService attestationServiceSpy = Mockito.spy(AwsAttestationService.class);
-    Mockito.doReturn(AwsSessionCredentials.create("abc", "abc", "aws-session-token"))
-        .when(attestationServiceSpy)
-        .getAWSCredentials();
-    Mockito.doNothing().when(attestationServiceSpy).initializeSignerRegion();
-    Mockito.doReturn(region).when(attestationServiceSpy).getAWSRegion();
+  public void shouldReturnAttestationWithJwtCredential() throws SFException {
+    AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
+    AwsSessionCredentials credentials =
+        AwsSessionCredentials.create("abc", "abc", "aws-session-token");
+    Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(credentials);
+    Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(credentials)))
+        .thenReturn(FAKE_JWT);
 
     AwsIdentityAttestationCreator attestationCreator =
-        new AwsIdentityAttestationCreator(attestationServiceSpy, new SFLoginInput());
+        new AwsIdentityAttestationCreator(attestationServiceMock, new SFLoginInput());
     WorkloadIdentityAttestation attestation = attestationCreator.createAttestation();
 
     assertNotNull(attestation);
     assertEquals(WorkloadIdentityProviderType.AWS, attestation.getProvider());
-    assertNotNull(attestation.getCredential());
-    Base64.Decoder decoder = Base64.getDecoder();
-    String json = new String(decoder.decode(attestation.getCredential()));
-    Map<String, Object> credentialMap = new ObjectMapper().readValue(json, HashMap.class);
-    assertEquals(3, credentialMap.size());
-    assertEquals(
-        String.format("https://%s?Action=GetCallerIdentity&Version=2011-06-15", expectedStsUrl),
-        credentialMap.get("url"));
-    assertEquals("POST", credentialMap.get("method"));
-    assertNotNull(credentialMap.get("headers"));
-    Map<String, String> headersMap = (Map<String, String>) credentialMap.get("headers");
-    assertEquals(6, headersMap.size());
-    assertEquals(expectedStsUrl, headersMap.get("Host"));
-    assertEquals("snowflakecomputing.com", headersMap.get("X-Snowflake-Audience"));
-    assertNotNull(headersMap.get("X-Amz-Date"));
-    assertTrue(headersMap.get("Authorization").matches("^AWS4-HMAC-SHA256 Credential=.*"));
-    assertEquals("aws-session-token", headersMap.get("X-Amz-Security-Token"));
-    assertNotNull(headersMap.get("x-amz-content-sha256"));
+    assertEquals(FAKE_JWT, attestation.getCredential());
+    assertNotNull(attestation.getUserIdentifierComponents());
+    assertEquals(0, attestation.getUserIdentifierComponents().size());
   }
 
   @Test
   public void shouldCreateAttestationWithoutImpersonationWhenImpersonationPathIsEmpty()
       throws SFException {
-    AwsAttestationService attestationServiceSpy = Mockito.spy(AwsAttestationService.class);
-    Mockito.doReturn(AwsSessionCredentials.create("abc", "abc", "aws-session-token"))
-        .when(attestationServiceSpy)
-        .getAWSCredentials();
-    Mockito.doNothing().when(attestationServiceSpy).initializeSignerRegion();
-    Mockito.doReturn(Region.US_EAST_1).when(attestationServiceSpy).getAWSRegion();
+    AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
+    AwsSessionCredentials credentials =
+        AwsSessionCredentials.create("abc", "abc", "aws-session-token");
+    Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(credentials);
+    Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(credentials)))
+        .thenReturn(FAKE_JWT);
 
     SFLoginInput loginInput = new SFLoginInput();
     loginInput.setWorkloadIdentityImpersonationPath(""); // Empty path
 
     AwsIdentityAttestationCreator attestationCreator =
-        new AwsIdentityAttestationCreator(attestationServiceSpy, loginInput);
+        new AwsIdentityAttestationCreator(attestationServiceMock, loginInput);
     WorkloadIdentityAttestation attestation = attestationCreator.createAttestation();
 
     assertNotNull(attestation);
     assertEquals(WorkloadIdentityProviderType.AWS, attestation.getProvider());
-    assertNotNull(attestation.getCredential());
+    assertEquals(FAKE_JWT, attestation.getCredential());
+    Mockito.verify(attestationServiceMock, Mockito.never()).getCredentialsViaRoleChaining(any());
   }
 
   @Test
   public void shouldThrowExceptionWhenImpersonationFailsWithNoInitialCredentials() {
     AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(null);
-    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
 
     SFLoginInput loginInput = new SFLoginInput();
     loginInput.setWorkloadIdentityImpersonationPath("arn:aws:iam::123456789012:role/TestRole");
@@ -136,26 +101,20 @@ public class AwsIdentityAttestationCreatorTest {
   @Test
   public void shouldCreateAttestationWithImpersonationPath() throws SFException {
     AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
-    SdkHttpRequest requestMock = mock(SdkHttpRequest.class);
-    Mockito.when(requestMock.getUri()).thenReturn(URI.create("https://snowflakecomputing.com"));
-    Mockito.when(requestMock.method()).thenReturn(SdkHttpMethod.GET);
 
     AwsSessionCredentials initialCredentials =
         AwsSessionCredentials.create("initial-key", "initial-secret", "initial-token");
-    Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
-    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
-    Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
-
     AwsSessionCredentials assumedCredentials =
         AwsSessionCredentials.create("assumed-key", "assumed-secret", "assumed-token");
+
+    Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
+    Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
     Mockito.when(
             attestationServiceMock.assumeRole(
                 initialCredentials, "arn:aws:iam::123456789012:role/TestRole", null))
         .thenReturn(assumedCredentials);
-
-    Mockito.doNothing().when(attestationServiceMock).initializeSignerRegion();
-    Mockito.when(attestationServiceMock.signRequestWithSigV4(any(), Mockito.eq(assumedCredentials)))
-        .thenReturn(requestMock);
+    Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(assumedCredentials)))
+        .thenReturn(FAKE_JWT);
 
     SFLoginInput loginInput = new SFLoginInput();
     loginInput.setWorkloadIdentityImpersonationPath("arn:aws:iam::123456789012:role/TestRole");
@@ -167,7 +126,7 @@ public class AwsIdentityAttestationCreatorTest {
 
     assertNotNull(attestation);
     assertEquals(WorkloadIdentityProviderType.AWS, attestation.getProvider());
-    assertNotNull(attestation.getCredential());
+    assertEquals(FAKE_JWT, attestation.getCredential());
 
     Mockito.verify(attestationServiceMock)
         .assumeRole(initialCredentials, "arn:aws:iam::123456789012:role/TestRole", null);
@@ -176,9 +135,6 @@ public class AwsIdentityAttestationCreatorTest {
   @Test
   public void shouldPassExternalIdToAssumeRoleWhenProvided() throws SFException {
     AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
-    SdkHttpRequest requestMock = mock(SdkHttpRequest.class);
-    Mockito.when(requestMock.getUri()).thenReturn(URI.create("https://snowflakecomputing.com"));
-    Mockito.when(requestMock.method()).thenReturn(SdkHttpMethod.GET);
 
     AwsSessionCredentials initialCredentials =
         AwsSessionCredentials.create("initial-key", "initial-secret", "initial-token");
@@ -186,15 +142,13 @@ public class AwsIdentityAttestationCreatorTest {
         AwsSessionCredentials.create("assumed-key", "assumed-secret", "assumed-token");
 
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
-    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
     Mockito.when(
             attestationServiceMock.assumeRole(
                 initialCredentials, "arn:aws:iam::123456789012:role/TestRole", "my-external-id"))
         .thenReturn(assumedCredentials);
-    Mockito.doNothing().when(attestationServiceMock).initializeSignerRegion();
-    Mockito.when(attestationServiceMock.signRequestWithSigV4(any(), Mockito.eq(assumedCredentials)))
-        .thenReturn(requestMock);
+    Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(assumedCredentials)))
+        .thenReturn(FAKE_JWT);
 
     SFLoginInput loginInput = new SFLoginInput();
     loginInput.setWorkloadIdentityImpersonationPath("arn:aws:iam::123456789012:role/TestRole");
@@ -206,7 +160,7 @@ public class AwsIdentityAttestationCreatorTest {
 
     assertNotNull(attestation);
     assertEquals(WorkloadIdentityProviderType.AWS, attestation.getProvider());
-    assertNotNull(attestation.getCredential());
+    assertEquals(FAKE_JWT, attestation.getCredential());
     Mockito.verify(attestationServiceMock)
         .assumeRole(
             initialCredentials, "arn:aws:iam::123456789012:role/TestRole", "my-external-id");
@@ -215,9 +169,6 @@ public class AwsIdentityAttestationCreatorTest {
   @Test
   public void shouldPassEmptyExternalIdToAssumeRoleWhenSetToEmptyString() throws SFException {
     AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
-    SdkHttpRequest requestMock = mock(SdkHttpRequest.class);
-    Mockito.when(requestMock.getUri()).thenReturn(URI.create("https://snowflakecomputing.com"));
-    Mockito.when(requestMock.method()).thenReturn(SdkHttpMethod.GET);
 
     AwsSessionCredentials initialCredentials =
         AwsSessionCredentials.create("initial-key", "initial-secret", "initial-token");
@@ -225,15 +176,13 @@ public class AwsIdentityAttestationCreatorTest {
         AwsSessionCredentials.create("assumed-key", "assumed-secret", "assumed-token");
 
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
-    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
     Mockito.when(
             attestationServiceMock.assumeRole(
                 initialCredentials, "arn:aws:iam::123456789012:role/TestRole", ""))
         .thenReturn(assumedCredentials);
-    Mockito.doNothing().when(attestationServiceMock).initializeSignerRegion();
-    Mockito.when(attestationServiceMock.signRequestWithSigV4(any(), Mockito.eq(assumedCredentials)))
-        .thenReturn(requestMock);
+    Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(assumedCredentials)))
+        .thenReturn(FAKE_JWT);
 
     SFLoginInput loginInput = new SFLoginInput();
     loginInput.setWorkloadIdentityImpersonationPath("arn:aws:iam::123456789012:role/TestRole");
@@ -253,9 +202,6 @@ public class AwsIdentityAttestationCreatorTest {
   @Test
   public void shouldOnlyPassExternalIdToLastHopInMultiHopChain() throws SFException {
     AwsAttestationService attestationServiceMock = mock(AwsAttestationService.class);
-    SdkHttpRequest requestMock = mock(SdkHttpRequest.class);
-    Mockito.when(requestMock.getUri()).thenReturn(URI.create("https://snowflakecomputing.com"));
-    Mockito.when(requestMock.method()).thenReturn(SdkHttpMethod.GET);
 
     AwsSessionCredentials initialCredentials =
         AwsSessionCredentials.create("initial-key", "initial-secret", "initial-token");
@@ -266,7 +212,6 @@ public class AwsIdentityAttestationCreatorTest {
         AwsSessionCredentials.create("final-key", "final-secret", "final-token");
 
     Mockito.when(attestationServiceMock.getAWSCredentials()).thenReturn(initialCredentials);
-    Mockito.when(attestationServiceMock.getAWSRegion()).thenReturn(Region.US_EAST_1);
     Mockito.when(attestationServiceMock.getCredentialsViaRoleChaining(any())).thenCallRealMethod();
     // First hop: no external ID
     Mockito.when(
@@ -278,9 +223,8 @@ public class AwsIdentityAttestationCreatorTest {
             attestationServiceMock.assumeRole(
                 intermediateCredentials, "arn:aws:iam::222222222222:role/RoleB", "my-external-id"))
         .thenReturn(finalCredentials);
-    Mockito.doNothing().when(attestationServiceMock).initializeSignerRegion();
-    Mockito.when(attestationServiceMock.signRequestWithSigV4(any(), Mockito.eq(finalCredentials)))
-        .thenReturn(requestMock);
+    Mockito.when(attestationServiceMock.getWebIdentityToken(Mockito.eq(finalCredentials)))
+        .thenReturn(FAKE_JWT);
 
     SFLoginInput loginInput = new SFLoginInput();
     loginInput.setWorkloadIdentityImpersonationPath(

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -176,29 +176,11 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>identity-spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>http-auth-aws</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>software.amazon.awssdk.crt</groupId>
-          <artifactId>aws-crt</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>http-auth-spi</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
Switch AWS workload identity attestation from a SigV4-presigned GetCallerIdentity request to STS GetWebIdentityToken, returning the signed JWT directly as the credential. Server already accepts both formats during migration, so this requires no env-var gate and the existing WIFLatestIT AWS scenario keeps working.

# Overview

SNOW-3411970

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
