### PR TITLE
NO-SNOW: Update version to 4.3.5-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 #### For all official JDBC Release Notes please refer to https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc
 
 # Changelog
+- v4.3.5-SNAPSHOT
+  - 
+
 - v4.3.4
   - Added validation of `account`, `port` and `protocol` in the auto-configuration (`connections.toml`) path, where the connect string's host is synthesized from `account`, so that none of the interpolated components can alter the resulting URL authority. Each dot-separated label of `account` may contain only letters, digits, underscores and hyphens (mirroring the Python connector), `port` must be a number in 1-65535, and `protocol` must be `http` or `https`. Absent or empty values keep their existing "not specified" meaning. As defense in depth, the `ACCOUNT` connection property now also rejects values containing a URL-authority delimiter (snowflakedb/snowflake-jdbc#2752).
   - Reduced sensitive detail in debug and response logging: the chunk result-master key is logged as a presence flag instead of its value, HTTP response header values are no longer logged (only header names), and chunk-download responses are rendered as a status line plus header names instead of `HttpResponse.toString()`, which would render every header value. `SecretDetector` additionally masks the `X-Amz-Credential` and `X-Amz-Security-Token` URL parameters, `qrmk`-labelled values and the SSE-C customer key header, and the connection-token pattern now covers session tokens of every minted version (snowflakedb/snowflake-jdbc#2751).

--- a/FIPS/pom.xml
+++ b/FIPS/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-jdbc-parent</artifactId>
-    <version>4.3.4</version>
+    <version>4.3.5-SNAPSHOT</version>
     <relativePath>../parent-pom.xml</relativePath>
   </parent>
 
   <artifactId>snowflake-jdbc-fips</artifactId>
-  <version>4.3.4</version>
+  <version>4.3.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>snowflake-jdbc-fips</name>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-jdbc-parent</artifactId>
-  <version>4.3.4</version>
+  <version>4.3.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-jdbc-parent</artifactId>
-    <version>4.3.4</version>
+    <version>4.3.5-SNAPSHOT</version>
     <relativePath>./parent-pom.xml</relativePath>
   </parent>
 
   <!-- Maven complains about using property here, but it makes install and deploy process easier to override final package names and localization -->
   <artifactId>${artifactId}</artifactId>
-  <version>4.3.4</version>
+  <version>4.3.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${artifactId}</name>


### PR DESCRIPTION
## Summary
- Start the next development cycle at `4.3.5-SNAPSHOT`
- Add a new empty changelog section for unreleased work

## Context
Stacked on #2753. Same pattern as #2728 after the 4.3.3 release: once 4.3.4 is cut, master should move to the next SNAPSHOT so subsequent changes do not land on a released version.

## Test plan
- [x] `./prepareNewVersion.sh 4.3.5-SNAPSHOT`
- [x] Changelog header matches prior SNAPSHOT bumps (empty bullet + blank line)
- [x] `./mvnw com.spotify.fmt:fmt-maven-plugin:format`
- [x] `./mvnw clean validate --batch-mode --show-version -P check-style`
- [ ] CI green on merge (after #2753)