### PR TITLE
SNOW-4009234: Fix getColumns default-value trim discard and NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
 
 - v4.3.3

--- a/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -1812,18 +1812,8 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
           String schemaName = showObjectResultSet.getString(2);
           String columnName = showObjectResultSet.getString(3);
           String dataTypeStr = showObjectResultSet.getString(4);
-          String defaultValue = showObjectResultSet.getString(6);
-          defaultValue.trim();
-          if (defaultValue.isEmpty()) {
-            defaultValue = null;
-          } else if (!stringsQuoted) {
-            if (defaultValue.startsWith("\'") && defaultValue.endsWith("\'")) {
-              // remove extra set of single quotes
-              defaultValue = defaultValue.substring(1, defaultValue.length() - 1);
-              // scan for 2 single quotes in a row and remove one of them
-              defaultValue = defaultValue.replace("''", "'");
-            }
-          }
+          String defaultValue =
+              normalizeColumnDefaultValue(showObjectResultSet.getString(6), stringsQuoted);
           String comment = showObjectResultSet.getString(9);
           String catalogName = showObjectResultSet.getString(10);
           String autoIncrement = showObjectResultSet.getString(11);
@@ -1924,6 +1914,28 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
         return false;
       }
     };
+  }
+
+  /**
+   * Normalize a SHOW COLUMNS default value for {@code DatabaseMetaData.getColumns()}. Null-safe:
+   * SQL NULL and whitespace-only values become {@code null}. Optionally strips wrapping single
+   * quotes when the session does not keep string defaults quoted.
+   */
+  static String normalizeColumnDefaultValue(String defaultValue, boolean stringsQuoted) {
+    if (defaultValue == null) {
+      return null;
+    }
+    defaultValue = defaultValue.trim();
+    if (defaultValue.isEmpty()) {
+      return null;
+    }
+    if (!stringsQuoted && defaultValue.startsWith("'") && defaultValue.endsWith("'")) {
+      // remove extra set of single quotes
+      defaultValue = defaultValue.substring(1, defaultValue.length() - 1);
+      // scan for 2 single quotes in a row and remove one of them
+      defaultValue = defaultValue.replace("''", "'");
+    }
+    return defaultValue;
   }
 
   static Integer getColumnSize(SnowflakeColumnMetadata columnMetadata) {

--- a/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplDefaultValueTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplDefaultValueTest.java
@@ -1,0 +1,43 @@
+package net.snowflake.client.internal.api.implementation.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeDatabaseMetaDataImplDefaultValueTest {
+
+  @Test
+  public void nullDefaultDoesNotThrowAndStaysNull() {
+    assertNull(SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue(null, false));
+    assertNull(SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue(null, true));
+  }
+
+  @Test
+  public void emptyAndWhitespaceDefaultsBecomeNull() {
+    assertNull(SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("", false));
+    assertNull(SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("   ", false));
+    assertNull(SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("\t", true));
+  }
+
+  @Test
+  public void unquotedNumericDefaultIsPreserved() {
+    assertEquals("5", SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("5", false));
+    assertEquals("5", SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("  5  ", false));
+  }
+
+  @Test
+  public void wrappingQuotesAreStrippedWhenStringsAreNotQuoted() {
+    assertEquals(
+        "apples", SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("'apples'", false));
+    assertEquals(
+        "apples", SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("  'apples'  ", false));
+    assertEquals("'", SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("''''", false));
+  }
+
+  @Test
+  public void wrappingQuotesAreKeptWhenStringsAreQuoted() {
+    assertEquals(
+        "'apples'", SnowflakeDatabaseMetaDataImpl.normalizeColumnDefaultValue("'apples'", true));
+  }
+}


### PR DESCRIPTION
## Summary
- `DatabaseMetaData.getColumns()` called `defaultValue.trim()` without assigning the result, so whitespace was never stripped.
- A SQL NULL default from SHOW COLUMNS made `getString()` return null and then NPE on `trim()` / `isEmpty()`.
- Normalization is now null-safe: trim, treat empty/whitespace as null, then apply the existing quote-unescaping path.

## Context
Standalone bug fix (SNOW-4009234). Branched from `master`, not stacked on the schema-filter PR.

## Test plan
- [x] `./mvnw -Dtest=SnowflakeDatabaseMetaDataImplDefaultValueTest test`
- [x] `./mvnw com.spotify.fmt:fmt-maven-plugin:format`
- [x] `./mvnw clean validate --batch-mode --show-version -P check-style`
- [ ] Null and whitespace-only defaults become null; quoted defaults still unescape when `stringsQuoted` is false


Made with [Cursor](https://cursor.com)