### PR TITLE
SNOW-4009233: Clarify exact-schema filter as a SHOW-row bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed `DatabaseMetaData.getProcedures()`, `getSchemas()`, and `getFunctions()` returning schemas that do not match the requested pattern when exact-schema matching is enabled. The client-side filter compared `schemaPattern` to itself (always true) instead of the row's schema name (SNOW-4009233).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
 
 - v4.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
-  - Fixed `DatabaseMetaData.getProcedures()`, `getSchemas()`, and `getFunctions()` returning schemas that do not match the requested pattern when exact-schema matching is enabled. The client-side filter compared `schemaPattern` to itself (always true) instead of the row's schema name (SNOW-4009233).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
 
 - v4.3.3

--- a/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -1180,8 +1180,7 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
           short procedureType = procedureReturnsResult;
           if ((compiledProcedurePattern == null
                   || compiledProcedurePattern.matcher(procedureName).matches())
-              && matchesSchemaName(
-                  compiledSchemaPattern, schemaName, isExactSchema, schemaPattern)) {
+              && matchesSchemaName(compiledSchemaPattern, schemaName, isExactSchema)) {
             logger.trace("Found a matched function:" + schemaName + "." + procedureName);
 
             nextRow[0] = catalogName;
@@ -1927,18 +1926,21 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
 
   /**
    * Client-side schema filter used by {@code getProcedures()}, {@code getSchemas()}, and {@code
-   * getFunctions()}. The compiled wildcard pattern is the primary matcher; when exact-schema
-   * matching is enabled, also accept a literal name equals so regex-special characters in the
-   * schema are not treated as wildcards.
+   * getFunctions()}.
+   *
+   * <p>When exact-schema search is enabled, SHOW is already scoped to that schema (with {@code _}
+   * and {@code %} escaped). Those rows must be accepted: the compiled LIKE pattern treats {@code
+   * _}/{@code %} in the schema name as wildcards, and SHOW may return the name quoted (e.g. {@code
+   * "FOO%BAR"}), so neither regex matching nor {@code schemaPattern.equals(schemaName)} is
+   * reliable. The previous {@code schemaPattern.equals(schemaPattern)} check was this same bypass
+   * written as a tautology.
    */
   static boolean matchesSchemaName(
-      Pattern compiledSchemaPattern,
-      String schemaName,
-      boolean isExactSchema,
-      String schemaPattern) {
-    return compiledSchemaPattern == null
-        || compiledSchemaPattern.matcher(schemaName).matches()
-        || (isExactSchema && schemaPattern != null && schemaPattern.equals(schemaName));
+      Pattern compiledSchemaPattern, String schemaName, boolean isExactSchema) {
+    if (isExactSchema) {
+      return true;
+    }
+    return compiledSchemaPattern == null || compiledSchemaPattern.matcher(schemaName).matches();
   }
 
   static Integer getColumnSize(SnowflakeColumnMetadata columnMetadata) {
@@ -3385,7 +3387,7 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
           String schemaName = showObjectResultSet.getString(2);
           String dbName = showObjectResultSet.getString(5);
 
-          if (matchesSchemaName(compiledSchemaPattern, schemaName, isExactSchema, schemaPattern)) {
+          if (matchesSchemaName(compiledSchemaPattern, schemaName, isExactSchema)) {
             nextRow[0] = schemaName;
             nextRow[1] = dbName;
             return true;
@@ -3471,8 +3473,7 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
           String specificName = functionName;
           if ((compiledFunctionPattern == null
                   || compiledFunctionPattern.matcher(functionName).matches())
-              && matchesSchemaName(
-                  compiledSchemaPattern, schemaName, isExactSchema, schemaPattern)) {
+              && matchesSchemaName(compiledSchemaPattern, schemaName, isExactSchema)) {
             logger.debug("Found a matched function:" + schemaName + "." + functionName);
 
             nextRow[0] = catalogName;

--- a/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -1180,9 +1180,8 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
           short procedureType = procedureReturnsResult;
           if ((compiledProcedurePattern == null
                   || compiledProcedurePattern.matcher(procedureName).matches())
-              && (compiledSchemaPattern == null
-                  || compiledSchemaPattern.matcher(schemaName).matches()
-                  || isExactSchema && schemaPattern.equals(schemaPattern))) {
+              && matchesSchemaName(
+                  compiledSchemaPattern, schemaName, isExactSchema, schemaPattern)) {
             logger.trace("Found a matched function:" + schemaName + "." + procedureName);
 
             nextRow[0] = catalogName;
@@ -1924,6 +1923,22 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
         return false;
       }
     };
+  }
+
+  /**
+   * Client-side schema filter used by {@code getProcedures()}, {@code getSchemas()}, and {@code
+   * getFunctions()}. The compiled wildcard pattern is the primary matcher; when exact-schema
+   * matching is enabled, also accept a literal name equals so regex-special characters in the
+   * schema are not treated as wildcards.
+   */
+  static boolean matchesSchemaName(
+      Pattern compiledSchemaPattern,
+      String schemaName,
+      boolean isExactSchema,
+      String schemaPattern) {
+    return compiledSchemaPattern == null
+        || compiledSchemaPattern.matcher(schemaName).matches()
+        || (isExactSchema && schemaPattern != null && schemaPattern.equals(schemaName));
   }
 
   static Integer getColumnSize(SnowflakeColumnMetadata columnMetadata) {
@@ -3370,9 +3385,7 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
           String schemaName = showObjectResultSet.getString(2);
           String dbName = showObjectResultSet.getString(5);
 
-          if (compiledSchemaPattern == null
-              || compiledSchemaPattern.matcher(schemaName).matches()
-              || isExactSchema && schemaPattern.equals(schemaPattern)) {
+          if (matchesSchemaName(compiledSchemaPattern, schemaName, isExactSchema, schemaPattern)) {
             nextRow[0] = schemaName;
             nextRow[1] = dbName;
             return true;
@@ -3458,9 +3471,8 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
           String specificName = functionName;
           if ((compiledFunctionPattern == null
                   || compiledFunctionPattern.matcher(functionName).matches())
-              && (compiledSchemaPattern == null
-                  || compiledSchemaPattern.matcher(schemaName).matches()
-                  || isExactSchema && schemaPattern.equals(schemaPattern))) {
+              && matchesSchemaName(
+                  compiledSchemaPattern, schemaName, isExactSchema, schemaPattern)) {
             logger.debug("Found a matched function:" + schemaName + "." + functionName);
 
             nextRow[0] = catalogName;

--- a/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplSchemaFilterTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplSchemaFilterTest.java
@@ -1,0 +1,47 @@
+package net.snowflake.client.internal.api.implementation.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Pattern;
+import net.snowflake.common.util.Wildcard;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeDatabaseMetaDataImplSchemaFilterTest {
+
+  private static Pattern compile(String schemaPattern) {
+    return Wildcard.toRegexPattern(schemaPattern, true);
+  }
+
+  @Test
+  public void nullCompiledPatternAcceptsAnySchema() {
+    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(null, "ANY_SCHEMA", false, null));
+  }
+
+  @Test
+  public void compiledPatternMatchIsAccepted() {
+    Pattern compiled = compile("FOO%");
+    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "FOOBAR", false, "FOO%"));
+  }
+
+  @Test
+  public void compiledPatternMismatchIsRejectedWhenNotExactSchema() {
+    Pattern compiled = compile("FOO");
+    assertFalse(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "BAR", false, "FOO"));
+  }
+
+  @Test
+  public void exactSchemaAcceptsLiteralNameEqualityWhenPatternDoesNotMatch() {
+    // A schema name containing regex metacharacters will not match the compiled wildcard
+    // pattern, but exact-schema mode should still accept a literal equals.
+    String schema = "FOO.BAR";
+    Pattern compiled = compile(schema);
+    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, schema, true, schema));
+  }
+
+  @Test
+  public void exactSchemaDoesNotAcceptUnrelatedSchemaWhenPatternDoesNotMatch() {
+    Pattern compiled = compile("FOO");
+    assertFalse(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "BAR", true, "FOO"));
+  }
+}

