### PR TITLE
NO-SNOW: bump BouncyCastle jars 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
   - Changed minimum heartbeat interval to 15 minutes (snowflakedb/snowflake-jdbc#2708).
   - Bumped grpc-java to 1.83.1 (snowflakedb/snowflake-jdbc#2707, snowflakedb/snowflake-jdbc#2713).
+  - Bumped BouncyCastle dependencies' versions (snowflakedb/snowflake-jdbc#2718).
 
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).

--- a/FIPS/public_pom.xml
+++ b/FIPS/public_pom.xml
@@ -32,8 +32,8 @@
     </scm>
 
     <properties>
-      <bouncycastle.bcfips.version>1.0.2.6</bouncycastle.bcfips.version>
-      <bouncycastle.bcpkixfips.version>1.0.8</bouncycastle.bcpkixfips.version>
+      <bouncycastle.bcfips.version>1.0.2.7</bouncycastle.bcfips.version>
+      <bouncycastle.bcpkixfips.version>1.0.12</bouncycastle.bcpkixfips.version>
       <jna.version>5.13.0</jna.version>
     </properties>
 

--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -23,7 +23,7 @@
     <mockito.version>3.5.6</mockito.version>
     <netty.version>4.1.136.Final</netty.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>
   </properties>
 

--- a/fat-jar-test-app/pom.xml
+++ b/fat-jar-test-app/pom.xml
@@ -88,12 +88,12 @@
                 <dependency>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bc-fips</artifactId>
-                    <version>1.0.2.6</version>
+                    <version>1.0.2.7</version>
                 </dependency>
                 <dependency>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcpkix-fips</artifactId>
-                    <version>1.0.8</version>
+                    <version>1.0.12</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -33,9 +33,9 @@
     <reactor.core.version>3.7.19</reactor.core.version>
     <reactor.netty.core.version>1.2.18</reactor.netty.core.version>
     <awssdk.encryption.s3.version>3.4.0</awssdk.encryption.s3.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
-    <bouncycastle.bcfips.version>1.0.2.6</bouncycastle.bcfips.version>
-    <bouncycastle.bcpkixfips.version>1.0.8</bouncycastle.bcpkixfips.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
+    <bouncycastle.bcfips.version>1.0.2.7</bouncycastle.bcfips.version>
+    <bouncycastle.bcpkixfips.version>1.0.12</bouncycastle.bcpkixfips.version>
     <bytebuddy.version>1.14.17</bytebuddy.version>
     <classworlds.version>1.1</classworlds.version>
     <checkerframework.version>3.49.0</checkerframework.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -44,7 +44,7 @@
     <reactor.core.version>3.7.19</reactor.core.version>
     <reactor.netty.core.version>1.2.18</reactor.netty.core.version>
     <awssdk.encryption.s3.version>3.4.0</awssdk.encryption.s3.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
     <commons.codec.version>1.17.0</commons.codec.version>
     <commons.io.version>2.17.0</commons.io.version>
     <commons.logging.version>1.2</commons.logging.version>


### PR DESCRIPTION
## Description

bumped the following dependencies

| Component | Scope | From | To |
|---|---|---|---|
| `org.bouncycastle:bcprov-jdk18on` | compile | `1.84` | **`1.85`** |
| `org.bouncycastle:bcpkix-jdk18on` | compile | `1.84` | **`1.85`** |
| `org.bouncycastle:bc-fips` | provided | `1.0.2.6` | **`1.0.2.7`** |
| `org.bouncycastle:bcpkix-fips` | provided | `1.0.8` | **`1.0.12`** |

to address some vulnerabilities. Confirmed that on this branch, scanner alerts are gone. 

## CVEs fixed, per component

### `org.bouncycastle:bcprov-jdk18on` — 1.84 → 1.85
> Non-FIPS provider. Fixed for all listed CVEs in **1.85**.

- [CVE-2026-59650](https://nvd.nist.gov/vuln/detail/CVE-2026-59650) — CWE-20, CVSS 9.3 — `DHAgreement` improperly validates peer values during key agreement.
- [CVE-2026-8763](https://nvd.nist.gov/vuln/detail/CVE-2026-8763) — CWE-295, CVSS 9.3 — Name Constraints bypass via trailing dot in `rfc822Name`/URI (`PKIXNameConstraintValidator`).
- [CVE-2026-12803](https://nvd.nist.gov/vuln/detail/CVE-2026-12803) — CWE-354, CVSS 8.7 — `KCCMBlockCipher` MAC nonce not bound when AAD absent → cross-nonce AEAD forgery.
- [CVE-2026-12816](https://nvd.nist.gov/vuln/detail/CVE-2026-12816) — CWE-354, CVSS 8.7 — `IESEngine` stream-mode MAC forgery via length-dependent KDF split.
- [CVE-2026-13506](https://nvd.nist.gov/vuln/detail/CVE-2026-13506) — CWE-674, CVSS 8.7 — Lazy ASN.1 sequence forcing resets the nesting-depth guard (uncontrolled recursion).
- [CVE-2026-14682](https://nvd.nist.gov/vuln/detail/CVE-2026-14682) — CWE-789, CVSS 8.7 — Possible OOM from unbounded up-front allocation on a definite-length read.
- [CVE-2026-58059](https://nvd.nist.gov/vuln/detail/CVE-2026-58059) — CWE-407, CVSS 8.7 — Quadratic-time escaping when stringifying X.500 distinguished names.
- [CVE-2026-58060](https://nvd.nist.gov/vuln/detail/CVE-2026-58060) — CWE-789, CVSS 8.7 — HSS public-key level count unbounded → huge allocation on verify.

### `org.bouncycastle:bcpkix-jdk18on` — 1.84 → 1.85
> Non-FIPS PKIX/CMS. Fixed for all listed CVEs in **1.85**.

- [CVE-2026-12802](https://nvd.nist.gov/vuln/detail/CVE-2026-12802) — CWE-354, CVSS 8.7 — CMS `AuthEnvelopedData` fails to enforce tag-length on decryption.
- [CVE-2026-59639](https://nvd.nist.gov/vuln/detail/CVE-2026-59639) — CWE-347, CVSS 8.7 — CMS `verifySignatures` returns `true` for `SignedData` with zero signers.
- [CVE-2026-59642](https://nvd.nist.gov/vuln/detail/CVE-2026-59642) — CWE-354, CVSS 8.7 — CMS `AuthenticatedData` content not bound to MAC when `authAttrs` present.
- [CVE-2026-59647](https://nvd.nist.gov/vuln/detail/CVE-2026-59647) — CWE-770, CVSS 6.9 — CRMF/CMP password-MAC honours an unbounded iteration count.

### `org.bouncycastle:bc-fips` — 1.0.2.6 → 1.0.2.7
> FIPS core provider (`provided` scope). NVD lists the **1.0.X series fixed in 1.0.2.7**.

- [CVE-2026-8763](https://nvd.nist.gov/vuln/detail/CVE-2026-8763) — CWE-295, CVSS 9.3 — Name Constraints bypass via trailing dot in `rfc822Name`/URI.
- [CVE-2026-13506](https://nvd.nist.gov/vuln/detail/CVE-2026-13506) — CWE-674, CVSS 8.7 — Lazy ASN.1 sequence forcing resets the nesting-depth guard (uncontrolled recursion).
- [CVE-2026-14682](https://nvd.nist.gov/vuln/detail/CVE-2026-14682) — CWE-789, CVSS 8.7 — Possible OOM from unbounded up-front allocation on a definite-length read.
- [CVE-2026-58059](https://nvd.nist.gov/vuln/detail/CVE-2026-58059) — CWE-407, CVSS 8.7 — Quadratic-time escaping when stringifying X.500 distinguished names.

### `org.bouncycastle:bcpkix-fips` — 1.0.8 → 1.0.12
> FIPS PKIX/CMS (`provided` scope). NVD lists the **1.0.X series fixed in 1.0.12**.

- [CVE-2026-12802](https://nvd.nist.gov/vuln/detail/CVE-2026-12802) — CWE-354, CVSS 8.7 — CMS `AuthEnvelopedData` fails to enforce tag-length on decryption.
- [CVE-2026-59639](https://nvd.nist.gov/vuln/detail/CVE-2026-59639) — CWE-347, CVSS 8.7 — CMS `verifySignatures` returns `true` for `SignedData` with zero signers.