### PR TITLE
SNOW-3709138: Map credential-rejection auth failures to SQLState 28000 instead of 08001

### DIFF
--- a/src/main/java/net/snowflake/client/internal/core/Constants.java
+++ b/src/main/java/net/snowflake/client/internal/core/Constants.java
@@ -3,6 +3,7 @@ package net.snowflake.client.internal.core;
 import static net.snowflake.client.internal.jdbc.SnowflakeUtil.systemGetProperty;
 
 import java.util.Optional;
+import java.util.Set;
 import net.snowflake.client.internal.jdbc.SnowflakeUtil;
 
 /*
@@ -24,6 +25,19 @@ public final class Constants {
   public static final int OAUTH_ACCESS_TOKEN_EXPIRED_GS_CODE = 390318;
 
   public static final int OAUTH_ACCESS_TOKEN_INVALID_GS_CODE = 390303;
+
+  // GitHub #2681: server (GS) error codes that represent credential/authentication rejection.
+  // These must surface as SQLState 28000 (INVALID_AUTHORIZATION_SPECIFICATION), not 08001.
+  public static final Set<Integer> AUTH_REJECTION_GS_CODES =
+      Set.of(
+          390100, // INCORRECT_USERNAME_PASSWORD
+          390144, // JWT_TOKEN_INVALID
+          394300, // JWT_TOKEN_INVALID_USER_IN_ISSUER
+          394301, // JWT_TOKEN_MISSING_ISSUE_OR_EXPIRATION_TIME
+          394304, // JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH
+          394305, // JWT_TOKEN_INVALID_ALGORITHM
+          394306, // JWT_TOKEN_INVALID_SIGNATURE
+          390303); // OAUTH_ACCESS_TOKEN_INVALID
 
   // Error message for IOException when no space is left for GET
   public static final String NO_SPACE_LEFT_ON_DEVICE_ERR = "No space left on device";

--- a/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
+++ b/src/main/java/net/snowflake/client/internal/core/SessionUtil.java
@@ -937,11 +937,11 @@ public class SessionUtil {
             loginInput.getUserName(),
             loginInput.getHostFromServerUrl(),
             errorMessage);
-        throw new SnowflakeSQLException(
-            NO_QUERY_ID,
-            errorMessage,
-            SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-            errorCode);
+        String sqlState =
+            Constants.AUTH_REJECTION_GS_CODES.contains(errorCode)
+                ? SqlState.INVALID_AUTHORIZATION_SPECIFICATION
+                : SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION;
+        throw new SnowflakeSQLException(NO_QUERY_ID, errorMessage, sqlState, errorCode);
       }
 
       // session token is in the data field of the returned json response

--- a/src/main/java/net/snowflake/client/internal/core/SessionUtilExternalBrowser.java
+++ b/src/main/java/net/snowflake/client/internal/core/SessionUtilExternalBrowser.java
@@ -211,11 +211,12 @@ public class SessionUtilExternalBrowser {
       // check the success field first
       if (!jsonNode.path("success").asBoolean()) {
         logger.debug("Response: {}", theString);
-        String errorCode = jsonNode.path("code").asText();
-        throw new SnowflakeSQLException(
-            SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-            Integer.valueOf(errorCode),
-            jsonNode.path("message").asText());
+        int errorCode = Integer.parseInt(jsonNode.path("code").asText());
+        String sqlState =
+            Constants.AUTH_REJECTION_GS_CODES.contains(errorCode)
+                ? SqlState.INVALID_AUTHORIZATION_SPECIFICATION
+                : SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION;
+        throw new SnowflakeSQLException(sqlState, errorCode, jsonNode.path("message").asText());
       }
 
       JsonNode dataNode = jsonNode.path("data");

--- a/src/test/java/net/snowflake/client/internal/core/SessionUtilExternalBrowserTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SessionUtilExternalBrowserTest.java
@@ -28,6 +28,7 @@ import net.snowflake.client.api.datasource.SnowflakeDataSource;
 import net.snowflake.client.api.datasource.SnowflakeDataSourceFactory;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.exception.SnowflakeSQLLoggedException;
+import net.snowflake.common.core.SqlState;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.hamcrest.MatcherAssert;
@@ -232,6 +233,37 @@ public class SessionUtilExternalBrowserTest {
                 sub.authenticate();
               });
       MatcherAssert.assertThat("Error is expected", ex.getErrorCode(), equalTo(123456));
+    }
+  }
+
+  @Test
+  public void testWrongPasswordMapsTo28000() throws Throwable {
+    final SFLoginInput loginInput = initMockLoginInput();
+
+    try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequestWithContext(
+                      Mockito.any(HttpRequestBase.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(HttpClientSettingsKey.class),
+                      Mockito.nullable(SFBaseSession.class)))
+          .thenReturn(
+              new HttpResponseWithHeaders(
+                  "{\"success\":\"false\",\"code\":\"390100\",\"message\":\"Incorrect username or password was specified.\"}",
+                  new HashMap<>()));
+
+      SessionUtilExternalBrowser sub =
+          FakeSessionUtilExternalBrowser.createInstance(loginInput, false);
+      SnowflakeSQLException ex =
+          assertThrows(SnowflakeSQLException.class, () -> sub.authenticate());
+      assertEquals(390100, ex.getErrorCode());
+      assertEquals(SqlState.INVALID_AUTHORIZATION_SPECIFICATION, ex.getSQLState());
     }
   }
 

--- a/src/test/java/net/snowflake/client/internal/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/SessionUtilLatestIT.java
@@ -715,7 +715,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
                       Mockito.nullable(SFBaseSession.class)))
           .thenReturn(
               new HttpResponseWithHeaders(
-                  "{\"code\":390100,\"message\":\"Incorrect username or password was specified.\",\"success\":false}",
+                  "{\"data\":null,\"code\":390100,\"message\":\"Incorrect username or password was specified.\",\"success\":false}",
                   new HashMap<>()));
       mockedHttpUtil
           .when(() -> HttpUtil.applyAdditionalHeadersForSnowsight(any(), any()))
@@ -749,7 +749,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
                       Mockito.nullable(SFBaseSession.class)))
           .thenReturn(
               new HttpResponseWithHeaders(
-                  "{\"code\":390144,\"message\":\"JWT token is invalid.\",\"success\":false}",
+                  "{\"data\":null,\"code\":390144,\"message\":\"JWT token is invalid.\",\"success\":false}",
                   new HashMap<>()));
       mockedHttpUtil
           .when(() -> HttpUtil.applyAdditionalHeadersForSnowsight(any(), any()))
@@ -783,7 +783,9 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
                       Mockito.nullable(SFBaseSession.class)))
           .thenReturn(
               new HttpResponseWithHeaders(
-                  "{\"code\":390201,\"message\":\"some non-auth failure\",\"success\":false}",
+                  // 390201 = SESSION_CREATION_OBJECT_DOES_NOT_EXIST_NOT_AUTHORIZED:
+                  // object-not-authorized, not credential rejection; must stay 08001
+                  "{\"data\":null,\"code\":390201,\"message\":\"some non-auth failure\",\"success\":false}",
                   new HashMap<>()));
       mockedHttpUtil
           .when(() -> HttpUtil.applyAdditionalHeadersForSnowsight(any(), any()))
@@ -793,6 +795,7 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
           assertThrows(
               SnowflakeSQLException.class,
               () -> SessionUtil.openSession(loginInput, connectionPropertiesMap, "ALL"));
+      assertEquals(390201, e.getErrorCode());
       assertEquals(SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION, e.getSQLState());
     }
   }

--- a/src/test/java/net/snowflake/client/internal/core/SessionUtilLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/core/SessionUtilLatestIT.java
@@ -695,4 +695,105 @@ public class SessionUtilLatestIT extends BaseJDBCTest {
       assertEquals((int) ErrorCode.IDP_INCORRECT_DESTINATION.getMessageCode(), ex.getErrorCode());
     }
   }
+
+  @Test
+  public void testWrongPasswordMapsTo28000() throws Throwable {
+    SFLoginInput loginInput = createLoginInput();
+    Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
+    try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequestWithContext(
+                      Mockito.any(HttpPost.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(HttpClientSettingsKey.class),
+                      Mockito.nullable(SFBaseSession.class)))
+          .thenReturn(
+              new HttpResponseWithHeaders(
+                  "{\"code\":390100,\"message\":\"Incorrect username or password was specified.\",\"success\":false}",
+                  new HashMap<>()));
+      mockedHttpUtil
+          .when(() -> HttpUtil.applyAdditionalHeadersForSnowsight(any(), any()))
+          .thenCallRealMethod();
+
+      SnowflakeSQLException e =
+          assertThrows(
+              SnowflakeSQLException.class,
+              () -> SessionUtil.openSession(loginInput, connectionPropertiesMap, "ALL"));
+      assertEquals(390100, e.getErrorCode());
+      assertEquals(SqlState.INVALID_AUTHORIZATION_SPECIFICATION, e.getSQLState());
+    }
+  }
+
+  @Test
+  public void testBadJwtMapsTo28000() throws Throwable {
+    SFLoginInput loginInput = createLoginInput();
+    Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
+    try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequestWithContext(
+                      Mockito.any(HttpPost.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(HttpClientSettingsKey.class),
+                      Mockito.nullable(SFBaseSession.class)))
+          .thenReturn(
+              new HttpResponseWithHeaders(
+                  "{\"code\":390144,\"message\":\"JWT token is invalid.\",\"success\":false}",
+                  new HashMap<>()));
+      mockedHttpUtil
+          .when(() -> HttpUtil.applyAdditionalHeadersForSnowsight(any(), any()))
+          .thenCallRealMethod();
+
+      SnowflakeSQLException e =
+          assertThrows(
+              SnowflakeSQLException.class,
+              () -> SessionUtil.openSession(loginInput, connectionPropertiesMap, "ALL"));
+      assertEquals(390144, e.getErrorCode());
+      assertEquals(SqlState.INVALID_AUTHORIZATION_SPECIFICATION, e.getSQLState());
+    }
+  }
+
+  @Test
+  public void testNonAuthFailureStays08001() throws Throwable {
+    SFLoginInput loginInput = createLoginInput();
+    Map<SFSessionProperty, Object> connectionPropertiesMap = initConnectionPropertiesMap();
+    try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+      mockedHttpUtil
+          .when(
+              () ->
+                  HttpUtil.executeGeneralRequestWithContext(
+                      Mockito.any(HttpPost.class),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.anyInt(),
+                      Mockito.nullable(HttpClientSettingsKey.class),
+                      Mockito.nullable(SFBaseSession.class)))
+          .thenReturn(
+              new HttpResponseWithHeaders(
+                  "{\"code\":390201,\"message\":\"some non-auth failure\",\"success\":false}",
+                  new HashMap<>()));
+      mockedHttpUtil
+          .when(() -> HttpUtil.applyAdditionalHeadersForSnowsight(any(), any()))
+          .thenCallRealMethod();
+
+      SnowflakeSQLException e =
+          assertThrows(
+              SnowflakeSQLException.class,
+              () -> SessionUtil.openSession(loginInput, connectionPropertiesMap, "ALL"));
+      assertEquals(SqlState.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION, e.getSQLState());
+    }
+  }
 }


### PR DESCRIPTION
# Overview

Fixes #2681.

> Note: no `SNOW-XXXX` Jira key is available — the repo's `jira_issue.yml` automation fails to mint one ("target project doesn't exist or you don't have permission to create issues in it"), so the title can't be prefixed yet. Maintainers may assign the SNOW key.

Snowflake server-side **credential-rejection** failures (wrong password, invalid JWT/key-pair, invalid OAuth token) are currently thrown with SQLState `08001` (`SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION`) — a *connection* class — because the login-failure throw site hardcodes that state regardless of the server error `code`. The correct class is `28000` (`INVALID_AUTHORIZATION_SPECIFICATION`), which the driver already uses for locally-detected missing credentials (`MISSING_USERNAME`/`MISSING_PASSWORD`). Tooling that classifies errors by SQLState (jOOQ, connection pools, retry frameworks) otherwise treats a bad password as a transient outage.

This PR maps a set of credential-rejection server codes to `28000`, leaving every other failure on `08001` (no regression). See #2681 for the full root-cause analysis and firsthand reproduction (`390100` wrong-password and `390144` bad-JWT, both observed returning `08001` on driver 4.3.1).

## Changes
- `Constants.java` — new `AUTH_REJECTION_GS_CODES = Set.of(390100, 390144, 394300, 394301, 394304, 394305, 394306, 390303)`.
- `SessionUtil.java` (login-failure throw, ~line 940) — select `INVALID_AUTHORIZATION_SPECIFICATION` for those codes, else keep `SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION`.
- `SessionUtilExternalBrowser.java` (external-browser login throw) — same selection, adapted to its `String` code / constructor.
- Tests: `SessionUtilLatestIT` (390100→28000, 390144→28000, and a non-auth `390201` regression guard that stays 08001) + `SessionUtilExternalBrowserTest` (390100→28000).

## Compatibility
Only the **SQLState string** changes for the listed codes; `getErrorCode()` (e.g. `390100`) is unchanged, so consumers keying on the error code are unaffected. The new constant lives in the non-published `internal.core` package — additive, no public-API/`japicmp` impact. No logging changes.

## Excluded (not credential rejection)
`390318` (OAuth expired — re-auth path), `390111`/`390112` (session lifecycle), `390195` (id-token) — all handled on other paths.

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master`
- [x] The code is correctly formatted (`mvn -P check-style validate`)
- [x] New public API is not unnecessarily exposed (new field is in non-published `internal.core`)
- [x] The pull request name is prefixed with `SNOW-XXXX:` — no Jira key minted (see note above)
- [x] Code is in compliance with internal logging requirements (no logging changes)

## External contributors
1. **Issue:** #2681
2. Pre-review checklist:
   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms — *no; only the SQLState classification of an already-rejected auth failure changes; authentication logic is untouched*
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding a new public/protected component not marked `@SnowflakeJdbcInternalApi` — *the new field is in the non-published `internal.core` package*
3. **How it solves the issue:** the misclassification originates from a hardcoded SQLState at the login-failure throw site; this PR selects the SQLState from the server `code` for known credential-rejection codes (reusing the existing `INVALID_AUTHORIZATION_SPECIFICATION` constant), so auth failures now surface as `28000` while genuine connection failures keep `08001`.

> Open question for maintainers (also in #2681): is `AUTH_REJECTION_GS_CODES` the complete/correct set of credential-rejection GS codes? Happy to adjust to the authoritative list.
