### PR TITLE
Remove obsolete FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY from MaxLobSizeLatestIT

### DIFF
--- a/src/test/java/net/snowflake/client/internal/jdbc/MaxLobSizeLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/MaxLobSizeLatestIT.java
@@ -31,7 +31,6 @@ public class MaxLobSizeLatestIT extends BaseJDBCTest {
   public void testIncreasedMaxLobSize() throws SQLException {
     try (Connection con = BaseJDBCTest.getConnection();
         Statement stmt = con.createStatement()) {
-      stmt.execute("alter session set FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY='ENABLED'");
       stmt.execute("alter session set ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT=false");
       SnowflakeSQLException e =
           assertThrows(
@@ -46,7 +45,6 @@ public class MaxLobSizeLatestIT extends BaseJDBCTest {
         assertThat(resultSet.getString(1), is(not(emptyOrNullString())));
       } finally {
         stmt.execute("alter session unset ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT");
-        stmt.execute("alter session unset FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY");
       }
     }
   }


### PR DESCRIPTION
## Problem

`MaxLobSizeLatestIT.testIncreasedMaxLobSize` fails with:

```
SQL compilation error: invalid parameter 'FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY'
```

The server-side rollout flag `FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY` was removed in GS (cleanup of `ENABLE_LARGE_LOBS_IN_MEMORY`). The in-memory large-LOB feature is now enabled by default, so `ALTER SESSION SET FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY=...` no longer compiles.

## Fix

Drop the `set`/`unset` of the removed flag. The test still exercises the actual behavior via `ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT` (still a live GS parameter):
- `false` → selecting a 20 MB `randstr` throws "exceeds supported length"
- `true` → the query succeeds

No other changes; the test is `@DontRunOnGithubActions` and runs against a real account.