### PR TITLE
NO-SNOW: Prevent unicode StreamLatestIT schemas from flaking DatabaseMetaDataIT

### DIFF
--- a/src/test/java/net/snowflake/client/internal/jdbc/StreamLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/StreamLatestIT.java
@@ -22,6 +22,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import net.snowflake.client.TestUtil;
 import net.snowflake.client.annotations.DontRunOnGithubActions;
 import net.snowflake.client.api.connection.DownloadStreamConfig;
 import net.snowflake.client.api.connection.SnowflakeConnection;
@@ -363,7 +364,12 @@ public class StreamLatestIT extends BaseJDBCTest {
   /** SNOW-3713887: uploadStream/downloadStream with unicode schema in stage name */
   @Test
   public void testUploadDownloadStreamWithUnicodeSchemaStage() throws Throwable {
-    String unicodeSchema = "\"日本語テスト_" + UUID.randomUUID().toString().substring(0, 5) + "\"";
+    String unicodeSchema =
+        "\""
+            + TestUtil.GENERATED_SCHEMA_PREFIX
+            + "日本語テスト_"
+            + UUID.randomUUID().toString().substring(0, 5)
+            + "\"";
     String stageName = "test_stream_stage_" + UUID.randomUUID().toString().replaceAll("-", "");
 
     try (Connection connection = getConnection();


### PR DESCRIPTION
## Summary
- Prefix ephemeral unicode schemas in `StreamLatestIT` with `GENERATED_` so shared-account metadata inventory tests filter them via `isSchemaGeneratedInTests`.

## Context
`testUploadDownloadStreamWithUnicodeSchemaStage` creates a Japanese-named schema that is not covered by the existing test-schema prefix filter. Concurrent `DatabaseMetaDataIT.testGetSchemas` compares account-wide vs database-scoped `getSchemas()` results and fails when that schema appears between the two calls (shown as `??????_<suffix>` in CI logs).

## Test plan
- [x] `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] `mvn clean validate --batch-mode --show-version -P check-style`
- [ ] Confirm leftover `日本語テスト_*` schema removed from the shared test account
- [ ] CI: `DatabaseMetaDataIT.testGetSchemas` / `StreamLatestIT.testUploadDownloadStreamWithUnicodeSchemaStage`