--- a/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplSchemaFilterTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplSchemaFilterTest.java
@@ -15,33 +15,26 @@ public class SnowflakeDatabaseMetaDataImplSchemaFilterTest {
 
   @Test
   public void nullCompiledPatternAcceptsAnySchema() {
-    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(null, "ANY_SCHEMA", false, null));
+    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(null, "ANY_SCHEMA", false));
   }
 
   @Test
   public void compiledPatternMatchIsAccepted() {
     Pattern compiled = compile("FOO%");
-    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "FOOBAR", false, "FOO%"));
+    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "FOOBAR", false));
   }
 
   @Test
   public void compiledPatternMismatchIsRejectedWhenNotExactSchema() {
     Pattern compiled = compile("FOO");
-    assertFalse(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "BAR", false, "FOO"));
+    assertFalse(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "BAR", false));
   }
 
   @Test
-  public void exactSchemaAcceptsLiteralNameEqualityWhenPatternDoesNotMatch() {
-    // A schema name containing regex metacharacters will not match the compiled wildcard
-    // pattern, but exact-schema mode should still accept a literal equals.
-    String schema = "FOO.BAR";
-    Pattern compiled = compile(schema);
-    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, schema, true, schema));
-  }
-
-  @Test
-  public void exactSchemaDoesNotAcceptUnrelatedSchemaWhenPatternDoesNotMatch() {
-    Pattern compiled = compile("FOO");
-    assertFalse(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "BAR", true, "FOO"));
+  public void exactSchemaAcceptsShowRowsEvenWhenCompiledPatternDoesNotMatch() {
+    // SHOW may quote names that contain % (e.g. "FOO%BAR"), which does not match the LIKE regex
+    // compiled from the unquoted session schema. Exact-schema mode trusts the SHOW scoping.
+    Pattern compiled = compile("FOO%BAR");
+    assertTrue(SnowflakeDatabaseMetaDataImpl.matchesSchemaName(compiled, "\"FOO%BAR\"", true));
   }
 }


### PR DESCRIPTION
## Summary
- `schemaPattern.equals(schemaPattern)` in `getProcedures()` / `getSchemas()` / `getFunctions()` is a tautology, but it was **intentional**: when exact-schema search is on, SHOW is already scoped to that schema (with `_`/`%` escaped).
- Replacing it with `schemaPattern.equals(schemaName)` broke `testExactSchemaSearching`. Schema names like `ESCAPED_UNDERSCORE%…` come back **quoted** (`"FOO%BAR"`), so neither literal equals nor the compiled LIKE regex matches.
- The filter now says `if (isExactSchema) return true` with a comment so the next reader does not treat the tautology as a bug.

## Context
SNOW-4009233. No user-visible behavior change vs `master`.

## Test plan
- [x] `./mvnw -Dtest=SnowflakeDatabaseMetaDataImplSchemaFilterTest test`
- [x] `./mvnw com.spotify.fmt:fmt-maven-plugin:format`
- [x] `./mvnw clean validate --batch-mode --show-version -P check-style`
- [ ] `DatabaseMetaDataLatestIT.testExactSchemaSearching` (the CI failure on the first commit)