### PR TITLE
SNOW-3488052: Prepare release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 #### For all official JDBC Release Notes please refer to https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc
 
 # Changelog
-- v4.2.1-SNAPSHOT
+- v4.3.0
     - Bumped AWS SDK from 2.37.5 to 2.45.1, which transitively brings netty up to 4.1.133.Final and resolves a cluster of High/Medium netty CVEs (HTTP request smuggling, CRLF injection, data amplification, resource allocation) flagged by Snyk against `netty-nio-client` in `thin_public_pom.xml` (snowflakedb/snowflake-jdbc#2654).
     - Bumped jackson to 2.18.7 to address two High-severity resource-exhaustion CVEs in jackson-core 2.18.4.1, and added a `.snyk` policy file with justified ignores for the dual-licensed `javax.servlet-api` / `javax.annotation-api` findings and the tika-core XXE (`SNYK-JAVA-ORGAPACHETIKA-14188255`), which has no Java-8-compatible fix and is not reachable through the driver's only Tika caller (snowflakedb/snowflake-jdbc#2654).
     - Fixed OAuth token requests sending `scope=session:role:null` when no scope is configured (or scope is empty/blank); the `scope` parameter is now omitted entirely in those cases (snowflakedb/snowflake-jdbc#2646).

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-jdbc-parent</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0</version>
     <relativePath>../parent-pom.xml</relativePath>
   </parent>
 
   <artifactId>snowflake-jdbc-fips</artifactId>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>4.3.0</version>
   <packaging>jar</packaging>
 
   <name>snowflake-jdbc-fips</name>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-jdbc-parent</artifactId>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>4.3.0</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-jdbc-parent</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0</version>
     <relativePath>./parent-pom.xml</relativePath>
   </parent>
 
   <!-- Maven complains about using property here, but it makes install and deploy process easier to override final package names and localization -->
   <artifactId>${artifactId}</artifactId>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>4.3.0</version>
   <packaging>jar</packaging>
 
   <name>${artifactId}</name>


### PR DESCRIPTION
## Summary
- Bump version from `4.2.1-SNAPSHOT` to `4.3.0` (MINOR bump per semver, since the release ships new backward-compatible functionality in addition to bug fixes).
- Update `pom.xml`, `parent-pom.xml`, and `FIPS/pom.xml` to `4.3.0`.
- Restructure the changelog entry into **Features**, **Bug fixes**, and **Internal changes** sections.

## Context
Prepares the next JDBC driver release. The unreleased `4.2.1-SNAPSHOT` block contained a new auto-configuration feature (`Properties()` now considered during connection build) alongside several bug fixes, which warrants a MINOR rather than PATCH bump.

## Test plan
- `./mvnw help:evaluate -Dexpression=project.version` resolves `4.3.0`.
- `./mvnw validate` BUILD SUCCESS across the reactor (`snowflake-jdbc` + `snowflake-jdbc-fips`); sortpom verify passed.
- `fmt-maven-plugin:format` 764 files processed, 0 reformatted.
- `clean validate -P check-style` 0 Checkstyle violations, BUILD SUCCESS.
- Confirmed no remaining `4.2.1-SNAPSHOT` references in the repo.