### PR TITLE
NO-SNOW: bump jackson-databind to 2.18.10 from 2.18.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Bumped grpc-java to 1.83.1 (snowflakedb/snowflake-jdbc#2707, snowflakedb/snowflake-jdbc#2713).
   - Bumped BouncyCastle dependencies' versions (snowflakedb/snowflake-jdbc#2718).
   - Bumped netty to 4.1.137.Final (snowflakedb/snowflake-jdbc#2719).
+  - Bumped jackson-databind to 2.18.10 (snowflakedb/snowflake-jdbc#2721).
 
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).

--- a/TestOnly/pom.xml
+++ b/TestOnly/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <arrow.version>17.0.0</arrow.version>
     <awaitility.version>4.2.0</awaitility.version>
-    <jacksondatabind.version>2.17.2</jacksondatabind.version>
+    <jacksondatabind.version>2.18.10</jacksondatabind.version>
     <jacoco.version>0.8.4</jacoco.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
     <jna.version>5.13.0</jna.version>

--- a/ci/wif/aws-lambda/pom.xml
+++ b/ci/wif/aws-lambda/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.18.10</version>
         </dependency>
         
         <!-- TAR/GZIP extraction -->

--- a/ci/wif/azure-function/pom.xml
+++ b/ci/wif/azure-function/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.18.10</version>
         </dependency>
         
         <!-- TAR/GZIP extraction - needed for WifTestHelper -->

--- a/ci/wif/gcp-function/pom.xml
+++ b/ci/wif/gcp-function/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.18.10</version>
         </dependency>
         
         <!-- TAR/GZIP extraction - needed for WifTestHelper -->

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -64,7 +64,7 @@
     <grpc.version>1.83.1</grpc.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hikaricp.version>2.4.3</hikaricp.version>
-    <jackson.version>2.18.9</jackson.version>
+    <jackson.version>2.18.10</jackson.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -58,7 +58,7 @@
     <google.jsr305.version>3.0.2</google.jsr305.version>
     <google.protobuf.java.version>4.33.5</google.protobuf.java.version>
     <grpc.version>1.83.1</grpc.version>
-    <jackson.version>2.18.9</jackson.version>
+    <jackson.version>2.18.10</jackson.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>
     <json.smart.version>2.5.2</json.smart.version>


### PR DESCRIPTION
### Description

Remediates [CVE-2026-68497](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.18.10) (adds StreamReadConstraints number-length limit to XMLGregorianCalendar/Duration deserialization), fixed upstream in jackson-databind 2.18.10. Also raises TestOnly (2.17.2) and the ci/wif functions (2.15.2) to the same 2.18.10 level.
