### PR TITLE
SNOW-3643336: Exclude stale SFBinary from snowflake-common shade to remove AWS SDK v1 bytecode references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - v4.3.1-SNAPSHOT
   - Fixed Azure PUT memory leak where each PUT instantiated a fresh `BlobServiceClient` whose underlying reactor-netty stack the SDK exposes no API to release; the Azure SDK `HttpClient` and its `ConnectionProvider` are now shared across all PUTs in a session and disposed at session close, mirroring the existing S3 pattern (snowflakedb/snowflake-jdbc#2658).
   - Fixed `SFResultJsonParser2Failed: invalid escaped unicode character` when a chunked JSON result contained UTF-16 surrogate-pair `\u` escapes (e.g. emoji) and the read buffer happened to split exactly 9 bytes after `\u`; the off-by-one boundary guard in `ResultJsonParserV2` now reserves the full 10 bytes a surrogate pair requires (snowflakedb/snowflake-jdbc#2660).
+  - Fixed (by removing) stale `com.amazonaws.util.Base16/Base64` bytecode references from the shaded JAR by excluding dead `SFBinary` and `SFBinaryFormat` classes from the bundled `snowflake-common` artifact. Security scanners shold no longer flag `snowflake-jdbc-thin` as containing AWS SDK v1 references. (snowflakedb/snowflake-jdbc#XXXX).
 
 - v4.3.0
     - Bumped AWS SDK from 2.37.5 to 2.45.1, which transitively brings netty up to 4.1.133.Final and resolves a cluster of High/Medium netty CVEs (HTTP request smuggling, CRLF injection, data amplification, resource allocation) flagged by Snyk against `netty-nio-client` in `thin_public_pom.xml` (snowflakedb/snowflake-jdbc#2654).

--- a/linkage-checker-exclusion-rules.xml
+++ b/linkage-checker-exclusion-rules.xml
@@ -75,12 +75,6 @@
         <Source><Package name="com.nimbusds.oauth2.sdk.assertions.saml2"/></Source>
         <Reason>Optional</Reason>
     </LinkageError>
-    <!-- AWS SDK v1 exclusions - com.amazonaws.util is not used in runtime -->
-    <LinkageError>
-        <Target><Package name="com.amazonaws.util"/></Target>
-        <Source><Package name="net.snowflake.common.core.SFBinary"/></Source>
-        <Reason>com.amazonaws.util is not used in runtime</Reason>
-    </LinkageError>
     <!-- AWS CRT exclusions - CRT is excluded from dependencies and not used in runtime -->
     <LinkageError>
         <Target><Package name="software.amazon.awssdk.crt"/></Target>

--- a/linkage-checker-exclusion-rules.xml
+++ b/linkage-checker-exclusion-rules.xml
@@ -75,6 +75,14 @@
         <Source><Package name="com.nimbusds.oauth2.sdk.assertions.saml2"/></Source>
         <Reason>Optional</Reason>
     </LinkageError>
+    <!-- snowflake-common's SFBinary still references com.amazonaws.util (AWS SDK v1).
+         The class is excluded from the shaded JAR via shade plugin filter (see pom.xml),
+         but the linkage checker runs before shading so the exclusion is still needed here. -->
+    <LinkageError>
+        <Target><Package name="com.amazonaws.util"/></Target>
+        <Source><Package name="net.snowflake.common.core.SFBinary"/></Source>
+        <Reason>SFBinary excluded from shaded JAR via shade filter (SNOW-3643336)</Reason>
+    </LinkageError>
     <!-- AWS CRT exclusions - CRT is excluded from dependencies and not used in runtime -->
     <LinkageError>
         <Target><Package name="software.amazon.awssdk.crt"/></Target>

--- a/pom.xml
+++ b/pom.xml
@@ -725,6 +725,17 @@
                       </excludes>
                     </filter>
                     <filter>
+                      <!-- Exclude snowflake-common's SFBinary/SFBinaryFormat: they still reference
+                           com.amazonaws.util.Base16/Base64 (AWS SDK v1). The JDBC driver uses its own
+                           internal copies at net.snowflake.client.internal.common.core which use
+                           Apache Commons Codec instead. See SNOW-3643336 / GitHub #2662. -->
+                      <artifact>net.snowflake:snowflake-common</artifact>
+                      <excludes>
+                        <exclude>net/snowflake/common/core/SFBinary.class</exclude>
+                        <exclude>net/snowflake/common/core/SFBinaryFormat*.class</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
                       <artifact>org.apache.arrow:arrow-vector</artifact>
                       <excludes>
                         <!-- codegen directory is used to generate java code for arrow vector package. Excludes them since we only need class file -->
@@ -1077,6 +1088,17 @@
                         <exclude>azure-*.properties</exclude>
                         <exclude>VersionInfo.java</exclude>
                         <exclude>project.properties</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
+                      <!-- Exclude snowflake-common's SFBinary/SFBinaryFormat: they still reference
+                           com.amazonaws.util.Base16/Base64 (AWS SDK v1). The JDBC driver uses its own
+                           internal copies at net.snowflake.client.internal.common.core which use
+                           Apache Commons Codec instead. See SNOW-3643336 / GitHub #2662. -->
+                      <artifact>net.snowflake:snowflake-common</artifact>
+                      <excludes>
+                        <exclude>net/snowflake/common/core/SFBinary.class</exclude>
+                        <exclude>net/snowflake/common/core/SFBinaryFormat*.class</exclude>
                       </excludes>
                     </filter>
                     <filter>


### PR DESCRIPTION


### Problem
Despite the AWS SDK v2 migration in JDBC 4.0.0 (PR #2393), `SFBinary.class` from the `snowflake-common` artifact still references `com.amazonaws.util.Base16` and `com.amazonaws.util.Base64` (AWS SDK v1) in its bytecode. When `snowflake-common` is shaded into the driver JARs, this class gets bundled and relocated to `net.snowflake.client.jdbc.internal.snowflake.common.core.SFBinary` — carrying the AWS SDK v1 constant pool references with it.
This causes two issues:
- **Security/compliance scanners** flag `snowflake-jdbc-thin` as containing AWS SDK v1 references, even though no `com.amazonaws` classes are actually bundled in the JAR.
- **Runtime `ClassNotFoundException`** if the `snowflake-common` `SFBinary` code path is ever reached without `aws-java-sdk-core` on the classpath (as reported in #2147).
### Root cause
The JDBC driver contains **two** copies of `SFBinary`:
1. **`net.snowflake.client.internal.common.core.SFBinary`** — the driver's own copy, fixed in PR #2393 to use `org.apache.commons.codec.binary.Base16/Base64`. All driver code uses this copy.
2. **`net.snowflake.common.core.SFBinary`** (from `snowflake-common` 5.1.4) — still references `com.amazonaws.util.Base16/Base64`. No driver code references this copy; it is dead code bundled into the shaded JAR.
The linkage checker exclusion in `linkage-checker-exclusion-rules.xml` was suppressing the known linkage error .

### Fix
- Add a Maven Shade plugin `<filter>` for `net.snowflake:snowflake-common` to exclude `SFBinary.class` and `SFBinaryFormat*.class` from the shaded JAR, in both the `thin-jar` and `self-contained-jar` profiles.
- Add a more explicit comment in `linkage-checker-exclusion-rules.xml` why is it still needed

### Testing
Built the thin JAR and verified with `javap -verbose`:
**Before (any released 4.x thin JAR, as reported in the GH issue):**
```
$ javap -verbose -classpath snowflake-jdbc-thin-4.3.0.jar
net.snowflake.client.jdbc.internal.snowflake.common.core.SFBinary
| grep amazonaws

#83 = Utf8               com/amazonaws/util/Base16
#84 = Class              #83           // com/amazonaws/util/Base16
#88 = Methodref          #84.#87       // com/amazonaws/util/Base16.decode:(Ljava/lang/String;)[B
#92 = Utf8               com/amazonaws/util/Base64
#93 = Class              #92           // com/amazonaws/util/Base64
#94 = Methodref          #93.#87       // com/amazonaws/util/Base64.decode:(Ljava/lang/String;)[B
#107 = Methodref          #84.#106      // com/amazonaws/util/Base16.encodeAsString:([B)Ljava/lang/String;
#109 = Methodref          #93.#106      // com/amazonaws/util/Base64.encodeAsString:([B)Ljava/lang/String;
```
**After (this branch):**
```
$ javap -verbose -classpath snowflake-jdbc-thin.jar
net.snowflake.client.jdbc.internal.snowflake.common.core.SFBinary

Error: class not found: net.snowflake.client.jdbc.internal.snowflake.common.core.SFBinary
```
The class is completely removed from the JAR. The driver's own internal `SFBinary` remains and references only the shaded Apache Commons Codec:
```
$ javap -verbose -classpath snowflake-jdbc-thin.jar
net.snowflake.client.internal.common.core.SFBinary
| grep -c amazonaws

0
```

The same was verified for the fat (self-contained) JAR.