### PR TITLE
SNOW-3619741: Fix Azure memory leak on PUT requests by caching underlying Netty per connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 # Changelog
 - v4.3.1-SNAPSHOT
-    - Fixed `SFResultJsonParser2Failed: invalid escaped unicode character` when a chunked JSON result contained UTF-16 surrogate-pair `\u` escapes (e.g. emoji) and the read buffer happened to split exactly 9 bytes after `\u`; the off-by-one boundary guard in `ResultJsonParserV2` now reserves the full 10 bytes a surrogate pair requires (snowflakedb/snowflake-jdbc#2660).
+  - Fixed Azure PUT memory leak where each PUT instantiated a fresh `BlobServiceClient` whose underlying reactor-netty stack the SDK exposes no API to release; the Azure SDK `HttpClient` and its `ConnectionProvider` are now shared across all PUTs in a session and disposed at session close, mirroring the existing S3 pattern (snowflakedb/snowflake-jdbc#2658).
+  - Fixed `SFResultJsonParser2Failed: invalid escaped unicode character` when a chunked JSON result contained UTF-16 surrogate-pair `\u` escapes (e.g. emoji) and the read buffer happened to split exactly 9 bytes after `\u`; the off-by-one boundary guard in `ResultJsonParserV2` now reserves the full 10 bytes a surrogate pair requires (snowflakedb/snowflake-jdbc#2660).
+
 - v4.3.0
     - Bumped AWS SDK from 2.37.5 to 2.45.1, which transitively brings netty up to 4.1.133.Final and resolves a cluster of High/Medium netty CVEs (HTTP request smuggling, CRLF injection, data amplification, resource allocation) flagged by Snyk against `netty-nio-client` in `thin_public_pom.xml` (snowflakedb/snowflake-jdbc#2654).
     - Bumped jackson to 2.18.7 to address two High-severity resource-exhaustion CVEs in jackson-core 2.18.4.1, and added a `.snyk` policy file with justified ignores for the dual-licensed `javax.servlet-api` / `javax.annotation-api` findings and the tika-core XXE (`SNYK-JAVA-ORGAPACHETIKA-14188255`), which has no Java-8-compatible fix and is not reachable through the driver's only Tika caller (snowflakedb/snowflake-jdbc#2654).

--- a/linkage-checker-exclusion-rules.xml
+++ b/linkage-checker-exclusion-rules.xml
@@ -159,6 +159,16 @@
         <Source><Package name="reactor.util"/></Source>
         <Reason>Optional</Reason>
     </LinkageError>
+    <LinkageError>
+        <Target><Package name="io.micrometer"/></Target>
+        <Source><Package name="reactor.netty"/></Source>
+        <Reason>Optional</Reason>
+    </LinkageError>
+    <LinkageError>
+        <Target><Package name="io.netty.incubator"/></Target>
+        <Source><Package name="reactor.netty"/></Source>
+        <Reason>Optional</Reason>
+    </LinkageError>
     <!--
     <LinkageError>
         <Target><Package name=""/></Target>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -26,9 +26,12 @@
     <avro.version>1.8.1</avro.version>
     <awaitility.version>4.2.0</awaitility.version>
     <awssdk.version>2.45.1</awssdk.version>
-    <azure.core.version>1.57.0</azure.core.version>
-    <azure.storage.blob.version>12.32.0</azure.storage.blob.version>
-    <azure.storage.common.version>12.31.0</azure.storage.common.version>
+    <azure.core.version>1.58.1</azure.core.version>
+    <azure.core.http.netty.version>1.16.5</azure.core.http.netty.version>
+    <azure.storage.blob.version>12.34.0</azure.storage.blob.version>
+    <azure.storage.common.version>12.33.0</azure.storage.common.version>
+    <reactor.core.version>3.7.19</reactor.core.version>
+    <reactor.netty.core.version>1.2.18</reactor.netty.core.version>
     <awssdk.encryption.s3.version>3.4.0</awssdk.encryption.s3.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <bouncycastle.bcfips.version>1.0.2.6</bouncycastle.bcfips.version>
@@ -237,6 +240,27 @@
         <groupId>com.azure</groupId>
         <artifactId>azure-core</artifactId>
         <version>${azure.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-core-http-netty</artifactId>
+        <version>${azure.core.http.netty.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-core</artifactId>
+        <version>${reactor.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-core</artifactId>
+        <version>${reactor.netty.core.version}</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
@@ -684,6 +708,22 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
       <version>${azure.core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core-http-netty</artifactId>
+      <version>${azure.core.http.netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty-core</artifactId>
+      <version>${reactor.netty.core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFBaseSession.java
@@ -67,6 +67,9 @@ public abstract class SFBaseSession {
   // Shared S3 Netty event-loop group; AutoCloseable to keep this base class AWS-free.
   private AutoCloseable s3EventLoopGroup;
   private boolean s3EventLoopGroupClosed;
+
+  private AutoCloseable azureHttpClient;
+  private boolean azureHttpClientClosed;
   private SFConnectionHandler sfConnectionHandler;
   protected List<SFException> sqlWarnings = new ArrayList<>();
   // Unique Session ID
@@ -1330,6 +1333,7 @@ public abstract class SFBaseSession {
       doClose(internalCallMarker);
     } finally {
       closeS3EventLoopGroup();
+      closeAzureHttpClient();
     }
   }
 
@@ -1377,6 +1381,33 @@ public abstract class SFBaseSession {
       logger.debug("Failed to close shared S3 event-loop group: {}", ex.toString());
     }
     s3EventLoopGroup = null;
+  }
+
+  /** Lazily create (or return) the per-session shared Azure SDK HTTP client. */
+  @SuppressWarnings("unchecked")
+  public synchronized <T extends AutoCloseable> T getOrCreateAzureHttpClient(
+      Supplier<? extends T> factory) {
+    if (azureHttpClientClosed) {
+      throw new IllegalStateException("Cannot create Azure HTTP client: session is already closed");
+    }
+    if (azureHttpClient == null) {
+      azureHttpClient = factory.get();
+    }
+    return (T) azureHttpClient;
+  }
+
+  /** Best-effort releases the held Azure HTTP client. Idempotent. */
+  protected synchronized void closeAzureHttpClient() {
+    azureHttpClientClosed = true;
+    if (azureHttpClient == null) {
+      return;
+    }
+    try {
+      azureHttpClient.close();
+    } catch (Exception ex) {
+      logger.debug("Failed to close shared Azure HttpClient: {}", ex.toString());
+    }
+    azureHttpClient = null;
   }
 
   /**

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/AzureHttpClientHolder.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/AzureHttpClientHolder.java
@@ -1,0 +1,54 @@
+package net.snowflake.client.internal.jdbc.cloud.storage;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+import java.time.Duration;
+import reactor.netty.resources.ConnectionProvider;
+
+/**
+ * Owns one Azure SDK {@link HttpClient} (and its underlying reactor-netty {@link
+ * ConnectionProvider}) per JDBC session. The Azure SDK exposes no close hook on its HttpClient, so
+ * the connection provider is built explicitly here and disposed at session close.
+ */
+final class AzureHttpClientHolder implements AutoCloseable {
+
+  // Reactor-netty pool sizing for the Azure SDK HTTP client. These are Azure/reactor-netty
+  // specific: the S3 path uses an aws-sdk Apache client (HttpUtil-driven) with a different pool
+  // model, so we keep these knobs local rather than forcing a shared abstraction.
+  static final int MAX_CONNECTIONS = 100;
+  static final Duration MAX_IDLE_TIME = Duration.ofSeconds(30);
+  static final Duration EVICT_IN_BACKGROUND_INTERVAL = Duration.ofSeconds(15);
+
+  private final ConnectionProvider connectionProvider;
+  private final HttpClient httpClient;
+
+  private AzureHttpClientHolder(ConnectionProvider connectionProvider, HttpClient httpClient) {
+    this.connectionProvider = connectionProvider;
+    this.httpClient = httpClient;
+  }
+
+  static AzureHttpClientHolder create(ProxyOptions proxyOptions) {
+    ConnectionProvider provider =
+        ConnectionProvider.builder("snowflake-azure-blob")
+            .maxConnections(MAX_CONNECTIONS)
+            .maxIdleTime(MAX_IDLE_TIME)
+            .evictInBackground(EVICT_IN_BACKGROUND_INTERVAL)
+            .build();
+    NettyAsyncHttpClientBuilder builder =
+        new NettyAsyncHttpClientBuilder().connectionProvider(provider);
+    if (proxyOptions != null) {
+      builder.proxy(proxyOptions);
+    }
+    return new AzureHttpClientHolder(provider, builder.build());
+  }
+
+  HttpClient httpClient() {
+    return httpClient;
+  }
+
+  @Override
+  public void close() {
+    connectionProvider.dispose();
+  }
+}

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeAzureClient.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeAzureClient.java
@@ -155,9 +155,16 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
       } else {
         proxyOptions = createSessionlessProxyOptionsForAzure(stage.getProxyProperties());
       }
-      HttpClientOptions clientOptions = new HttpClientOptions();
-      clientOptions.setProxyOptions(proxyOptions);
-      builder.clientOptions(clientOptions);
+      if (session != null) {
+        final ProxyOptions effectiveProxy = proxyOptions;
+        AzureHttpClientHolder holder =
+            session.getOrCreateAzureHttpClient(() -> AzureHttpClientHolder.create(effectiveProxy));
+        builder.httpClient(holder.httpClient());
+      } else {
+        HttpClientOptions clientOptions = new HttpClientOptions();
+        clientOptions.setProxyOptions(proxyOptions);
+        builder.clientOptions(clientOptions);
+      }
       this.azStorageClient = builder.buildClient();
     } catch (URISyntaxException ex) {
       throw new IllegalArgumentException("invalid_azure_credentials");
@@ -218,11 +225,9 @@ public class SnowflakeAzureClient implements SnowflakeStorageClient {
     setupAzureClient(stageInfo, encMat, session);
   }
 
-  /** shuts down the client */
+  /** No-op; the HttpClient lifecycle is owned by SFBaseSession. */
   @Override
-  public void shutdown() {
-    /* Not available */
-  }
+  public void shutdown() {}
 
   /**
    * For a set of remote storage objects under a remote location and a given prefix/path returns

--- a/src/test/java/net/snowflake/client/internal/core/SFBaseSessionAzureHttpClientTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SFBaseSessionAzureHttpClientTest.java
@@ -1,0 +1,103 @@
+package net.snowflake.client.internal.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class SFBaseSessionAzureHttpClientTest {
+
+  /** Factory runs at most once; subsequent calls return the same instance. */
+  @Test
+  public void shouldCreateClientLazilyAndReuseIt() {
+    SFSession session = new SFSession();
+    AtomicInteger calls = new AtomicInteger();
+    CountingCloseable first =
+        session.getOrCreateAzureHttpClient(
+            () -> {
+              calls.incrementAndGet();
+              return new CountingCloseable();
+            });
+    CountingCloseable second =
+        session.getOrCreateAzureHttpClient(
+            () -> {
+              calls.incrementAndGet();
+              return new CountingCloseable();
+            });
+
+    assertSame(first, second);
+    assertEquals(1, calls.get(), "factory should be invoked exactly once, got " + calls.get());
+    assertFalse(first.closed);
+  }
+
+  /** {@code closeAzureHttpClient} closes the held resource and is idempotent. */
+  @Test
+  public void shouldCloseClientOnceAndBeIdempotent() {
+    TestSession session = new TestSession();
+    CountingCloseable holder = session.getOrCreateAzureHttpClient(CountingCloseable::new);
+
+    session.invokeCloseAzureHttpClient();
+    session.invokeCloseAzureHttpClient();
+
+    assertTrue(holder.closed);
+    assertEquals(1, holder.closeCount, "close should run exactly once, got " + holder.closeCount);
+  }
+
+  /**
+   * After close, attempts to (re)create the client must throw — otherwise we'd resurrect a client
+   * that nothing will ever close.
+   */
+  @Test
+  public void shouldRejectGetOrCreateAfterClose() {
+    TestSession session = new TestSession();
+    session.invokeCloseAzureHttpClient();
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> session.getOrCreateAzureHttpClient(CountingCloseable::new));
+  }
+
+  /**
+   * A failure in the holder's close() must not propagate out of {@code closeAzureHttpClient}, and
+   * the session must still be poisoned so no caller can resurrect the client. A second close() must
+   * be a no-op.
+   */
+  @Test
+  public void shouldSwallowExceptionFromHolderClose() {
+    TestSession session = new TestSession();
+    session.getOrCreateAzureHttpClient(
+        () ->
+            () -> {
+              throw new RuntimeException("boom");
+            });
+
+    session.invokeCloseAzureHttpClient();
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> session.getOrCreateAzureHttpClient(CountingCloseable::new));
+    session.invokeCloseAzureHttpClient();
+  }
+
+  /** Test subclass that exposes the protected close hook so we can drive lifecycle directly. */
+  private static class TestSession extends SFSession {
+    void invokeCloseAzureHttpClient() {
+      closeAzureHttpClient();
+    }
+  }
+
+  private static class CountingCloseable implements AutoCloseable {
+    boolean closed;
+    int closeCount;
+
+    @Override
+    public void close() {
+      closed = true;
+      closeCount++;
+    }
+  }
+}

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -37,9 +37,12 @@
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <awssdk.version>2.45.1</awssdk.version>
-    <azure.core.version>1.57.0</azure.core.version>
-    <azure.storage.blob.version>12.32.0</azure.storage.blob.version>
-    <azure.storage.common.version>12.31.0</azure.storage.common.version>
+    <azure.core.version>1.58.1</azure.core.version>
+    <azure.core.http.netty.version>1.16.5</azure.core.http.netty.version>
+    <azure.storage.blob.version>12.34.0</azure.storage.blob.version>
+    <azure.storage.common.version>12.33.0</azure.storage.common.version>
+    <reactor.core.version>3.7.19</reactor.core.version>
+    <reactor.netty.core.version>1.2.18</reactor.netty.core.version>
     <awssdk.encryption.s3.version>3.4.0</awssdk.encryption.s3.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <commons.codec.version>1.17.0</commons.codec.version>
@@ -244,6 +247,22 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
       <version>${azure.core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core-http-netty</artifactId>
+      <version>${azure.core.http.netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty-core</artifactId>
+      <version>${reactor.netty.core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>


### PR DESCRIPTION
# Summary

Cache the Azure SDK HttpClient (and its underlying reactor-netty ConnectionProvider) per JDBC session instead of creating a new one per setupAzureClient call. The Azure SDK never closes its HttpClient, so the previous behavior leaked Netty pools on every PUT and on every SAS-token renewal. The session now owns the lifecycle and disposes the ConnectionProvider on close, mirroring the S3 event-loop-group pattern.

# Overview

SNOW-3619741

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
