### PR TITLE
SNOW-4039899: PUT throughput probe (diagnostic, do not merge)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,17 +1,8 @@
 name: Build and Test
 
+# SNOW-4039899 scratch branch: heavy matrix disabled so only the PUT throughput
+# probe runs. Restore this on: block before merging anything real.
 on:
-    push:
-        branches:
-            - master
-        tags:
-            - v*
-    pull_request:
-        branches:
-            - master
-            - SNOW-**
-            - NO-SNOW-**
-        types: [opened, synchronize, reopened, labeled, unlabeled]
     workflow_dispatch:
         inputs:
           logLevel:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,11 +2,9 @@ name: Changelog Check
 permissions:
   contents: read
 
+# SNOW-4039899 scratch branch: disabled (see put-throughput-probe.yml).
 on:
-  pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   check_change_log:

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,9 +1,8 @@
 name: Check Style
 
+# SNOW-4039899 scratch branch: disabled (see put-throughput-probe.yml).
 on:
-    pull_request:
-        branches:
-            - master
+    workflow_dispatch:
 jobs:
     check-style:
         name: Check Style

--- a/.github/workflows/put-throughput-probe.yml
+++ b/.github/workflows/put-throughput-probe.yml
@@ -1,0 +1,67 @@
+name: SNOW-4039899 PUT throughput probe
+
+# Scratch workflow for the SNOW-4039899 investigation. Runs ONLY the three-mode
+# encrypted-PUT throughput probe on a GitHub-hosted runner (fast uplink), to test
+# whether the CipherInputStream 512-byte trickle is the real throughput limiter.
+# The heavy build-test matrix is disabled on this branch (see the other workflows'
+# on: blocks, trimmed to workflow_dispatch only for this PR).
+
+on:
+  push:
+    branches:
+      - SNOW-4039899-put-throughput
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  put-probe:
+    name: 20MB encrypted PUT — default vs coalesce vs tempfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Decrypt AWS test parameters and key (same mechanism as build-test)
+        shell: bash
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+          JDBC_PRIVATE_KEY_SECRET: ${{ secrets.JDBC_PRIVATE_KEY_SECRET }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/probe-ws"
+          gpg --quiet --batch --yes --decrypt --passphrase="$PARAMETERS_SECRET" \
+            --output "$GITHUB_WORKSPACE/probe-ws/parameters.json" \
+            .github/workflows/parameters_aws.json.gpg
+          gpg --quiet --batch --yes --decrypt --passphrase="$JDBC_PRIVATE_KEY_SECRET" \
+            --output "$GITHUB_WORKSPACE/probe-ws/rsa_key_jdbc.p8" \
+            .github/workflows/rsa_keys/rsa_key_jdbc_aws.p8.gpg
+          echo "decrypted parameters + key"
+
+      - name: Build patched fat jar
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./mvnw -B -q -DskipTests -Dossrh-deploy=false -Pself-contained-jar clean package
+          ls -la target/snowflake-jdbc.jar
+
+      - name: Run PUT throughput probe (all three modes)
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}/probe-ws
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: |
+          set -euo pipefail
+          # Export SNOWFLAKE_TEST_* from the decrypted params, exactly like ci/container/test_component.sh.
+          eval "$(jq -r '.testconnection | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' "$WORKSPACE/parameters.json")"
+          # Point key-pair auth at the decrypted key (resolved against WORKSPACE by the probe).
+          export SNOWFLAKE_TEST_PRIVATE_KEY_FILE=rsa_key_jdbc.p8
+          unset SNOWFLAKE_TEST_PASSWORD || true   # force JWT path
+          javac -d probe-ws ci/probe/PutThroughputProbe.java
+          java -cp "target/snowflake-jdbc.jar:probe-ws" PutThroughputProbe 20M

--- a/.github/workflows/put-throughput-probe.yml
+++ b/.github/workflows/put-throughput-probe.yml
@@ -57,9 +57,15 @@ jobs:
           WORKSPACE: ${{ github.workspace }}/probe-ws
           AWS_EC2_METADATA_DISABLED: "true"
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          PARAMS="$WORKSPACE/parameters.json"
+          # Diagnostics (safe: names/structure only, never values).
+          echo "params file: $PARAMS ($(wc -c < "$PARAMS") bytes)"
+          echo "top-level keys: $(jq -r 'keys | join(",")' "$PARAMS" 2>&1)"
+          echo "testconnection keys: $(jq -r '.testconnection // {} | keys | join(",")' "$PARAMS" 2>&1)"
           # Export SNOWFLAKE_TEST_* from the decrypted params, exactly like ci/container/test_component.sh.
