### PR TITLE
SNOW-466174: Include thrown stack traces in SFFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed `SFFormatter` omitting the associated stack trace when a log record has a thrown exception (SNOW-466174).
   - Fixed Linux credential cache parsing checking the root JSON node type a second time instead of the `tokens` child, which could fail the cache load when `tokens` was present but not an object (SNOW-4009235).
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).

--- a/src/main/java/net/snowflake/client/internal/log/SFFormatter.java
+++ b/src/main/java/net/snowflake/client/internal/log/SFFormatter.java
@@ -1,5 +1,7 @@
 package net.snowflake.client.internal.log;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -47,6 +49,12 @@ public class SFFormatter extends Formatter {
     builder.append(methodName).append(":");
     builder.append(lineNumber).append(" - ");
     builder.append(formatMessage(record));
+    if (record.getThrown() != null) {
+      StringWriter stringWriter = new StringWriter();
+      record.getThrown().printStackTrace(new PrintWriter(stringWriter));
+      builder.append("\n");
+      builder.append(stringWriter);
+    }
     builder.append("\n");
     return builder.toString();
   }

--- a/src/test/java/net/snowflake/client/internal/log/SFFormatterTest.java
+++ b/src/test/java/net/snowflake/client/internal/log/SFFormatterTest.java
@@ -71,6 +71,21 @@ public class SFFormatterTest {
     }
   }
 
+  @Test
+  public void testThrownStackTraceIsIncluded() {
+    SFFormatter formatter = new SFFormatter();
+    LogRecord record = new LogRecord(Level.SEVERE, "failed to connect");
+    record.setSourceClassName(SFFormatter.CLASS_NAME_PREFIX + "TestClass");
+    record.setSourceMethodName("TestMethod");
+    record.setThrown(new RuntimeException("boom"));
+
+    String formatted = formatter.format(record);
+
+    assertTrue(formatted.contains("failed to connect"));
+    assertTrue(formatted.contains("java.lang.RuntimeException: boom"));
+    assertTrue(formatted.contains("at "));
+  }
+
   /**
    * A log generator could generate log record directly and fill in necessary field specified by
    * constructor


### PR DESCRIPTION
## Summary
- `SFFormatter.format()` now appends `record.getThrown()` via `printStackTrace` so JDK14 logger exception overloads include the stack trace instead of only the message line.

## Context
Backlog grooming follow-up: small driver fix for SNOW-466174.

## Test plan
- `./mvnw com.spotify.fmt:fmt-maven-plugin:format`
- `./mvnw clean validate --batch-mode --show-version -P check-style`
- `./mvnw -Dtest=SFFormatterTest test` (3 tests, including `testThrownStackTraceIsIncluded`)


Made with [Cursor](https://cursor.com)