### PR TITLE
SNOW-3229469: Format DECFLOAT strings like ODBC format_decfloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
-  - Fixed DECFLOAT `ResultSet.getString()` using engineering notation (`120E+198`) instead of ODBC-style formatting: plain decimal when the unsigned form fits in 38 characters (e.g. `100`), otherwise normalized scientific notation (`1.2e200`) (SNOW-3229469).
+  - Fixed DECFLOAT `ResultSet.getString()` using engineering notation (`120E+198`) instead of normalized scientific notation (`1.2e200`); values whose unsigned plain form fits in 38 characters stay in plain decimal (SNOW-3229469).
   - Fixed `SFFormatter` omitting the associated stack trace when a log record has a thrown exception (SNOW-466174).
   - Fixed Linux credential cache parsing checking the root JSON node type a second time instead of the `tokens` child, which could fail the cache load when `tokens` was present but not an object (SNOW-4009235).
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed DECFLOAT `ResultSet.getString()` using engineering notation (`123E-9`) instead of canonical scientific notation (`1.23E-7`) (SNOW-3229469).
   - Fixed Linux credential cache parsing checking the root JSON node type a second time instead of the `tokens` child, which could fail the cache load when `tokens` was present but not an object (SNOW-4009235).
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).

--- a/src/main/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverter.java
+++ b/src/main/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverter.java
@@ -121,85 +121,56 @@ class DecfloatToDecimalConverter extends AbstractArrowVectorConverter {
     if (isNull(index)) {
       return null;
     }
-    BigDecimal value = toBigDecimal(index);
-    return formatDecfloat(value.unscaledValue(), -value.scale());
+    return formatDecfloat(toBigDecimal(index));
   }
 
   /**
-   * Formats a DECFLOAT as a string, matching ODBC {@code format_decfloat}.
+   * Formats a DECFLOAT string per SNOW-3229469.
    *
-   * <p>Uses plain decimal when the unsigned form fits in {@link #MAX_PLAIN_DIGITS} characters, and
-   * normalized scientific notation otherwise. Scientific notation uses a single non-zero digit
-   * before the decimal point, lowercase {@code e}, and no {@code +} on positive exponents.
-   *
-   * @param significand unscaled integer significand
-   * @param exponent power of ten such that the value is {@code significand * 10^exponent}
-   * @return formatted DECFLOAT string
+   * <ul>
+   *   <li>{@code 0} for zero
+   *   <li>plain decimal when the unsigned form fits in {@link #MAX_PLAIN_DIGITS} characters ({@code
+   *       "123.456"}, {@code "100"})
+   *   <li>otherwise normalized scientific notation: one non-zero digit before the decimal point,
+   *       lowercase {@code e}, no {@code +} on the exponent ({@code "1.2e200"} not {@code "12e199"}
+   *       / {@code "1.2E+200"})
+   * </ul>
    */
