### PR TITLE
SNOW-3887909 bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -138,7 +138,7 @@ jobs:
                 java-version: ${{ matrix.runConfig.javaVersion }}
                 distribution: 'temurin'
                 cache: maven
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v7
               with:
                 python-version: '3.12'
                 architecture: 'x64'
@@ -194,7 +194,7 @@ jobs:
                 java-version: ${{ matrix.runConfig.javaVersion }}
                 distribution: 'zulu'
                 cache: maven
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v7
               with:
                 python-version: '3.12'
             - name: Install Homebrew Bash

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{!contains(github.event.pull_request.labels.*.name, 'NO-CHANGELOG-UPDATES')}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -9,7 +9,7 @@ jobs:
         name: Check Style
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Check Style
               shell: bash
               run: mvn clean validate --batch-mode --show-version -P check-style

--- a/.github/workflows/snyk-issue.yml
+++ b/.github/workflows/snyk-issue.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout action
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: snowflakedb/whitesource-actions
         token: ${{ secrets.WHITESOURCE_ACTION_TOKEN }}

--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -15,13 +15,13 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'sfc-gh-snyk-sca-sa' }}
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
 
     - name: checkout action
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: snowflakedb/whitesource-actions
         token: ${{ secrets.WHITESOURCE_ACTION_TOKEN }}

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -45,7 +45,7 @@ jobs:
     if: needs.detect-changes.outputs.any-pom == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Run Snyk aggregate project test
         uses: snyk/actions/maven@master
@@ -63,7 +63,7 @@ jobs:
     if: needs.detect-changes.outputs.parent-pom == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Run Snyk parent-pom test
         uses: snyk/actions/maven@master
@@ -81,7 +81,7 @@ jobs:
     if: needs.detect-changes.outputs.public-pom == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Run Snyk public-pom test
         uses: snyk/actions/maven@master
@@ -99,7 +99,7 @@ jobs:
     if: needs.detect-changes.outputs.thin-public-pom == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Run Snyk thin-public-pom test
         uses: snyk/actions/maven@master
@@ -117,7 +117,7 @@ jobs:
     if: needs.detect-changes.outputs.fips-public-pom == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Run Snyk FIPS public-pom test
         uses: snyk/actions/maven@master
@@ -148,7 +148,7 @@ jobs:
           - ci/wif/azure-function/pom.xml
           - ci/wif/gcp-function/pom.xml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Snyk monitor ${{ matrix.pom }}
         uses: snyk/actions/maven@master


### PR DESCRIPTION
## Summary
- Bump outdated GitHub Actions JavaScript actions to Node 24-compatible majors to avoid Node.js 20 runner deprecation warnings.
- `actions/checkout`: `@v3`/`@v4` → `@v7` (changelog, check-style, snyk workflows)
- `actions/setup-python`: `@v5` → `@v7` (build-test)
- Left already-current majors alone (`actions/checkout@v5`, `actions/setup-java@v5` in build-test)

## Test plan
- [ ] Confirm workflow YAML validates / Actions pick up the new majors
- [ ] Spot-check a workflow run for absence of Node.js 20 deprecation warnings on bumped actions

Made with [Cursor](https://cursor.com)