### PR TITLE
NO-SNOW: Bump jsoup to 1.23.2  from 1.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
   - Bumped the following dependencies:
-    - jsoup to 1.23.2 (snowflakedb/snowflake-jdbc#XXXX).
+    - jsoup to 1.23.2 (snowflakedb/snowflake-jdbc#2735).
 
 - v4.3.3
   - Fixed GCS stage uploads corrupting files on virtual-hosted-style GCP accounts (`useVirtualUrl=true`, e.g. SPCS on GCP) (snowflakedb/snowflake-jdbc#2716).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   - Fixed Linux credential cache parsing checking the root JSON node type a second time instead of the `tokens` child, which could fail the cache load when `tokens` was present but not an object (SNOW-4009235).
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
+  - Bumped the following dependencies:
+    - jsoup to 1.23.2 (snowflakedb/snowflake-jdbc#XXXX).
 
 - v4.3.3
   - Fixed GCS stage uploads corrupting files on virtual-hosted-style GCP accounts (`useVirtualUrl=true`, e.g. SPCS on GCP) (snowflakedb/snowflake-jdbc#2716).

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -72,7 +72,7 @@
     <junit4.version>4.13.2</junit4.version>
     <junit.version>5.11.1</junit.version>
     <junit.platform.version>1.11.1</junit.platform.version>
-    <jsoup.version>1.23.1</jsoup.version>
+    <jsoup.version>1.23.2</jsoup.version>
     <logback.version>1.3.6</logback.version>
     <mockito.version>4.11.0</mockito.version>
     <nimbusds.oauth2.version>11.30.1</nimbusds.oauth2.version>

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -62,7 +62,7 @@
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>
     <json.smart.version>2.5.2</json.smart.version>
-    <jsoup.version>1.23.1</jsoup.version>
+    <jsoup.version>1.23.2</jsoup.version>
     <metrics.version>2.2.0</metrics.version>
     <netty.version>4.1.137.Final</netty.version>
     <nimbusds.version>10.6</nimbusds.version>


### PR DESCRIPTION
### Description
Bumped jsoup to 1.23.2 to address [CVE-2026-75140](https://nvd.nist.gov/vuln/detail/CVE-2026-75140)