### PR TITLE
SNOW-3982613: setObject(byte[], Types.BINARY/VARBINARY/LONGVARBINARY) binds hex, not toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
-  - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#XXXX).
+  - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
 
 - v4.3.3
   - Fixed GCS stage uploads corrupting files on virtual-hosted-style GCP accounts (`useVirtualUrl=true`, e.g. SPCS on GCP) (snowflakedb/snowflake-jdbc#2716).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
-  - 
+  - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#XXXX).
 
 - v4.3.3
   - Fixed GCS stage uploads corrupting files on virtual-hosted-style GCP accounts (`useVirtualUrl=true`, e.g. SPCS on GCP) (snowflakedb/snowflake-jdbc#2716).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
-  - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
+  - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
 
 - v4.3.3
   - Fixed GCS stage uploads corrupting files on virtual-hosted-style GCP accounts (`useVirtualUrl=true`, e.g. SPCS on GCP) (snowflakedb/snowflake-jdbc#2716).

--- a/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -516,7 +516,9 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
       setYearMonthInterval(parameterIndex, (String) x);
     } else if (targetSqlType == SnowflakeType.EXTRA_TYPES_DAY_TIME_INTERVAL) {
       setDayTimeInterval(parameterIndex, (String) x);
-    } else if ((targetSqlType == Types.BINARY || targetSqlType == Types.VARBINARY)
+    } else if ((targetSqlType == Types.BINARY
+            || targetSqlType == Types.VARBINARY
+            || targetSqlType == Types.LONGVARBINARY)
         && x instanceof byte[]) {
       // byte[] must be hex-encoded via setBytes, not String.valueOf'd (SNOW-3982613)
       setBytes(parameterIndex, (byte[]) x);

--- a/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -516,6 +516,10 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
       setYearMonthInterval(parameterIndex, (String) x);
     } else if (targetSqlType == SnowflakeType.EXTRA_TYPES_DAY_TIME_INTERVAL) {
       setDayTimeInterval(parameterIndex, (String) x);
+    } else if ((targetSqlType == Types.BINARY || targetSqlType == Types.VARBINARY)
+        && x instanceof byte[]) {
+      // byte[] must be hex-encoded via setBytes, not String.valueOf'd (SNOW-3982613)
+      setBytes(parameterIndex, (byte[]) x);
     } else {
       logger.trace(
           "setObject(parameterIndex: {}, Object x, sqlType: {})",

--- a/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImplSetObjectBinaryTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImplSetObjectBinaryTest.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Regression tests for SNOW-3982613: setObject(idx, byte[], Types.BINARY/VARBINARY) must hex-encode
- * the byte[] (as setBytes does), not bind String.valueOf(byte[]) ("[B@..").
+ * Regression tests for SNOW-3982613: setObject(idx, byte[], Types.BINARY/VARBINARY/LONGVARBINARY)
+ * must hex-encode the byte[] (as setBytes does), not bind String.valueOf(byte[]) ("[B@..").
  */
 class SnowflakePreparedStatementImplSetObjectBinaryTest {
 
@@ -65,7 +65,7 @@ class SnowflakePreparedStatementImplSetObjectBinaryTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {Types.BINARY, Types.VARBINARY})
+  @ValueSource(ints = {Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY})
   void setObjectByteArrayWithTypeBindsHex(int sqlType) throws SQLException {
     SnowflakePreparedStatementImpl stmt = newStatement();
     stmt.setObject(1, BYTES, sqlType);

--- a/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImplSetObjectBinaryTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImplSetObjectBinaryTest.java
@@ -1,0 +1,81 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import net.snowflake.client.internal.core.ParameterBindingDTO;
+import net.snowflake.client.internal.core.SFBaseSession;
+import net.snowflake.client.internal.core.SFBaseStatement;
+import net.snowflake.client.internal.jdbc.SFConnectionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Regression tests for SNOW-3982613: setObject(idx, byte[], Types.BINARY/VARBINARY) must hex-encode
+ * the byte[] (as setBytes does), not bind String.valueOf(byte[]) ("[B@..").
+ */
+class SnowflakePreparedStatementImplSetObjectBinaryTest {
+
+  private static final byte[] BYTES = {
+    (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF, 0x00, 0x01, 0x02, 0x03
+  };
+  private static final String EXPECTED_HEX = "DEADBEEF00010203";
+
+  private SnowflakeConnectionImpl mockConnection;
+
+  @BeforeEach
+  void setUp() throws SQLException {
+    mockConnection = mock(SnowflakeConnectionImpl.class);
+    SFConnectionHandler mockHandler = mock(SFConnectionHandler.class);
+    SFBaseStatement mockSFStatement = mock(SFBaseStatement.class);
+    SFBaseSession mockSession = mock(SFBaseSession.class);
+
+    when(mockConnection.getHandler(any())).thenReturn(mockHandler);
+    when(mockHandler.getSFStatement()).thenReturn(mockSFStatement);
+    when(mockConnection.getSFBaseSession(any())).thenReturn(mockSession);
+    when(mockConnection.getSessionID()).thenReturn("test-session-id");
+    when(mockConnection.isClosed()).thenReturn(false);
+    when(mockConnection.getShowStatementParameters()).thenReturn(false);
+  }
+
+  private SnowflakePreparedStatementImpl newStatement() throws SQLException {
+    return new SnowflakePreparedStatementImpl(
+        mockConnection,
+        "insert into t values (?)",
+        false,
+        ResultSet.TYPE_FORWARD_ONLY,
+        ResultSet.CONCUR_READ_ONLY,
+        ResultSet.CLOSE_CURSORS_AT_COMMIT);
+  }
+
+  private static void assertHexBinding(ParameterBindingDTO binding) {
+    String value = String.valueOf(binding.getValue());
+    assertEquals("BINARY", binding.getType());
+    assertEquals(EXPECTED_HEX, value.toUpperCase());
+    assertFalse(value.contains("[B@"), "byte[] must not be bound via String.valueOf");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {Types.BINARY, Types.VARBINARY})
+  void setObjectByteArrayWithTypeBindsHex(int sqlType) throws SQLException {
+    SnowflakePreparedStatementImpl stmt = newStatement();
+    stmt.setObject(1, BYTES, sqlType);
+    assertHexBinding(stmt.getParameterBindings().get("1"));
+  }
+
+  @Test
+  void setObjectByteArrayWithScaleDelegatesAndBindsHex() throws SQLException {
+    SnowflakePreparedStatementImpl stmt = newStatement();
+    stmt.setObject(1, BYTES, Types.BINARY, 0);
+    assertHexBinding(stmt.getParameterBindings().get("1"));
+  }
+}


### PR DESCRIPTION
## Problem
The 3-arg `PreparedStatement.setObject(parameterIndex, Object, targetSqlType)` has no `Types.BINARY`/`Types.VARBINARY`/`Types.LONGVARBINARY` branch, so a `byte[]` falls through to the generic path and is bound as `String.valueOf(byte[])` — the array object reference `"[B@.."`.

- **`Types.BINARY`**: the server rejects the bind — `Invalid bind value ([B@..) for type (BINARY)` (error 2086, SQLSTATE 22000).
- **`Types.VARBINARY`**: throws `DATA_TYPE_NOT_SUPPORTED` client-side (code 200018, SQLSTATE 0A000, `Data type not supported for binding: -3`) before it ever reaches the server.
- **`Types.LONGVARBINARY`**: same client-side throw (`Data type not supported for binding: -4`).
- The 4-arg `setObject(…, scaleOrLength)` delegates to the 3-arg method, so it is affected too.

**Impact:** any application binding binary data via the typed `setObject(idx, byte[], Types.BINARY/VARBINARY/LONGVARBINARY)` overloads cannot insert binary values; only `setBytes` and the 2-arg `setObject` worked. We got a customer complaint due to this.

## Fix
Route a `byte[]` with `Types.BINARY`/`Types.VARBINARY`/`Types.LONGVARBINARY` to `setBytes`, which hex-encodes via `SFBinary.toHex()` — the same encoding the 2-arg `setObject` already uses. One branch added; all other type combinations are unchanged. v4 only (no v3 backport).

Snowflake has a single `BINARY` type, so all three JDBC binary type codes map onto it — routing them through `setBytes` is correct. Note that Snowflake `BINARY` is capped at **8 MB (8,388,608 bytes)**; `LONGVARBINARY` sources that exceed this (e.g. Vertica `LONG VARBINARY` allows up to 32,000,000 bytes / ~30.5 MB) are still subject to that server-side limit — this fix corrects the encoding, it does not raise the size ceiling. See the [Vertica → Snowflake binary data type mapping](https://docs.snowflake.com/en/migrations/aim-for-datawarehouses/code-conversion/translation-references/vertica/vertica-data-types#binary-data-type).

## Tests
- **Unit (new):** `SnowflakePreparedStatementImplSetObjectBinaryTest` mocks the connection and inspects the resulting bind for `Types.BINARY`, `Types.VARBINARY`, `Types.LONGVARBINARY`, and the 4-arg delegation. Confirmed non-vacuous: **without** the fix it fails `2 failures + 2 errors` (`[B@..` for the BINARY param and the 4-arg case; `Data type not supported for binding: -3`/`-4` for VARBINARY/LONGVARBINARY); **with** the fix `4/4 pass`.
- **e2e (live account):** read back with `HEX_ENCODE` after binding `{DE AD BE EF 00 01 02 03}`.
  - `BINARY` column: insert via typed `setObject(…, Types.BINARY)`, typed `setObject(…, Types.LONGVARBINARY)`, `setBytes`, and 2-arg `setObject`. Before: typed `Types.BINARY` fails with error 2086 (`Invalid bind value ([B@..) for type (BINARY)`) and typed `Types.LONGVARBINARY` throws client-side (`Data type not supported for binding: -4`); after: all store `DEADBEEF00010203`.
  - `VARBINARY` column: insert via typed `setObject(…, Types.VARBINARY)`. Before: client-side `SnowflakeSQLException` code 200018 / SQLSTATE 0A000 (`Data type not supported for binding: -3`); after: stores `DEADBEEF00010203`.
