### PR TITLE
SNOW-3630146: Fix ResultJsonParserV2 off-by-one for \u surrogate pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.1-SNAPSHOT
+    - Fixed `SFResultJsonParser2Failed: invalid escaped unicode character` when a chunked JSON result contained UTF-16 surrogate-pair `\u` escapes (e.g. emoji) and the read buffer happened to split exactly 9 bytes after `\u`; the off-by-one boundary guard in `ResultJsonParserV2` now reserves the full 10 bytes a surrogate pair requires (snowflakedb/snowflake-jdbc#2660).
 - v4.3.0
     - Bumped AWS SDK from 2.37.5 to 2.45.1, which transitively brings netty up to 4.1.133.Final and resolves a cluster of High/Medium netty CVEs (HTTP request smuggling, CRLF injection, data amplification, resource allocation) flagged by Snyk against `netty-nio-client` in `thin_public_pom.xml` (snowflakedb/snowflake-jdbc#2654).
     - Bumped jackson to 2.18.7 to address two High-severity resource-exhaustion CVEs in jackson-core 2.18.4.1, and added a `.snyk` policy file with justified ignores for the dual-licensed `javax.servlet-api` / `javax.annotation-api` findings and the tika-core XXE (`SNYK-JAVA-ORGAPACHETIKA-14188255`), which has no Java-8-compatible fix and is not reachable through the driver's only Tika caller (snowflakedb/snowflake-jdbc#2654).

--- a/src/main/java/net/snowflake/client/internal/jdbc/ResultJsonParserV2.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/ResultJsonParserV2.java
@@ -321,7 +321,7 @@ public class ResultJsonParserV2 {
 
               // have to have at least 4+2+4=10 chars left to read
               // already saw "\\u", now missing "AAAA\\uAAAA"
-              if (in.remaining() >= 9 || (lastData && in.remaining() >= 3)) {
+              if (in.remaining() >= 10 || (lastData && in.remaining() >= 4)) {
                 if (!parseCodepoint(in)) {
                   throw new SnowflakeSQLLoggedException(
                       session,
@@ -331,8 +331,8 @@ public class ResultJsonParserV2 {
                 }
                 state = State.IN_STRING;
               } else {
-                // if the number of bytes left un-parsed in the buffer is less than 9 (unless it is
-                // the last remaining data in the buffer),
+                // if the number of bytes left un-parsed in the buffer is less than 10 (or less
+                // than 4 if it is the last remaining data in the buffer),
                 // there is not enough bytes to parse the codepoint. Move the position back 1,
                 // so we can re-enter parsing at this position with the ESCAPE state.
                 ((Buffer) in).position(((Buffer) in).position() - 1);

--- a/src/test/java/net/snowflake/client/internal/jdbc/ResultJsonParserV2Test.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/ResultJsonParserV2Test.java
@@ -209,6 +209,42 @@ public class ResultJsonParserV2Test {
     assertEquals("03 C3 A4 00 ", stringToHex(chunk.getCell(0, 0).toString()));
   }
 
+  // SNOW-3630146: a surrogate pair (e.g. the loudspeaker emoji, encoded as
+  // backslash-uD83D backslash-uDCE2) needs 10 bytes after the parser consumes
+  // backslash-u: XXXX + backslash-u + XXXX. The buffer-boundary guard at
+  // ResultJsonParserV2.java:324 only checks `>= 9`, so when a chunk boundary
+  // leaves exactly 9 bytes after backslash-u, the parser enters parseCodepoint
+  // with too few bytes and throws "SFResultJsonParser2Failed: invalid escaped
+  // unicode character".
+  @Test
+  public void testSurrogatePairSplitOnBufferBoundary() throws SnowflakeSQLException {
+    SFSession session = null;
+    String json = "[\"\\uD83D\\uDCE2\"]";
+    byte[] data = json.getBytes(StandardCharsets.UTF_8);
+    assertEquals(16, data.length);
+
+    JsonResultChunk chunk = new JsonResultChunk("", 1, 1, data.length, session);
+    ResultJsonParserV2 jp = new ResultJsonParserV2();
+    jp.startParsing(chunk, session);
+
+    // 13-byte slice: after the parser consumes "[", quote, backslash, "u",
+    // exactly 9 bytes remain ("D83D" + backslash + "uDCE"), which is the
+    // off-by-one boundary.
+    ByteBuffer first = ByteBuffer.wrap(data, 0, 13);
+    jp.continueParsing(first, session);
+
+    // With the fix, the parser rolls back to before `u` and defers. Resume from
+    // the unconsumed position with the remainder.
+    int resumeFrom = first.position();
+    ByteBuffer rest = ByteBuffer.wrap(data, resumeFrom, data.length - resumeFrom);
+    jp.continueParsing(rest, session);
+    byte[] tail = new byte[rest.remaining()];
+    rest.get(tail);
+    jp.endParsing(ByteBuffer.wrap(tail), session);
+
+    assertEquals("📢", chunk.getCell(0, 0).toString());
+  }
+
   public static String stringToHex(String input) {
     byte[] byteArray = input.getBytes(StandardCharsets.UTF_8);
     StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
# Summary

`ResultJsonParserV2.continueParsingInternal` reserves the wrong number of bytes when deciding whether the buffer holds a complete \u escape, so a chunked JSON response containing a UTF-16 surrogate-pair escape (most commonly emoji like 📢 → `\uD83D\uDCE2`) intermittently fails with `SFResultJsonParser2Failed: invalid escaped unicode character whenever a chunk boundary lands at exactly 9 bytes after \u`.

After consuming `\u`, the parser still needs `XXXX\uXXXX` — that's 10 bytes for a surrogate pair, or 4 for the lone-BMP final-chunk case. The existing guard checks `>= 9 / >= 3`, off-by-one in both branches: parseCodepoint reads 4 hex digits, then if it finds another \u reads 4 more, so an exact 9-byte tail leaves it short and it throws.

### How the code solves the issue

`src/main/java/net/snowflake/client/internal/jdbc/ResultJsonParserV2.java` — bumps the boundary guard from `>= 9 / >= 3` to `>= 10 / >= 4`. When the available bytes fall under the new threshold, the parser rolls the position back one byte and defers — the same mechanism the existing code uses for short BMP escapes — so the  continueParsing call resumes cleanly with the rest of the chunk appended. No state-machine changes, no behavior change for inputs that already had ≥ 10 bytes available.

# Overview

SNOW-XXXXX

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
