### PR TITLE
NO-SNOW: bump jsoup to 1.23.1 from 1.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
   - Fixed GCS stage uploads corrupting files on virtual-hosted-style GCP accounts (`useVirtualUrl=true`, e.g. SPCS on GCP) (snowflakedb/snowflake-jdbc#2716).
   - Fixed `SLF4JLogger` performing expensive `SecretDetector.maskSecrets()` regex work even when the log level is disabled, added level guards to all `(String, boolean)` and `(String, Throwable)` overloads to match `JDK14Logger` behavior (snowflakedb/snowflake-jdbc#2712).
   - Fixed the self-contained JAR shipping the non-gRPC-shaded Netty native libraries (`libnetty_transport_native_epoll_*`, `libnetty_transport_native_kqueue_*`, `libnetty_resolver_dns_native_macos_*`) unshaded, which caused an `UnsatisfiedLinkError` when they conflicted with a user's own Netty on the classpath. These libraries are now relocated with the `libnet_snowflake_client_jdbc_internal_netty_*` prefix to match the relocated `io.netty` package (snowflakedb/snowflake-jdbc#2705).
-  - Bumped `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
   - Changed minimum heartbeat interval to 15 minutes (snowflakedb/snowflake-jdbc#2708).
-  - Bumped grpc-java to 1.83.1 (snowflakedb/snowflake-jdbc#2707, snowflakedb/snowflake-jdbc#2713).
-  - Bumped BouncyCastle dependencies' versions (snowflakedb/snowflake-jdbc#2718).
-  - Bumped netty to 4.1.137.Final (snowflakedb/snowflake-jdbc#2719).
+  - Bumped the following dependencies:
+    - `google-cloud-storage` from 2.44.1 to 2.69.0, with all required transitive dependency version updates (`google-cloud-core`, `google-api-grpc`, `google-auth-library`, `google-http-client`, `gax`, `protobuf`, `guava`, `slf4j`, and others) (snowflakedb/snowflake-jdbc#2691).
+    - grpc-java to 1.83.1 (snowflakedb/snowflake-jdbc#2707, snowflakedb/snowflake-jdbc#2713).
+    - BouncyCastle dependencies' versions (snowflakedb/snowflake-jdbc#2718).
+    - netty to 4.1.137.Final (snowflakedb/snowflake-jdbc#2719).
+    - jsoup to 1.23.1 (snowflakedb/snowflake-jdbc#XXXX).
 
 - v4.3.2
   - Fixed `RestRequest` logging retryable, temporal non-200 responses as `ERROR` (now: `WARN`), and fixed `SnowflakeChunkDownloader` using flat, short jitter between retries (now uses `DecorrelatedJitterBackoff(1 s, 16 s)` like http requests) (snowflakedb/snowflake-jdbc#2693).

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -72,7 +72,7 @@
     <junit4.version>4.13.2</junit4.version>
     <junit.version>5.11.1</junit.version>
     <junit.platform.version>1.11.1</junit.platform.version>
-    <jsoup.version>1.15.3</jsoup.version>
+    <jsoup.version>1.23.1</jsoup.version>
     <logback.version>1.3.6</logback.version>
     <mockito.version>4.11.0</mockito.version>
     <nimbusds.oauth2.version>11.30.1</nimbusds.oauth2.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -62,7 +62,7 @@
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>
     <json.smart.version>2.5.2</json.smart.version>
-    <jsoup.version>1.15.3</jsoup.version>
+    <jsoup.version>1.23.1</jsoup.version>
     <metrics.version>2.2.0</metrics.version>
     <netty.version>4.1.137.Final</netty.version>
     <nimbusds.version>10.6</nimbusds.version>


### PR DESCRIPTION
### Description

* Snyk finding from another PR; for a Low/Medium severity CVE [CVE-2026-71497](https://nvd.nist.gov/vuln/detail/CVE-2026-71497)
* Tiny bit of restructure for the dependency bumps since v4.3.2 in the changelog