### PR TITLE
SNOW-3824832 Shade non-gRPC Netty native libraries in fat jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.3-SNAPSHOT
+  - Fixed the self-contained JAR shipping the non-gRPC-shaded Netty native libraries (`libnetty_transport_native_epoll_*`, `libnetty_transport_native_kqueue_*`, `libnetty_resolver_dns_native_macos_*`) unshaded, which caused an `UnsatisfiedLinkError` when they conflicted with a user's own Netty on the classpath. These libraries are now relocated with the `libnet_snowflake_client_jdbc_internal_netty_*` prefix to match the relocated `io.netty` package (snowflakedb/snowflake-jdbc#2705).
   - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).

--- a/pom.xml
+++ b/pom.xml
@@ -1033,6 +1033,21 @@
                       <pattern>META-INF.native.libio_grpc_netty_shaded_netty_transport_native_epoll</pattern>
                       <shadedPattern>META-INF.native.lib${shadeNativeBase}_grpc_netty_shaded_netty_transport_native_epoll</shadedPattern>
                     </relocation>
+                    <!-- Relocate the non-gRPC-shaded Netty native libraries so their names match the relocated io.netty
+                         package. Otherwise Netty's NativeLibraryLoader looks for lib${shadeNativeBase}_netty_* and fails
+                         with UnsatisfiedLinkError when the unshaded libnetty_* files are present. See issue #2705. -->
+                    <relocation>
+                      <pattern>META-INF.native.libnetty_transport_native_epoll</pattern>
+                      <shadedPattern>META-INF.native.lib${shadeNativeBase}_netty_transport_native_epoll</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>META-INF.native.libnetty_transport_native_kqueue</pattern>
+                      <shadedPattern>META-INF.native.lib${shadeNativeBase}_netty_transport_native_kqueue</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>META-INF.native.libnetty_resolver_dns_native_macos</pattern>
+                      <shadedPattern>META-INF.native.lib${shadeNativeBase}_netty_resolver_dns_native_macos</shadedPattern>
+                    </relocation>
                     <relocation>
                       <pattern>org.checkerframework</pattern>
                       <shadedPattern>${shadeBase}.org.checkerframework</shadedPattern>


### PR DESCRIPTION
Relocate libnetty_transport_native_epoll, libnetty_transport_native_kqueue, and libnetty_resolver_dns_native_macos with the
libnet_snowflake_client_jdbc_internal_netty_ prefix so their names match the relocated io.netty package. Otherwise Netty's NativeLibraryLoader fails with UnsatisfiedLinkError when the unshaded libnetty_* files conflict with a user's own Netty on the classpath.

Fixes snowflakedb/snowflake-jdbc#2705

# Overview

SNOW-XXXXX

## Pre-review self checklist
- [ ] PR branch is updated with all the changes from `master` branch
- [ ] The code is correctly formatted (run `mvn -P check-style validate`)
- [ ] New public API is not unnecessary exposed (run `mvn verify` and inspect `target/japicmp/japicmp.html`)
- [ ] The pull request name is prefixed with `SNOW-XXXX: `
- [ ] Code is in compliance with internal logging requirements

## External contributors - please answer these questions before submitting a pull request. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Issue: #NNNN


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency or upgrading an existing one
   - [ ] I am adding new public/protected component not marked with `@SnowflakeJdbcInternalApi` (note that public/protected methods/fields in classes marked with this annotation are already internal)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
