### PR TITLE
NO-SNOW: Add missing Serializable to ConnectionIdentifierShape class

### DIFF
--- a/src/main/java/net/snowflake/client/internal/core/ConnectionIdentifierShape.java
+++ b/src/main/java/net/snowflake/client/internal/core/ConnectionIdentifierShape.java
@@ -1,5 +1,6 @@
 package net.snowflake.client.internal.core;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Properties;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
@@ -38,7 +39,11 @@ import net.snowflake.client.internal.jdbc.SnowflakeUtil;
  * <p>TODO(SNOW-3548350): remove this class and its callers after the connection-identifier-shape
  * data collection wraps up (target: 2026-11-30).
  */
-public final class ConnectionIdentifierShape {
+public final class ConnectionIdentifierShape implements Serializable {
+
+  // Serializable because SnowflakeConnectString.parse copies the carrier Properties entry into its
+  // own parameters map, which is then reachable from SnowflakeResultSetSerializableV1.
+  private static final long serialVersionUID = 1L;
 
   // TODO(SNOW-3548350): wire-format keys for the client_connection_identifier_shape telemetry
   // event. The five keys are byte-identical across all four Snowflake drivers.


### PR DESCRIPTION
ConnectionFactory stashes the shape on the Properties bag under CONNECTION_IDENTIFIER_SHAPE_KEY. SnowflakeConnectString.parse copies all Properties entries verbatim into its parameters map, which then lives on SnowflakeResultSetSerializableV1.snowflakeConnectionString — non-transient, so ObjectOutputStream-based result-set splitting trips on the NotSerializable shape value. Fixes SnowflakeResultSetSerializableIT.

# Overview

SNOW-XXXXX

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
