### PR TITLE
SNOW-3236395: Escape quotes in getTablePrivileges SQL literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed `DatabaseMetaData.getTablePrivileges()` concatenating unescaped table and schema names into SQL string literals, which allowed a quote character to break out of the query (SNOW-3236395).
   - Fixed null nested structured-type fields throwing `NullPointerException` in `JsonSqlOutput` when binding via `SQLOutput` reference writers such as `writeObject`, `writeBigDecimal`, `writeBytes`, `writeDate`, and `writeTimestamp` (SNOW-1449489).
   - Changed session-open property dump, GLOBAL/CHINA domain connection, and OAuth authentication-flow start messages from INFO to DEBUG to reduce log noise (snowflakedb/snowflake-jdbc#2377).
   - Fixed `SnowflakeBasicDataSource` requiring a password for Workload Identity Federation and Programmatic Access Token authentication (snowflakedb/snowflake-jdbc#2621).

--- a/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -248,7 +248,7 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
 
   // used to get convert string back to normal after its special characters have been escaped to
   // send it through Wildcard regex
-  private String unescapeChars(String escapedString) {
+  private static String unescapeChars(String escapedString) {
     String unescapedString = escapedString.replace("\\_", "_");
     unescapedString = unescapedString.replace("\\%", "%");
     unescapedString = unescapedString.replace("\\\\", "\\");
@@ -258,8 +258,52 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
 
   // In SQL, double quotes must be escaped with an additional pair of double quotes. Add additional
   // quotes to avoid syntax errors with SQL queries.
-  private String escapeSqlQuotes(String originalString) {
+  private static String escapeSqlQuotes(String originalString) {
     return originalString.replace("\"", "\"\"");
+  }
+
+  /** Escape a value for use inside a single-quoted SQL string literal. */
+  static String escapeSqlStringLiteral(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.replace("'", "''");
+  }
+
+  private static boolean isMetadataPatternMatchingAll(String pattern) {
+    return pattern == null
+        || pattern.isEmpty()
+        || pattern.trim().equals("%")
+        || pattern.trim().equals(".*");
+  }
+
+  /**
+   * Build the INFORMATION_SCHEMA query for {@link #getTablePrivileges}. Table and schema names are
+   * placed in single-quoted string literals, so single quotes are doubled (SNOW-3236395).
+   */
+  static String buildTablePrivilegesQuery(
+      String catalog, String schemaPattern, String tableNamePattern, boolean isExactSchema) {
+    String showView = "select * from ";
+
+    if (!isMetadataPatternMatchingAll(catalog)) {
+      showView += "\"" + escapeSqlQuotes(catalog) + "\".";
+    }
+    showView += "information_schema.table_privileges";
+
+    if (!isMetadataPatternMatchingAll(tableNamePattern)) {
+      showView += " where table_name = '" + escapeSqlStringLiteral(tableNamePattern) + "'";
+    }
+
+    if (!isMetadataPatternMatchingAll(schemaPattern)) {
+      String unescapedSchema = isExactSchema ? schemaPattern : unescapeChars(schemaPattern);
+      if (showView.contains("where table_name")) {
+        showView += " and table_schema = '" + escapeSqlStringLiteral(unescapedSchema) + "'";
+      } else {
+        showView += " where table_schema = '" + escapeSqlStringLiteral(unescapedSchema) + "'";
+      }
+    }
+    showView += " order by table_catalog, table_schema, table_name, privilege_type";
+    return showView;
   }
 
   /**
@@ -2055,35 +2099,8 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
     String schemaPattern = result.schema();
     boolean isExactSchema = result.isExactSchema();
 
-    String showView = "select * from ";
-
-    if (catalog != null
-        && !catalog.isEmpty()
-        && !catalog.trim().equals("%")
-        && !catalog.trim().equals(".*")) {
-      showView += "\"" + escapeSqlQuotes(catalog) + "\".";
-    }
-    showView += "information_schema.table_privileges";
-
-    if (tableNamePattern != null
-        && !tableNamePattern.isEmpty()
-        && !tableNamePattern.trim().equals("%")
-        && !tableNamePattern.trim().equals(".*")) {
-      showView += " where table_name = '" + tableNamePattern + "'";
-    }
-
-    if (schemaPattern != null
-        && !schemaPattern.isEmpty()
-        && !schemaPattern.trim().equals("%")
-        && !schemaPattern.trim().equals(".*")) {
-      String unescapedSchema = isExactSchema ? schemaPattern : unescapeChars(schemaPattern);
-      if (showView.contains("where table_name")) {
-        showView += " and table_schema = '" + unescapedSchema + "'";
-      } else {
-        showView += " where table_schema = '" + unescapedSchema + "'";
-      }
-    }
-    showView += " order by table_catalog, table_schema, table_name, privilege_type";
+    String showView =
+        buildTablePrivilegesQuery(catalog, schemaPattern, tableNamePattern, isExactSchema);
 
     final String catalogIn = catalog;
     final String schemaIn = schemaPattern;

--- a/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -262,12 +262,15 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
     return originalString.replace("\"", "\"\"");
   }
 
-  /** Escape a value for use inside a single-quoted SQL string literal. */
+  /**
+   * Escape a value for a single-quoted Snowflake SQL string literal. Backslashes are doubled first
+   * so {@code \'} cannot close the string; then {@code '} is doubled.
+   */
   static String escapeSqlStringLiteral(String value) {
     if (value == null) {
       return null;
     }
-    return value.replace("'", "''");
+    return value.replace("\\", "\\\\").replace("'", "''");
   }
 
   /**
@@ -2073,11 +2076,13 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
     }
     showView += "information_schema.table_privileges";
 
+    boolean hasTablePredicate = false;
     if (tableNamePattern != null
         && !tableNamePattern.isEmpty()
         && !tableNamePattern.trim().equals("%")
         && !tableNamePattern.trim().equals(".*")) {
       showView += " where table_name = '" + escapeSqlStringLiteral(tableNamePattern) + "'";
+      hasTablePredicate = true;
     }
 
     if (schemaPattern != null
@@ -2085,7 +2090,7 @@ public class SnowflakeDatabaseMetaDataImpl implements SnowflakeDatabaseMetaData 
         && !schemaPattern.trim().equals("%")
         && !schemaPattern.trim().equals(".*")) {
       String unescapedSchema = isExactSchema ? schemaPattern : unescapeChars(schemaPattern);
-      if (showView.contains("where table_name")) {
+      if (hasTablePredicate) {
         showView += " and table_schema = '" + escapeSqlStringLiteral(unescapedSchema) + "'";
       } else {
         showView += " where table_schema = '" + escapeSqlStringLiteral(unescapedSchema) + "'";

--- a/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplTablePrivilegesQueryTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplTablePrivilegesQueryTest.java
@@ -1,0 +1,75 @@
+package net.snowflake.client.internal.api.implementation.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeDatabaseMetaDataImplTablePrivilegesQueryTest {
+
+  @Test
+  public void escapeSqlStringLiteralDoublesSingleQuotes() {
+    assertEquals("O''Brien", SnowflakeDatabaseMetaDataImpl.escapeSqlStringLiteral("O'Brien"));
+    assertEquals("a''''b", SnowflakeDatabaseMetaDataImpl.escapeSqlStringLiteral("a''b"));
+  }
+
+  @Test
+  public void tableNameQuoteDoesNotBreakOutOfTheLiteral() {
+    String sql =
+        SnowflakeDatabaseMetaDataImpl.buildTablePrivilegesQuery(
+            "CAT", "SCH", "foo' OR '1'='1", false);
+    assertEquals(
+        "select * from \"CAT\".information_schema.table_privileges"
+            + " where table_name = 'foo'' OR ''1''=''1'"
+            + " and table_schema = 'SCH'"
+            + " order by table_catalog, table_schema, table_name, privilege_type",
+        sql);
+    assertFalse(sql.contains("where table_name = 'foo' OR"));
+  }
+
+  @Test
+  public void schemaQuoteDoesNotBreakOutOfTheLiteral() {
+    String sql =
+        SnowflakeDatabaseMetaDataImpl.buildTablePrivilegesQuery(
+            "CAT", "SCH' OR '1'='1", "T", false);
+    assertEquals(
+        "select * from \"CAT\".information_schema.table_privileges"
+            + " where table_name = 'T'"
+            + " and table_schema = 'SCH'' OR ''1''=''1'"
+            + " order by table_catalog, table_schema, table_name, privilege_type",
+        sql);
+  }
+
+  @Test
+  public void multistatementInjectionStaysInsideTheTableLiteral() {
+    String sql =
+        SnowflakeDatabaseMetaDataImpl.buildTablePrivilegesQuery(
+            "CAT", null, "x'; select 11 as bar; --", false);
+    assertEquals(
+        "select * from \"CAT\".information_schema.table_privileges"
+            + " where table_name = 'x''; select 11 as bar; --'"
+            + " order by table_catalog, table_schema, table_name, privilege_type",
+        sql);
+  }
+
+  @Test
+  public void wildcardTableOmitsTablePredicate() {
+    String sql = SnowflakeDatabaseMetaDataImpl.buildTablePrivilegesQuery("CAT", "SCH", "%", false);
+    assertEquals(
+        "select * from \"CAT\".information_schema.table_privileges"
+            + " where table_schema = 'SCH'"
+            + " order by table_catalog, table_schema, table_name, privilege_type",
+        sql);
+  }
+
+  @Test
+  public void catalogDoubleQuotesAreEscapedInTheIdentifier() {
+    String sql =
+        SnowflakeDatabaseMetaDataImpl.buildTablePrivilegesQuery("dbwith\"quotes", null, "T", false);
+    assertEquals(
+        "select * from \"dbwith\"\"quotes\".information_schema.table_privileges"
+            + " where table_name = 'T'"
+            + " order by table_catalog, table_schema, table_name, privilege_type",
+        sql);
+  }
+}

--- a/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplTablePrivilegesQueryTest.java
+++ b/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplTablePrivilegesQueryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class SnowflakeDatabaseMetaDataImplTablePrivilegesQueryTest {
 
   @Test
-  public void escapeSqlStringLiteralDoublesSingleQuotes() {
+  public void escapeSqlStringLiteralDoublesQuotesAndBackslashes() {
     assertNull(SnowflakeDatabaseMetaDataImpl.escapeSqlStringLiteral(null));
     assertEquals("ORDERS", SnowflakeDatabaseMetaDataImpl.escapeSqlStringLiteral("ORDERS"));
     assertEquals("O''Brien", SnowflakeDatabaseMetaDataImpl.escapeSqlStringLiteral("O'Brien"));
@@ -19,5 +19,10 @@ public class SnowflakeDatabaseMetaDataImplTablePrivilegesQueryTest {
     assertEquals(
         "x''; select 11 as bar; --",
         SnowflakeDatabaseMetaDataImpl.escapeSqlStringLiteral("x'; select 11 as bar; --"));
+    // Snowflake reads \' as an escaped quote; backslash must be doubled first.
+    assertEquals(
+        "foo\\\\'' OR 1=1 --",
+        SnowflakeDatabaseMetaDataImpl.escapeSqlStringLiteral("foo\\' OR 1=1 --"));
+    assertEquals("foo\\\\", SnowflakeDatabaseMetaDataImpl.escapeSqlStringLiteral("foo\\"));
   }
 }

--- a/src/test/java/net/snowflake/client/internal/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/DatabaseMetaDataLatestIT.java
@@ -485,6 +485,13 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCWithSharedConnectionIT {
                 startingDatabase, startingSchema, tablePrivilegesSqlInjection)) {
           assertFalse(resultSet.next());
         }
+
+        String tablePrivilegesBackslashInjection = "foo\\' OR 1=1 --";
+        try (ResultSet resultSet =
+            metaData.getTablePrivileges(
+                startingDatabase, startingSchema, tablePrivilegesBackslashInjection)) {
+          assertFalse(resultSet.next());
+        }
       } finally {
         // Clean up by unsetting multistatement
         statement.execute("alter session unset MULTI_STATEMENT_COUNT");

--- a/src/test/java/net/snowflake/client/internal/jdbc/DatabaseMetaDataLatestIT.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/DatabaseMetaDataLatestIT.java
@@ -478,6 +478,13 @@ public class DatabaseMetaDataLatestIT extends BaseJDBCWithSharedConnectionIT {
           // assert result set is empty
           assertFalse(resultSet.next());
         }
+
+        String tablePrivilegesSqlInjection = "x'; select 11 as bar; --";
+        try (ResultSet resultSet =
+            metaData.getTablePrivileges(
+                startingDatabase, startingSchema, tablePrivilegesSqlInjection)) {
+          assertFalse(resultSet.next());
+        }
       } finally {
         // Clean up by unsetting multistatement
         statement.execute("alter session unset MULTI_STATEMENT_COUNT");


### PR DESCRIPTION
## Summary
- `DatabaseMetaData.getTablePrivileges()` now doubles single quotes in table and schema names before concatenating them into `INFORMATION_SCHEMA` string literals, so a quote can no longer break out of the query.

## Context
Bug-bounty follow-up for SNOW-3236395. Catalog identifiers were already escaped; table and schema values in `WHERE table_name = '...'` / `table_schema = '...'` were not.

## Test plan
- `./mvnw com.spotify.fmt:fmt-maven-plugin:format`
- `./mvnw clean validate --batch-mode --show-version -P check-style`
- `./mvnw -Dtest=SnowflakeDatabaseMetaDataImplTablePrivilegesQueryTest test`


Made with [Cursor](https://cursor.com)