-  static String formatDecfloat(BigInteger significand, int exponent) {
-    if (significand.signum() == 0) {
+  static String formatDecfloat(BigDecimal value) {
+    if (value.signum() == 0) {
       return "0";
     }
-
-    boolean negative = significand.signum() < 0;
-    BigInteger absSig = significand.abs();
-    int exp = exponent;
-    while (absSig.mod(BigInteger.TEN).signum() == 0) {
-      absSig = absSig.divide(BigInteger.TEN);
-      exp++;
+    BigDecimal stripped = value.stripTrailingZeros();
+    if (fitsInPlainDecimal(stripped)) {
+      return stripped.toPlainString();
     }
+    return toNormalizedScientific(stripped);
+  }
 
-    String digits = absSig.toString();
-    int n = digits.length();
-    int plainLen;
-    if (exp >= 0) {
-      plainLen = n + exp;
-    } else {
-      int absExp = -exp;
-      if (absExp < n) {
-        plainLen = n + 1;
-      } else {
-        plainLen = 2 + absExp;
-      }
-    }
+  /** True when the unsigned plain-decimal form is at most {@link #MAX_PLAIN_DIGITS} characters. */
+  private static boolean fitsInPlainDecimal(BigDecimal value) {
+    String plain = value.toPlainString();
+    int unsignedLength = value.signum() < 0 ? plain.length() - 1 : plain.length();
+    return unsignedLength <= MAX_PLAIN_DIGITS;
+  }
+
+  /**
+   * {@code d.ddddeN}: coefficient has exactly one non-zero digit before the decimal point; the
+   * exponent is adjusted to match.
+   */
+  private static String toNormalizedScientific(BigDecimal value) {
+    String digits = value.unscaledValue().abs().toString();
+    int exponent = digits.length() - 1 - value.scale();
 
     StringBuilder result = new StringBuilder();
-    if (plainLen <= MAX_PLAIN_DIGITS) {
-      if (exp >= 0) {
-        result.append(digits);
-        for (int i = 0; i < exp; i++) {
-          result.append('0');
-        }
-      } else {
-        int absExp = -exp;
-        if (absExp < n) {
-          int decimalPos = n - absExp;
-          result.append(digits, 0, decimalPos);
-          result.append('.');
-          result.append(digits, decimalPos, n);
-        } else {
-          int leadingZeros = absExp - n;
-          result.append("0.");
-          for (int i = 0; i < leadingZeros; i++) {
-            result.append('0');
-          }
-          result.append(digits);
-        }
-      }
-    } else {
-      long adjustedExp = (long) exp + n - 1;
-      result.append(digits.charAt(0));
-      if (n > 1) {
-        result.append('.');
-        result.append(digits, 1, n);
-      }
-      result.append('e');
-      result.append(adjustedExp);
+    if (value.signum() < 0) {
+      result.append('-');
     }
-
-    if (negative) {
-      result.insert(0, '-');
+    result.append(digits.charAt(0));
+    if (digits.length() > 1) {
+      result.append('.').append(digits, 1, digits.length());
     }
+    result.append('e').append(exponent);
     return result.toString();
   }
 

--- a/src/main/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverter.java
+++ b/src/main/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverter.java
@@ -118,7 +118,7 @@ class DecfloatToDecimalConverter extends AbstractArrowVectorConverter {
     if (isNull(index)) {
       return null;
     }
-    return toBigDecimal(index).toEngineeringString();
+    return toBigDecimal(index).toString();
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverter.java
+++ b/src/main/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverter.java
@@ -13,6 +13,9 @@ import org.apache.arrow.vector.complex.StructVector;
 
 class DecfloatToDecimalConverter extends AbstractArrowVectorConverter {
 
+  /** DECFLOAT precision; unsigned plain form is used when it fits in this many characters. */
+  static final int MAX_PLAIN_DIGITS = 38;
+
   private StructVector vector;
 
   public DecfloatToDecimalConverter(ValueVector vector, int idx, DataConversionContext context) {
@@ -118,7 +121,86 @@ class DecfloatToDecimalConverter extends AbstractArrowVectorConverter {
     if (isNull(index)) {
       return null;
     }
-    return toBigDecimal(index).toString();
+    BigDecimal value = toBigDecimal(index);
+    return formatDecfloat(value.unscaledValue(), -value.scale());
+  }
+
+  /**
+   * Formats a DECFLOAT as a string, matching ODBC {@code format_decfloat}.
+   *
+   * <p>Uses plain decimal when the unsigned form fits in {@link #MAX_PLAIN_DIGITS} characters, and
+   * normalized scientific notation otherwise. Scientific notation uses a single non-zero digit
+   * before the decimal point, lowercase {@code e}, and no {@code +} on positive exponents.
+   *
+   * @param significand unscaled integer significand
+   * @param exponent power of ten such that the value is {@code significand * 10^exponent}
+   * @return formatted DECFLOAT string
+   */
+  static String formatDecfloat(BigInteger significand, int exponent) {
+    if (significand.signum() == 0) {
+      return "0";
+    }
+
+    boolean negative = significand.signum() < 0;
+    BigInteger absSig = significand.abs();
+    int exp = exponent;
+    while (absSig.mod(BigInteger.TEN).signum() == 0) {
+      absSig = absSig.divide(BigInteger.TEN);
+      exp++;
+    }
+
+    String digits = absSig.toString();
+    int n = digits.length();
+    int plainLen;
+    if (exp >= 0) {
+      plainLen = n + exp;
+    } else {
+      int absExp = -exp;
+      if (absExp < n) {
+        plainLen = n + 1;
+      } else {
+        plainLen = 2 + absExp;
+      }
+    }
+
+    StringBuilder result = new StringBuilder();
+    if (plainLen <= MAX_PLAIN_DIGITS) {
+      if (exp >= 0) {
+        result.append(digits);
+        for (int i = 0; i < exp; i++) {
+          result.append('0');
+        }
+      } else {
+        int absExp = -exp;
+        if (absExp < n) {
+          int decimalPos = n - absExp;
+          result.append(digits, 0, decimalPos);
+          result.append('.');
+          result.append(digits, decimalPos, n);
+        } else {
+          int leadingZeros = absExp - n;
+          result.append("0.");
+          for (int i = 0; i < leadingZeros; i++) {
+            result.append('0');
+          }
+          result.append(digits);
+        }
+      }
+    } else {
+      long adjustedExp = (long) exp + n - 1;
+      result.append(digits.charAt(0));
+      if (n > 1) {
+        result.append('.');
+        result.append(digits, 1, n);
+      }
+      result.append('e');
+      result.append(adjustedExp);
+    }
+
+    if (negative) {
+      result.insert(0, '-');
+    }
+    return result.toString();
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverter.java
+++ b/src/main/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverter.java
@@ -13,7 +13,12 @@ import org.apache.arrow.vector.complex.StructVector;
 
 class DecfloatToDecimalConverter extends AbstractArrowVectorConverter {
 
-  /** DECFLOAT precision; unsigned plain form is used when it fits in this many characters. */
+  /**
+   * Max unsigned plain-decimal <em>characters</em> (including {@code '.'} and a leading {@code
+   * "0."}), matching ODBC {@code format_decfloat}. This is not "38 significant digits": a 38-digit
+   * integer stays plain, but the same digits with a fraction (the {@code '.'} makes 39 chars) go
+   * scientific.
+   */
   static final int MAX_PLAIN_DIGITS = 38;
 
   private StructVector vector;
@@ -147,10 +152,22 @@ class DecfloatToDecimalConverter extends AbstractArrowVectorConverter {
     return toNormalizedScientific(stripped);
   }
 
-  /** True when the unsigned plain-decimal form is at most {@link #MAX_PLAIN_DIGITS} characters. */
+  /**
+   * True when the unsigned plain-decimal form is at most {@link #MAX_PLAIN_DIGITS} characters.
+   * Length is computed from {@code precision}/{@code scale} so large-exponent values (e.g. {@code
+   * 1e16384}) do not allocate a multi-kilobyte {@code toPlainString()} just to measure it.
+   */
   private static boolean fitsInPlainDecimal(BigDecimal value) {
-    String plain = value.toPlainString();
-    int unsignedLength = value.signum() < 0 ? plain.length() - 1 : plain.length();
+    int precision = value.precision();
+    int scale = value.scale();
+    int unsignedLength;
+    if (scale <= 0) {
+      unsignedLength = precision - scale;
+    } else if (precision > scale) {
+      unsignedLength = precision + 1;
+    } else {
+      unsignedLength = scale + 2;
+    }
     return unsignedLength <= MAX_PLAIN_DIGITS;
   }
 

--- a/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
@@ -55,6 +55,13 @@ public class DecfloatToDecimalConverterTest extends BaseConverterTest {
         format("1.2345678901234567890123456789012345678E+100"));
     assertEquals("-1.234e8000", format("-1.234E+8000"));
     assertEquals("0.000000123", format("1.23E-7"));
+    assertEquals("-42", format("-42"));
+    assertEquals("-1.5", format("-1.5"));
+    assertEquals("-789.012", format("-789.012"));
+    // -987 * 10^-17; sign does not count toward the 38-character budget.
+    assertEquals(
+        "-0.00000000000000987",
+        DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.valueOf(-987), 17)));
   }
 
   @Test

--- a/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
@@ -83,6 +83,17 @@ public class DecfloatToDecimalConverterTest extends BaseConverterTest {
         DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.ONE, 36)));
     assertEquals(
         "1e-37", DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.ONE, 37)));
+    // 38-character budget includes '.': 38-digit integer stays plain; 38 significant digits
+    // with a fraction (the '.' makes 39 chars) go scientific.
+    BigDecimal thirtyEightDigitInteger = new BigDecimal(BigInteger.TEN.pow(37));
+    assertEquals(
+        thirtyEightDigitInteger.toPlainString(),
+        DecfloatToDecimalConverter.formatDecfloat(thirtyEightDigitInteger));
+    BigDecimal thirtyEightSigWithFraction =
+        new BigDecimal(BigInteger.TEN.pow(37).add(BigInteger.valueOf(8)), 1);
+    assertEquals(
+        "1." + zeros(36) + "8e36",
+        DecfloatToDecimalConverter.formatDecfloat(thirtyEightSigWithFraction));
   }
 
   @Test
@@ -111,6 +122,14 @@ public class DecfloatToDecimalConverterTest extends BaseConverterTest {
 
   private static String format(String literal) {
     return DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(literal));
+  }
+
+  private static String zeros(int count) {
+    StringBuilder out = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      out.append('0');
+    }
+    return out.toString();
   }
 
   private StructVector createDecfloatVector(BigDecimal... values) {

--- a/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
@@ -1,0 +1,86 @@
+package net.snowflake.client.internal.core.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.snowflake.client.internal.core.SFException;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class DecfloatToDecimalConverterTest extends BaseConverterTest {
+
+  private BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+  private StructVector structVector;
+
+  @AfterEach
+  public void closeVector() {
+    if (structVector != null) {
+      structVector.close();
+    }
+    allocator.close();
+  }
+
+  @Test
+  public void testToStringUsesCanonicalScientificNotation() throws SFException {
+    BigDecimal scientificValue = new BigDecimal("1.23E-7");
+    BigDecimal plainValue = new BigDecimal("123.456");
+
+    structVector = createDecfloatVector(scientificValue, plainValue, null);
+    ArrowVectorConverter converter = new DecfloatToDecimalConverter(structVector, 0, this);
+
+    assertEquals("1.23E-7", converter.toString(0));
+    assertEquals("123E-9", scientificValue.toEngineeringString());
+    assertEquals("123.456", converter.toString(1));
+    assertNull(converter.toString(2));
+    assertEquals(scientificValue, converter.toBigDecimal(0));
+    assertEquals(plainValue, converter.toBigDecimal(1));
+    assertNull(converter.toBigDecimal(2));
+  }
+
+  private StructVector createDecfloatVector(BigDecimal... values) {
+    Map<String, String> customFieldMeta = new HashMap<>();
+    customFieldMeta.put("logicalType", "DECFLOAT");
+
+    FieldType significandType =
+        new FieldType(true, Types.MinorType.VARBINARY.getType(), null, customFieldMeta);
+    FieldType exponentType =
+        new FieldType(true, Types.MinorType.SMALLINT.getType(), null, customFieldMeta);
+
+    StructVector vector = StructVector.empty("testVector", allocator);
+    List<Field> fieldList = new ArrayList<>();
+    fieldList.add(new Field("significand", significandType, null));
+    fieldList.add(new Field("exponent", exponentType, null));
+    vector.initializeChildrenFromFields(fieldList);
+
+    VarBinaryVector significand = vector.getChild("significand", VarBinaryVector.class);
+    SmallIntVector exponent = vector.getChild("exponent", SmallIntVector.class);
+
+    for (int i = 0; i < values.length; i++) {
+      if (values[i] == null) {
+        significand.setNull(i);
+        exponent.setNull(i);
+      } else {
+        BigInteger unscaled = values[i].unscaledValue();
+        significand.setSafe(i, unscaled.toByteArray());
+        exponent.setSafe(i, (short) -values[i].scale());
+        vector.setIndexDefined(i);
+      }
+    }
+    vector.setValueCount(values.length);
+    return vector;
+  }
+}

--- a/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
@@ -44,29 +44,49 @@ public class DecfloatToDecimalConverterTest extends BaseConverterTest {
   }
 
   @Test
-  public void testFormatDecfloatMatchesTicketExamples() {
-    assertEquals("0", DecfloatToDecimalConverter.formatDecfloat(BigInteger.ZERO, 0));
-    assertEquals("123.456", formatFromLiteral("123.456"));
-    assertEquals("1.2e200", formatFromLiteral("1.2e200"));
-    assertEquals("1e16384", formatFromLiteral("1E+16384"));
+  public void testFormatDecfloatMatchesJiraExamples() {
+    assertEquals("0", DecfloatToDecimalConverter.formatDecfloat(BigDecimal.ZERO));
+    assertEquals("123.456", format("123.456"));
+    // Coefficient is 1.2 (not 12); exponent is e200 (not e199).
+    assertEquals("1.2e200", format("1.2e200"));
+    assertEquals("1e16384", format("1E+16384"));
     assertEquals(
         "1.2345678901234567890123456789012345678e100",
-        formatFromLiteral("1.2345678901234567890123456789012345678E+100"));
-    assertEquals("-1.234e8000", formatFromLiteral("-1.234E+8000"));
-    assertEquals("0.000000123", formatFromLiteral("1.23E-7"));
+        format("1.2345678901234567890123456789012345678E+100"));
+    assertEquals("-1.234e8000", format("-1.234E+8000"));
+    assertEquals("0.000000123", format("1.23E-7"));
   }
 
   @Test
   public void testFormatDecfloatWholeNumbersStayPlain() {
     // significand=1, exponent=2 → scale -2. BigDecimal.toString() would emit "1E+2".
-    assertEquals("100", DecfloatToDecimalConverter.formatDecfloat(BigInteger.ONE, 2));
-    assertEquals("1000000", DecfloatToDecimalConverter.formatDecfloat(BigInteger.ONE, 6));
-    assertEquals("100", formatFromLiteral("100"));
-    assertEquals("1000000", formatFromLiteral("1000000"));
+    assertEquals(
+        "100", DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.ONE, -2)));
+    assertEquals(
+        "1000000", DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.ONE, -6)));
+    assertEquals("100", format("100"));
+    assertEquals("1000000", format("1000000"));
   }
 
   @Test
