### PR TITLE
SNOW-3053414 prevent NPE from exposing JDBC internals in OAuth cache key lookup

### DIFF
--- a/src/main/java/net/snowflake/client/internal/core/CredentialManager.java
+++ b/src/main/java/net/snowflake/client/internal/core/CredentialManager.java
@@ -404,6 +404,10 @@ public class CredentialManager {
    * but rather IdP-specific
    */
   static String getHostForOAuthCacheKey(SFLoginInput loginInput) throws SFException {
+    if (loginInput.getOauthLoginInput() == null) {
+      throw new SFException(
+          ErrorCode.INTERNAL_ERROR, "OAuth configuration is not initialized for this connection");
+    }
     String oauthTokenRequestUrl = loginInput.getOauthLoginInput().getTokenRequestUrl();
     if (oauthTokenRequestUrl != null) {
       URI parsedUrl = URI.create(oauthTokenRequestUrl);

--- a/src/test/java/net/snowflake/client/internal/core/CredentialManagerTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/CredentialManagerTest.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.internal.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,6 +43,12 @@ class CredentialManagerTest {
   @AfterAll
   public static void tearDown() {
     CredentialManager.resetSecureStorageManager();
+  }
+
+  @Test
+  public void shouldThrowSFExceptionNotNPEWhenOauthLoginInputIsNull() {
+    SFLoginInput loginInput = createGenericLoginInput();
+    assertThrows(SFException.class, () -> CredentialManager.getHostForOAuthCacheKey(loginInput));
   }
 
   @Test


### PR DESCRIPTION
# Overview
[SNOW-3053414](https://snowflakecomputing.atlassian.net/browse/SNOW-3053414)
`getHostForOAuthCacheKey` dereferenced `getOauthLoginInput()` without a null check. Java NPEs exposed class names and method signatures to end users.                                                                      
                                                                                                                                                                    
Fix: explicit null check throws `SFException` instead of letting the JVM generate a verbose NPE with internal implementation details.                                    

## Pre-review self checklist
- [x] PR branch is updated with all the changes from `master` branch
- [x] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [x] The pull request name is prefixed with `SNOW-XXXX: `
- [x] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: SNOW-3053414


2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.


[SNOW-3053414]: https://snowflakecomputing.atlassian.net/browse/SNOW-3053414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