-          eval "$(jq -r '.testconnection | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' "$WORKSPACE/parameters.json")"
+          eval "$(jq -r '.testconnection | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' "$PARAMS")"
+          echo "SNOWFLAKE_TEST_HOST set: $([ -n "${SNOWFLAKE_TEST_HOST:-}" ] && echo yes || echo NO)"
           # Point key-pair auth at the decrypted key (resolved against WORKSPACE by the probe).
           export SNOWFLAKE_TEST_PRIVATE_KEY_FILE=rsa_key_jdbc.p8
           unset SNOWFLAKE_TEST_PASSWORD || true   # force JWT path

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,9 +1,9 @@
 ---
 name: Run semgrep checks
 
+# SNOW-4039899 scratch branch: disabled (see put-throughput-probe.yml).
 on:
-  pull_request:
-    branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -1,8 +1,7 @@
 name: snyk-pr
+# SNOW-4039899 scratch branch: disabled (see put-throughput-probe.yml).
 on:
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -1,9 +1,7 @@
 name: Snyk Scan
 
+# SNOW-4039899 scratch branch: PR trigger disabled (see put-throughput-probe.yml).
 on:
-  pull_request:
-    branches:
-      - master
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:

--- a/ci/probe/PutThroughputProbe.java
+++ b/ci/probe/PutThroughputProbe.java
@@ -1,0 +1,141 @@
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * SNOW-4039899 throughput probe. Uploads the same ~20 MB file to a client-side-encrypted internal
+ * stage three times, once per candidate fix, and prints the wall time of each so we can tell whether
+ * the {@code CipherInputStream} 512-byte read is actually the throughput limiter:
+ *
+ * <ul>
+ *   <li>{@code default}  — current driver behaviour (bare BufferedInputStream over the cipher stream)
+ *   <li>{@code coalesce} — read-fully wrapper that hands the SDK full-size buffers
+ *   <li>{@code tempfile} — drain the encrypted stream to disk and {@code fromFile()} it
+ * </ul>
+ *
+ * The switch is read live by {@code SnowflakeS3Client.upload} via {@code -Dsf.uploadFix}, so all three
+ * run in one JVM against one connection. Credentials come from the standard {@code SNOWFLAKE_TEST_*}
+ * environment the JDBC CI already exports; key-pair (JWT) auth mirrors the ticket's Domo writeback.
+ *
+ * <p>Run locally against a slow uplink and all three converge (bandwidth-bound). Run on a fast host
+ * (GitHub runner) and, if the trickle is real, {@code default} stays slow while the other two recover.
+ */
+public class PutThroughputProbe {
+  private static final String[] MODES = {"default", "coalesce", "tempfile"};
+
+  public static void main(String[] args) throws Exception {
+    long fileBytes = args.length > 0 ? parseSize(args[0]) : 20L * 1024 * 1024;
+
+    File src = new File(System.getProperty("java.io.tmpdir"), "put-probe-payload.dat");
+    if (!src.exists() || src.length() != fileBytes) {
+      try (RandomAccessFile raf = new RandomAccessFile(src, "rw")) {
+        raf.setLength(fileBytes);
+      }
+    }
+    System.out.println("[probe] payload=" + src + " size=" + src.length());
+
+    String host = req("SNOWFLAKE_TEST_HOST");
+    String port = env("SNOWFLAKE_TEST_PORT", "443");
+    Properties p = new Properties();
+    p.put("account", req("SNOWFLAKE_TEST_ACCOUNT"));
+    p.put("user", req("SNOWFLAKE_TEST_USER"));
+    p.put("db", req("SNOWFLAKE_TEST_DATABASE"));
+    p.put("schema", env("SNOWFLAKE_TEST_SCHEMA", "public"));
+    p.put("warehouse", req("SNOWFLAKE_TEST_WAREHOUSE"));
+    p.put("role", req("SNOWFLAKE_TEST_ROLE"));
+
+    String keyFile = System.getenv("SNOWFLAKE_TEST_PRIVATE_KEY_FILE");
+    if (keyFile != null && !keyFile.isEmpty()) {
+      String workspace = System.getenv("WORKSPACE");
+      String resolved =
+          (workspace != null && !new File(keyFile).isAbsolute())
+              ? new File(workspace, keyFile).getPath()
+              : keyFile;
+      p.put("private_key_file", resolved);
+      String keyPwd = System.getenv("SNOWFLAKE_TEST_PRIVATE_KEY_PWD");
+      if (keyPwd != null && !keyPwd.isEmpty()) {
+        p.put("private_key_pwd", keyPwd);
+      }
+      p.put("authenticator", "SNOWFLAKE_JWT");
+      System.out.println("[probe] auth=key-pair keyFile=" + resolved);
+    } else {
+      p.put("password", req("SNOWFLAKE_TEST_PASSWORD"));
+      System.out.println("[probe] auth=password");
+    }
+
+    String url = "jdbc:snowflake://" + host + ":" + port;
+    Class.forName("net.snowflake.client.jdbc.SnowflakeDriver");
+    System.out.println("[probe] connecting to " + url + " as " + p.get("user"));
+
+    try (Connection conn = DriverManager.getConnection(url, p);
+        Statement st = conn.createStatement()) {
+      st.execute("CREATE OR REPLACE TEMPORARY STAGE put_probe_stage");
+      System.out.println("[probe] stage ready; internal stage => client-side encrypted");
+
+      long[] millis = new long[MODES.length];
+      for (int i = 0; i < MODES.length; i++) {
+        String mode = MODES[i];
+        if ("default".equals(mode)) {
+          System.clearProperty("sf.uploadFix");
+        } else {
+          System.setProperty("sf.uploadFix", mode);
+        }
+        String put =
+            "PUT file://"
+                + src.getAbsolutePath()
+                + " @put_probe_stage auto_compress=false overwrite=true";
+        long t0 = System.currentTimeMillis();
+        st.execute(put);
+        millis[i] = System.currentTimeMillis() - t0;
+        double rate = src.length() / 1024.0 / (millis[i] / 1000.0);
+        System.out.printf(
+            "[probe] RESULT mode=%-8s ms=%-8d rate=%.1f KB/s%n", mode, millis[i], rate);
+      }
+
+      System.out.println("\n[probe] ===== SUMMARY (20 MB client-side-encrypted PUT) =====");
+      for (int i = 0; i < MODES.length; i++) {
+        System.out.printf("[probe]   %-8s %,d ms%n", MODES[i], millis[i]);
+      }
+      double best = Double.MAX_VALUE, worst = 0;
+      for (long m : millis) {
+        best = Math.min(best, m);
+        worst = Math.max(worst, m);
+      }
+      System.out.printf(
+          "[probe]   spread: worst/best = %.2fx  => %s%n",
+          worst / best,
+          worst / best > 3.0
+              ? "client-side path IS the limiter (trickle confirmed)"
+              : "all modes converge => bandwidth-bound, trickle NOT the limiter");
+    }
+  }
+
+  private static String env(String k, String def) {
+    String v = System.getenv(k);
+    return (v == null || v.isEmpty()) ? def : v;
+  }
+
+  private static String req(String k) {
+    String v = System.getenv(k);
+    if (v == null || v.isEmpty()) {
+      throw new IllegalStateException("missing required env " + k);
+    }
+    return v;
+  }
+
+  private static long parseSize(String s) {
+    s = s.trim().toUpperCase();
+    long mult = 1;
+    if (s.endsWith("G")) {
+      mult = 1024L * 1024 * 1024;
+      s = s.substring(0, s.length() - 1);
+    } else if (s.endsWith("M")) {
+      mult = 1024L * 1024;
+      s = s.substring(0, s.length() - 1);
+    }
+    return (long) (Double.parseDouble(s) * mult);
+  }
+}

