### PR TITLE
NO-SNOW: Bump version to 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 #### For all official JDBC Release Notes please refer to https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc
 
 # Changelog
-- v4.3.1-SNAPSHOT
+- v4.3.1
   - Fixed GCS-backed internal stage PUT failing with opaque `invalid_gcs_credentials` in SPCS pods on GCP: the GCS SDK's Application Default Credentials (ADC) probe was reaching out to `metadata.google.internal` which is unreachable inside SPCS; explicit credentials are now always set when a `GCS_ACCESS_TOKEN` is present, suppressing the ADC probe entirely. Also fixed `GCSAccessStrategyAwsSdk` rejecting custom GCS endpoints that lack an `https://` scheme prefix (e.g. bare `storage.me-central2.rep.googleapis.com`), mirroring the existing handling in `GCSDefaultAccessStrategy`. The catch-all in `setupGCSClient` now chains and logs the original exception instead of swallowing it (snowflakedb/snowflake-jdbc#2664).
   - Fixed Azure PUT memory leak where each PUT instantiated a fresh `BlobServiceClient` whose underlying reactor-netty stack the SDK exposes no API to release; the Azure SDK `HttpClient` and its `ConnectionProvider` are now shared across all PUTs in a session and disposed at session close, mirroring the existing S3 pattern (snowflakedb/snowflake-jdbc#2658).
   - Fixed `SFResultJsonParser2Failed: invalid escaped unicode character` when a chunked JSON result contained UTF-16 surrogate-pair `\u` escapes (e.g. emoji) and the read buffer happened to split exactly 9 bytes after `\u`; the off-by-one boundary guard in `ResultJsonParserV2` now reserves the full 10 bytes a surrogate pair requires (snowflakedb/snowflake-jdbc#2660).

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-jdbc-parent</artifactId>
-    <version>4.3.1-SNAPSHOT</version>
+    <version>4.3.1</version>
     <relativePath>../parent-pom.xml</relativePath>
   </parent>
 
   <artifactId>snowflake-jdbc-fips</artifactId>
-  <version>4.3.1-SNAPSHOT</version>
+  <version>4.3.1</version>
   <packaging>jar</packaging>
 
   <name>snowflake-jdbc-fips</name>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-jdbc-parent</artifactId>
-  <version>4.3.1-SNAPSHOT</version>
+  <version>4.3.1</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-jdbc-parent</artifactId>
-    <version>4.3.1-SNAPSHOT</version>
+    <version>4.3.1</version>
     <relativePath>./parent-pom.xml</relativePath>
   </parent>
 
   <!-- Maven complains about using property here, but it makes install and deploy process easier to override final package names and localization -->
   <artifactId>${artifactId}</artifactId>
-  <version>4.3.1-SNAPSHOT</version>
+  <version>4.3.1</version>
   <packaging>jar</packaging>
 
   <name>${artifactId}</name>


### PR DESCRIPTION
## Summary
- Bump version from `4.3.1-SNAPSHOT` to `4.3.1` for release across `pom.xml`, `parent-pom.xml`, `FIPS/pom.xml`, and `CHANGELOG.md`.

## Context
Emergency patch release including the GCS ADC probe fix for SPCS (SNOW-3643369), Azure PUT memory leak fix, JSON surrogate-pair parsing fix, SFBinary cleanup, and grpc-java bump.

## Test plan
- Verified no remaining `4.3.1-SNAPSHOT` references in the repository.
- Version changes follow the same pattern as prior release bumps (e.g. #2659, #2442).


Made with [Cursor](https://cursor.com)