### PR TITLE
SNOW-3807845 Increment minimum heartbeat interval to 15 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Changelog
 - v4.3.3-SNAPSHOT
   - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
+  - Changed minimum heartbeat interval to 15 minutes (snowflakedb/snowflake-jdbc#2708).
+
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).
   - Fixed GCS PUT operations not retrying on transient errors (e.g. HTTP 503) despite `putGetMaxRetries` being configured (snowflakedb/snowflake-jdbc#2688).

--- a/src/main/java/net/snowflake/client/internal/core/HeartbeatRegistry.java
+++ b/src/main/java/net/snowflake/client/internal/core/HeartbeatRegistry.java
@@ -144,8 +144,13 @@ public class HeartbeatRegistry {
     // Calculate required interval: min of requested frequency and 1/4 of token validity
     long requiredInterval = Math.min(heartbeatFrequencyInSecs, masterTokenValidityInSecs / 4);
 
-    // Enforce minimum interval of 1 second
-    requiredInterval = Math.max(requiredInterval, 1);
+    // Enforce a minimum interval of 15 minutes. This never reduces the effective heartbeat
+    // cadence below what a user could request: CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY is
+    // itself clamped to a minimum of 900s (see SFBaseSession.setHeartbeatFrequency), so the driver
+    // is never expected to heartbeat more often than every 15 minutes. The floor also guards
+    // against a degenerate masterTokenValidity (e.g. 0 when absent from the login response), which
+    // would otherwise drive the interval to 0 and cause a heartbeat busy loop.
+    requiredInterval = Math.max(requiredInterval, 15 * 60);
 
     logger.debug(
         "Adding session {} with interval {}s (requested: {}s, validity: {}s)",

--- a/src/test/java/net/snowflake/client/internal/core/HeartbeatRegistryTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/HeartbeatRegistryTest.java
@@ -68,10 +68,11 @@ public class HeartbeatRegistryTest {
 
   @Test
   public void testAddSession_SingleSession() {
+    // interval = min(10, 60/4) = 10, floored to the 900s minimum
     registry.addSession(mockSession1, 60, 10);
 
     assertEquals(1, registry.getActiveThreadCount());
-    assertEquals(1, registry.getSessionCountForInterval(10));
+    assertEquals(1, registry.getSessionCountForInterval(900));
   }
 
   @Test
@@ -79,9 +80,9 @@ public class HeartbeatRegistryTest {
     registry.addSession(mockSession1, 60, 10);
     registry.addSession(mockSession2, 60, 10);
 
-    // Only ONE thread should exist
+    // Only ONE thread should exist (both sessions floored to the 900s minimum interval)
     assertEquals(1, registry.getActiveThreadCount());
-    assertEquals(2, registry.getSessionCountForInterval(10));
+    assertEquals(2, registry.getSessionCountForInterval(900));
 
     // Verify scheduler called only ONCE (no reschedule)
     verify(mockExecutor, times(1)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
@@ -89,7 +90,7 @@ public class HeartbeatRegistryTest {
 
   @Test
   public void testAddSession_MultipleSessionsDifferentIntervals_Independent() {
-    // Session 1: 60s validity, 10s heartbeat (interval = 10s)
+    // Session 1: 60s validity, 10s heartbeat (interval = 10s, floored to 900s)
     registry.addSession(mockSession1, 60, 10);
 
     // Session 2: 4h validity, 1h heartbeat (interval = 3600s)
@@ -97,18 +98,29 @@ public class HeartbeatRegistryTest {
 
     // TWO independent threads should exist
     assertEquals(2, registry.getActiveThreadCount());
-    assertEquals(1, registry.getSessionCountForInterval(10));
+    assertEquals(1, registry.getSessionCountForInterval(900));
     assertEquals(1, registry.getSessionCountForInterval(3600));
   }
 
   @Test
   public void testAddSession_CalculatesIntervalCorrectly() {
-    // Requested 100s, but validity/4 = 60/4 = 15s
-    registry.addSession(mockSession1, 60, 100);
+    // Requested 1000s, but validity/4 = 14400/4 = 3600s; both are above the 900s floor,
+    // so the interval reflects the min() of the two (1000s).
+    registry.addSession(mockSession1, 14400, 1000);
 
-    // Should use 15s (minimum of 100 and 60/4)
+    // Should use 1000s (minimum of 1000 and 14400/4)
     assertEquals(1, registry.getActiveThreadCount());
-    assertEquals(1, registry.getSessionCountForInterval(15));
+    assertEquals(1, registry.getSessionCountForInterval(1000));
+  }
+
+  @Test
+  public void testAddSession_IntervalFlooredToMinimum() {
+    // interval = min(10, 60/4) = 10, but is floored to the 900s minimum
+    registry.addSession(mockSession1, 60, 10);
+
+    assertEquals(1, registry.getActiveThreadCount());
+    assertEquals(1, registry.getSessionCountForInterval(900));
+    assertEquals(0, registry.getSessionCountForInterval(10));
   }
 
   @Test
@@ -135,11 +147,12 @@ public class HeartbeatRegistryTest {
     registry.addSession(mockSession1, 60, 10);
     registry.addSession(mockSession2, 60, 10);
 
-    assertEquals(2, registry.getSessionCountForInterval(10));
+    // both floored to the 900s minimum interval
+    assertEquals(2, registry.getSessionCountForInterval(900));
 
     registry.removeSession(mockSession1);
 
-    assertEquals(1, registry.getSessionCountForInterval(10));
+    assertEquals(1, registry.getSessionCountForInterval(900));
     assertEquals(1, registry.getActiveThreadCount());
   }
 
@@ -184,10 +197,11 @@ public class HeartbeatRegistryTest {
 
   @Test
   public void testCriticalBug_ShortSessionNotExpiredByLongSession() throws Exception {
-    // This tests the fix for the critical bug
+    // This tests the fix for the critical bug: a shorter-interval session must be heartbeated on
+    // its own schedule, independently of a longer-interval session.
 
-    // Session A: 60s validity, 10s heartbeat (interval = min(10, 60/4) = 10s)
-    registry.addSession(mockSession1, 60, 10);
+    // Session A: 1h validity, 15min heartbeat (interval = min(900, 3600/4) = 900s)
+    registry.addSession(mockSession1, 3600, 900);
 
     // Session B: 4h validity, 1h heartbeat (interval = min(3600, 14400/4) = 3600s)
     registry.addSession(mockSession2, 14400, 3600);
@@ -195,14 +209,14 @@ public class HeartbeatRegistryTest {
     // Verify TWO independent threads exist
     assertEquals(2, registry.getActiveThreadCount());
 
-    // Advance time by 65 seconds (past session1's validity)
-    manualClock.advance(Duration.ofSeconds(65));
+    // Advance time past session A's interval
+    manualClock.advance(Duration.ofSeconds(905));
 
     // Clear previous invocations
     clearInvocations(mockSession1, mockSession2);
 
-    // Trigger 10s heartbeat (for short-lived session)
-    registry.triggerHeartbeatForInterval(10);
+    // Trigger 900s heartbeat (for shorter-interval session)
+    registry.triggerHeartbeatForInterval(900);
 
     // Verify: Session1 got heartbeat (NOT expired)
     try {
@@ -216,11 +230,11 @@ public class HeartbeatRegistryTest {
 
   @Test
   public void testTriggerHeartbeatForInterval_OnlyAffectsSpecifiedInterval() throws Exception {
-    registry.addSession(mockSession1, 60, 10);
-    registry.addSession(mockSession2, 14400, 3600);
+    registry.addSession(mockSession1, 3600, 900); // interval = 900s
+    registry.addSession(mockSession2, 14400, 3600); // interval = 3600s
 
-    // Trigger only 10s interval
-    registry.triggerHeartbeatForInterval(10);
+    // Trigger only 900s interval
+    registry.triggerHeartbeatForInterval(900);
 
     try {
       verify(mockSession1, times(1)).heartbeat();


### PR DESCRIPTION
# Overview

Enforces a minimum heartbeat interval of 15 minutes (900 seconds) instead of the previous minimum of 1 second. This prevents sessions from sending heartbeats too frequently, reducing unnecessary load.