### PR TITLE
SNOW-4036693: Clamp DecorrelatedJitterBackoff previous sleep to base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
-  - Fixed `DecorrelatedJitterBackoff.nextSleepTime` throwing `IllegalArgumentException: bound must be greater than origin` during HTTP request retries when the retry-timeout branch trimmed the backoff below the minimum and that value was fed back into the next jitter calculation; the previous sleep is now clamped to at least the minimum backoff (snowflakedb/snowflake-jdbc#XXXX).
+  - Fixed `DecorrelatedJitterBackoff.nextSleepTime` throwing `IllegalArgumentException: bound must be greater than origin` during HTTP request retries when the retry-timeout branch trimmed the backoff below the minimum and that value was fed back into the next jitter calculation; the previous sleep is now clamped to at least the minimum backoff (snowflakedb/snowflake-jdbc#2744).
   - Fixed `DatabaseMetaData.getTablePrivileges()` concatenating unescaped table and schema names into SQL string literals, which allowed a quote character to break out of the query (SNOW-3236395).
   - Fixed DECFLOAT `ResultSet.getString()` using engineering notation (`120E+198`) instead of normalized scientific notation (`1.2e200`); values whose unsigned plain form fits in 38 characters stay in plain decimal (SNOW-3229469).
   - Fixed null nested structured-type fields throwing `NullPointerException` in `JsonSqlOutput` when binding via `SQLOutput` reference writers such as `writeObject`, `writeBigDecimal`, `writeBytes`, `writeDate`, and `writeTimestamp` (SNOW-1449489).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed `DecorrelatedJitterBackoff.nextSleepTime` throwing `IllegalArgumentException: bound must be greater than origin` during HTTP request retries when the retry-timeout branch trimmed the backoff below the minimum and that value was fed back into the next jitter calculation; the previous sleep is now clamped to at least the minimum backoff (snowflakedb/snowflake-jdbc#XXXX).
   - Fixed `DatabaseMetaData.getTablePrivileges()` concatenating unescaped table and schema names into SQL string literals, which allowed a quote character to break out of the query (SNOW-3236395).
   - Fixed DECFLOAT `ResultSet.getString()` using engineering notation (`120E+198`) instead of normalized scientific notation (`1.2e200`); values whose unsigned plain form fits in 38 characters stay in plain decimal (SNOW-3229469).
   - Fixed null nested structured-type fields throwing `NullPointerException` in `JsonSqlOutput` when binding via `SQLOutput` reference writers such as `writeObject`, `writeBigDecimal`, `writeBytes`, `writeDate`, and `writeTimestamp` (SNOW-1449489).

--- a/src/main/java/net/snowflake/client/internal/util/DecorrelatedJitterBackoff.java
+++ b/src/main/java/net/snowflake/client/internal/util/DecorrelatedJitterBackoff.java
@@ -17,7 +17,9 @@ public class DecorrelatedJitterBackoff {
   }
 
   public long nextSleepTime(long sleep) {
-    return Math.min(cap, ThreadLocalRandom.current().nextLong(base, sleep * 3));
+    // A caller may feed back a timeout-trimmed value below base; clamp so the bound stays > origin.
+    long boundedSleep = Math.max(sleep, base);
+    return Math.min(cap, ThreadLocalRandom.current().nextLong(base, boundedSleep * 3));
   }
 
   public long getJitterForLogin(long currentTime) {

--- a/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
@@ -768,7 +768,8 @@ public class RestRequestTest {
     }
   }
 
-  // SNOW-4036693: a timeout-trimmed previous backoff below min must not throw on the non-login path.
+  // SNOW-4036693: a timeout-trimmed previous backoff below min must not throw on the non-login
+  // path.
   @Test
   public void getNewBackoffInMilliHandlesPreviousBackoffBelowMin() {
     long minBackoffInMilli = 1000;

--- a/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
+++ b/src/test/java/net/snowflake/client/internal/jdbc/RestRequestTest.java
@@ -768,6 +768,35 @@ public class RestRequestTest {
     }
   }
 
+  // SNOW-4036693: a timeout-trimmed previous backoff below min must not throw on the non-login path.
+  @Test
+  public void getNewBackoffInMilliHandlesPreviousBackoffBelowMin() {
+    long minBackoffInMilli = 1000;
+    long maxBackoffInMilli = 16000;
+    DecorrelatedJitterBackoff decorrelatedJitterBackoff =
+        new DecorrelatedJitterBackoff(minBackoffInMilli, maxBackoffInMilli);
+    long retryTimeoutInMilli = 5 * 60 * 1000L;
+    long elapsedMilliForTransientIssues = 0;
+
+    for (long previousBackoffInMilli : new long[] {0, 1, 100, 200, 333}) {
+      long backoffInMilli =
+          assertDoesNotThrow(
+              () ->
+                  RestRequest.getNewBackoffInMilli(
+                      previousBackoffInMilli,
+                      false,
+                      decorrelatedJitterBackoff,
+                      10,
+                      retryTimeoutInMilli,
+                      elapsedMilliForTransientIssues));
+      assertTrue(
+          backoffInMilli >= minBackoffInMilli && backoffInMilli <= maxBackoffInMilli,
+          String.format(
+              "previousBackoff=%dms: next backoff %dms should be within [%d, %d]",
+              previousBackoffInMilli, backoffInMilli, minBackoffInMilli, maxBackoffInMilli));
+    }
+  }
+
   /**
    * Test that IllegalStateException during HTTP request execution triggers a rebuild of the HTTP
    * client.

--- a/src/test/java/net/snowflake/client/internal/util/DecorrelatedJitterBackoffTest.java
+++ b/src/test/java/net/snowflake/client/internal/util/DecorrelatedJitterBackoffTest.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class DecorrelatedJitterBackoffTest {
 
@@ -66,6 +67,24 @@ public class DecorrelatedJitterBackoffTest {
           String.format(
               "Retry %d, iteration %d: Result %dms should be <= %dms (min(cap=%d, sleep*3=%d)) for currentSleepTime=%dms",
               attemptNumber, i, result, expectedMax, cap, currentSleepTime * 3, currentSleepTime));
+    }
+  }
+
+  // SNOW-4036693: a previous sleep below base must not throw "bound must be greater than origin".
+  @ParameterizedTest(name = "previousSleep={0}ms stays within [base, cap]")
+  @ValueSource(longs = {0L, 1L, 100L, 200L, 333L, 334L, 500L, 999L, 1000L})
+  public void nextSleepTimeHandlesPreviousSleepBelowBase(long previousSleep) {
+    long base = 1000L;
+    long cap = 16000L;
+    DecorrelatedJitterBackoff backoff = new DecorrelatedJitterBackoff(base, cap);
+
+    for (int i = 0; i < 1000; i++) {
+      long result = backoff.nextSleepTime(previousSleep);
+      assertTrue(
+          result >= base && result <= cap,
+          String.format(
+              "previousSleep=%dms, iteration %d: result %dms must stay within [%d, %d]",
+              previousSleep, i, result, base, cap));
     }
   }
 }


### PR DESCRIPTION
## Problem
`DecorrelatedJitterBackoff.nextSleepTime(sleep)` computes `nextLong(base, sleep * 3)`, which throws `IllegalArgumentException: bound must be greater than origin` when `sleep * 3 <= base` (i.e. `sleep <= 333` ms with the default `base = 1000`). On the HTTP retry path, `RestRequest.getNewBackoffInMilli`'s retry-timeout branch trims the backoff to the time remaining before the deadline (0–333 ms) and stores it; that value is fed back as `sleep` on the next retry and throws. Reported in #2743.
  
## Impact 
Under the default 300 s retry timeout, a retry that lands in the narrow window where the trimmed backoff is ≤ 333 ms and another retry follows fails with an unexpected `IllegalArgumentException` instead of normal retry/timeout handling. Infrequent but user-visible.
  
## Fix
Clamp the previous sleep up to `base` before computing the bound, so `nextLong`'s bound always exceeds its origin. This enforces the decorrelated-jitter precondition (`sleep >= base`) in the primitive, preserves the jitter, leaves the intentional timeout-trimming in `getNewBackoffInMilli` unchanged, and covers all callers (`RestRequest`, OCSP `SFTrustManager`, `SnowflakeChunkDownloader`).
  
## Test
- `DecorrelatedJitterBackoffTest.nextSleepTimeHandlesPreviousSleepBelowBase` — previous sleeps of 0–1000 ms no longer throw and stay within `[base, cap]`.
- `RestRequestTest.getNewBackoffInMilliHandlesPreviousBackoffBelowMin` — reproduces the reported non-login `getNewBackoffInMilli` → `nextSleepTime` path with sub-minimum backoffs.
  
Both fail before the change and pass after.
