### PR TITLE
 SNOW-3725168: Handle VECTOR type in isCaseSensitive and getColumnClassName

### DIFF
--- a/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeResultSetMetaDataV1.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/SnowflakeResultSetMetaDataV1.java
@@ -7,6 +7,7 @@ import java.util.List;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.api.resultset.FieldMetadata;
 import net.snowflake.client.api.resultset.SnowflakeResultSetMetaData;
+import net.snowflake.client.api.resultset.SnowflakeType;
 import net.snowflake.client.internal.core.SFBaseSession;
 import net.snowflake.client.internal.core.SFException;
 import net.snowflake.client.internal.core.SFResultSetMetaData;
@@ -123,6 +124,9 @@ public class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, Snowflak
   @Override
   public boolean isCaseSensitive(int column) throws SQLException {
     int colType = getColumnType(column);
+    if (colType == SnowflakeType.EXTRA_TYPES_VECTOR) {
+      colType = Types.VARCHAR;
+    }
 
     switch (colType) {
         // Note: SF types GEOGRAPHY, GEOMETRY are also represented as VARCHAR.
@@ -177,6 +181,9 @@ public class SnowflakeResultSetMetaDataV1 implements ResultSetMetaData, Snowflak
     logger.trace("String getColumnClassName(int column)", false);
 
     int type = this.getColumnType(column);
+    if (type == SnowflakeType.EXTRA_TYPES_VECTOR) {
+      type = Types.VARCHAR;
+    }
 
     return SnowflakeTypeUtil.javaTypeToClassName(type);
   }

--- a/src/test/java/net/snowflake/client/internal/jdbc/ResultSetLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/ResultSetLatestIT.java
@@ -45,6 +45,7 @@ import net.snowflake.client.annotations.DontRunOnGithubActions;
 import net.snowflake.client.api.exception.ErrorCode;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.api.resultset.SnowflakeResultSetMetaData;
+import net.snowflake.client.api.resultset.SnowflakeType;
 import net.snowflake.client.category.TestTags;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.api.implementation.resultset.SnowflakeBaseResultSet;
@@ -672,6 +673,19 @@ public class ResultSetLatestIT extends ResultSet0IT {
     }
   }
 
+  @ParameterizedTest
+  @ArgumentsSource(SimpleResultFormatProvider.class)
+  public void testGetDataTypeWithVector(String queryResultFormat) throws SQLException {
+    try (Statement statement = createStatement(queryResultFormat)) {
+      statement.execute("create or replace table vector_test(v vector(int, 3))");
+      try (ResultSet resultSet = statement.executeQuery("select * from vector_test")) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        assertEquals(SnowflakeType.EXTRA_TYPES_VECTOR, resultSetMetaData.getColumnType(1));
+        assertEquals(String.class.getName(), resultSetMetaData.getColumnClassName(1));
+      }
+    }
+  }
+
   /**
    * Test getClob(int), and getClob(String) handle SQL nulls and don't throw a NullPointerException
    * (SNOW-749517)
@@ -908,7 +922,8 @@ public class ResultSetLatestIT extends ResultSet0IT {
               + "  array_col1 ARRAY,"
               + "  text_col1 TEXT,"
               + "  varchar_col VARCHAR(16777216),"
-              + "  char_col CHAR(16777216)"
+              + "  char_col CHAR(16777216),"
+              + "  vector_col VECTOR(INT, 3)"
               + ");";
 
       statement.execute(sampleCreateTableWithAllColTypes);
@@ -933,6 +948,7 @@ public class ResultSetLatestIT extends ResultSet0IT {
         assertTrue(metaData.isCaseSensitive(15)); // TEXT
         assertTrue(metaData.isCaseSensitive(16)); // VARCHAR
         assertTrue(metaData.isCaseSensitive(17)); // CHAR
+        assertTrue(metaData.isCaseSensitive(18)); // VECTOR
       }
     }
   }


### PR DESCRIPTION
# Overview

SNOW-3725168

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [x] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #2684


2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   This PR resolves the issue where the Snowflake `VECTOR` data type was not correctly mapped to a standard JDBC type, causing external tools and ORMs to fail when retrieving vector columns.

   **Solution:**
   The fix correctly maps `SnowflakeType.EXTRA_TYPES_VECTOR` to `java.sql.Types.VARCHAR`. 
Since the driver internally already extracts `VECTOR` data as a JSON string via `getString(columnIndex)`, mapping it to `VARCHAR` ensures maximum compatibility with standard JDBC clients without breaking internal driver logic.