--- a/ci/probe/PutThroughputProbe.java
+++ b/ci/probe/PutThroughputProbe.java
@@ -37,10 +37,13 @@ public class PutThroughputProbe {
     }
     System.out.println("[probe] payload=" + src + " size=" + src.length());
 
-    String host = req("SNOWFLAKE_TEST_HOST");
+    // CI's testconnection provides only ACCOUNT (no HOST/PORT); mirror AbstractDriverIT and
+    // derive host = <account>.snowflakecomputing.com, port 443, when they are absent.
+    String account = req("SNOWFLAKE_TEST_ACCOUNT");
+    String host = env("SNOWFLAKE_TEST_HOST", account + ".snowflakecomputing.com");
     String port = env("SNOWFLAKE_TEST_PORT", "443");
     Properties p = new Properties();
-    p.put("account", req("SNOWFLAKE_TEST_ACCOUNT"));
+    p.put("account", account);
     p.put("user", req("SNOWFLAKE_TEST_USER"));
     p.put("db", req("SNOWFLAKE_TEST_DATABASE"));
     p.put("schema", env("SNOWFLAKE_TEST_SCHEMA", "public"));

--- a/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/cloud/storage/SnowflakeS3Client.java
@@ -10,6 +10,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
@@ -695,18 +696,45 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
         PutObjectRequest request = putRequestBuilder.build();
 
         if (uploadStreamInfo.right) {
+          // SNOW-4039899 prototype switch: -Dsf.uploadFix=coalesce|tempfile|<default>
+          //  default   : current behaviour — bare BufferedInputStream over the CipherInputStream,
+          //              which trickles ~512 B per read into the async pipeline.
+          //  coalesce  : a read-fully wrapper that fills each SDK read to its requested length,
+          //              collapsing ~32 async onNext events into 1 while staying fully streamed.
+          //  tempfile  : drain the (already-encrypted) stream to a temp file and fromFile() it,
+          //              giving the SDK a seekable source (real parallelism, no trickle).
+          String uploadFix = System.getProperty("sf.uploadFix", "");
+          AsyncRequestBody body;
+          if ("tempfile".equals(uploadFix)) {
+            File encTmp = File.createTempFile("sf-upload-", ".enc");
+            encTmp.deleteOnExit();
+            try (InputStream in = uploadStreamInfo.left) {
+              java.nio.file.Files.copy(
+                  in, encTmp.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+            logger.info(
+                "sf.uploadFix=tempfile: encrypted stream drained to {} ({} bytes)",
+                encTmp.getAbsolutePath(),
+                encTmp.length());
+            body = AsyncRequestBody.fromFile(encTmp);
+          } else if ("coalesce".equals(uploadFix)) {
+            body =
+                AsyncRequestBody.fromInputStream(
+                    new CoalescingInputStream(uploadStreamInfo.left),
+                    request.contentLength(),
+                    executorService);
+          } else {
+            body =
+                AsyncRequestBody.fromInputStream(
+                    // wrapping with BufferedInputStream to mitigate
+                    // https://github.com/aws/aws-sdk-java-v2/issues/6174
+                    new BufferedInputStream(uploadStreamInfo.left),
+                    request.contentLength(),
+                    executorService);
+          }
           myUpload =
               tx.upload(
-                  UploadRequest.builder()
-                      .putObjectRequest(request)
-                      .requestBody(
-                          AsyncRequestBody.fromInputStream(
-                              // wrapping with BufferedInputStream to mitigate
-                              // https://github.com/aws/aws-sdk-java-v2/issues/6174
-                              new BufferedInputStream(uploadStreamInfo.left),
-                              request.contentLength(),
-                              executorService))
-                      .build());
+                  UploadRequest.builder().putObjectRequest(request).requestBody(body).build());
         } else {
           myUpload =
               tx.upload(
@@ -1095,6 +1123,33 @@ public class SnowflakeS3Client implements SnowflakeStorageClient {
       } catch (ReflectiveOperationException ex) {
         logger.warn("Reflective shutdown of SdkEventLoopGroup failed (SDK shape changed?)", ex);
       }
+    }
+  }
+
+  /**
+   * SNOW-4039899 prototype (sf.uploadFix=coalesce): fills each {@code read(byte[],off,len)} to its
+   * requested length by looping over the underlying stream. The client-side-encryption path hands
+   * the SDK a {@link javax.crypto.CipherInputStream}, whose {@code read} returns at most one cipher
+   * block (~512 B) regardless of the length asked for; the async upload publisher then emits one
+   * {@code onNext} per ~512 B, throttling a multi-MB part to a trickle. Coalescing here keeps the
+   * reads synchronous and cheap while presenting the SDK with full-size buffers.
+   */
+  private static final class CoalescingInputStream extends FilterInputStream {
+    CoalescingInputStream(InputStream in) {
+      super(in);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      int total = 0;
+      while (total < len) {
+        int n = in.read(b, off + total, len - total);
+        if (n < 0) {
+          return total == 0 ? -1 : total;
+        }
+        total += n;
+      }
+      return total;
     }
   }
 }


### PR DESCRIPTION
## SNOW-4039899 — PUT throughput probe (scratch branch, do not merge)

Draft/diagnostic only. Determines whether the intermittent slow PUT to an internal AWS stage is caused by the client-side-encryption stream path (`CipherInputStream` capping `read()` at ~512 B) or is simply bandwidth-bound.

### What runs
`put-throughput-probe.yml` (push-triggered) builds the fat jar and runs `ci/probe/PutThroughputProbe.java` against the CI AWS account, PUTting a ~20 MB file three times:

| mode | request body |
|------|--------------|
| `default` | `AsyncRequestBody.fromInputStream(BufferedInputStream(...))` — current code |
| `coalesce` | `fromInputStream` with a wrapper that fills the full buffer per read |
| `tempfile` | drain encrypted stream to temp file, `AsyncRequestBody.fromFile(...)` |

Verdict logic: worst/best spread > 3x ⇒ trickle confirmed (a fix is warranted); otherwise bandwidth-bound.

### CI
All existing workflows are trimmed to `workflow_dispatch` on this branch so only the probe runs. **Not for merge** — the `sf.uploadFix` `System.getProperty` switch and neutered CI are diagnostic scaffolding.