-  public void testToStringUsesOdbcStyleFormatting() throws SFException {
+  public void testFormatDecfloatUsesScientificWhenPlainExceeds38Digits() {
+    // 123 followed by 35 zeros is 38 characters → plain; one more zero → scientific.
+    assertEquals(
+        "12300000000000000000000000000000000000",
+        DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.valueOf(123), -35)));
+    assertEquals(
+        "1.23e38",
+        DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.valueOf(123), -36)));
+    // 0. followed by 36 zeros and 1 is 38 characters → plain; one more zero → scientific.
+    assertEquals(
+        "0.000000000000000000000000000000000001",
+        DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.ONE, 36)));
+    assertEquals(
+        "1e-37", DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(BigInteger.ONE, 37)));
+  }
+
+  @Test
+  public void testToStringUsesNormalizedScientificOrPlainDecimal() throws SFException {
     structVector =
         createDecfloatVector(
             new BigDecimal("1.2e200"),
@@ -89,9 +109,8 @@ public class DecfloatToDecimalConverterTest extends BaseConverterTest {
     assertEquals(0, new BigDecimal("1000000").compareTo(converter.toBigDecimal(3)));
   }
 
-  private static String formatFromLiteral(String literal) {
-    BigDecimal value = new BigDecimal(literal);
-    return DecfloatToDecimalConverter.formatDecfloat(value.unscaledValue(), -value.scale());
+  private static String format(String literal) {
+    return DecfloatToDecimalConverter.formatDecfloat(new BigDecimal(literal));
   }
 
   private StructVector createDecfloatVector(BigDecimal... values) {

--- a/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/arrow/DecfloatToDecimalConverterTest.java
@@ -19,36 +19,79 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class DecfloatToDecimalConverterTest extends BaseConverterTest {
 
-  private BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+  private BufferAllocator allocator;
   private StructVector structVector;
+
+  @BeforeEach
+  public void setupAllocator() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
 
   @AfterEach
   public void closeVector() {
     if (structVector != null) {
       structVector.close();
+      structVector = null;
     }
-    allocator.close();
+    if (allocator != null) {
+      allocator.close();
+    }
   }
 
   @Test
-  public void testToStringUsesCanonicalScientificNotation() throws SFException {
-    BigDecimal scientificValue = new BigDecimal("1.23E-7");
-    BigDecimal plainValue = new BigDecimal("123.456");
+  public void testFormatDecfloatMatchesTicketExamples() {
+    assertEquals("0", DecfloatToDecimalConverter.formatDecfloat(BigInteger.ZERO, 0));
+    assertEquals("123.456", formatFromLiteral("123.456"));
+    assertEquals("1.2e200", formatFromLiteral("1.2e200"));
+    assertEquals("1e16384", formatFromLiteral("1E+16384"));
+    assertEquals(
+        "1.2345678901234567890123456789012345678e100",
+        formatFromLiteral("1.2345678901234567890123456789012345678E+100"));
+    assertEquals("-1.234e8000", formatFromLiteral("-1.234E+8000"));
+    assertEquals("0.000000123", formatFromLiteral("1.23E-7"));
+  }
 
-    structVector = createDecfloatVector(scientificValue, plainValue, null);
+  @Test
+  public void testFormatDecfloatWholeNumbersStayPlain() {
+    // significand=1, exponent=2 → scale -2. BigDecimal.toString() would emit "1E+2".
+    assertEquals("100", DecfloatToDecimalConverter.formatDecfloat(BigInteger.ONE, 2));
+    assertEquals("1000000", DecfloatToDecimalConverter.formatDecfloat(BigInteger.ONE, 6));
+    assertEquals("100", formatFromLiteral("100"));
+    assertEquals("1000000", formatFromLiteral("1000000"));
+  }
+
+  @Test
+  public void testToStringUsesOdbcStyleFormatting() throws SFException {
+    structVector =
+        createDecfloatVector(
+            new BigDecimal("1.2e200"),
+            new BigDecimal("123.456"),
+            new BigDecimal(BigInteger.ONE, -2),
+            new BigDecimal(BigInteger.ONE, -6),
+            new BigDecimal("0"),
+            null);
     ArrowVectorConverter converter = new DecfloatToDecimalConverter(structVector, 0, this);
 
-    assertEquals("1.23E-7", converter.toString(0));
-    assertEquals("123E-9", scientificValue.toEngineeringString());
+    assertEquals("1.2e200", converter.toString(0));
     assertEquals("123.456", converter.toString(1));
-    assertNull(converter.toString(2));
-    assertEquals(scientificValue, converter.toBigDecimal(0));
-    assertEquals(plainValue, converter.toBigDecimal(1));
-    assertNull(converter.toBigDecimal(2));
+    assertEquals("100", converter.toString(2));
+    assertEquals("1000000", converter.toString(3));
+    assertEquals("0", converter.toString(4));
+    assertNull(converter.toString(5));
+    assertEquals(new BigDecimal("1.2e200"), converter.toBigDecimal(0));
+    assertEquals(new BigDecimal("123.456"), converter.toBigDecimal(1));
+    assertEquals(0, new BigDecimal("100").compareTo(converter.toBigDecimal(2)));
+    assertEquals(0, new BigDecimal("1000000").compareTo(converter.toBigDecimal(3)));
+  }
+
+  private static String formatFromLiteral(String literal) {
+    BigDecimal value = new BigDecimal(literal);
+    return DecfloatToDecimalConverter.formatDecfloat(value.unscaledValue(), -value.scale());
   }
 
   private StructVector createDecfloatVector(BigDecimal... values) {


### PR DESCRIPTION
## Summary
- DECFLOAT `ResultSet.getString()` now uses ODBC-style `format_decfloat` instead of `BigDecimal.toEngineeringString()` or `toString()`.
- Plain decimal when the unsigned form fits in 38 characters (e.g. `100`, `123.456`, `0.000000123`).
- Normalized scientific notation otherwise: one non-zero digit before the decimal, lowercase `e`, no `+` on positive exponents (e.g. `1.2e200`, `1e16384`).

## Context
Backlog grooming follow-up for SNOW-3229469. Matches ODBC `format_decfloat` behavior (not Node.js).

## Test plan
- [x] `./mvnw com.spotify.fmt:fmt-maven-plugin:format`
- [x] `./mvnw clean validate --batch-mode --show-version -P check-style`
- [x] `./mvnw -Dtest=DecfloatToDecimalConverterTest test`
- [x] Whole-number cases (`100`, `1000000`) stay plain
- [x] Ticket scientific-notation examples (`1.2e200`, `1e16384`, `1.23E-7` → `0.000000123`)

Made with [Cursor](https://cursor.com)