### PR TITLE
SNOW-1449489: Handle nulls in JsonSqlOutput writers via withNextValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed `SQLOutput.writeObject(null)` throwing `NullPointerException` when binding a structured object with a null nested `SQLData` field (SNOW-1449489).
   - Fixed Linux credential cache parsing checking the root JSON node type a second time instead of the `tokens` child, which could fail the cache load when `tokens` was present but not an object (SNOW-4009235).
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
-  - Fixed `SQLOutput.writeObject(null)` throwing `NullPointerException` when binding a structured object with a null nested `SQLData` field (SNOW-1449489).
+  - Fixed null nested structured-type fields throwing `NullPointerException` in `JsonSqlOutput` when binding via `SQLOutput` reference writers such as `writeObject`, `writeBigDecimal`, `writeBytes`, `writeDate`, and `writeTimestamp` (SNOW-1449489).
   - Fixed `SFFormatter` omitting the associated stack trace when a log record has a thrown exception (SNOW-466174).
   - Fixed Linux credential cache parsing checking the root JSON node type a second time instead of the `tokens` child, which could fail the cache load when `tokens` was present but not an object (SNOW-4009235).
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).

--- a/src/main/java/net/snowflake/client/internal/core/JsonSqlOutput.java
+++ b/src/main/java/net/snowflake/client/internal/core/JsonSqlOutput.java
@@ -362,12 +362,6 @@ public class JsonSqlOutput implements SQLOutput {
   }
 
   private void withNextValue(
-      ThrowingTriCallable<JSONObject, String, Optional<SnowflakeColumn>, SQLException> action)
-      throws SQLException {
-    applyNextValue(action);
-  }
-
-  private void withNextValue(
       Object value,
       ThrowingTriCallable<JSONObject, String, Optional<SnowflakeColumn>, SQLException> action)
       throws SQLException {
@@ -375,7 +369,17 @@ public class JsonSqlOutput implements SQLOutput {
       writeNullValue();
       return;
     }
-    applyNextValue(action);
+    withNextValue(action);
+  }
+
+  private void withNextValue(
+      ThrowingTriCallable<JSONObject, String, Optional<SnowflakeColumn>, SQLException> action)
+      throws SQLException {
+    Field field = fields.next();
+    String fieldName = field.getName();
+    Optional<SnowflakeColumn> maybeColumn =
+        Optional.ofNullable(field.getAnnotation(SnowflakeColumn.class));
+    action.apply(json, fieldName, maybeColumn);
   }
 
   private void writeNullValue() {
@@ -386,16 +390,6 @@ public class JsonSqlOutput implements SQLOutput {
     nullSchema.setName(fieldName);
     nullSchema.setFields(new ArrayList<>());
     schema.getFields().add(nullSchema);
-  }
-
-  private void applyNextValue(
-      ThrowingTriCallable<JSONObject, String, Optional<SnowflakeColumn>, SQLException> action)
-      throws SQLException {
-    Field field = fields.next();
-    String fieldName = field.getName();
-    Optional<SnowflakeColumn> maybeColumn =
-        Optional.ofNullable(field.getAnnotation(SnowflakeColumn.class));
-    action.apply(json, fieldName, maybeColumn);
   }
 
   private SnowflakeDateTimeFormat getDateTimeFormat(String format) {

--- a/src/main/java/net/snowflake/client/internal/core/JsonSqlOutput.java
+++ b/src/main/java/net/snowflake/client/internal/core/JsonSqlOutput.java
@@ -82,6 +82,7 @@ public class JsonSqlOutput implements SQLOutput {
   @Override
   public void writeString(String value) throws SQLException {
     withNextValue(
+        value,
         ((json, fieldName, maybeColumn) -> {
           json.put(fieldName, value);
           schema.getFields().add(FieldSchemaCreator.buildSchemaForText(fieldName, maybeColumn));
@@ -162,6 +163,7 @@ public class JsonSqlOutput implements SQLOutput {
   @Override
   public void writeBigDecimal(BigDecimal value) throws SQLException {
     withNextValue(
+        value,
         ((json, fieldName, maybeColumn) -> {
           json.put(fieldName, value);
           schema
@@ -175,6 +177,7 @@ public class JsonSqlOutput implements SQLOutput {
   @Override
   public void writeBytes(byte[] value) throws SQLException {
     withNextValue(
+        value,
         ((json, fieldName, maybeColumn) -> {
           json.put(fieldName, new SFBinary(value).toHex());
           schema
@@ -186,6 +189,7 @@ public class JsonSqlOutput implements SQLOutput {
   @Override
   public void writeDate(Date value) throws SQLException {
     withNextValue(
+        value,
         ((json, fieldName, maybeColumn) -> {
           json.put(
               fieldName,
@@ -197,6 +201,7 @@ public class JsonSqlOutput implements SQLOutput {
   @Override
   public void writeTime(Time x) throws SQLException {
     withNextValue(
+        x,
         ((json, fieldName, maybeColumn) -> {
           long nanosSinceMidnight;
           if (session.getTreatTimeAsWallClockTime()) {
@@ -221,6 +226,7 @@ public class JsonSqlOutput implements SQLOutput {
   @Override
   public void writeTimestamp(Timestamp value) throws SQLException {
     withNextValue(
+        value,
         ((json, fieldName, maybeColumn) -> {
           String timestampSessionType =
               (String)
@@ -276,15 +282,8 @@ public class JsonSqlOutput implements SQLOutput {
   @Override
   public void writeObject(SQLData sqlData) throws SQLException {
     withNextValue(
+        sqlData,
         ((json, fieldName, maybeColumn) -> {
-          if (sqlData == null) {
-            json.put(fieldName, null);
-            BindingParameterMetadata structSchema = new BindingParameterMetadata("object");
-            structSchema.setName(fieldName);
-            structSchema.setFields(new ArrayList<>());
-            schema.getFields().add(structSchema);
-            return;
-          }
           JsonSqlOutput jsonSqlOutput = new JsonSqlOutput(sqlData, session);
           sqlData.writeSQL(jsonSqlOutput);
           json.put(fieldName, jsonSqlOutput.getJsonObject());
@@ -363,6 +362,33 @@ public class JsonSqlOutput implements SQLOutput {
   }
 
   private void withNextValue(
+      ThrowingTriCallable<JSONObject, String, Optional<SnowflakeColumn>, SQLException> action)
+      throws SQLException {
+    applyNextValue(action);
+  }
+
+  private void withNextValue(
+      Object value,
+      ThrowingTriCallable<JSONObject, String, Optional<SnowflakeColumn>, SQLException> action)
+      throws SQLException {
+    if (value == null) {
+      writeNullValue();
+      return;
+    }
+    applyNextValue(action);
+  }
+
+  private void writeNullValue() {
+    Field field = fields.next();
+    String fieldName = field.getName();
+    json.put(fieldName, null);
+    BindingParameterMetadata nullSchema = new BindingParameterMetadata("object");
+    nullSchema.setName(fieldName);
+    nullSchema.setFields(new ArrayList<>());
+    schema.getFields().add(nullSchema);
+  }
+
+  private void applyNextValue(
       ThrowingTriCallable<JSONObject, String, Optional<SnowflakeColumn>, SQLException> action)
       throws SQLException {
     Field field = fields.next();

--- a/src/main/java/net/snowflake/client/internal/core/JsonSqlOutput.java
+++ b/src/main/java/net/snowflake/client/internal/core/JsonSqlOutput.java
@@ -277,6 +277,14 @@ public class JsonSqlOutput implements SQLOutput {
   public void writeObject(SQLData sqlData) throws SQLException {
     withNextValue(
         ((json, fieldName, maybeColumn) -> {
+          if (sqlData == null) {
+            json.put(fieldName, null);
+            BindingParameterMetadata structSchema = new BindingParameterMetadata("object");
+            structSchema.setName(fieldName);
+            structSchema.setFields(new ArrayList<>());
+            schema.getFields().add(structSchema);
+            return;
+          }
           JsonSqlOutput jsonSqlOutput = new JsonSqlOutput(sqlData, session);
           sqlData.writeSQL(jsonSqlOutput);
           json.put(fieldName, jsonSqlOutput.getJsonObject());

--- a/src/test/java/net/snowflake/client/internal/core/SQLInputOutputTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SQLInputOutputTest.java
@@ -6,10 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.SQLData;
 import java.sql.SQLException;
 import java.sql.SQLInput;
 import java.sql.SQLOutput;
+import java.sql.Timestamp;
 import java.util.HashMap;
 import net.snowflake.client.internal.jdbc.BindingParameterMetadata;
 import org.junit.jupiter.api.Test;
@@ -50,19 +53,67 @@ public class SQLInputOutputTest {
 
   @Test
   public void testWriteObjectNullNestedDoesNotThrow() throws SQLException {
-    SFSession session = new SFSession();
-    session.setCommonParameters(new HashMap<>());
-
+    SFSession session = createSession();
     NestedNullHolder holder = new NestedNullHolder();
     JsonSqlOutput output = new JsonSqlOutput(holder, session);
     holder.writeSQL(output);
 
-    assertTrue(output.getJsonObject().containsKey("nested"));
-    assertNull(output.getJsonObject().get("nested"));
-    BindingParameterMetadata nestedSchema = output.getSchema().getFields().get(0);
-    assertEquals("nested", nestedSchema.getName());
-    assertEquals("object", nestedSchema.getType());
-    assertTrue(nestedSchema.getFields().isEmpty());
+    assertNullField(output, "nested");
+  }
+
+  @Test
+  public void testWriteBigDecimalNullDoesNotThrow() throws SQLException {
+    SFSession session = createSession();
+    BigDecimalNullHolder holder = new BigDecimalNullHolder();
+    JsonSqlOutput output = new JsonSqlOutput(holder, session);
+    holder.writeSQL(output);
+
+    assertNullField(output, "amount");
+  }
+
+  @Test
+  public void testWriteBytesNullDoesNotThrow() throws SQLException {
+    SFSession session = createSession();
+    BytesNullHolder holder = new BytesNullHolder();
+    JsonSqlOutput output = new JsonSqlOutput(holder, session);
+    holder.writeSQL(output);
+
+    assertNullField(output, "payload");
+  }
+
+  @Test
+  public void testWriteTimestampNullDoesNotThrow() throws SQLException {
+    SFSession session = createSession();
+    TimestampNullHolder holder = new TimestampNullHolder();
+    JsonSqlOutput output = new JsonSqlOutput(holder, session);
+    holder.writeSQL(output);
+
+    assertNullField(output, "createdAt");
+  }
+
+  @Test
+  public void testWriteDateNullDoesNotThrow() throws SQLException {
+    SFSession session = createSession();
+    DateNullHolder holder = new DateNullHolder();
+    JsonSqlOutput output = new JsonSqlOutput(holder, session);
+    holder.writeSQL(output);
+
+    assertNullField(output, "eventDate");
+  }
+
+  private static SFSession createSession() {
+    SFSession session = new SFSession();
+    session.setCommonParameters(new HashMap<>());
+    return session;
+  }
+
+  private static void assertNullField(JsonSqlOutput output, String fieldName) {
+    assertTrue(output.getJsonObject().containsKey(fieldName));
+    assertNull(output.getJsonObject().get(fieldName));
+    BindingParameterMetadata fieldSchema = output.getSchema().getFields().get(0);
+    assertEquals(fieldName, fieldSchema.getName());
+    assertEquals("object", fieldSchema.getType());
+    assertTrue(fieldSchema.getFields().isEmpty());
   }
 
   private static class NestedNullHolder implements SQLData {
@@ -79,6 +130,74 @@ public class SQLInputOutputTest {
     @Override
     public void writeSQL(SQLOutput stream) throws SQLException {
       stream.writeObject(nested);
+    }
+  }
+
+  private static class BigDecimalNullHolder implements SQLData {
+    private BigDecimal amount;
+
+    @Override
+    public String getSQLTypeName() {
+      return null;
+    }
+
+    @Override
+    public void readSQL(SQLInput stream, String typeName) {}
+
+    @Override
+    public void writeSQL(SQLOutput stream) throws SQLException {
+      stream.writeBigDecimal(amount);
+    }
+  }
+
+  private static class BytesNullHolder implements SQLData {
+    private byte[] payload;
+
+    @Override
+    public String getSQLTypeName() {
+      return null;
+    }
+
+    @Override
+    public void readSQL(SQLInput stream, String typeName) {}
+
+    @Override
+    public void writeSQL(SQLOutput stream) throws SQLException {
+      stream.writeBytes(payload);
+    }
+  }
+
+  private static class TimestampNullHolder implements SQLData {
+    private Timestamp createdAt;
+
+    @Override
+    public String getSQLTypeName() {
+      return null;
+    }
+
+    @Override
+    public void readSQL(SQLInput stream, String typeName) {}
+
+    @Override
+    public void writeSQL(SQLOutput stream) throws SQLException {
+      stream.writeTimestamp(createdAt);
+    }
+  }
+
+  private static class DateNullHolder implements SQLData {
+    private Date eventDate;
+
+    @Override
+    public String getSQLTypeName() {
+      return null;
+    }
+
+    @Override
+    public void readSQL(SQLInput stream, String typeName) {}
+
+    @Override
+    public void writeSQL(SQLOutput stream) throws SQLException {
+      stream.writeDate(eventDate);
     }
   }
 }

--- a/src/test/java/net/snowflake/client/internal/core/SQLInputOutputTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SQLInputOutputTest.java
@@ -1,9 +1,17 @@
 package net.snowflake.client.internal.core;
 
 import static net.snowflake.client.TestUtil.expectSnowflakeLoggedFeatureNotSupportedException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.sql.SQLData;
+import java.sql.SQLException;
+import java.sql.SQLInput;
+import java.sql.SQLOutput;
+import java.util.HashMap;
+import net.snowflake.client.internal.jdbc.BindingParameterMetadata;
 import org.junit.jupiter.api.Test;
 
 public class SQLInputOutputTest {
@@ -38,5 +46,39 @@ public class SQLInputOutputTest {
     expectSnowflakeLoggedFeatureNotSupportedException(() -> sqloutput.writeNClob(null));
     expectSnowflakeLoggedFeatureNotSupportedException(() -> sqloutput.writeRowId(null));
     expectSnowflakeLoggedFeatureNotSupportedException(() -> sqloutput.writeSQLXML(null));
+  }
+
+  @Test
+  public void testWriteObjectNullNestedDoesNotThrow() throws SQLException {
+    SFSession session = new SFSession();
+    session.setCommonParameters(new HashMap<>());
+
+    NestedNullHolder holder = new NestedNullHolder();
+    JsonSqlOutput output = new JsonSqlOutput(holder, session);
+    holder.writeSQL(output);
+
+    assertTrue(output.getJsonObject().containsKey("nested"));
+    assertNull(output.getJsonObject().get("nested"));
+    BindingParameterMetadata nestedSchema = output.getSchema().getFields().get(0);
+    assertEquals("nested", nestedSchema.getName());
+    assertEquals("object", nestedSchema.getType());
+    assertTrue(nestedSchema.getFields().isEmpty());
+  }
+
+  private static class NestedNullHolder implements SQLData {
+    private SQLData nested;
+
+    @Override
+    public String getSQLTypeName() {
+      return null;
+    }
+
+    @Override
+    public void readSQL(SQLInput stream, String typeName) {}
+
+    @Override
+    public void writeSQL(SQLOutput stream) throws SQLException {
+      stream.writeObject(nested);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `JsonSqlOutput` now handles null values in a shared `withNextValue` path for all reference-typed writers (`writeObject`, `writeBigDecimal`, `writeBytes`, `writeDate`, `writeTime`, `writeTimestamp`, `writeString`), writing JSON `null` and an empty object bind schema instead of throwing `NullPointerException`.
- Primitive writers still use the value-less overload so `false`/`0` are not treated as null.

## Context
Backlog grooming follow-up for SNOW-1449489 (inserting a structured type with a null nested field). Addresses review feedback to cover all nullable writers, not only `writeObject`.

## Test plan
- `./mvnw com.spotify.fmt:fmt-maven-plugin:format`
- `./mvnw clean validate --batch-mode --show-version -P check-style` (0 Checkstyle violations)
- `./mvnw -Dtest=SQLInputOutputTest test` — new null-writer tests pass; pre-existing `testJsonSqlOutPutUnSupportedTest` still fails locally on Java 24 due to Mockito/Byte Buddy (unchanged)
