### PR TITLE
SNOW-3649698: Validate PrivateLink and OCSP cache server hosts against the Snowflake domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v4.3.4-SNAPSHOT
+  - Fixed `PrivateLinkDetector.isPrivateLink()` accepting any hostname that merely contained `.privatelink.snowflakecomputing.` as a substring, so a host such as `evil.privatelink.snowflakecomputing.attacker.com` was classified as a PrivateLink Snowflake host; a hostname must now actually end with `.snowflakecomputing.<tld>`. The OCSP response cache server URL, which is held in a JVM-wide static field, is now rejected when its host is not a Snowflake host (SNOW-3649698).
   - Fixed `DecorrelatedJitterBackoff.nextSleepTime` throwing `IllegalArgumentException: bound must be greater than origin` during HTTP request retries when the retry-timeout branch trimmed the backoff below the minimum and that value was fed back into the next jitter calculation; the previous sleep is now clamped to at least the minimum backoff (snowflakedb/snowflake-jdbc#2744).
   - Fixed `DatabaseMetaData.getTablePrivileges()` concatenating unescaped table and schema names into SQL string literals, which allowed a quote character to break out of the query (SNOW-3236395).
   - Fixed DECFLOAT `ResultSet.getString()` using engineering notation (`120E+198`) instead of normalized scientific notation (`1.2e200`); values whose unsigned plain form fits in 38 characters stay in plain decimal (SNOW-3229469).

--- a/src/main/java/net/snowflake/client/internal/core/PrivateLinkDetector.java
+++ b/src/main/java/net/snowflake/client/internal/core/PrivateLinkDetector.java
@@ -1,15 +1,64 @@
 package net.snowflake.client.internal.core;
 
 public class PrivateLinkDetector {
+
+  private static final String SNOWFLAKE_DOMAIN = ".snowflakecomputing.";
+
   /**
-   * We can only tell if private link is enabled for certain hosts when the hostname contains the
-   * word 'privatelink' but we don't have a good way of telling if a private link connection is
-   * expected for internal stages for example.
-   *
-   * @param host host
-   * @return true if host is considered as privatelink environment
+   * @param host hostname or URL string
+   * @return true if host is a PrivateLink Snowflake environment
    */
   public static boolean isPrivateLink(String host) {
-    return host.toLowerCase().contains(".privatelink.snowflakecomputing.");
+    if (host == null) {
+      return false;
+    }
+    String hostname = extractHostname(host).toLowerCase();
+    return endsWithSnowflakeDomain(hostname) && hostname.contains(".privatelink.");
+  }
+
+  /**
+   * Validates that the given host belongs to the Snowflake domain (*.snowflakecomputing.{tld}).
+   *
+   * @param host bare hostname to validate
+   * @return true if host is a valid Snowflake domain
+   */
+  public static boolean isSnowflakeHost(String host) {
+    if (host == null) {
+      return false;
+    }
+    return endsWithSnowflakeDomain(host.toLowerCase());
+  }
+
+  /**
+   * A valid Snowflake hostname has the form {@code <account-labels>.snowflakecomputing.<tld>} where
+   * there is at least one label before the domain and the TLD is a single alphabetic segment.
+   */
+  private static boolean endsWithSnowflakeDomain(String lower) {
+    int idx = lower.lastIndexOf(SNOWFLAKE_DOMAIN);
+    if (idx <= 0) {
+      return false;
+    }
+    String tld = lower.substring(idx + SNOWFLAKE_DOMAIN.length());
+    return !tld.isEmpty()
+        && tld.indexOf('.') < 0
+        && tld.chars().allMatch(c -> c >= 'a' && c <= 'z');
+  }
+
+  /**
+   * Extracts the hostname from a string that may be a full URL or a bare hostname. Returns the host
+   * portion without scheme, port, or path.
+   *
+   * <p>Examples:
+   *
+   * <ul>
+   *   <li>{@code "https://host.com:443/path"} → {@code "host.com"}
+   *   <li>{@code "host.com"} → {@code "host.com"}
+   * </ul>
+   *
+   * First replace strips everything up to and including "://" (the scheme). Second replace strips
+   * everything from the first ":" or "/" onward (port and path).
+   */
+  static String extractHostname(String hostOrUrl) {
+    return hostOrUrl.replaceAll("^[^/]*//", "").replaceAll("[:/].*", "");
   }
 }

--- a/src/main/java/net/snowflake/client/internal/core/SFTrustManager.java
+++ b/src/main/java/net/snowflake/client/internal/core/SFTrustManager.java
@@ -301,9 +301,13 @@ public class SFTrustManager extends X509ExtendedTrustManager {
     if (ocspCacheServerUrl == null || SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN != null) {
       return;
     }
+    URL url = new URL(ocspCacheServerUrl);
+    if (!isAllowedOcspHost(url.getHost())) {
+      logger.debug("Rejected OCSP cache server URL with non-Snowflake host: {}", url.getHost());
+      return;
+    }
     SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE = ocspCacheServerUrl;
     if (!SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE.startsWith(DEFAULT_OCSP_CACHE_HOST_PREFIX)) {
-      URL url = new URL(SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE);
       if (url.getPort() > 0) {
         SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN =
             String.format(
@@ -316,6 +320,21 @@ public class SFTrustManager extends X509ExtendedTrustManager {
           "Reset OCSP response cache server URL to: {}",
           SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN);
     }
+  }
+
+  /**
+   * Checks whether the given host is an allowed OCSP cache server host. Allowed hosts must either
+   * start with "ocsp." followed by a valid Snowflake host, or be a Snowflake host itself.
+   */
+  static boolean isAllowedOcspHost(String host) {
+    if (host == null) {
+      return false;
+    }
+    String normalized = host.toLowerCase();
+    if (normalized.startsWith("ocsp.")) {
+      return PrivateLinkDetector.isSnowflakeHost(normalized.substring("ocsp.".length()));
+    }
+    return PrivateLinkDetector.isSnowflakeHost(normalized);
   }
 
   static void setOCSPResponseCacheServerURL(String serverURL) {
@@ -1481,10 +1500,12 @@ public class SFTrustManager extends X509ExtendedTrustManager {
 
     void resetOCSPResponseCacheServer(String host) {
       String ocspCacheServerUrl;
-      if (host.toLowerCase().contains(".global.snowflakecomputing.")) {
+      if (PrivateLinkDetector.isSnowflakeHost(host)
+          && host.toLowerCase().contains(".global.snowflakecomputing.")) {
         ocspCacheServerUrl =
             String.format("https://ocspssd%s/%s", host.substring(host.indexOf('-')), "ocsp");
-      } else if (host.toLowerCase().contains(".snowflakecomputing.")) {
+      } else if (PrivateLinkDetector.isSnowflakeHost(host)
+          && host.toLowerCase().contains(".snowflakecomputing.")) {
         ocspCacheServerUrl =
             String.format("https://ocspssd%s/%s", host.substring(host.indexOf('.')), "ocsp");
       } else {

--- a/src/test/java/net/snowflake/client/internal/core/PrivateLinkDetectorTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/PrivateLinkDetectorTest.java
@@ -1,8 +1,11 @@
 package net.snowflake.client.internal.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -34,5 +37,79 @@ public class PrivateLinkDetectorTest {
         expectedToBePrivateLink,
         PrivateLinkDetector.isPrivateLink(host),
         String.format("Expecting %s to be private link: %s", host, expectedToBePrivateLink));
+  }
+
+  @Test
+  public void shouldRejectPrivateLinkHostWithTrailingAttackerDomain() {
+    assertFalse(
+        PrivateLinkDetector.isPrivateLink("evil.privatelink.snowflakecomputing.attacker.com"),
+        "Hostname with extra labels after the TLD must not be treated as PrivateLink");
+  }
+
+  @Test
+  public void shouldRejectPrivateLinkSubstringInNonSnowflakeDomain() {
+    assertFalse(
+        PrivateLinkDetector.isPrivateLink("x.privatelink.snowflakecomputing.com.attacker.com"),
+        "Snowflake domain embedded as a subdomain of attacker must not match");
+  }
+
+  @Test
+  public void shouldHandleNullHost() {
+    assertFalse(PrivateLinkDetector.isPrivateLink(null));
+  }
+
+  @Test
+  public void shouldDetectPrivateLinkFromFullUrl() {
+    assertTrue(
+        PrivateLinkDetector.isPrivateLink("https://test.privatelink.snowflakecomputing.com"));
+    assertTrue(
+        PrivateLinkDetector.isPrivateLink("https://test.privatelink.snowflakecomputing.com:443/"));
+    assertFalse(PrivateLinkDetector.isPrivateLink("https://test.snowflakecomputing.com"));
+    assertFalse(
+        PrivateLinkDetector.isPrivateLink(
+            "https://evil.privatelink.snowflakecomputing.attacker.com"));
+  }
+
+  static class IsSnowflakeHostDataProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+      return Stream.of(
+          Arguments.of("account.us-east-1.snowflakecomputing.com", true),
+          Arguments.of("account.snowflakecomputing.com", true),
+          Arguments.of("account.snowflakecomputing.cn", true),
+          Arguments.of("account.privatelink.snowflakecomputing.com", true),
+          Arguments.of("account.global.snowflakecomputing.com", true),
+          Arguments.of("ACCOUNT.SNOWFLAKECOMPUTING.COM", true),
+          Arguments.of("evil.privatelink.snowflakecomputing.attacker.com", false),
+          Arguments.of("snowflakecomputing.com.attacker.com", false),
+          Arguments.of("account.snowflakecomputing.com.evil.com", false),
+          Arguments.of("attacker.com", false),
+          Arguments.of("snowflakecomputing.com", false),
+          Arguments.of(null, false));
+    }
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(IsSnowflakeHostDataProvider.class)
+  public void shouldValidateSnowflakeHost(String host, boolean expectedToBeSnowflake) {
+    assertEquals(
+        expectedToBeSnowflake,
+        PrivateLinkDetector.isSnowflakeHost(host),
+        String.format("Expecting %s to be Snowflake host: %s", host, expectedToBeSnowflake));
+  }
+
+  @Test
+  public void shouldRejectHostWithOnlySnowflakeComputingDomain() {
+    assertFalse(
+        PrivateLinkDetector.isSnowflakeHost("snowflakecomputing.com"),
+        "Bare snowflakecomputing.com without account label must not be valid");
+  }
+
+  @Test
+  public void shouldAcceptMultiLabelSnowflakeHost() {
+    assertTrue(
+        PrivateLinkDetector.isSnowflakeHost("abc.us-west-2.aws.snowflakecomputing.com"),
+        "Multi-label subdomain must be accepted");
   }
 }

--- a/src/test/java/net/snowflake/client/internal/core/SFTrustManagerOcspCachePoisoningTest.java
+++ b/src/test/java/net/snowflake/client/internal/core/SFTrustManagerOcspCachePoisoningTest.java
@@ -1,11 +1,17 @@
 package net.snowflake.client.internal.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import net.snowflake.client.internal.jdbc.OCSPErrorCode;
 import net.snowflake.client.internal.util.SFPair;
 import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /** Regression: a non-SUCCESSFUL OCSP cache entry must surface as SFOCSPException, not NPE. */
@@ -14,6 +20,12 @@ public class SFTrustManagerOcspCachePoisoningTest {
   /** RFC 6960 unauthorized(6) OCSP response: SEQUENCE { ENUMERATED 6 }. */
   private static final String UNAUTHORIZED_OCSP_B64 =
       Base64.encodeBase64String(new byte[] {0x30, 0x03, 0x0A, 0x01, 0x06});
+
+  @AfterEach
+  public void resetStaticState() {
+    SFTrustManager.SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE = null;
+    SFTrustManager.SF_OCSP_RESPONSE_CACHE_SERVER_RETRY_URL_PATTERN = null;
+  }
 
   @Test
   public void validateRevocationStatusMain_throwsSfOcspExceptionForUnauthorizedResponse() {
@@ -30,5 +42,91 @@ public class SFTrustManagerOcspCachePoisoningTest {
         ex.getErrorCode(),
         "Unauthorized(6) payloads must surface as INVALID_OCSP_RESPONSE so isCached evicts them"
             + " and the fail-open gate engages");
+  }
+
+  @Test
+  public void resetOCSPResponseCacherServerURL_rejectsNonSnowflakeHost() throws IOException {
+    SFTrustManager.resetOCSPResponseCacherServerURL(
+        "http://ocsp.evil.privatelink.snowflakecomputing.attacker.com/ocsp_response_cache.json");
+
+    assertNull(
+        SFTrustManager.SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE,
+        "URL with attacker-controlled host must not be accepted");
+  }
+
+  @Test
+  public void resetOCSPResponseCacherServerURL_acceptsLegitimatePrivateLinkHost()
+      throws IOException {
+    String legitimateUrl =
+        "http://ocsp.account.privatelink.snowflakecomputing.com/ocsp_response_cache.json";
+    SFTrustManager.resetOCSPResponseCacherServerURL(legitimateUrl);
+
+    assertSame(
+        legitimateUrl,
+        SFTrustManager.SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE,
+        "Legitimate PrivateLink OCSP cache URL must be accepted");
+  }
+
+  @Test
+  public void resetOCSPResponseCacherServerURL_rejectsSnowflakeDomainAsSubdomain()
+      throws IOException {
+    SFTrustManager.resetOCSPResponseCacherServerURL(
+        "http://ocsp.account.snowflakecomputing.com.evil.com/ocsp_response_cache.json");
+
+    assertNull(
+        SFTrustManager.SF_OCSP_RESPONSE_CACHE_SERVER_URL_VALUE,
+        "Snowflake domain embedded in attacker domain must not be accepted");
+  }
+
+  @Test
+  public void ocspCacheServer_nonSnowflakeHostFallsBackToSafeDefault() {
+    SFTrustManager.OCSPCacheServer cacheServer = new SFTrustManager.OCSPCacheServer();
+    cacheServer.resetOCSPResponseCacheServer("evil.privatelink.snowflakecomputing.attacker.com");
+
+    assertEquals(
+        "https://ocspssd.snowflakecomputing.com/ocsp/fetch",
+        cacheServer.SF_OCSP_RESPONSE_CACHE_SERVER,
+        "Host with .snowflakecomputing. as substring but invalid domain must fall back to safe default");
+  }
+
+  @Test
+  public void ocspCacheServer_acceptsLegitimateSnowflakeHost() {
+    SFTrustManager.OCSPCacheServer cacheServer = new SFTrustManager.OCSPCacheServer();
+    cacheServer.resetOCSPResponseCacheServer("account.us-west-2.aws.snowflakecomputing.com");
+
+    assertTrue(
+        cacheServer.SF_OCSP_RESPONSE_CACHE_SERVER.contains("ocspssd"),
+        "Legitimate Snowflake host must produce a valid OCSP cache server URL");
+  }
+
+  @Test
+  public void ocspCacheServer_acceptsGlobalSnowflakeHost() {
+    SFTrustManager.OCSPCacheServer cacheServer = new SFTrustManager.OCSPCacheServer();
+    cacheServer.resetOCSPResponseCacheServer("account-abc123.global.snowflakecomputing.com");
+
+    assertTrue(
+        cacheServer.SF_OCSP_RESPONSE_CACHE_SERVER.contains("ocspssd"),
+        "Global Snowflake host must produce a valid OCSP cache server URL");
+  }
+
+  @Test
+  public void isAllowedOcspHost_acceptsOcspPrefixedSnowflakeHost() {
+    assertTrue(SFTrustManager.isAllowedOcspHost("ocsp.account.privatelink.snowflakecomputing.com"));
+  }
+
+  @Test
+  public void isAllowedOcspHost_rejectsOcspPrefixedAttackerHost() {
+    assertFalse(
+        SFTrustManager.isAllowedOcspHost("ocsp.evil.privatelink.snowflakecomputing.attacker.com"));
+  }
+
+  @Test
+  public void isAllowedOcspHost_rejectsNullHost() {
+    assertFalse(SFTrustManager.isAllowedOcspHost(null));
+  }
+
+  @Test
+  public void isAllowedOcspHost_acceptsPlainSnowflakeHost() {
+    assertTrue(SFTrustManager.isAllowedOcspHost("account.snowflakecomputing.com"));
   }
 }


### PR DESCRIPTION
## Summary
- `PrivateLinkDetector.isPrivateLink()` now requires a hostname to genuinely end with `.snowflakecomputing.<tld>`, instead of testing for a `.privatelink.snowflakecomputing.` substring anywhere in the string.
- Adds `isSnowflakeHost()` as the reusable domain check and `extractHostname()` so a full URL and a bare host are classified the same way.
- Adds `SFTrustManager.isAllowedOcspHost()` and applies it to both OCSP cache server URL paths (`resetOCSPResponseCacherServerURL` and `OCSPCacheServer.resetOCSPResponseCacheServer`). A URL whose host is not a Snowflake host is ignored, and `OCSPCacheServer` falls back to its safe default.

## Context
The OCSP cache server URL lives in a JVM-wide static field, so whatever the first connection puts there applies to every later connection in the same JVM. The old substring check accepted hostnames that merely contained the Snowflake domain somewhere in the middle.

First of two PRs for SNOW-3649698; #2749 follows.

## Test plan
- [x] `./mvnw com.spotify.fmt:fmt-maven-plugin:format` — 0 reformatted
- [x] `./mvnw clean validate --batch-mode --show-version -P check-style` — 0 violations
- [x] `./mvnw -Dtest=UnitTestSuite test` — 1311 tests, 0 failures, 0 errors
- [x] `PrivateLinkDetectorTest` (27) and `SFTrustManagerOcspCachePoisoningTest` (11), covering embedded-domain hosts, extra labels after the TLD, full-URL input and the bare apex
