### PR TITLE
SNOW-3863592: Add level guards to SLF4JLogger to prevent unnecessary secret masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.3-SNAPSHOT
+  - Fixed `SLF4JLogger` performing expensive `SecretDetector.maskSecrets()` regex work even when the log level is disabled, added level guards to all `(String, boolean)` and `(String, Throwable)` overloads to match `JDK14Logger` behavior (snowflakedb/snowflake-jdbc#XXXX).
   - Fixed the self-contained JAR shipping the non-gRPC-shaded Netty native libraries (`libnetty_transport_native_epoll_*`, `libnetty_transport_native_kqueue_*`, `libnetty_resolver_dns_native_macos_*`) unshaded, which caused an `UnsatisfiedLinkError` when they conflicted with a user's own Netty on the classpath. These libraries are now relocated with the `libnet_snowflake_client_jdbc_internal_netty_*` prefix to match the relocated `io.netty` package (snowflakedb/snowflake-jdbc#2705).
   - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
   - Changed minimum heartbeat interval to 15 minutes (snowflakedb/snowflake-jdbc#2708).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.3.3-SNAPSHOT
-  - Fixed `SLF4JLogger` performing expensive `SecretDetector.maskSecrets()` regex work even when the log level is disabled, added level guards to all `(String, boolean)` and `(String, Throwable)` overloads to match `JDK14Logger` behavior (snowflakedb/snowflake-jdbc#XXXX).
+  - Fixed `SLF4JLogger` performing expensive `SecretDetector.maskSecrets()` regex work even when the log level is disabled, added level guards to all `(String, boolean)` and `(String, Throwable)` overloads to match `JDK14Logger` behavior (snowflakedb/snowflake-jdbc#2712).
   - Fixed the self-contained JAR shipping the non-gRPC-shaded Netty native libraries (`libnetty_transport_native_epoll_*`, `libnetty_transport_native_kqueue_*`, `libnetty_resolver_dns_native_macos_*`) unshaded, which caused an `UnsatisfiedLinkError` when they conflicted with a user's own Netty on the classpath. These libraries are now relocated with the `libnet_snowflake_client_jdbc_internal_netty_*` prefix to match the relocated `io.netty` package (snowflakedb/snowflake-jdbc#2705).
   - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
   - Changed minimum heartbeat interval to 15 minutes (snowflakedb/snowflake-jdbc#2708).

--- a/src/main/java/net/snowflake/client/internal/core/SFBaseResultSet.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFBaseResultSet.java
@@ -156,7 +156,7 @@ public abstract class SFBaseResultSet {
   }
 
   public boolean wasNull() {
-    logger.trace("boolean wasNull() returning {}", wasNull);
+    logger.trace("boolean wasNull() returning {}", (Object) wasNull);
 
     return wasNull;
   }

--- a/src/main/java/net/snowflake/client/internal/log/SLF4JLogger.java
+++ b/src/main/java/net/snowflake/client/internal/log/SLF4JLogger.java
@@ -46,7 +46,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void debug(String msg, boolean isMasked) {
-    if (!isDebugEnabled()) return;
+    if (!isDebugEnabled()) {
+      return;
+    }
     msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
@@ -76,7 +78,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void debug(String msg, Throwable t) {
-    if (!isDebugEnabled()) return;
+    if (!isDebugEnabled()) {
+      return;
+    }
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {
@@ -88,7 +92,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void error(String msg, boolean isMasked) {
-    if (!isErrorEnabled()) return;
+    if (!isErrorEnabled()) {
+      return;
+    }
     msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
@@ -106,7 +112,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void error(String msg, Throwable t) {
-    if (!isErrorEnabled()) return;
+    if (!isErrorEnabled()) {
+      return;
+    }
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {
@@ -118,7 +126,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void info(String msg, boolean isMasked) {
-    if (!isInfoEnabled()) return;
+    if (!isInfoEnabled()) {
+      return;
+    }
     msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
@@ -136,7 +146,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void info(String msg, Throwable t) {
-    if (!isInfoEnabled()) return;
+    if (!isInfoEnabled()) {
+      return;
+    }
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {
@@ -148,7 +160,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void trace(String msg, boolean isMasked) {
-    if (!isTraceEnabled()) return;
+    if (!isTraceEnabled()) {
+      return;
+    }
     msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
@@ -166,7 +180,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void trace(String msg, Throwable t) {
-    if (!isTraceEnabled()) return;
+    if (!isTraceEnabled()) {
+      return;
+    }
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {
@@ -178,7 +194,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void warn(String msg, boolean isMasked) {
-    if (!isWarnEnabled()) return;
+    if (!isWarnEnabled()) {
+      return;
+    }
     msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
@@ -196,7 +214,9 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void warn(String msg, Throwable t) {
-    if (!isWarnEnabled()) return;
+    if (!isWarnEnabled()) {
+      return;
+    }
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {

--- a/src/main/java/net/snowflake/client/internal/log/SLF4JLogger.java
+++ b/src/main/java/net/snowflake/client/internal/log/SLF4JLogger.java
@@ -46,7 +46,8 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void debug(String msg, boolean isMasked) {
-    msg = isMasked == true ? SecretDetector.maskSecrets(msg) : msg;
+    if (!isDebugEnabled()) return;
+    msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
           .log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
@@ -75,6 +76,7 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void debug(String msg, Throwable t) {
+    if (!isDebugEnabled()) return;
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {
@@ -86,7 +88,8 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void error(String msg, boolean isMasked) {
-    msg = isMasked == true ? SecretDetector.maskSecrets(msg) : msg;
+    if (!isErrorEnabled()) return;
+    msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
           .log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, null);
@@ -103,6 +106,7 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void error(String msg, Throwable t) {
+    if (!isErrorEnabled()) return;
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {
@@ -114,7 +118,8 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void info(String msg, boolean isMasked) {
-    msg = isMasked == true ? SecretDetector.maskSecrets(msg) : msg;
+    if (!isInfoEnabled()) return;
+    msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
           .log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, null);
@@ -131,6 +136,7 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void info(String msg, Throwable t) {
+    if (!isInfoEnabled()) return;
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {
@@ -142,7 +148,8 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void trace(String msg, boolean isMasked) {
-    msg = isMasked == true ? SecretDetector.maskSecrets(msg) : msg;
+    if (!isTraceEnabled()) return;
+    msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
           .log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, null);
@@ -159,6 +166,7 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void trace(String msg, Throwable t) {
+    if (!isTraceEnabled()) return;
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {
@@ -170,7 +178,8 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void warn(String msg, boolean isMasked) {
-    msg = isMasked == true ? SecretDetector.maskSecrets(msg) : msg;
+    if (!isWarnEnabled()) return;
+    msg = isMasked ? SecretDetector.maskSecrets(msg) : msg;
     if (isLocationAwareLogger) {
       ((LocationAwareLogger) slf4jLogger)
           .log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, null);
@@ -187,6 +196,7 @@ public class SLF4JLogger implements SFLogger {
   }
 
   public void warn(String msg, Throwable t) {
+    if (!isWarnEnabled()) return;
     msg = SecretDetector.maskSecrets(msg);
     Throwable masked = (t == null) ? null : new MaskedException(t);
     if (isLocationAwareLogger) {

--- a/src/main/java/net/snowflake/client/internal/log/SLF4JLogger.java
+++ b/src/main/java/net/snowflake/client/internal/log/SLF4JLogger.java
@@ -143,7 +143,7 @@ public class SLF4JLogger implements SFLogger {
       ((LocationAwareLogger) slf4jLogger)
           .log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, masked);
     } else {
-      slf4jLogger.error(msg, masked);
+      slf4jLogger.info(msg, masked);
     }
   }
 
@@ -184,7 +184,7 @@ public class SLF4JLogger implements SFLogger {
       ((LocationAwareLogger) slf4jLogger)
           .log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, null);
     } else {
-      slf4jLogger.error(msg);
+      slf4jLogger.warn(msg);
     }
   }
 
@@ -203,7 +203,7 @@ public class SLF4JLogger implements SFLogger {
       ((LocationAwareLogger) slf4jLogger)
           .log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, masked);
     } else {
-      slf4jLogger.error(msg, masked);
+      slf4jLogger.warn(msg, masked);
     }
   }
 

--- a/src/test/java/net/snowflake/client/internal/log/MaskedExceptionLoggerIntegrationTest.java
+++ b/src/test/java/net/snowflake/client/internal/log/MaskedExceptionLoggerIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReference;
@@ -78,6 +79,7 @@ public class MaskedExceptionLoggerIntegrationTest {
     SLF4JLogger logger = new SLF4JLogger(MaskedExceptionLoggerIntegrationTest.class.getName());
 
     org.slf4j.Logger mockLogger = mock(org.slf4j.Logger.class);
+    when(mockLogger.isErrorEnabled()).thenReturn(true);
     injectSlf4jLogger(logger, mockLogger);
 
     logger.error(SECRET_MSG, new Exception(SECRET_MSG));

--- a/src/test/java/net/snowflake/client/internal/log/SLF4JLoggerLevelGuardTest.java
+++ b/src/test/java/net/snowflake/client/internal/log/SLF4JLoggerLevelGuardTest.java
@@ -1,0 +1,115 @@
+package net.snowflake.client.internal.log;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import net.snowflake.client.category.TestTags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+/**
+ * Tests that SLF4JLogger level guards prevent expensive SecretDetector.maskSecrets() calls when
+ * logging is disabled. Regression test for SNOW-3863592.
+ */
+@Tag(TestTags.CORE)
+public class SLF4JLoggerLevelGuardTest {
+
+  private static final String SECRET_MSG =
+      "credentials=(aws_key_id='abc123' aws_secret_key='rtyuiop')";
+
+  /**
+   * Simulates the SNOW-3863592 scenario: trace(msg, boolean) called in a hot loop with trace
+   * disabled (INFO level). The level guard must prevent any call to the underlying logger.
+   */
+  @Test
+  public void testBooleanOverloadsSkippedAtInfoLevel() throws Exception {
+    // INFO level: trace and debug disabled, info/warn/error enabled
+    SLF4JLogger logger = createLoggerWithMock(false, false, true, true, true);
+    Logger mockLogger = getMockLogger(logger);
+
+    logger.trace(SECRET_MSG, true);
+    logger.debug(SECRET_MSG, true);
+
+    verify(mockLogger, never()).trace(anyString());
+    verify(mockLogger, never()).debug(anyString());
+  }
+
+  /** Simulates all levels disabled (OFF). No method should reach the underlying logger. */
+  @Test
+  public void testAllOverloadsSkippedWhenOff() throws Exception {
+    SLF4JLogger logger = createLoggerWithMock(false, false, false, false, false);
+    Logger mockLogger = getMockLogger(logger);
+
+    logger.trace(SECRET_MSG, true);
+    logger.debug(SECRET_MSG, true);
+    logger.info(SECRET_MSG, true);
+    logger.warn(SECRET_MSG, true);
+    logger.error(SECRET_MSG, true);
+    logger.trace(SECRET_MSG, new Exception("x"));
+    logger.debug(SECRET_MSG, new Exception("x"));
+    logger.info(SECRET_MSG, new Exception("x"));
+    logger.warn(SECRET_MSG, new Exception("x"));
+    logger.error(SECRET_MSG, new Exception("x"));
+
+    verify(mockLogger, never()).trace(anyString());
+    verify(mockLogger, never()).debug(anyString());
+    verify(mockLogger, never()).info(anyString());
+    verify(mockLogger, never()).error(anyString());
+    verify(mockLogger, never()).trace(anyString(), any(Throwable.class));
+    verify(mockLogger, never()).debug(anyString(), any(Throwable.class));
+    verify(mockLogger, never()).error(anyString(), any(Throwable.class));
+  }
+
+  /** When the level IS enabled, masking must still work (no regression). */
+  @Test
+  public void testMaskingStillWorksWhenEnabled() throws Exception {
+    SLF4JLogger logger = createLoggerWithMock(true, true, true, true, true);
+    Logger mockLogger = getMockLogger(logger);
+
+    logger.trace(SECRET_MSG, true);
+
+    verify(mockLogger).trace(anyString());
+  }
+
+  private SLF4JLogger createLoggerWithMock(
+      boolean traceEnabled,
+      boolean debugEnabled,
+      boolean infoEnabled,
+      boolean warnEnabled,
+      boolean errorEnabled)
+      throws Exception {
+    SLF4JLogger logger = new SLF4JLogger(SLF4JLoggerLevelGuardTest.class);
+    Logger mockLogger = mock(Logger.class);
+
+    when(mockLogger.isTraceEnabled()).thenReturn(traceEnabled);
+    when(mockLogger.isDebugEnabled()).thenReturn(debugEnabled);
+    when(mockLogger.isInfoEnabled()).thenReturn(infoEnabled);
+    when(mockLogger.isWarnEnabled()).thenReturn(warnEnabled);
+    when(mockLogger.isErrorEnabled()).thenReturn(errorEnabled);
+
+    injectSlf4jLogger(logger, mockLogger);
+    return logger;
+  }
+
+  private Logger getMockLogger(SLF4JLogger logger) throws Exception {
+    Field loggerField = SLF4JLogger.class.getDeclaredField("slf4jLogger");
+    loggerField.setAccessible(true);
+    return (Logger) loggerField.get(logger);
+  }
+
+  private static void injectSlf4jLogger(SLF4JLogger target, Logger newLogger) throws Exception {
+    Field loggerField = SLF4JLogger.class.getDeclaredField("slf4jLogger");
+    loggerField.setAccessible(true);
+    loggerField.set(target, newLogger);
+
+    Field locationAwareField = SLF4JLogger.class.getDeclaredField("isLocationAwareLogger");
+    locationAwareField.setAccessible(true);
+    locationAwareField.setBoolean(target, false);
+  }
+}


### PR DESCRIPTION
### Problem

When `SLF4JLogger` is selected as the JDBC logger implementation, result-set fetches are significantly slower than with `JDK14Logger` — even when logging is set to OFF or INFO. The overhead scales linearly with the number of NULL values in the result set.

### Impact

Customer reports: production workloads using `SLF4JLogger` experience up to ~42x slower fetch times on NULL-heavy result sets. A job completing in ~40 seconds regresses to ~2 minutes.

### Root Cause

Two compounding issues:

1. **Missing level guards in `SLF4JLogger`**: The `(String, boolean)` and `(String, Throwable)` method overloads perform expensive `SecretDetector.maskSecrets()` regex work unconditionally — without first checking whether the log level is enabled. In contrast, `JDK14Logger` checks `isLoggable(level)` before any masking. The `(String, Object...)` varargs overloads already had the correct guard pattern.

2. **Method overload mis-resolution in `SFBaseResultSet.wasNull()`**: The call `logger.trace("boolean wasNull() returning {}", wasNull)` inadvertently resolves to `trace(String, boolean isMasked)` because Java prefers primitive `boolean` matching over autoboxing to `Object...`. The `wasNull` data value is misinterpreted as the `isMasked` control flag — triggering masking on every NULL cell fetched.

### Fix

- Add `isXxxEnabled()` guards to all 10 unguarded methods in `SLF4JLogger` (5 levels × `boolean` + `Throwable` overloads), matching `JDK14Logger` behavior.
- Cast to `(Object)` in the `wasNull()` call site to force the varargs overload and correct the developer's original intent.
- Fix pre-existing wrong-level bugs in `SLF4JLogger` else-branches: `info(String, Throwable)`, `warn(String, boolean)`, and `warn(String, Throwable)` were calling `slf4jLogger.error(...)` instead of the correct level method. Not part of the original issue but fixed while in the area.
- Update existing test that now requires the mock to report the level as enabled.
- Add new unit tests verifying the guards work at INFO and OFF levels.

### Manual E2E Validation

Tested against a live Snowflake account (AWS US East 2 deployment) with 1,000,000 rows × 10 VARCHAR columns, `SLF4JLogger` selected, logging set to OFF. Default Arrow result format.

| NULL % | JDK14Logger (baseline) | SLF4JLogger BEFORE fix | SLF4JLogger AFTER fix |
|--------|------------------------|------------------------|-----------------------|
| 0%     | 10,434 ms              | 10,293 ms              | 9,701 ms              |
| 50%    | 4,641 ms               | 10,467 ms              | 4,310 ms              |
| 100%   | 226 ms                 | 9,531 ms               | 216 ms                |

After the fix, `SLF4JLogger` achieves full performance parity with `JDK14Logger` across all NULL ratios.

### Files Changed

- `src/main/java/net/snowflake/client/internal/log/SLF4JLogger.java`
- `src/main/java/net/snowflake/client/internal/core/SFBaseResultSet.java`
- `src/test/java/net/snowflake/client/internal/log/MaskedExceptionLoggerIntegrationTest.java`
- `src/test/java/net/snowflake/client/internal/log/SLF4JLoggerLevelGuardTest.java` (new)