### PR TITLE
NO-SNOW: Snyk dep bumps and suppressions (jackson, AWS SDK, netty, .snyk)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,41 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  'snyk:lic:maven:javax.servlet:javax.servlet-api:(CDDL-1.1_OR_GPL-2.0-with-classpath-exception)':
+    - '*':
+        reason: >-
+          Dual-licensed CDDL-1.1 OR GPL-2.0-with-classpath-exception. Electing
+          the CDDL-1.1 branch, which Snowflake's OSS policy permits when the
+          package is unmodified or not distributed. This dependency is consumed
+          as an unmodified binary Maven artifact (servlet API interfaces only)
+          and is not patched, shaded, or repackaged by snowflake-jdbc.
+        expires: 2027-06-02T00:00:00.000Z
+  'snyk:lic:maven:javax.annotation:javax.annotation-api:(CDDL-1.1_OR_GPL-2.0-with-classpath-exception)':
+    - '*':
+        reason: >-
+          Dual-licensed CDDL-1.1 OR GPL-2.0-with-classpath-exception. Electing
+          the CDDL-1.1 branch, which Snowflake's OSS policy permits when the
+          package is unmodified or not distributed. Pulled transitively via
+          com.google.cloud:google-cloud-storage as an unmodified binary Maven
+          artifact (annotation API only); not patched, shaded, or repackaged
+          by snowflake-jdbc.
+        expires: 2027-06-02T00:00:00.000Z
+  'SNYK-JAVA-ORGAPACHETIKA-14188255':
+    - '*':
+        reason: >-
+          XXE in tika-core. Fix is only available in tika 3.2.2+, which is
+          compiled for Java 11. snowflake-jdbc compiles and ships Java 8
+          bytecode (maven-compiler source/target=8 in pom.xml) and shades
+          tika-core into the published fat jar, so bumping tika to 3.x would
+          break every customer still on JDK 8. The entire tika 2.x line is
+          unpatched per the Snyk advisory, so no Java-8-compatible upgrade
+          path exists. Risk in this codebase is also low: the only caller is
+          net.snowflake.client.internal.core.FileTypeDetector, which invokes
+          Tika.detect(File) for MIME sniffing on local files the user has
+          themselves staged for PUT/GET. Detection sniffs magic bytes and
+          extensions; it does not parse attacker-controlled XML for any
+          security decision, so the XXE attack vector is not reachable
+          through this caller. Revisit when the Java baseline is raised to
+          11 and replace with tika 3.2.2+ at that point.
+        expires: 2027-06-02T00:00:00.000Z
+patch: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.2.1-SNAPSHOT
+    - Bumped jackson to 2.18.7 to address two High-severity resource-exhaustion CVEs in jackson-core 2.18.4.1, and added a `.snyk` policy file with justified ignores for the dual-licensed `javax.servlet-api` / `javax.annotation-api` findings and the tika-core XXE (`SNYK-JAVA-ORGAPACHETIKA-14188255`), which has no Java-8-compatible fix and is not reachable through the driver's only Tika caller (snowflakedb/snowflake-jdbc#2654).
     - Fixed OAuth token requests sending `scope=session:role:null` when no scope is configured (or scope is empty/blank); the `scope` parameter is now omitted entirely in those cases (snowflakedb/snowflake-jdbc#2646).
     - Fixed Okta native SSO federated login sending malformed JSON to `/api/v1/authn` (HTTP 400 from Okta) when the username or password contained JSON-special characters such as double quotes or backslashes; the request body is now serialized with Jackson instead of string concatenation.
     - Added one in-band telemetry record per successful login describing which connection-identifier fields the user supplied (`account_provided`, `account_with_region`, `account_org_provided`, `region_provided`, `host_provided`). No hostname or account value is included. This is gated by the existing server-side `CLIENT_TELEMETRY_ENABLED` parameter and can additionally be disabled locally by setting `SF_TELEMETRY_DISABLE_CONNECTION_SHAPE=true`. The telemetry collection is time-boxed and will be removed in a future release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.2.1-SNAPSHOT
-    - Bumped AWS SDK from 2.37.5 to 2.46.0, which transitively brings netty up to 4.1.133.Final and resolves a cluster of High/Medium netty CVEs (HTTP request smuggling, CRLF injection, data amplification, resource allocation) flagged by Snyk against `netty-nio-client` in `thin_public_pom.xml` (snowflakedb/snowflake-jdbc#2654).
+    - Bumped AWS SDK from 2.37.5 to 2.45.1, which transitively brings netty up to 4.1.133.Final and resolves a cluster of High/Medium netty CVEs (HTTP request smuggling, CRLF injection, data amplification, resource allocation) flagged by Snyk against `netty-nio-client` in `thin_public_pom.xml` (snowflakedb/snowflake-jdbc#2654).
     - Bumped jackson to 2.18.7 to address two High-severity resource-exhaustion CVEs in jackson-core 2.18.4.1, and added a `.snyk` policy file with justified ignores for the dual-licensed `javax.servlet-api` / `javax.annotation-api` findings and the tika-core XXE (`SNYK-JAVA-ORGAPACHETIKA-14188255`), which has no Java-8-compatible fix and is not reachable through the driver's only Tika caller (snowflakedb/snowflake-jdbc#2654).
     - Fixed OAuth token requests sending `scope=session:role:null` when no scope is configured (or scope is empty/blank); the `scope` parameter is now omitted entirely in those cases (snowflakedb/snowflake-jdbc#2646).
     - Fixed Okta native SSO federated login sending malformed JSON to `/api/v1/authn` (HTTP 400 from Okta) when the username or password contained JSON-special characters such as double quotes or backslashes; the request body is now serialized with Jackson instead of string concatenation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.2.1-SNAPSHOT
+    - Bumped AWS SDK from 2.37.5 to 2.46.0, which transitively brings netty up to 4.1.133.Final and resolves a cluster of High/Medium netty CVEs (HTTP request smuggling, CRLF injection, data amplification, resource allocation) flagged by Snyk against `netty-nio-client` in `thin_public_pom.xml` (snowflakedb/snowflake-jdbc#2654).
     - Bumped jackson to 2.18.7 to address two High-severity resource-exhaustion CVEs in jackson-core 2.18.4.1, and added a `.snyk` policy file with justified ignores for the dual-licensed `javax.servlet-api` / `javax.annotation-api` findings and the tika-core XXE (`SNYK-JAVA-ORGAPACHETIKA-14188255`), which has no Java-8-compatible fix and is not reachable through the driver's only Tika caller (snowflakedb/snowflake-jdbc#2654).
     - Fixed OAuth token requests sending `scope=session:role:null` when no scope is configured (or scope is empty/blank); the `scope` parameter is now omitted entirely in those cases (snowflakedb/snowflake-jdbc#2646).
     - Fixed Okta native SSO federated login sending malformed JSON to `/api/v1/authn` (HTTP 400 from Okta) when the username or password contained JSON-special characters such as double quotes or backslashes; the request body is now serialized with Jackson instead of string concatenation.

--- a/linkage-checker-exclusion-rules.xml
+++ b/linkage-checker-exclusion-rules.xml
@@ -102,6 +102,11 @@
         <Source><Package name="software.amazon.awssdk.transfer"/></Source>
         <Reason>CRT dependency excluded, not used in runtime</Reason>
     </LinkageError>
+    <LinkageError>
+        <Target><Package name="software.amazon.awssdk.crt"/></Target>
+        <Source><Package name="software.amazon.awssdk.checksums.internal"/></Source>
+        <Reason>CRT dependency excluded, not used in runtime</Reason>
+    </LinkageError>
     <!-- AWS SDK SignerProperty fields - false positives from linkage checker 1.5.13 -->
     <!-- These fields exist in the actual JARs and are resolvable in IDEs, but linkage checker incorrectly reports them as missing -->
     <LinkageError>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -25,7 +25,7 @@
     <asm.version>9.7.1</asm.version>
     <avro.version>1.8.1</avro.version>
     <awaitility.version>4.2.0</awaitility.version>
-    <awssdk.version>2.37.5</awssdk.version>
+    <awssdk.version>2.46.0</awssdk.version>
     <azure.core.version>1.57.0</azure.core.version>
     <azure.storage.blob.version>12.32.0</azure.storage.blob.version>
     <azure.storage.common.version>12.31.0</azure.storage.common.version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -25,7 +25,7 @@
     <asm.version>9.7.1</asm.version>
     <avro.version>1.8.1</avro.version>
     <awaitility.version>4.2.0</awaitility.version>
-    <awssdk.version>2.46.0</awssdk.version>
+    <awssdk.version>2.45.1</awssdk.version>
     <azure.core.version>1.57.0</azure.core.version>
     <azure.storage.blob.version>12.32.0</azure.storage.blob.version>
     <azure.storage.common.version>12.31.0</azure.storage.common.version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -59,7 +59,7 @@
     <grpc.version>1.81.0</grpc.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hikaricp.version>2.4.3</hikaricp.version>
-    <jackson.version>2.18.4.1</jackson.version>
+    <jackson.version>2.18.7</jackson.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,9 @@
               <ignoreNonCompile>true</ignoreNonCompile>
               <ignoredUnusedDeclaredDependencies>
                 <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>software.amazon.awssdk:http-auth-aws</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>software.amazon.awssdk:http-auth-spi</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>software.amazon.awssdk:identity-spi</ignoredUnusedDeclaredDependency>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -108,6 +108,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-annotations</artifactId>
         <version>${animal.sniffer.annotations.version}</version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -55,7 +55,7 @@
     <google.jsr305.version>3.0.2</google.jsr305.version>
     <google.protobuf.java.version>4.28.2</google.protobuf.java.version>
     <grpc.version>1.81.0</grpc.version>
-    <jackson.version>2.18.4.1</jackson.version>
+    <jackson.version>2.18.7</jackson.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>
     <json.smart.version>2.5.2</json.smart.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -36,7 +36,7 @@
     <animal.sniffer.annotations.version>1.27</animal.sniffer.annotations.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
-    <awssdk.version>2.46.0</awssdk.version>
+    <awssdk.version>2.45.1</awssdk.version>
     <azure.core.version>1.57.0</azure.core.version>
     <azure.storage.blob.version>12.32.0</azure.storage.blob.version>
     <azure.storage.common.version>12.31.0</azure.storage.common.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -36,7 +36,7 @@
     <animal.sniffer.annotations.version>1.27</animal.sniffer.annotations.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
-    <awssdk.version>2.37.5</awssdk.version>
+    <awssdk.version>2.46.0</awssdk.version>
     <azure.core.version>1.57.0</azure.core.version>
     <azure.storage.blob.version>12.32.0</azure.storage.blob.version>
     <azure.storage.common.version>12.31.0</azure.storage.common.version>


### PR DESCRIPTION
  ## Summary

  Resolves Snyk findings via dependency bumps + targeted suppressions.

  **Bumps**
  - jackson `2.18.4.1` → `2.18.7` (fixes 2 High CVEs in jackson-core)
  - AWS SDK `2.37.5` → `2.45.1` (transitively brings netty `4.1.133.Final`, clearing 11 netty CVEs flagged by Snyk)
  - Import `netty-bom` in `thin_public_pom.xml` so Azure SDK transitives also resolve to `4.1.133.Final` (clears the last 2 netty findings)

  **Suppressions in new `.snyk`** (all expire 2027-06-02)
  - `javax.servlet-api` / `javax.annotation-api` dual CDDL-1.1/GPL — electing CDDL-1.1 branch (Snowflake-permitted for unmodified Maven artifacts)
  - tika-core XXE (`SNYK-JAVA-ORGAPACHETIKA-14188255`) — fix is only in tika 3.2.2+ which requires Java 11; we still target Java 8. The only caller (`FileTypeDetector`) MIME-sniffs local files via magic bytes and
  never parses attacker-controlled XML, so the vector isn't reachable. Revisit when the Java baseline moves to 11.

  **Build-config fixes for the AWS SDK bump**
  - `analyze-only` ignores for `http-auth-aws`, `http-auth-spi`, `identity-spi` — declared in `parent-pom.xml` and used at compile time, but the analyzer credits the transitive `s3` path and reports the explicit
  declarations as redundant.
  - Linkage-checker exclusion for `software.amazon.awssdk.checksums.internal` → `software.amazon.awssdk.crt` — new in 2.45.1, same false positive as four existing CRT exclusions; CRT codepath unreachable because
  `aws-crt` is excluded.

  ## Test plan
  - [ ] CI green
  - [ ] Snyk re-scan shows the 4 originally targeted findings (2 jackson, tika, license) cleared/ignored
  - [ ] Snyk Thin Public POM Test goes from 13 issues → 0