### PR TITLE
SNOW-3824832 Shade non-gRPC Netty native libraries in fat jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.3-SNAPSHOT
+  - Fixed the self-contained JAR shipping the non-gRPC-shaded Netty native libraries (`libnetty_transport_native_epoll_*`, `libnetty_transport_native_kqueue_*`, `libnetty_resolver_dns_native_macos_*`) unshaded, which caused an `UnsatisfiedLinkError` when they conflicted with a user's own Netty on the classpath. These libraries are now relocated with the `libnet_snowflake_client_jdbc_internal_netty_*` prefix to match the relocated `io.netty` package (snowflakedb/snowflake-jdbc#2705).
   - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).

--- a/pom.xml
+++ b/pom.xml
@@ -1033,6 +1033,21 @@
                       <pattern>META-INF.native.libio_grpc_netty_shaded_netty_transport_native_epoll</pattern>
                       <shadedPattern>META-INF.native.lib${shadeNativeBase}_grpc_netty_shaded_netty_transport_native_epoll</shadedPattern>
                     </relocation>
+                    <!-- Relocate the non-gRPC-shaded Netty native libraries so their names match the relocated io.netty
+                         package. Otherwise Netty's NativeLibraryLoader looks for lib${shadeNativeBase}_netty_* and fails
+                         with UnsatisfiedLinkError when the unshaded libnetty_* files are present. See issue #2705. -->
+                    <relocation>
+                      <pattern>META-INF.native.libnetty_transport_native_epoll</pattern>
+                      <shadedPattern>META-INF.native.lib${shadeNativeBase}_netty_transport_native_epoll</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>META-INF.native.libnetty_transport_native_kqueue</pattern>
+                      <shadedPattern>META-INF.native.lib${shadeNativeBase}_netty_transport_native_kqueue</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>META-INF.native.libnetty_resolver_dns_native_macos</pattern>
+                      <shadedPattern>META-INF.native.lib${shadeNativeBase}_netty_resolver_dns_native_macos</shadedPattern>
+                    </relocation>
                     <relocation>
                       <pattern>org.checkerframework</pattern>
                       <shadedPattern>${shadeBase}.org.checkerframework</shadedPattern>


### PR DESCRIPTION
This PR fixes the self-contained JAR shipping the non-gRPC-shaded Netty native libraries unshaded, which caused an `UnsatisfiedLinkError` when they conflicted with a user's own Netty on the classpath (see #2705).

The fat jar relocates `io.netty` → `net.snowflake.client.jdbc.internal.io.netty`, so Netty's `NativeLibraryLoader` looks for native libs prefixed with `libnet_snowflake_client_jdbc_internal_netty_*`. Only the gRPC-shaded native libs were being renamed; the plain `io.netty` ones (`libnetty_transport_native_epoll_*`, `libnetty_transport_native_kqueue_*`, `libnetty_resolver_dns_native_macos_*`) were shipped as-is. This PR adds the missing `maven-shade-plugin` resource relocations for them.

Verified by building the self-contained jar and inspecting `META-INF/native/` — all entries now carry the `net_snowflake_client_jdbc_internal_` prefix (or are unrelated third-party libs such as `conscrypt_*`), so no bare `libnetty_*` files remain.

`META-INF/native/` directory after this change:
```
total 25128
drwxr-xr-x+ 16 halil.sener     512 jul.  8 19:18 .
drwxr-xr-x+ 17 halil.sener     544 jul. 22 13:02 ..
-rw-r--r--+  1 halil.sener 2744832 mrt. 30  2021 conscrypt_openjdk_jni-windows-x86_64.dll
-rw-r--r--+  1 halil.sener 1832448 mrt. 30  2021 conscrypt_openjdk_jni-windows-x86.dll
-rw-r--r--+  1 halil.sener 2453088 mrt. 30  2021 libconscrypt_openjdk_jni-linux-x86_64.so
-rw-r--r--+  1 halil.sener 2802928 mrt. 30  2021 libconscrypt_openjdk_jni-osx-x86_64.dylib
-rw-r--r--+  1 halil.sener 2806136 feb.  4 07:58 libnet_snowflake_client_jdbc_internal_grpc_netty_shaded_netty_tcnative_linux_aarch_64.so
-rw-r--r--+  1 halil.sener 3033872 feb.  4 07:50 libnet_snowflake_client_jdbc_internal_grpc_netty_shaded_netty_tcnative_linux_x86_64.so
-rw-r--r--+  1 halil.sener 2798992 feb.  4 07:49 libnet_snowflake_client_jdbc_internal_grpc_netty_shaded_netty_tcnative_osx_aarch_64.jnilib
-rw-r--r--+  1 halil.sener 3059048 feb.  4 07:51 libnet_snowflake_client_jdbc_internal_grpc_netty_shaded_netty_tcnative_osx_x86_64.jnilib
-rw-r--r--+  1 halil.sener  108520 mei   4 23:49 libnet_snowflake_client_jdbc_internal_grpc_netty_shaded_netty_transport_native_epoll_aarch_64.so
-rw-r--r--+  1 halil.sener   99584 mei   4 23:49 libnet_snowflake_client_jdbc_internal_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so
-rw-r--r--+  1 halil.sener   42160 jul.  8 19:22 libnet_snowflake_client_jdbc_internal_netty_resolver_dns_native_macos_x86_64.jnilib
-rw-r--r--+  1 halil.sener   99584 jul.  8 19:18 libnet_snowflake_client_jdbc_internal_netty_transport_native_epoll_x86_64.so
-rw-r--r--+  1 halil.sener   55304 jul.  8 19:23 libnet_snowflake_client_jdbc_internal_netty_transport_native_kqueue_x86_64.jnilib
-rw-r--r--+  1 halil.sener 3762176 feb.  4 07:47 net_snowflake_client_jdbc_internal_grpc_netty_shaded_netty_tcnative_windows_x86_64.dll
```

Fixes #2705



---

🤖 Generated with [Claude Code](https://claude.com/claude-code)