### PR TITLE
SNOW-2452748: Log session-open and OAuth start at DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Changed session-open property dump, GLOBAL/CHINA domain connection, and OAuth authentication-flow start messages from INFO to DEBUG to reduce log noise (snowflakedb/snowflake-jdbc#2377).
   - Fixed `SFFormatter` omitting the associated stack trace when a log record has a thrown exception (SNOW-466174).
   - Fixed Linux credential cache parsing checking the root JSON node type a second time instead of the `tokens` child, which could fail the cache load when `tokens` was present but not an object (SNOW-4009235).
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).

--- a/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
+++ b/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
@@ -86,28 +86,9 @@ public class FatJarTestApp {
     System.out.println("[INFO] Verifying " + mode + " log output (" + logOutput.length() + " chars)");
     String logsPrelude = logOutput.substring(0, Math.min(2000, logOutput.length()));
 
-    // PUT "Starting upload ..." remains INFO. Session-open is DEBUG (GH #2377); JUL FINE and
-    // logback net.snowflake=DEBUG still emit it, so require both to prove INFO and DEBUG paths.
-    boolean hasStartUpload = logOutput.contains("Starting upload");
-    if (!hasStartUpload) {
-      System.err.println("[FAIL] Log output does not contain 'Starting upload' (expected INFO from PUT)");
-      System.err.println("[DEBUG] First 2000 chars of log output:");
-      System.err.println(logsPrelude);
-      System.exit(1);
-    }
-    System.out.println("[PASS] Found 'Starting upload' INFO log in " + mode + " log output");
-
-    boolean hasOpeningSession = logOutput.contains("Opening session");
-    if (!hasOpeningSession) {
-      System.err.println(
-          "[FAIL] Log output does not contain 'Opening session' (expected DEBUG log from SFSession; "
-              + "ensure net.snowflake DEBUG is enabled for SLF4J or JUL FINE level)");
-      System.err.println("[DEBUG] First 2000 chars of log output:");
-      System.err.println(logsPrelude);
-      System.exit(1);
-    }
-    System.out.println("[PASS] Found 'Opening session' DEBUG log in " + mode + " log output");
-
+    // Do not assert on Snowflake log message text. Wording and levels change (GH #2377 moved
+    // session-open to DEBUG); PUT "Starting upload" also depends on the cloud transfer path.
+    // This app exists to prove fat-jar logging reaches the file, including relocated cloud SDKs.
     boolean hasCloudSdkLog = false;
     for (String pattern : CLOUD_SDK_LOGGER_PATTERNS) {
       if (logOutput.contains(pattern)) {

--- a/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
+++ b/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
@@ -86,15 +86,16 @@ public class FatJarTestApp {
     System.out.println("[INFO] Verifying " + mode + " log output (" + logOutput.length() + " chars)");
     String logsPrelude = logOutput.substring(0, Math.min(2000, logOutput.length()));
 
-    // Session-open messages are DEBUG (GH #2377); SQL execution remains INFO.
-    boolean hasExecuteLog = logOutput.contains("Execute:");
-    if (!hasExecuteLog) {
-      System.err.println("[FAIL] Log output does not contain 'Execute:' (expected INFO SQL log from SFStatement)");
+    // PUT "Starting upload ..." remains INFO. Session-open is DEBUG (GH #2377); JUL FINE and
+    // logback net.snowflake=DEBUG still emit it, so require both to prove INFO and DEBUG paths.
+    boolean hasStartUpload = logOutput.contains("Starting upload");
+    if (!hasStartUpload) {
+      System.err.println("[FAIL] Log output does not contain 'Starting upload' (expected INFO from PUT)");
       System.err.println("[DEBUG] First 2000 chars of log output:");
       System.err.println(logsPrelude);
       System.exit(1);
     }
-    System.out.println("[PASS] Found 'Execute:' INFO log in " + mode + " log output");
+    System.out.println("[PASS] Found 'Starting upload' INFO log in " + mode + " log output");
 
     boolean hasOpeningSession = logOutput.contains("Opening session");
     if (!hasOpeningSession) {

--- a/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
+++ b/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
@@ -4,13 +4,15 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
-import java.util.logging.LogManager;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 public class FatJarTestApp {
 
@@ -76,6 +78,12 @@ public class FatJarTestApp {
       try (InputStream is = FatJarTestApp.class.getResourceAsStream("/logging.properties")) {
         LogManager.getLogManager().readConfiguration(is);
       }
+      // Session-open is DEBUG (JUL FINE). Force it so the assertion below is not log-level flaky.
+      Logger snowflakeLogger = Logger.getLogger("net.snowflake");
+      snowflakeLogger.setLevel(Level.FINE);
+      if (!snowflakeLogger.isLoggable(Level.FINE)) {
+        throw new IllegalStateException("JUL net.snowflake logger is not at FINE/DEBUG");
+      }
       System.out.println("[INFO] JUL logging to: " + logFile.getAbsolutePath());
     }
   }
@@ -86,9 +94,17 @@ public class FatJarTestApp {
     System.out.println("[INFO] Verifying " + mode + " log output (" + logOutput.length() + " chars)");
     String logsPrelude = logOutput.substring(0, Math.min(2000, logOutput.length()));
 
-    // Do not assert on Snowflake log message text. Wording and levels change (GH #2377 moved
-    // session-open to DEBUG); PUT "Starting upload" also depends on the cloud transfer path.
-    // This app exists to prove fat-jar logging reaches the file, including relocated cloud SDKs.
+    // Session-open is DEBUG (GH #2377). JUL setup forces FINE; SLF4J logback sets net.snowflake=DEBUG.
+    boolean hasOpeningSession = logOutput.contains("Opening session");
+    if (!hasOpeningSession) {
+      System.err.println(
+          "[FAIL] Log output does not contain 'Opening session' (DEBUG log from SFSession)");
+      System.err.println("[DEBUG] First 2000 chars of log output:");
+      System.err.println(logsPrelude);
+      System.exit(1);
+    }
+    System.out.println("[PASS] Found 'Opening session' in " + mode + " log output");
+
     boolean hasCloudSdkLog = false;
     for (String pattern : CLOUD_SDK_LOGGER_PATTERNS) {
       if (logOutput.contains(pattern)) {

--- a/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
+++ b/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
@@ -4,15 +4,13 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.util.logging.LogManager;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 public class FatJarTestApp {
 
@@ -78,12 +76,6 @@ public class FatJarTestApp {
       try (InputStream is = FatJarTestApp.class.getResourceAsStream("/logging.properties")) {
         LogManager.getLogManager().readConfiguration(is);
       }
-      // Session-open is DEBUG (JUL FINE). Force it so the assertion below is not log-level flaky.
-      Logger snowflakeLogger = Logger.getLogger("net.snowflake");
-      snowflakeLogger.setLevel(Level.FINE);
-      if (!snowflakeLogger.isLoggable(Level.FINE)) {
-        throw new IllegalStateException("JUL net.snowflake logger is not at FINE/DEBUG");
-      }
       System.out.println("[INFO] JUL logging to: " + logFile.getAbsolutePath());
     }
   }
@@ -94,11 +86,9 @@ public class FatJarTestApp {
     System.out.println("[INFO] Verifying " + mode + " log output (" + logOutput.length() + " chars)");
     String logsPrelude = logOutput.substring(0, Math.min(2000, logOutput.length()));
 
-    // Session-open is DEBUG (GH #2377). JUL setup forces FINE; SLF4J logback sets net.snowflake=DEBUG.
     boolean hasOpeningSession = logOutput.contains("Opening session");
     if (!hasOpeningSession) {
-      System.err.println(
-          "[FAIL] Log output does not contain 'Opening session' (DEBUG log from SFSession)");
+      System.err.println("[FAIL] Log output does not contain 'Opening session' (expected from SFSession)");
       System.err.println("[DEBUG] First 2000 chars of log output:");
       System.err.println(logsPrelude);
       System.exit(1);

--- a/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
+++ b/fat-jar-test-app/src/main/java/net/snowflake/FatJarTestApp.java
@@ -86,14 +86,26 @@ public class FatJarTestApp {
     System.out.println("[INFO] Verifying " + mode + " log output (" + logOutput.length() + " chars)");
     String logsPrelude = logOutput.substring(0, Math.min(2000, logOutput.length()));
 
-    boolean hasOpeningSession = logOutput.contains("Opening session");
-    if (!hasOpeningSession) {
-      System.err.println("[FAIL] Log output does not contain 'Opening session' (expected from SFSession)");
+    // Session-open messages are DEBUG (GH #2377); SQL execution remains INFO.
+    boolean hasExecuteLog = logOutput.contains("Execute:");
+    if (!hasExecuteLog) {
+      System.err.println("[FAIL] Log output does not contain 'Execute:' (expected INFO SQL log from SFStatement)");
       System.err.println("[DEBUG] First 2000 chars of log output:");
       System.err.println(logsPrelude);
       System.exit(1);
     }
-    System.out.println("[PASS] Found 'Opening session' in " + mode + " log output");
+    System.out.println("[PASS] Found 'Execute:' INFO log in " + mode + " log output");
+
+    boolean hasOpeningSession = logOutput.contains("Opening session");
+    if (!hasOpeningSession) {
+      System.err.println(
+          "[FAIL] Log output does not contain 'Opening session' (expected DEBUG log from SFSession; "
+              + "ensure net.snowflake DEBUG is enabled for SLF4J or JUL FINE level)");
+      System.err.println("[DEBUG] First 2000 chars of log output:");
+      System.err.println(logsPrelude);
+      System.exit(1);
+    }
+    System.out.println("[PASS] Found 'Opening session' DEBUG log in " + mode + " log output");
 
     boolean hasCloudSdkLog = false;
     for (String pattern : CLOUD_SDK_LOGGER_PATTERNS) {

--- a/src/main/java/net/snowflake/client/internal/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFSession.java
@@ -642,7 +642,7 @@ public class SFSession extends SFBaseSession {
     stopwatch.start();
     performSanityCheckOnProperties();
     Map<SFSessionProperty, Object> connectionPropertiesMap = getConnectionPropertiesMap();
-    logger.info(
+    logger.debug(
         "Opening session with server: {}, account: {}, user: {}, password is {}, role: {}, database: {}, schema: {},"
             + " warehouse: {}, validate default parameters: {}, authenticator: {}, ocsp mode: {},"
             + " passcode in password: {}, passcode is {}, private key is {}, disable socks proxy: {},"
@@ -812,7 +812,7 @@ public class SFSession extends SFBaseSession {
                 : false) // Default to false (platform detection enabled)
         .setMaxRetryCount(maxHttpRetries);
 
-    logger.info(
+    logger.debug(
         "Connecting to {} Snowflake domain",
         loginInput.getHostFromServerUrl().toLowerCase().endsWith(".cn") ? "CHINA" : "GLOBAL");
 

--- a/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthAuthorizationCodeAccessTokenProvider.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthAuthorizationCodeAccessTokenProvider.java
@@ -65,7 +65,7 @@ public class OAuthAuthorizationCodeAccessTokenProvider implements AccessTokenPro
   @Override
   public TokenResponseDTO getAccessToken(SFLoginInput loginInput) throws SFException {
     try {
-      logger.info("Starting OAuth authorization code authentication flow...");
+      logger.debug("Starting OAuth authorization code authentication flow...");
       CodeVerifier pkceVerifier = new CodeVerifier();
       URI redirectUri = OAuthUtil.buildRedirectUri(loginInput.getOauthLoginInput());
       AuthorizationCode authorizationCode =

--- a/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthClientCredentialsAccessTokenProvider.java
+++ b/src/main/java/net/snowflake/client/internal/core/auth/oauth/OAuthClientCredentialsAccessTokenProvider.java
@@ -41,7 +41,7 @@ public class OAuthClientCredentialsAccessTokenProvider implements AccessTokenPro
   private TokenResponseDTO exchangeClientCredentialsForAccessToken(
       SFLoginInput loginInput, String dpopNonce, boolean retried) throws SFException {
     try {
-      logger.info("Starting OAuth client credentials authentication flow...");
+      logger.debug("Starting OAuth client credentials authentication flow...");
       HttpRequestBase tokenRequest = buildTokenRequest(loginInput, dpopNonce);
       return OAuthUtil.sendTokenRequest(tokenRequest, loginInput);
     } catch (SnowflakeUseDPoPNonceException e) {


### PR DESCRIPTION
## Summary
- Move session-open property dump, GLOBAL/CHINA domain line, and OAuth "starting flow" messages from INFO to DEBUG (GH #2377).

## Test plan
- [ ] Unit/checkstyle as run locally
- [ ] fat-jar-test-app still verifies logging
- [ ] INFO no longer prints those lines; DEBUG still does


Made with [Cursor](https://cursor.com)