### PR TITLE
NO-SNOW: Pass JAVA_TOOL_OPTIONS to Docker container in CI tests

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -58,6 +58,7 @@ for name in "${!TARGET_TEST_IMAGES[@]}"; do
         -e ADDITIONAL_MAVEN_PROFILE \
         -e CLOUD_PROVIDER \
         -e is_old_driver \
+        -e JAVA_TOOL_OPTIONS \
         ${TEST_IMAGE_NAMES[$name]} \
         /mnt/host/ci/container/test_component.sh
 done


### PR DESCRIPTION
## Summary
- Pass `JAVA_TOOL_OPTIONS` environment variable through to the Docker container in `ci/test.sh`
- This fixes `Java heap space` OOM errors in the forked Failsafe JVM during Linux Docker-based integration tests (`test-linux`, `test-rocky`)

## Context
The GitHub Actions workflow sets `JAVA_TOOL_OPTIONS: "-Xms1g -Xmx4g"` for all test jobs, but `ci/test.sh` never passes this variable into the Docker container via `-e`. The Mac and Windows jobs run `test_component.sh` directly (no Docker), so they inherit the variable naturally. Only Docker-based Linux tests are affected — the forked JVM defaults to a small heap and runs out of memory.

## Test plan
- Verify that `test-linux` and `test-rocky` CI jobs no longer fail with `Java heap space` errors
- Confirm Mac/Windows jobs are unaffected (they don't use this script)


Made with [Cursor](https://cursor.com)