### PR TITLE
NO-SNOW: Load minicore lazily on first connection instead of driver class-load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Changelog
 - v4.3.2-SNAPSHOT
   - Bumped jackson-databind to 2.18.8 from 2.18.7 (snowflakedb/snowflake-jdbc#2669).
+  - Fixed snowflake-jdbc writing a `snowflake-minicore-*` temp directory and loading the native library at driver class-load time even when the driver was never used (e.g. when present on the classpath only as a transitive dependency). Minicore now loads lazily when the first Snowflake connection is created (`ConnectionFactory.createConnection`) instead of during `DriverInitializer.initialize()` (snowflakedb/snowflake-jdbc#2670).
   
 - v4.3.1
   - Fixed GCS-backed internal stage PUT failing with opaque `invalid_gcs_credentials` in SPCS pods on GCP: the GCS SDK's Application Default Credentials (ADC) probe was reaching out to `metadata.google.internal` which is unreachable inside SPCS; explicit credentials are now always set when a `GCS_ACCESS_TOKEN` is present, suppressing the ADC probe entirely. Also fixed `GCSAccessStrategyAwsSdk` rejecting custom GCS endpoints that lack an `https://` scheme prefix (e.g. bare `storage.me-central2.rep.googleapis.com`), mirroring the existing handling in `GCSDefaultAccessStrategy`. The catch-all in `setupGCSClient` now chains and logs the original exception instead of swallowing it (snowflakedb/snowflake-jdbc#2664).

--- a/src/main/java/net/snowflake/client/internal/core/minicore/Minicore.java
+++ b/src/main/java/net/snowflake/client/internal/core/minicore/Minicore.java
@@ -24,9 +24,16 @@ public class Minicore {
     this.library = library;
   }
 
-  public static synchronized void initializeAsync() {
+  public static void initializeAsync() {
     if (INITIALIZATION_FUTURE != null) {
-      return; // Already started
+      return; // Already started — volatile read only, no lock
+    }
+    initializeAsyncSlow();
+  }
+
+  private static synchronized void initializeAsyncSlow() {
+    if (INITIALIZATION_FUTURE != null) {
+      return; // Re-check under lock
     }
 
     // Check if minicore is disabled via environment variable
@@ -92,7 +99,7 @@ public class Minicore {
     return loadResult;
   }
 
-  public static synchronized boolean hasInitializationStarted() {
+  public static boolean hasInitializationStarted() {
     return INITIALIZATION_FUTURE != null;
   }
 

--- a/src/main/java/net/snowflake/client/internal/driver/ConnectionFactory.java
+++ b/src/main/java/net/snowflake/client/internal/driver/ConnectionFactory.java
@@ -7,6 +7,7 @@ import java.util.Properties;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.config.ConnectionParameters;
+import net.snowflake.client.internal.core.minicore.Minicore;
 import net.snowflake.client.internal.jdbc.SnowflakeConnectString;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
@@ -50,6 +51,17 @@ public final class ConnectionFactory {
     if (!SnowflakeConnectString.hasSupportedPrefix(params.getUrl())) {
       // Per JDBC spec: Driver.connect() should return null if URL is not recognized
       return null;
+    }
+
+    // Begin loading minicore asynchronously as soon as we confirm this is a
+    // Snowflake connection attempt. This gives the native library a head start
+    // to be warm by first login, without loading at driver class-load time when
+    // the driver is merely on the classpath as a transitive dependency
+    // (SNOW-3561155 / gosnowflake#1807).
+    try {
+      Minicore.initializeAsync();
+    } catch (Throwable t) {
+      logger.trace("Failed to start minicore initialization: {}", t.getMessage());
     }
 
     // Parse and validate the connection string

--- a/src/main/java/net/snowflake/client/internal/driver/DriverInitializer.java
+++ b/src/main/java/net/snowflake/client/internal/driver/DriverInitializer.java
@@ -3,7 +3,6 @@ package net.snowflake.client.internal.driver;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import net.snowflake.client.internal.core.SecurityUtil;
-import net.snowflake.client.internal.core.minicore.Minicore;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
 import net.snowflake.client.internal.jdbc.telemetryOOB.TelemetryService;
 import net.snowflake.client.internal.log.SFLogger;
@@ -52,7 +51,6 @@ public final class DriverInitializer {
     initializeArrowSupport();
     initializeSecurityProvider();
     initializeTelemetry();
-    initializeMinicore();
 
     initialized = true;
     logger.debug("Snowflake JDBC Driver initialization complete");
@@ -156,21 +154,6 @@ public final class DriverInitializer {
       logger.debug("Out-of-band telemetry disabled");
     } catch (Throwable t) {
       logger.warn("Failed to configure telemetry: {}", t.getMessage());
-    }
-  }
-
-  /**
-   * Start asynchronous minicore native library loading.
-   *
-   * <p>Minicore is loaded in the background so it can overlap with connection setup. The loading
-   * result is reported via telemetry during session establishment.
-   */
-  private static void initializeMinicore() {
-    try {
-      Minicore.initializeAsync();
-      logger.debug("Minicore async initialization started");
-    } catch (Throwable t) {
-      logger.trace("Failed to start minicore initialization", t);
     }
   }
 

--- a/src/test/java/net/snowflake/client/internal/driver/ConnectionFactoryTest.java
+++ b/src/test/java/net/snowflake/client/internal/driver/ConnectionFactoryTest.java
@@ -1,0 +1,59 @@
+package net.snowflake.client.internal.driver;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+import net.snowflake.client.category.TestTags;
+import net.snowflake.client.internal.core.minicore.Minicore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(TestTags.CORE)
+public class ConnectionFactoryTest {
+
+  @BeforeEach
+  public void setUp() {
+    Minicore.resetForTesting();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    Minicore.resetForTesting();
+  }
+
+  @Test
+  public void testCreateConnectionTriggersMinicoreForSnowflakeUrl() {
+    assertFalse(
+        Minicore.hasInitializationStarted(), "Minicore should not be started before connection");
+
+    try {
+      ConnectionFactory.createConnection(
+          "jdbc:snowflake://fake.account.snowflakecomputing.com", new Properties());
+    } catch (Exception e) {
+      // Expected — the fake host will fail during connection setup.
+      // We only care that minicore was triggered before the failure.
+    }
+
+    assertTrue(
+        Minicore.hasInitializationStarted(),
+        "Minicore should be started when ConnectionFactory processes a Snowflake URL");
+  }
+
+  @Test
+  public void testCreateConnectionDoesNotTriggerMinicoreForNonSnowflakeUrl() throws Exception {
+    assertFalse(
+        Minicore.hasInitializationStarted(), "Minicore should not be started before connection");
+
+    assertNull(
+        ConnectionFactory.createConnection("jdbc:mysql://localhost:3306/db", new Properties()),
+        "Non-Snowflake URL should return null per JDBC spec");
+
+    assertFalse(
+        Minicore.hasInitializationStarted(),
+        "Minicore should not be started for non-Snowflake URLs");
+  }
+}

--- a/src/test/java/net/snowflake/client/internal/driver/DriverInitializerTest.java
+++ b/src/test/java/net/snowflake/client/internal/driver/DriverInitializerTest.java
@@ -1,25 +1,33 @@
 package net.snowflake.client.internal.driver;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.snowflake.client.category.TestTags;
 import net.snowflake.client.internal.core.minicore.Minicore;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag(TestTags.CORE)
 public class DriverInitializerTest {
 
+  @AfterEach
+  public void tearDown() {
+    DriverInitializer.resetForTesting();
+    Minicore.resetForTesting();
+  }
+
   @Test
-  public void testInitializeTriggersMinicore() {
+  public void testInitializeDoesNotTriggerMinicore() {
     DriverInitializer.resetForTesting();
     Minicore.resetForTesting();
 
     DriverInitializer.initialize();
 
     assertTrue(DriverInitializer.isInitialized(), "DriverInitializer should be initialized");
-    assertTrue(
+    assertFalse(
         Minicore.hasInitializationStarted(),
-        "Minicore async initialization should have been started by DriverInitializer.initialize()");
+        "Minicore should not be started by DriverInitializer — it loads lazily on first connection");
   }
 }


### PR DESCRIPTION
## Summary
- Minicore native library loading is now deferred until the first actual Snowflake connection attempt (`ConnectionFactory.createConnection()`), instead of eagerly loading during `SnowflakeDriver`'s static initializer
- This prevents filesystem writes (temp dir extraction) and native library loading (`dlopen` via JNA) when the driver is merely on the classpath as a transitive dependency
- Mirrors the identical change in the Go driver: https://github.com/snowflakedb/gosnowflake/pull/1807

## Context
When snowflake-jdbc is on the classpath, Java's `ServiceLoader` auto-discovers and loads all registered JDBC drivers when `DriverManager` is first used — even for non-Snowflake connections. The `SnowflakeDriver` static block called `DriverInitializer.initialize()` → `Minicore.initializeAsync()`, which extracts the native library to a temp directory and calls `Native.load` (JNA). This side effect fired on class-load alone.

The fix removes minicore from `DriverInitializer.initialize()` and instead triggers `Minicore.initializeAsync()` lazily in `ConnectionFactory.createConnection()`, after confirming the URL has the `jdbc:snowflake://` prefix. The call remains async, idempotent (`synchronized` + null guard), and wrapped in `try/catch Throwable` so it never affects connection creation.

### Behavior note (intentional, not a regression)
The first login request may more frequently report `CORE_LOAD_ERROR: "Minicore is still loading"` in `CLIENT_ENVIRONMENT` since the async load now starts concurrently with connection setup rather than having a head start from class-load time. The in-band `client_minicore_load` telemetry (sent after login) will still capture the real version. This is the same best-effort trade-off the Go driver PR accepts.

## Test plan
- Added `ConnectionFactoryTest.testCreateConnectionTriggersMinicoreForSnowflakeUrl` — verifies minicore is started when `ConnectionFactory` processes a Snowflake URL
- Added `ConnectionFactoryTest.testCreateConnectionDoesNotTriggerMinicoreForNonSnowflakeUrl` — verifies non-Snowflake URLs don't trigger minicore
- Updated `DriverInitializerTest.testInitializeDoesNotTriggerMinicore` — verifies `DriverInitializer.initialize()` no longer starts minicore
- Added `@AfterEach` cleanup to `DriverInitializerTest` for test isolation
- Existing `MinicoreTest`, `MinicoreTelemetryWiremockIT`, and `MinicoreTelemetryTest` remain passing (they test minicore APIs directly)
- `mvn com.spotify.fmt:fmt-maven-plugin:format` — 0 reformatted
- `mvn clean validate -P check-style` — 0 checkstyle violations


Made with [Cursor](https://cursor.com)