### PR TITLE
NO-SNOW: bump grpc-java to 1.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Changelog
 - v4.3.3-SNAPSHOT
   - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
+  - Bumped grpc-java to 1.83.0 (snowflakedb/snowflake-jdbc#XXXX).
+  
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).
   - Fixed GCS PUT operations not retrying on transient errors (e.g. HTTP 503) despite `putGetMaxRetries` being configured (snowflakedb/snowflake-jdbc#2688).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Changelog
 - v4.3.3-SNAPSHOT
   - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
-  - Bumped grpc-java to 1.83.0 (snowflakedb/snowflake-jdbc#XXXX).
+  - Bumped grpc-java to 1.83.0 (snowflakedb/snowflake-jdbc#2707).
   
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -663,6 +663,30 @@
                       </excludes>
                     </filter>
                     <filter>
+                      <!-- dev.cel (CEL runtime, common, protobuf) are pulled in transitively by
+                           grpc-xds 1.83.0. grpc-xds is itself a pre-shaded fat jar that already
+                           embeds these classes under io.grpc.xds.shaded.dev.cel.*, which our
+                           io.grpc relocation handles correctly. The separate dev.cel Maven artifacts
+                           are therefore redundant in the fat jar and must be excluded to avoid
+                           unshaded dev/cel/* classes failing the namespace content check. -->
+                      <artifact>dev.cel:common</artifact>
+                      <excludes>
+                        <exclude>**</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
+                      <artifact>dev.cel:runtime</artifact>
+                      <excludes>
+                        <exclude>**</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
+                      <artifact>dev.cel:protobuf</artifact>
+                      <excludes>
+                        <exclude>**</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
                       <artifact>org.apache.arrow:arrow-vector</artifact>
                       <excludes>
                         <!-- codegen directory is used to generate java code for arrow vector package. Excludes them since we only need class file -->

--- a/linkage-checker-exclusion-rules.xml
+++ b/linkage-checker-exclusion-rules.xml
@@ -182,6 +182,11 @@
         <Reason>VarHandle @PolymorphicSignature methods are valid at runtime; false positive in linkage checker 1.5.13 with guava 33.5.0-jre</Reason>
     </LinkageError>
     <LinkageError>
+        <Target><Package name="java.lang.invoke"/></Target>
+        <Source><Package name="io.grpc.netty.shaded.io.netty"/></Source>
+        <Reason>VarHandle @PolymorphicSignature methods used by Netty 4.2.x (bundled in grpc-netty-shaded 1.83.0) in VarHandleByteBufferAccess and RefCnt; these code paths are only activated on Java 9+ via capability checks, never loaded on Java 8; false positive in linkage checker</Reason>
+    </LinkageError>
+    <LinkageError>
         <Target><Package name="java.util.zip"/></Target>
         <Source><Package name="com.google.common.hash"/></Source>
         <Reason>guava 33.5.0-jre uses CRC32C (Java 9+) with a runtime version check; safe on Java 8</Reason>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -60,7 +60,7 @@
     <google.j2objc-annotations.version>3.1</google.j2objc-annotations.version>
     <google.proto.iam.version>1.67.0</google.proto.iam.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
-    <google.protobuf.java.version>4.33.2</google.protobuf.java.version>
+    <google.protobuf.java.version>4.33.5</google.protobuf.java.version>
     <grpc.version>1.83.0</grpc.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hikaricp.version>2.4.3</hikaricp.version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -61,7 +61,7 @@
     <google.proto.iam.version>1.67.0</google.proto.iam.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
     <google.protobuf.java.version>4.33.2</google.protobuf.java.version>
-    <grpc.version>1.82.2</grpc.version>
+    <grpc.version>1.83.0</grpc.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hikaricp.version>2.4.3</hikaricp.version>
     <jackson.version>2.18.9</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1018,6 +1018,10 @@
                       <shadedPattern>${shadeBase}.grpc</shadedPattern>
                     </relocation>
                     <relocation>
+                      <pattern>dev.cel</pattern>
+                      <shadedPattern>${shadeBase}.dev.cel</shadedPattern>
+                    </relocation>
+                    <relocation>
                       <pattern>META-INF.native.io_grpc_netty_shaded_netty_tcnative</pattern>
                       <shadedPattern>META-INF.native.${shadeNativeBase}_grpc_netty_shaded_netty_tcnative</shadedPattern>
                     </relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -1018,10 +1018,6 @@
                       <shadedPattern>${shadeBase}.grpc</shadedPattern>
                     </relocation>
                     <relocation>
-                      <pattern>dev.cel</pattern>
-                      <shadedPattern>${shadeBase}.dev.cel</shadedPattern>
-                    </relocation>
-                    <relocation>
                       <pattern>META-INF.native.io_grpc_netty_shaded_netty_tcnative</pattern>
                       <shadedPattern>META-INF.native.${shadeNativeBase}_grpc_netty_shaded_netty_tcnative</shadedPattern>
                     </relocation>
@@ -1115,6 +1111,30 @@
                            annotations pulled in transitively by google-cloud-storage >=2.69.0 via guava.
                            They carry no runtime behaviour and do not need to be shaded. -->
                       <artifact>org.jspecify:jspecify</artifact>
+                      <excludes>
+                        <exclude>**</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
+                      <!-- dev.cel (CEL runtime, common, protobuf) are pulled in transitively by
+                           grpc-xds 1.83.0. grpc-xds is itself a pre-shaded fat jar that already
+                           embeds these classes under io.grpc.xds.shaded.dev.cel.*, which our
+                           io.grpc relocation handles correctly. The separate dev.cel Maven artifacts
+                           are therefore redundant in the fat jar and must be excluded to avoid
+                           unshaded dev/cel/* classes failing the namespace content check. -->
+                      <artifact>dev.cel:common</artifact>
+                      <excludes>
+                        <exclude>**</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
+                      <artifact>dev.cel:runtime</artifact>
+                      <excludes>
+                        <exclude>**</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
+                      <artifact>dev.cel:protobuf</artifact>
                       <excludes>
                         <exclude>**</exclude>
                       </excludes>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -57,7 +57,7 @@
     <google.http.client.version>2.1.0</google.http.client.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
     <google.protobuf.java.version>4.33.2</google.protobuf.java.version>
-    <grpc.version>1.82.2</grpc.version>
+    <grpc.version>1.83.0</grpc.version>
     <jackson.version>2.18.9</jackson.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -56,7 +56,7 @@
     <google.guava.version>33.5.0-jre</google.guava.version>
     <google.http.client.version>2.1.0</google.http.client.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
-    <google.protobuf.java.version>4.33.2</google.protobuf.java.version>
+    <google.protobuf.java.version>4.33.5</google.protobuf.java.version>
     <grpc.version>1.83.0</grpc.version>
     <jackson.version>2.18.9</jackson.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>


### PR DESCRIPTION
## Description

grpc-java 1.83.0 now bundles netty 4.2.15.Final (earlier: 4.1.133.Final in 1.82.2) so bumping to this dependency to have access to the [security fixes](https://netty.io/news/2026/06/01/4-2-15-Final.html) published with this version