### PR TITLE
Match auth IT error messages by substring to ignore appended request id

### DIFF
--- a/src/test/java/net/snowflake/client/authentication/ExternalBrowserLatestIT.java
+++ b/src/test/java/net/snowflake/client/authentication/ExternalBrowserLatestIT.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.authentication;
 
 import static net.snowflake.client.authentication.AuthConnectionParameters.getExternalBrowserConnectionParameters;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -49,7 +50,8 @@ class ExternalBrowserLatestIT {
 
     authTestHelper.connectAndProvideCredentials(provideCredentialsThread, connectThread);
     authTestHelper.verifyExceptionIsThrown(
-        "The user you were trying to authenticate as differs from the user currently logged in at the IDP.");
+        containsString(
+            "The user you were trying to authenticate as differs from the user currently logged in at the IDP."));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/authentication/OauthLatestIT.java
+++ b/src/test/java/net/snowflake/client/authentication/OauthLatestIT.java
@@ -51,7 +51,8 @@ public class OauthLatestIT {
     properties.put("user", "differentUsername");
     authTestHelper.connectAndExecuteSimpleQuery(properties, null);
     authTestHelper.verifyExceptionIsThrown(
-        "The user you were trying to authenticate as differs from the user tied to the access token.");
+        containsString(
+            "The user you were trying to authenticate as differs from the user tied to the access token."));
   }
 
   private String getToken() throws IOException {

--- a/src/test/java/net/snowflake/client/authentication/OauthOktaAuthorizationCodeLatestIT.java
+++ b/src/test/java/net/snowflake/client/authentication/OauthOktaAuthorizationCodeLatestIT.java
@@ -1,6 +1,7 @@
 package net.snowflake.client.authentication;
 
 import static net.snowflake.client.authentication.AuthConnectionParameters.getOAuthExternalAuthorizationCodeConnectionParameters;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -58,7 +59,8 @@ public class OauthOktaAuthorizationCodeLatestIT {
 
     authTestHelper.connectAndProvideCredentials(provideCredentialsThread, connectThread);
     authTestHelper.verifyExceptionIsThrown(
-        "The user you were trying to authenticate as differs from the user tied to the access token.");
+        containsString(
+            "The user you were trying to authenticate as differs from the user tied to the access token."));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/authentication/OauthOktaClientCredentialsLatestIT.java
+++ b/src/test/java/net/snowflake/client/authentication/OauthOktaClientCredentialsLatestIT.java
@@ -2,6 +2,7 @@ package net.snowflake.client.authentication;
 
 import static net.snowflake.client.authentication.AuthConnectionParameters.OKTA;
 import static net.snowflake.client.authentication.AuthConnectionParameters.getOAuthOktaClientCredentialParameters;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -44,7 +45,8 @@ public class OauthOktaClientCredentialsLatestIT {
 
     authTestHelper.connectAndExecuteSimpleQuery(properties, null);
     authTestHelper.verifyExceptionIsThrown(
-        "The user you were trying to authenticate as differs from the user tied to the access token.");
+        containsString(
+            "The user you were trying to authenticate as differs from the user tied to the access token."));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/authentication/OauthSnowflakeAuthorizationCodeLatestIT.java
+++ b/src/test/java/net/snowflake/client/authentication/OauthSnowflakeAuthorizationCodeLatestIT.java
@@ -2,6 +2,7 @@ package net.snowflake.client.authentication;
 
 import static net.snowflake.client.authentication.AuthConnectionParameters.OAUTH_PASSWORD;
 import static net.snowflake.client.authentication.AuthConnectionParameters.getOAuthSnowflakeAuthorizationCodeConnectionParameters;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -72,7 +73,8 @@ public class OauthSnowflakeAuthorizationCodeLatestIT {
 
     authTestHelper.connectAndProvideCredentials(provideCredentialsThread, connectThread);
     authTestHelper.verifyExceptionIsThrown(
-        "The user you were trying to authenticate as differs from the user tied to the access token.");
+        containsString(
+            "The user you were trying to authenticate as differs from the user tied to the access token."));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/authentication/OauthSnowflakeAuthorizationCodeWildcardsLatestIT.java
+++ b/src/test/java/net/snowflake/client/authentication/OauthSnowflakeAuthorizationCodeWildcardsLatestIT.java
@@ -2,6 +2,7 @@ package net.snowflake.client.authentication;
 
 import static net.snowflake.client.authentication.AuthConnectionParameters.OAUTH_PASSWORD;
 import static net.snowflake.client.authentication.AuthConnectionParameters.getOAuthSnowflakeWildcardsAuthorizationCodeConnectionParameters;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -72,7 +73,8 @@ public class OauthSnowflakeAuthorizationCodeWildcardsLatestIT {
 
     authTestHelper.connectAndProvideCredentials(provideCredentialsThread, connectThread);
     authTestHelper.verifyExceptionIsThrown(
-        "The user you were trying to authenticate as differs from the user tied to the access token.");
+        containsString(
+            "The user you were trying to authenticate as differs from the user tied to the access token."));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/authentication/PATLatestIT.java
+++ b/src/test/java/net/snowflake/client/authentication/PATLatestIT.java
@@ -5,6 +5,7 @@ import static net.snowflake.client.authentication.AuthConnectionParameters.SNOWF
 import static net.snowflake.client.authentication.AuthConnectionParameters.SNOWFLAKE_USER;
 import static net.snowflake.client.authentication.AuthConnectionParameters.getOktaConnectionParameters;
 import static net.snowflake.client.authentication.AuthConnectionParameters.getPATConnectionParameters;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -45,7 +46,7 @@ public class PATLatestIT {
     Properties properties = getPATConnectionParameters();
     properties.put("token", "invalidToken");
     authTestHelper.connectAndExecuteSimpleQuery(properties, null);
-    authTestHelper.verifyExceptionIsThrown("Programmatic access token is invalid.");
+    authTestHelper.verifyExceptionIsThrown(containsString("Programmatic access token is invalid."));
   }
 
   @Test
@@ -54,7 +55,7 @@ public class PATLatestIT {
     properties.put("token", getPAT());
     properties.put("user", "differentUsername");
     authTestHelper.connectAndExecuteSimpleQuery(properties, null);
-    authTestHelper.verifyExceptionIsThrown("Programmatic access token is invalid.");
+    authTestHelper.verifyExceptionIsThrown(containsString("Programmatic access token is invalid."));
     removePAT();
   }
 


### PR DESCRIPTION
## Problem

8 tests in `AuthenticationTestSuite` fail because the exact-match assertion in `AuthTestHelper.verifyExceptionIsThrown(String)` no longer matches. The server now appends a request/query id in brackets to these auth error messages:

```
Expected: is "...tied to the access token."
     but: was "...tied to the access token. [d2adb234-b969-4b37-b871-399abfc69208]"
```

Affected tests:
- `ExternalBrowserLatestIT.shouldThrowErrorForMismatchedUsername`
- `OauthLatestIT.shouldThrowErrorForMismatchedOauthUsername`
- `OauthOktaAuthorizationCodeLatestIT.shouldThrowErrorForMismatchedOauthOktaUsername`
- `OauthOktaClientCredentialsLatestIT.shouldThrowErrorForClientCredentialsMismatchedUsername`
- `OauthSnowflakeAuthorizationCodeLatestIT.shouldThrowErrorForMismatchedOauthSnowflakeUsername`
- `OauthSnowflakeAuthorizationCodeWildcardsLatestIT.shouldThrowErrorForMismatchedOauthSnowflakeUsername`
- `PATLatestIT.shouldThrowErrorForInvalidPAT`
- `PATLatestIT.shouldThrowErrorForMismatchedPATUsername`

## Fix

Wrap the expected message at the affected call sites in `containsString(...)`, using the existing `verifyExceptionIsThrown(Matcher<String>)` overload. This ignores the appended request id while still asserting the meaningful part of the message. This matches the convention already used in `OauthLatestIT` (`verifyExceptionIsThrown(containsString("Invalid OAuth access token"))`).

The `AuthTestHelper` is left unchanged, so other callers keep their exact-match behavior.