### PR TITLE
Bump grpc-java to 1.84.0 from 1.83.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
   - Bumped the following dependencies:
+    - grpc-java to 1.84.0 (snowflakedb/snowflake-jdbc#XXXX).
     - jsoup to 1.23.2 (snowflakedb/snowflake-jdbc#2735).
 
 - v4.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - Fixed `DatabaseMetaData.getColumns()` discarding `trim()` on column default values and throwing `NullPointerException` when SHOW COLUMNS returns a SQL NULL default (SNOW-4009234).
   - Fixed `PreparedStatement.setObject(parameterIndex, byte[], Types.BINARY)` (and `Types.VARBINARY`/`Types.LONGVARBINARY`) binding the array's object reference (`[B@..`) instead of its hex value, causing a server-side `Invalid bind value ... for type (BINARY)` error; `byte[]` is now hex-encoded as `setBytes` does (snowflakedb/snowflake-jdbc#2731).
   - Bumped the following dependencies:
-    - grpc-java to 1.84.0 (snowflakedb/snowflake-jdbc#XXXX).
+    - grpc-java to 1.84.0 (snowflakedb/snowflake-jdbc#2747).
     - jsoup to 1.23.2 (snowflakedb/snowflake-jdbc#2735).
 
 - v4.3.3

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -664,7 +664,7 @@
                     </filter>
                     <filter>
                       <!-- dev.cel (CEL runtime, common, protobuf) are pulled in transitively by
-                           grpc-xds 1.83.0. grpc-xds is itself a pre-shaded fat jar that already
+                           grpc-xds. grpc-xds is itself a pre-shaded fat jar that already
                            embeds these classes under io.grpc.xds.shaded.dev.cel.*, which our
                            io.grpc relocation handles correctly. The separate dev.cel Maven artifacts
                            are therefore redundant in the fat jar and must be excluded to avoid

--- a/linkage-checker-exclusion-rules.xml
+++ b/linkage-checker-exclusion-rules.xml
@@ -184,7 +184,7 @@
     <LinkageError>
         <Target><Package name="java.lang.invoke"/></Target>
         <Source><Package name="io.grpc.netty.shaded.io.netty"/></Source>
-        <Reason>VarHandle @PolymorphicSignature methods used by Netty 4.2.x (bundled in grpc-netty-shaded 1.83.0) in VarHandleByteBufferAccess and RefCnt; these code paths are only activated on Java 9+ via capability checks, never loaded on Java 8; false positive in linkage checker</Reason>
+        <Reason>VarHandle @PolymorphicSignature methods used by Netty 4.2.x (bundled in grpc-netty-shaded) in VarHandleByteBufferAccess and RefCnt; these code paths are only activated on Java 9+ via capability checks, never loaded on Java 8; false positive in linkage checker</Reason>
     </LinkageError>
     <LinkageError>
         <Target><Package name="java.util.zip"/></Target>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -61,7 +61,7 @@
     <google.proto.iam.version>1.67.0</google.proto.iam.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
     <google.protobuf.java.version>4.33.5</google.protobuf.java.version>
-    <grpc.version>1.83.1</grpc.version>
+    <grpc.version>1.84.0</grpc.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hikaricp.version>2.4.3</hikaricp.version>
     <jackson.version>2.18.10</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1132,7 +1132,7 @@
                     </filter>
                     <filter>
                       <!-- dev.cel (CEL runtime, common, protobuf) are pulled in transitively by
-                           grpc-xds 1.83.0. grpc-xds is itself a pre-shaded fat jar that already
+                           grpc-xds. grpc-xds is itself a pre-shaded fat jar that already
                            embeds these classes under io.grpc.xds.shaded.dev.cel.*, which our
                            io.grpc relocation handles correctly. The separate dev.cel Maven artifacts
                            are therefore redundant in the fat jar and must be excluded to avoid

--- a/thin_public_pom.xml
+++ b/thin_public_pom.xml
@@ -57,7 +57,7 @@
     <google.http.client.version>2.1.0</google.http.client.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
     <google.protobuf.java.version>4.33.5</google.protobuf.java.version>
-    <grpc.version>1.83.1</grpc.version>
+    <grpc.version>1.84.0</grpc.version>
     <jackson.version>2.18.10</jackson.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jna.version>5.13.0</jna.version>


### PR DESCRIPTION
### Description
bumped grpc-java to 1.84.0; and removed some stale '1.83.0' mentions from comments.