### PR TITLE
NO-SNOW: bump netty to 4.1.137.Final from 4.1.136.Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Changed minimum heartbeat interval to 15 minutes (snowflakedb/snowflake-jdbc#2708).
   - Bumped grpc-java to 1.83.1 (snowflakedb/snowflake-jdbc#2707, snowflakedb/snowflake-jdbc#2713).
   - Bumped BouncyCastle dependencies' versions (snowflakedb/snowflake-jdbc#2718).
-  - Bumped netty to 4.1.137.Final (snowflakedb/snowflake-jdbc#XXXX).
+  - Bumped netty to 4.1.137.Final (snowflakedb/snowflake-jdbc#2719).
 
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Changed minimum heartbeat interval to 15 minutes (snowflakedb/snowflake-jdbc#2708).
   - Bumped grpc-java to 1.83.1 (snowflakedb/snowflake-jdbc#2707, snowflakedb/snowflake-jdbc#2713).
   - Bumped BouncyCastle dependencies' versions (snowflakedb/snowflake-jdbc#2718).
+  - Bumped netty to 4.1.137.Final (snowflakedb/snowflake-jdbc#XXXX).
 
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).

--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -21,7 +21,7 @@
     <junit.version>5.11.1</junit.version>
     <surefire.version>3.5.1</surefire.version>
     <mockito.version>3.5.6</mockito.version>
-    <netty.version>4.1.136.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <bouncycastle.version>1.85</bouncycastle.version>
     <shadeBase>net.snowflake.client.jdbc.internal</shadeBase>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -76,7 +76,7 @@
     <logback.version>1.3.6</logback.version>
     <mockito.version>4.11.0</mockito.version>
     <nimbusds.oauth2.version>11.30.1</nimbusds.oauth2.version>
-    <netty.version>4.1.136.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <nimbusds.version>10.6</nimbusds.version>
     <opencensus.version>0.31.1</opencensus.version>
     <opentelemetry.version>1.62.0</opentelemetry.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -64,7 +64,7 @@
     <json.smart.version>2.5.2</json.smart.version>
     <jsoup.version>1.15.3</jsoup.version>
     <metrics.version>2.2.0</metrics.version>
-    <netty.version>4.1.136.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <nimbusds.version>10.6</nimbusds.version>
     <nimbusds.oauth2.version>11.30.1</nimbusds.oauth2.version>
     <opentelemetry.version>1.62.0</opentelemetry.version>


### PR DESCRIPTION
### Description
Bumping netty dependency to 4.1.137.Final to address [several vulnerabilities](https://netty.io/news/2026/08/06/4-1-137-Final.html)