### PR TITLE
SNOW-4009235: Type-check Linux credential cache tokens node, not root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed Linux credential cache parsing checking the root JSON node type a second time instead of the `tokens` child, which could fail the cache load when `tokens` was present but not an object (SNOW-4009235).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
 
 - v4.3.3

--- a/src/main/java/net/snowflake/client/internal/core/SecureStorageLinuxManager.java
+++ b/src/main/java/net/snowflake/client/internal/core/SecureStorageLinuxManager.java
@@ -122,7 +122,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
     return jsonNode;
   }
 
-  private Map<String, Map<String, String>> readJsonStoreCache(JsonNode node) {
+  Map<String, Map<String, String>> readJsonStoreCache(JsonNode node) {
     Map<String, Map<String, String>> cache = new HashMap<>();
     if (node == null || !node.getNodeType().equals(JsonNodeType.OBJECT)) {
       logger.debug("Invalid cache file format.");
@@ -131,7 +131,7 @@ public class SecureStorageLinuxManager implements SecureStorageManager {
     cache.put(CACHE_FILE_TOKENS_OBJECT_NAME, new HashMap<>());
     JsonNode credentialsNode = node.get(CACHE_FILE_TOKENS_OBJECT_NAME);
     Map<String, String> credentialsCache = cache.get(CACHE_FILE_TOKENS_OBJECT_NAME);
-    if (credentialsNode != null && node.getNodeType().equals(JsonNodeType.OBJECT)) {
+    if (credentialsNode != null && credentialsNode.isObject()) {
       for (Iterator<Map.Entry<String, JsonNode>> itr = credentialsNode.fields(); itr.hasNext(); ) {
         Map.Entry<String, JsonNode> credential = itr.next();
         credentialsCache.put(credential.getKey(), credential.getValue().asText());

--- a/src/test/java/net/snowflake/client/internal/core/SecureStorageLinuxManagerCacheParseTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SecureStorageLinuxManagerCacheParseTest.java
@@ -1,0 +1,65 @@
+package net.snowflake.client.internal.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class SecureStorageLinuxManagerCacheParseTest {
+
+  private static final ObjectMapper MAPPER = ObjectMapperFactory.getObjectMapper();
+
+  @Test
+  public void validTokensObjectIsLoaded() {
+    ObjectNode tokens = MAPPER.createObjectNode();
+    tokens.put("host:user:ID_TOKEN", "secret");
+    ObjectNode root = MAPPER.createObjectNode();
+    root.set("tokens", tokens);
+
+    Map<String, Map<String, String>> cache =
+        SecureStorageLinuxManager.getInstance().readJsonStoreCache(root);
+
+    assertEquals("secret", cache.get("tokens").get("host:user:ID_TOKEN"));
+  }
+
+  @Test
+  public void missingTokensYieldsEmptyMap() {
+    ObjectNode root = MAPPER.createObjectNode();
+
+    Map<String, Map<String, String>> cache =
+        SecureStorageLinuxManager.getInstance().readJsonStoreCache(root);
+
+    assertTrue(cache.get("tokens").isEmpty());
+  }
+
+  @Test
+  public void nonObjectTokensDoesNotThrowAndYieldsEmptyMap() {
+    ObjectNode stringTokens = MAPPER.createObjectNode();
+    stringTokens.set("tokens", TextNode.valueOf("not-an-object"));
+
+    Map<String, Map<String, String>> fromString =
+        SecureStorageLinuxManager.getInstance().readJsonStoreCache(stringTokens);
+    assertTrue(fromString.get("tokens").isEmpty());
+
+    ArrayNode array = MAPPER.createArrayNode();
+    array.add("token");
+    ObjectNode arrayTokens = MAPPER.createObjectNode();
+    arrayTokens.set("tokens", array);
+
+    Map<String, Map<String, String>> fromArray =
+        SecureStorageLinuxManager.getInstance().readJsonStoreCache(arrayTokens);
+    assertTrue(fromArray.get("tokens").isEmpty());
+  }
+
+  @Test
+  public void nonObjectRootYieldsEmptyCache() {
+    Map<String, Map<String, String>> cache =
+        SecureStorageLinuxManager.getInstance().readJsonStoreCache(TextNode.valueOf("oops"));
+    assertTrue(cache.isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
- `SecureStorageLinuxManager.readJsonStoreCache()` already requires the root JSON to be an object, then checked `node.getNodeType()` again instead of the `tokens` child.
- A non-object `tokens` value (string or array) is now skipped instead of being treated as a field map.
- `readJsonStoreCache` is package-private so the parse cases can be unit-tested.

## Context
Standalone bug fix (SNOW-4009235). Branched from `master`, not stacked on the metadata PRs.

## Test plan
- [x] `./mvnw -Dtest=SecureStorageLinuxManagerCacheParseTest test`
- [x] `./mvnw com.spotify.fmt:fmt-maven-plugin:format`
- [x] `./mvnw clean validate --batch-mode --show-version -P check-style`
- [ ] Valid `tokens` objects still load; string/array `tokens` and a missing `tokens` field yield an empty token map


Made with [Cursor](https://cursor.com)